### PR TITLE
ci: Cargo pins → cohab pin-overrides (kills bump-then-tag race)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1512,9 +1512,52 @@ jobs:
   #
   # Implementation lives in `CIRISAI/CIRISConformance` as a reusable
   # workflow — see that repo's README for adding new cases.
+  # ─── extract-substrate-pins: Cargo.toml → JSON pin-overrides ────────
+  #
+  # Reads edge's actual Cargo.toml pins for ciris-persist (Python wheel)
+  # and ciris-keyring (= ciris-verify Python wheel — both come from
+  # CIRISVerify at the same tag) and emits a JSON object that the
+  # cohabitation gate feeds into the harness's `pin-overrides` input.
+  #
+  # This eliminates the substrate-currency race: edge's own Cargo pin
+  # IS the cohabitation contract. The conformance matrix becomes
+  # documentation-of-record + nightly drift gate, but is no longer on
+  # the critical path of an edge release. Before this job existed, we
+  # had to force-push a conformance matrix bump in lockstep with every
+  # edge tag (v1.1.9 / v1.1.10 / v1.1.11 / v1.1.12 all hit it).
+  extract-substrate-pins:
+    name: extract substrate pins from Cargo.toml
+    runs-on: ubuntu-latest
+    outputs:
+      pin-overrides: ${{ steps.extract.outputs.json }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: extract
+        run: |
+          python3 <<'PYEOF' >> "$GITHUB_OUTPUT"
+          import re, json
+          text = open('Cargo.toml').read()
+          def find_tag(crate):
+              m = re.search(rf'^{re.escape(crate)}\s*=\s*\{{[^}}]*tag\s*=\s*"v(\d+\.\d+\.\d+)"', text, re.M)
+              if not m:
+                  raise SystemExit(f'no tag found for {crate} in Cargo.toml')
+              return m.group(1)
+          persist = find_tag('ciris-persist')
+          keyring = find_tag('ciris-keyring')
+          crypto  = find_tag('ciris-crypto')
+          assert keyring == crypto, f'ciris-keyring ({keyring}) and ciris-crypto ({crypto}) must share a tag — both come from CIRISVerify'
+          pins = {
+              'ciris-persist': f'ciris-persist=={persist}',
+              'ciris-verify':  f'ciris-verify=={keyring}',
+          }
+          print(f'json={json.dumps(pins)}')
+          PYEOF
+          echo "extracted:"
+          grep '^json=' "$GITHUB_OUTPUT"
+
   cohabitation-conformance:
     name: cohabitation (${{ matrix.platform }} × ${{ matrix.backend }})
-    needs: pyo3-wheel
+    needs: [pyo3-wheel, extract-substrate-pins]
     strategy:
       fail-fast: false
       matrix:
@@ -1531,6 +1574,7 @@ jobs:
       backend: ${{ matrix.backend }}
       under-test-wheel-artifact: ciris_edge-wheel-${{ matrix.platform }}
       under-test-package: ciris-edge
+      pin-overrides: ${{ needs.extract-substrate-pins.outputs.pin-overrides }}
 
   # ─── publish-pypi: tag-gated wheel upload via OIDC ──────────────────
   #


### PR DESCRIPTION
## Why

Every substrate-currency bump this session (v1.1.9 → v1.1.10 → v1.1.11
→ v1.1.12) hit the same race: edge's tag CI cohab cells installed
the matrix-pinned persist version from PyPI, but the under-test wheel
was compiled against a *different* persist version (whatever
Cargo.toml said). When the two disagreed, init_edge_runtime refused
and the tag CI failed — not because cohab was broken, but because the
matrix was a stale cache of edge's actual Cargo pin.

The mitigation each time was to force-push a conformance matrix bump
in lockstep with the edge tag. Brittle, requires cross-repo
coordination, briefly broke other consumers' CI during the window.

## What

CIRISConformance#12 (merged 7cfdac3) added a \`pin-overrides\` input
to the reusable run-against-wheels workflow that lets callers install
named siblings from any pip-installable spec (\`pkg==ver\` for
cross-publish alignment, \`git+url@ref\` for branch fire-tests).

This PR consumes it. New \`extract-substrate-pins\` job:
- Reads Cargo.toml
- Extracts ciris-persist's git tag (e.g. v3.14.3)
- Extracts ciris-keyring's git tag (= ciris-verify version, since
  both come from CIRISVerify at the same tag — asserts equality
  with ciris-crypto's tag)
- Emits JSON: \`{"ciris-persist": "ciris-persist==3.14.3", "ciris-verify": "ciris-verify==4.8.0"}\`
- Outputs to \`pin-overrides\` for the cohab job

Cohab job adds \`needs: extract-substrate-pins\` + passes
\`pin-overrides: \${{ needs.extract-substrate-pins.outputs.pin-overrides }}\`.

## Effect

Edge's own Cargo pin IS the cohabitation contract going forward.
The conformance matrix becomes documentation-of-record + nightly
drift gate (CIRISConformance's scheduled run), but is no longer on
the critical path of an edge release.

## Validation

Extractor logic tested locally against live Cargo.toml — produces
expected JSON for the current v3.14.3 / v4.8.0 / v4.8.0 pins. YAML
parse-clean. The PR's own CI run will exercise the new wiring end-to-
end against PyPI-published persist 3.14.3 + verify 4.8.0 (which is
exactly the matrix pin too, so this PR's cohab cells should pass
identically with or without the override applied — the differential
behavior shows up on the next substrate bump).