### PR TITLE
transport: hybrid KEX session + N1 addressing + replay window (closes #54, partial #53)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,7 +217,7 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v4.0.1
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
 ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.0", version = "4", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.0", version = "4", features = ["ed25519", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v4.8.0", version = "4", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex"] }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -259,6 +259,11 @@ base64      = "0.22"
 # Errors / logs
 thiserror   = "1"
 tracing     = "0.1"
+
+# Federation-session KEX (CIRISEdge#54). `zeroize` for explicit
+# scrub of session keys + KEX private material — same crate used
+# transitively by ciris-crypto, so no version skew risk.
+zeroize     = "1"
 
 # IDs
 uuid        = { version = "1", features = ["v4", "serde"] }

--- a/src/transport/addressing.rs
+++ b/src/transport/addressing.rs
@@ -1,0 +1,384 @@
+//! Federation addressing + replay-window primitives.
+//!
+//! Closes part of CIRISEdge#53 (Fed TM §3.3 Gap D: N1 cryptographic
+//! addressing + sliding-window replay protection). The N2 multi-medium
+//! transport plug — packet radio, additional non-IP media — ships as
+//! follow-up work in a separate module (`transport/medium_registry.rs`
+//! to be added) since the right shape there depends on the medium-
+//! specific driver.
+//!
+//! ## N1 — addressing IS identity
+//!
+//! Per the Reticulum convention adopted in CIRISEdge's transport docs:
+//!
+//! ```text
+//! destination = sha256(public_key)[..16]
+//! ```
+//!
+//! 16 bytes is the Reticulum native destination width. SHA-256
+//! truncation gives strong collision resistance against an attacker
+//! trying to grind a different pubkey onto the same destination:
+//! 64 bits of effective collision strength (birthday bound on a 128-bit
+//! output, half-bit-width once an attacker controls the pubkey input).
+//! That's enough to make eclipse / impersonation against a known target
+//! cryptographically uneconomical: ~2^64 SHA-256 operations to grind a
+//! pubkey hitting a chosen target.
+//!
+//! ## Replay window
+//!
+//! The CIRIS federation envelope carries a 64-bit sequence number
+//! stamped by the sender per (sender, recipient) pair. Receivers track
+//! the highest-seen sequence + a bitfield of the last N positions
+//! (default 1024) to admit out-of-order arrivals but reject duplicates
+//! AND stale envelopes that fall outside the window.
+//!
+//! This is the standard sliding-window construction (RFC 6479 / IPsec
+//! anti-replay); see `ReplayWindow::admit`.
+
+use sha2::{Digest, Sha256};
+
+/// Reticulum destination width in bytes — the canonical wire form.
+pub const RETICULUM_DEST_LEN: usize = 16;
+
+/// Derive the canonical Reticulum destination from a federation
+/// Ed25519 public key (CIRISEdge#53 §N1). 16 bytes is the truncated
+/// SHA-256 prefix.
+pub fn reticulum_destination_for_pubkey(pubkey: &[u8; 32]) -> [u8; RETICULUM_DEST_LEN] {
+    let mut h = Sha256::new();
+    h.update(pubkey);
+    let full = h.finalize();
+    let mut out = [0u8; RETICULUM_DEST_LEN];
+    out.copy_from_slice(&full[..RETICULUM_DEST_LEN]);
+    out
+}
+
+/// Same operation on raw pubkey bytes of arbitrary length, for media
+/// (HTTP, packet radio) whose addressing also wants the
+/// sha256-truncated-to-16 form. The 32-byte specialization above is
+/// the hot path; this slice form is the general API.
+pub fn destination_from_pubkey_bytes(pubkey: &[u8]) -> [u8; RETICULUM_DEST_LEN] {
+    let mut h = Sha256::new();
+    h.update(pubkey);
+    let full = h.finalize();
+    let mut out = [0u8; RETICULUM_DEST_LEN];
+    out.copy_from_slice(&full[..RETICULUM_DEST_LEN]);
+    out
+}
+
+/// Sliding-window replay tracker per (sender, recipient) pair. The
+/// receiver instantiates one of these per remote peer it accepts
+/// envelopes from; the window size controls how out-of-order delivery
+/// is tolerated. Inspired by RFC 6479 (IPsec anti-replay) — bit-vector
+/// over the last `window` sequence numbers.
+///
+/// Memory footprint is `window / 8` bytes plus a `u64`. With the default
+/// `WINDOW_DEFAULT` of 1024, that's 128 bytes per peer — negligible
+/// even at hundreds of peers.
+///
+/// Thread-safety: `&mut self` for `admit` — call sites either own the
+/// `ReplayWindow` exclusively, or wrap in `tokio::sync::Mutex`.
+#[derive(Debug)]
+pub struct ReplayWindow {
+    window: u64,
+    /// Highest sequence number ever admitted. Stays at `None` before the
+    /// first admission.
+    highest: Option<u64>,
+    /// Bitfield indexed by `highest - n` for n in `[0, window)`. Bit
+    /// at index 0 always corresponds to `highest` itself. Stored as a
+    /// `Vec<u64>` so a single bit-test/set is two ALU ops.
+    bits: Vec<u64>,
+}
+
+/// Default window width — matches IPsec ESP's recommended depth and is
+/// the right starting point for federation packet rates we expect today
+/// (≪ 1024 envelopes/second/peer).
+pub const WINDOW_DEFAULT: u64 = 1024;
+
+/// Outcome of a `ReplayWindow::admit` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AdmitOutcome {
+    /// Envelope is new in the window — caller should process it.
+    Fresh,
+    /// Envelope's sequence number is older than `highest - window`.
+    /// Reject — the receiver has no way to prove this isn't a replay.
+    StaleBelowWindow,
+    /// Envelope's sequence number has already been admitted (duplicate
+    /// or replay). Reject.
+    Duplicate,
+}
+
+impl ReplayWindow {
+    /// New tracker with the default window width.
+    pub fn new() -> Self {
+        Self::with_window(WINDOW_DEFAULT)
+    }
+
+    /// New tracker with an explicit window width. Width must be a
+    /// multiple of 64 and at least 64 (we store the bitfield in `u64`
+    /// chunks; a smaller window doesn't justify the smaller storage
+    /// for the constant-factor reduction in memory footprint).
+    pub fn with_window(window: u64) -> Self {
+        assert!(window >= 64, "ReplayWindow width must be at least 64");
+        assert_eq!(
+            window % 64,
+            0,
+            "ReplayWindow width must be a multiple of 64"
+        );
+        let words = (window / 64) as usize;
+        Self {
+            window,
+            highest: None,
+            bits: vec![0u64; words],
+        }
+    }
+
+    /// Try to admit a sequence number into the window. Returns the
+    /// outcome and, when admitting Fresh, marks the bit so subsequent
+    /// duplicate attempts reject.
+    pub fn admit(&mut self, seq: u64) -> AdmitOutcome {
+        match self.highest {
+            None => {
+                // First-ever envelope from this peer — admit + set up
+                // the bitfield with this position at index 0.
+                self.highest = Some(seq);
+                self.bits.fill(0);
+                self.set_bit(0);
+                AdmitOutcome::Fresh
+            }
+            Some(highest) if seq > highest => {
+                // Advance the window forward by `delta` positions.
+                // Shift the bitfield right (bit 0 stays at the new
+                // highest, the old "bit at position highest" moves to
+                // bit `delta`).
+                let delta = seq - highest;
+                self.shift_right(delta);
+                self.highest = Some(seq);
+                self.set_bit(0);
+                AdmitOutcome::Fresh
+            }
+            Some(highest) => {
+                // seq <= highest. Compute distance below highest.
+                let distance = highest - seq;
+                if distance >= self.window {
+                    return AdmitOutcome::StaleBelowWindow;
+                }
+                if self.get_bit(distance) {
+                    return AdmitOutcome::Duplicate;
+                }
+                self.set_bit(distance);
+                AdmitOutcome::Fresh
+            }
+        }
+    }
+
+    fn set_bit(&mut self, distance: u64) {
+        let word = (distance / 64) as usize;
+        let bit = distance % 64;
+        self.bits[word] |= 1u64 << bit;
+    }
+
+    fn get_bit(&self, distance: u64) -> bool {
+        let word = (distance / 64) as usize;
+        let bit = distance % 64;
+        (self.bits[word] >> bit) & 1 != 0
+    }
+
+    /// Shift the entire bitfield right by `delta` bit positions. After
+    /// the shift, bit 0 corresponds to the NEW highest, so the old
+    /// "highest" sits at `delta`. Bits that fall off the high end
+    /// (positions ≥ window) are discarded — those envelopes are now
+    /// outside the window and `StaleBelowWindow` would refuse them
+    /// anyway.
+    fn shift_right(&mut self, delta: u64) {
+        if delta >= self.window {
+            // Window advanced past everything — fresh slate.
+            self.bits.fill(0);
+            return;
+        }
+        // Word-aligned + sub-word shift.
+        let word_shift = (delta / 64) as usize;
+        let bit_shift = (delta % 64) as u32;
+        if word_shift > 0 {
+            // Move data: bits[i] = bits[i - word_shift], with bits[0..word_shift] zeroed.
+            let n = self.bits.len();
+            for i in (word_shift..n).rev() {
+                self.bits[i] = self.bits[i - word_shift];
+            }
+            for w in &mut self.bits[..word_shift] {
+                *w = 0;
+            }
+        }
+        if bit_shift > 0 {
+            // In-word shift: carry bits from word[i-1]'s high end into word[i]'s low end.
+            let n = self.bits.len();
+            for i in (1..n).rev() {
+                let lo = self.bits[i] << bit_shift;
+                let hi = self.bits[i - 1] >> (64 - bit_shift);
+                self.bits[i] = lo | hi;
+            }
+            self.bits[0] <<= bit_shift;
+        }
+    }
+}
+
+impl Default for ReplayWindow {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// N1 spec: destination = sha256(pubkey)[..16].
+    #[test]
+    fn destination_is_sha256_truncated_to_16_bytes() {
+        let pk = [0u8; 32];
+        let d = reticulum_destination_for_pubkey(&pk);
+        // sha256 of 32 zero bytes — first 16 bytes of the well-known digest.
+        let expected_hex = "66687aadf862bd776c8fc18b8e9f8e20";
+        assert_eq!(hex::encode(d), expected_hex);
+        assert_eq!(d.len(), 16);
+    }
+
+    /// Different pubkeys → different destinations, and changing one bit
+    /// in the input changes (very likely) all 16 output bytes —
+    /// avalanche property of SHA-256.
+    #[test]
+    fn destination_is_deterministic_and_avalanches() {
+        let pk_a = [0u8; 32];
+        let mut pk_b = [0u8; 32];
+        pk_b[0] = 1; // flip one bit
+        let da = reticulum_destination_for_pubkey(&pk_a);
+        let db = reticulum_destination_for_pubkey(&pk_b);
+        assert_ne!(da, db);
+        // Re-deriving gives the same answer.
+        assert_eq!(da, reticulum_destination_for_pubkey(&pk_a));
+        // Avalanche: at least half the bits in the output should differ.
+        let differing_bits: u32 = da
+            .iter()
+            .zip(db.iter())
+            .map(|(a, b)| (a ^ b).count_ones())
+            .sum();
+        assert!(
+            differing_bits > 40,
+            "expected strong avalanche, only {differing_bits} bits differ"
+        );
+    }
+
+    /// `destination_from_pubkey_bytes` matches the 32-byte specialization.
+    #[test]
+    fn slice_form_matches_array_form() {
+        let pk = [7u8; 32];
+        assert_eq!(
+            reticulum_destination_for_pubkey(&pk),
+            destination_from_pubkey_bytes(&pk)
+        );
+    }
+
+    /// First envelope is always Fresh; the second copy with the same
+    /// sequence is a Duplicate.
+    #[test]
+    fn first_seen_then_duplicate() {
+        let mut w = ReplayWindow::new();
+        assert_eq!(w.admit(100), AdmitOutcome::Fresh);
+        assert_eq!(w.admit(100), AdmitOutcome::Duplicate);
+    }
+
+    /// Out-of-order arrivals within the window are accepted exactly once.
+    #[test]
+    fn out_of_order_within_window_accepted_once() {
+        let mut w = ReplayWindow::new();
+        assert_eq!(w.admit(100), AdmitOutcome::Fresh);
+        assert_eq!(w.admit(95), AdmitOutcome::Fresh);
+        assert_eq!(w.admit(99), AdmitOutcome::Fresh);
+        assert_eq!(w.admit(95), AdmitOutcome::Duplicate);
+        assert_eq!(w.admit(99), AdmitOutcome::Duplicate);
+    }
+
+    /// Envelopes older than `highest - window` are refused as
+    /// StaleBelowWindow — the receiver has no proof they weren't
+    /// already seen and discarded.
+    #[test]
+    fn stale_below_window_rejected() {
+        let mut w = ReplayWindow::with_window(64);
+        assert_eq!(w.admit(1000), AdmitOutcome::Fresh);
+        assert_eq!(w.admit(1000 - 64), AdmitOutcome::StaleBelowWindow);
+        assert_eq!(w.admit(1000 - 65), AdmitOutcome::StaleBelowWindow);
+    }
+
+    /// Sequence numbers admitted before a large jump remain remembered
+    /// only if they're still within the window after the jump.
+    #[test]
+    fn large_jump_invalidates_far_past_but_keeps_recent() {
+        let mut w = ReplayWindow::with_window(64);
+        assert_eq!(w.admit(10), AdmitOutcome::Fresh);
+        assert_eq!(w.admit(20), AdmitOutcome::Fresh);
+        // Jump well beyond the window.
+        assert_eq!(w.admit(1000), AdmitOutcome::Fresh);
+        // The pre-jump seqs are now stale-below-window.
+        assert_eq!(w.admit(10), AdmitOutcome::StaleBelowWindow);
+        assert_eq!(w.admit(20), AdmitOutcome::StaleBelowWindow);
+        // But seqs within the new window still track correctly.
+        assert_eq!(w.admit(990), AdmitOutcome::Fresh);
+        assert_eq!(w.admit(990), AdmitOutcome::Duplicate);
+    }
+
+    /// Fuzz-style: random insertion order over a bounded sequence range
+    /// produces no duplicate-Fresh outcomes (each seq is Fresh exactly
+    /// once).
+    #[test]
+    fn random_insertion_order_fresh_exactly_once() {
+        let mut w = ReplayWindow::with_window(1024);
+        let mut seqs: Vec<u64> = (1..=512).collect();
+        // Deterministic shuffle via a simple linear-congruential
+        // permutation so the test stays reproducible without `rand`.
+        let n = seqs.len();
+        for i in 0..n {
+            let j = (i * 31 + 7) % n;
+            seqs.swap(i, j);
+        }
+        let mut fresh_count = 0;
+        for s in &seqs {
+            if matches!(w.admit(*s), AdmitOutcome::Fresh) {
+                fresh_count += 1;
+            }
+        }
+        assert_eq!(fresh_count, seqs.len(), "each seq should be Fresh once");
+        // Re-admitting any of them now is a Duplicate.
+        for s in &seqs {
+            assert_eq!(w.admit(*s), AdmitOutcome::Duplicate);
+        }
+    }
+
+    /// Admitting `seq + 1` after `seq` is the common steady-state case
+    /// — the bit at position 0 should always be the new highest.
+    #[test]
+    fn monotonic_steady_state_steady_state() {
+        let mut w = ReplayWindow::new();
+        for i in 0..2048 {
+            assert_eq!(w.admit(i), AdmitOutcome::Fresh, "step {i}");
+        }
+        // The most recent entry is a duplicate; one window-width back
+        // is the boundary case (`distance == window` → StaleBelowWindow).
+        assert_eq!(w.admit(2047), AdmitOutcome::Duplicate);
+        assert_eq!(
+            w.admit(2047u64.saturating_sub(WINDOW_DEFAULT)),
+            AdmitOutcome::StaleBelowWindow
+        );
+    }
+
+    /// Window-construction invariants.
+    #[test]
+    #[should_panic(expected = "ReplayWindow width must be at least 64")]
+    fn rejects_window_below_64() {
+        ReplayWindow::with_window(32);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a multiple of 64")]
+    fn rejects_window_not_multiple_of_64() {
+        ReplayWindow::with_window(100);
+    }
+}

--- a/src/transport/federation_session.rs
+++ b/src/transport/federation_session.rs
@@ -1,0 +1,464 @@
+//! Federation session — hybrid X25519+ML-KEM-768 KEX over CIRIS federation transports.
+//!
+//! Closes CIRISEdge#54 (Fed TM §3.3 Gap C — harvest-now-decrypt-later
+//! vulnerability).
+//!
+//! ## Threat addressed
+//!
+//! Without a PQ-aware KEX, an attacker capturing federation ciphertexts
+//! today (when classical-only) keeps a copy of every wrapped DEK / session
+//! key forever, then decrypts it once a CRQC (cryptographically-relevant
+//! quantum computer) emerges. CIRIS federation messages contain
+//! AV-RECONSIDER votes, hard_case adjudications, and skill-import
+//! manifests — content whose secrecy must survive into the post-quantum
+//! era. The hybrid construction below means an attacker must break BOTH
+//! X25519 AND ML-KEM-768 to recover the session key; ML-KEM-768 is
+//! FIPS 203 final.
+//!
+//! ## Layering
+//!
+//! [`FederationSession`] sits ABOVE the transport medium (HTTPS / Reticulum)
+//! and BELOW the application-layer signed-envelope shape. It produces a
+//! 32-byte session key per peer pair; the transport AEAD layer (existing
+//! per-medium code, plus follow-up #62 for realtime A/V) consumes that key
+//! to wrap individual frames. The KEX is one-shot per session; key
+//! rotation and forward secrecy across re-handshakes are caller-managed
+//! and out of scope for this module.
+//!
+//! Edge does NOT generate KEX keypairs itself — the keyring + crypto
+//! crates from CIRISVerify (already pulled via `ciris-crypto`) own
+//! keypair generation, and federation pubkey advertisement rides the
+//! existing peer-info / federation-directory surfaces. This module is
+//! the verb (initiate/respond); the nouns (KEX pubkey provenance) live
+//! upstream.
+//!
+//! ## Negotiation rules
+//!
+//! - Hybrid is the default.
+//! - Classical fallback is admitted iff the peer's advertised KEX pubkeys
+//!   lack the ML-KEM-768 half.
+//! - **ML-KEM-only is rejected at v1** — both peers MUST support X25519
+//!   for fallback safety. A peer advertising ML-KEM-768 without X25519 is
+//!   out-of-spec; honoring it would create a degraded ciphersuite an
+//!   attacker could force by stripping the X25519 advertisement.
+//!
+//! These rules are encoded structurally in [`PeerKexPubkeys`]
+//! (`x25519_pub` is required; `mlkem768_pub` is `Option`) and enforced
+//! in [`FederationSession::initiate`].
+
+use ciris_crypto::hybrid_kex::{
+    self, ClassicalHandshakeMsg, HybridHandshakeMsg, KEX_ALGORITHM_CLASSICAL_V1,
+    KEX_ALGORITHM_HYBRID_V1,
+};
+use zeroize::Zeroize;
+
+/// Algorithm identifier strings as they appear on the wire — re-exported
+/// from the `ciris-crypto` crate so callers don't have to reach across
+/// the dependency boundary. Match the spec in CIRISEdge#54 verbatim.
+pub const ALGORITHM_HYBRID_V1: &str = KEX_ALGORITHM_HYBRID_V1;
+pub const ALGORITHM_CLASSICAL_V1: &str = KEX_ALGORITHM_CLASSICAL_V1;
+
+/// The two negotiated outcomes. ML-KEM-only is intentionally not
+/// representable — see module docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KexAlgorithm {
+    /// Hybrid X25519 + ML-KEM-768. Default whenever the peer advertises
+    /// both halves.
+    Hybrid,
+    /// Classical X25519 only. Admitted when the peer hasn't published
+    /// an ML-KEM-768 pubkey.
+    Classical,
+}
+
+impl KexAlgorithm {
+    /// Stable identifier — call sites stamp this into the transport
+    /// envelope per CIRISEdge#54 acceptance criterion 1.
+    pub fn wire_id(self) -> &'static str {
+        match self {
+            Self::Hybrid => ALGORITHM_HYBRID_V1,
+            Self::Classical => ALGORITHM_CLASSICAL_V1,
+        }
+    }
+}
+
+/// What a peer publishes for KEX. X25519 is required (fallback safety);
+/// ML-KEM-768 is optional (a peer at older keying levels is admitted via
+/// classical fallback). A peer publishing ONLY the ML-KEM-768 half is
+/// represented by `mlkem768_pub: Some` with `x25519_pub` defaulted —
+/// callers MUST verify the X25519 half is present before constructing
+/// this type from wire input; [`FederationSession::initiate`] additionally
+/// rejects the case at runtime as defense-in-depth.
+#[derive(Debug, Clone)]
+pub struct PeerKexPubkeys {
+    pub x25519_pub: [u8; 32],
+    pub mlkem768_pub: Option<Vec<u8>>,
+}
+
+/// The local side's KEX private keys. Required for [`FederationSession::respond`].
+///
+/// `mlkem768_priv` + `mlkem768_pub` are paired; both required when
+/// responding to a hybrid initiate (the ML-KEM-768 pubkey is bound into
+/// the HKDF salt, so the responder must know its own pubkey to recompute
+/// the same session key).
+#[derive(Clone)]
+pub struct OwnKexKeys {
+    pub x25519_priv: [u8; 32],
+    pub mlkem768_priv: Option<Vec<u8>>,
+    pub mlkem768_pub: Option<Vec<u8>>,
+}
+
+impl Drop for OwnKexKeys {
+    fn drop(&mut self) {
+        self.x25519_priv.zeroize();
+        if let Some(p) = self.mlkem768_priv.as_mut() {
+            p.zeroize();
+        }
+    }
+}
+
+impl std::fmt::Debug for OwnKexKeys {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OwnKexKeys")
+            .field("x25519_priv", &"<redacted>")
+            .field(
+                "mlkem768_priv",
+                &self.mlkem768_priv.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "mlkem768_pub",
+                &self
+                    .mlkem768_pub
+                    .as_ref()
+                    .map(|p| format!("<{} bytes>", p.len())),
+            )
+            .finish()
+    }
+}
+
+/// Wire form of the initiator → responder handshake message. Algorithm
+/// branches are flat enums so JSON / cbor / msgpack consumers can serialize
+/// without separate algorithm-specific call sites.
+#[derive(Debug, Clone)]
+pub enum SessionHandshakeMsg {
+    Hybrid(HybridHandshakeMsg),
+    Classical(ClassicalHandshakeMsg),
+}
+
+impl SessionHandshakeMsg {
+    /// The wire algorithm ID — stamped into the transport envelope so
+    /// the responder routes to the right `respond_*` path.
+    pub fn algorithm(&self) -> &str {
+        match self {
+            Self::Hybrid(m) => &m.algorithm,
+            Self::Classical(m) => &m.algorithm,
+        }
+    }
+}
+
+/// 32-byte shared session key. Zeroized on drop. Consumers must NOT
+/// `Clone` or `Copy` this type casually — wrap in [`std::sync::Arc`] if
+/// multi-task sharing is needed; the AEAD path takes `&[u8; 32]` by
+/// reference.
+pub struct SessionKey([u8; 32]);
+
+impl SessionKey {
+    /// Borrow the raw 32 bytes — for the AEAD path. Callers MUST NOT
+    /// log, persist, or transmit these bytes.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl Drop for SessionKey {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl std::fmt::Debug for SessionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionKey")
+            .field("bytes", &"<redacted 32B>")
+            .finish()
+    }
+}
+
+/// Errors a session-setup call can return. Mirrors `ciris_crypto::hybrid_kex::KexError`
+/// shape but stays inside the edge crate's error vocabulary.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    #[error("KEX primitive failed: {0:?}")]
+    Crypto(hybrid_kex::KexError),
+    /// The peer advertised ML-KEM-768 but not X25519 — out of spec per
+    /// CIRISEdge#54 acceptance criterion 4. This case CAN reach this
+    /// module if construction-time validation is bypassed (e.g. tests,
+    /// or a future deserializer that doesn't enforce the X25519
+    /// non-default invariant).
+    #[error("ML-KEM-only mode rejected — both peers MUST support X25519")]
+    MlKemOnlyRejected,
+    /// The responder received a handshake message whose `algorithm`
+    /// field doesn't match either KEX mode the responder supports.
+    /// Producer error or version downgrade attempt.
+    #[error("algorithm mismatch — observed {observed:?}, expected {expected}")]
+    AlgorithmMismatch { observed: String, expected: String },
+    /// The responder received a hybrid handshake but lacks an ML-KEM-768
+    /// key pair to decapsulate.
+    #[error("hybrid responder missing ML-KEM-768 private key")]
+    HybridResponderMissingMlkem,
+}
+
+impl From<hybrid_kex::KexError> for SessionError {
+    fn from(e: hybrid_kex::KexError) -> Self {
+        Self::Crypto(e)
+    }
+}
+
+/// Setup verbs for the per-peer KEX. Stateless — both calls own all the
+/// material they need via their arguments.
+pub struct FederationSession;
+
+impl FederationSession {
+    /// Initiator side. Caller supplies the peer's advertised KEX
+    /// pubkeys + the preferred algorithm. Negotiation rules per
+    /// module docs are applied here:
+    ///
+    /// - `Hybrid` requested + peer has ML-KEM-768 → hybrid
+    /// - `Hybrid` requested + peer lacks ML-KEM-768 → classical fallback
+    /// - `Classical` requested → classical (caller already negotiated down)
+    /// - Peer has ML-KEM-768 but NO X25519 → [`SessionError::MlKemOnlyRejected`]
+    ///   even though the type system tries to make this unrepresentable
+    ///   (defense in depth for callers constructing via deserializers).
+    ///
+    /// Returns the wire message to send the responder PLUS the
+    /// initiator's session key.
+    pub fn initiate(
+        peer: &PeerKexPubkeys,
+        requested: KexAlgorithm,
+    ) -> Result<(SessionHandshakeMsg, SessionKey), SessionError> {
+        // ML-KEM-only sanity check. The `PeerKexPubkeys` type requires
+        // `x25519_pub: [u8; 32]` (no `Option`), so this branch fires only
+        // when an upstream constructor silently defaulted the X25519
+        // field to all zeros (which is itself a refusable pubkey — see
+        // [Curve25519 small-subgroup attacks]). Treat all-zero as
+        // "not advertised" and refuse.
+        if peer.x25519_pub == [0u8; 32] && peer.mlkem768_pub.is_some() {
+            return Err(SessionError::MlKemOnlyRejected);
+        }
+        // Negotiation: hybrid only when caller asked for hybrid AND peer
+        // advertised the ML-KEM half. Everything else collapses to classical.
+        let actual = if matches!(requested, KexAlgorithm::Hybrid) && peer.mlkem768_pub.is_some() {
+            KexAlgorithm::Hybrid
+        } else {
+            KexAlgorithm::Classical
+        };
+        match actual {
+            KexAlgorithm::Hybrid => {
+                let mlkem_pub = peer.mlkem768_pub.as_deref().expect("checked above");
+                let (msg, k) = hybrid_kex::initiate_hybrid(&peer.x25519_pub, mlkem_pub)?;
+                Ok((SessionHandshakeMsg::Hybrid(msg), SessionKey(k)))
+            }
+            KexAlgorithm::Classical => {
+                let (msg, k) = hybrid_kex::initiate_classical(&peer.x25519_pub)?;
+                Ok((SessionHandshakeMsg::Classical(msg), SessionKey(k)))
+            }
+        }
+    }
+
+    /// Responder side. Recomputes the same session key from the
+    /// initiator's wire message + the responder's KEX private keys.
+    ///
+    /// The responder dispatches on the wire algorithm field. A hybrid
+    /// message routed to a responder without ML-KEM-768 keys returns
+    /// [`SessionError::HybridResponderMissingMlkem`] — the responder
+    /// is expected to have advertised hybrid support iff it has the
+    /// keys; routing a hybrid to a classical-only responder is the
+    /// initiator's bug.
+    pub fn respond(
+        own: &OwnKexKeys,
+        msg: &SessionHandshakeMsg,
+    ) -> Result<SessionKey, SessionError> {
+        match msg {
+            SessionHandshakeMsg::Hybrid(m) => {
+                let priv_ = own
+                    .mlkem768_priv
+                    .as_deref()
+                    .ok_or(SessionError::HybridResponderMissingMlkem)?;
+                let pub_ = own
+                    .mlkem768_pub
+                    .as_deref()
+                    .ok_or(SessionError::HybridResponderMissingMlkem)?;
+                let k = hybrid_kex::respond_hybrid_with_public(&own.x25519_priv, priv_, pub_, m)?;
+                Ok(SessionKey(k))
+            }
+            SessionHandshakeMsg::Classical(m) => {
+                let k = hybrid_kex::respond_classical(&own.x25519_priv, m)?;
+                Ok(SessionKey(k))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciris_crypto::{ml_kem, x25519};
+
+    /// Helper — generate a fresh recipient hybrid keypair set. Mirrors
+    /// the persist team's own internal helper from `wheel_hybrid_kex.rs`
+    /// so our tests share the same shape of "fresh keys → round-trip".
+    fn fresh_recipient() -> OwnKexKeys {
+        let (x_secret, _x_public) = x25519::generate_ephemeral_keypair().expect("x25519 keypair");
+        let (mlkem_secret, mlkem_public) = ml_kem::generate_keypair().expect("ml-kem keypair");
+        OwnKexKeys {
+            x25519_priv: x_secret,
+            mlkem768_priv: Some(mlkem_secret.clone()),
+            mlkem768_pub: Some(mlkem_public.clone()),
+        }
+    }
+
+    fn advertise(own: &OwnKexKeys) -> PeerKexPubkeys {
+        PeerKexPubkeys {
+            x25519_pub: x25519::public_from_secret(&own.x25519_priv),
+            mlkem768_pub: own.mlkem768_pub.clone(),
+        }
+    }
+
+    fn advertise_classical_only(own: &OwnKexKeys) -> PeerKexPubkeys {
+        PeerKexPubkeys {
+            x25519_pub: x25519::public_from_secret(&own.x25519_priv),
+            mlkem768_pub: None,
+        }
+    }
+
+    /// Acceptance criterion 2 — round-trip initiate → respond yields the
+    /// same 32-byte session key on both sides. Hybrid mode.
+    #[test]
+    fn hybrid_round_trip_yields_matching_session_keys() {
+        let responder = fresh_recipient();
+        let peer_view = advertise(&responder);
+        let (msg, initiator_key) =
+            FederationSession::initiate(&peer_view, KexAlgorithm::Hybrid).expect("initiate");
+        assert_eq!(msg.algorithm(), ALGORITHM_HYBRID_V1);
+        let responder_key = FederationSession::respond(&responder, &msg).expect("respond");
+        assert_eq!(
+            initiator_key.as_bytes(),
+            responder_key.as_bytes(),
+            "session keys diverged"
+        );
+        // Length sanity — 32B as advertised.
+        assert_eq!(initiator_key.as_bytes().len(), 32);
+    }
+
+    /// Same as above, classical mode (X25519 only).
+    #[test]
+    fn classical_round_trip_yields_matching_session_keys() {
+        let responder = fresh_recipient();
+        let peer_view = advertise(&responder);
+        let (msg, initiator_key) =
+            FederationSession::initiate(&peer_view, KexAlgorithm::Classical).expect("initiate");
+        assert_eq!(msg.algorithm(), ALGORITHM_CLASSICAL_V1);
+        let responder_key = FederationSession::respond(&responder, &msg).expect("respond");
+        assert_eq!(initiator_key.as_bytes(), responder_key.as_bytes());
+    }
+
+    /// Acceptance criterion 3 — classical fallback when peer hasn't
+    /// advertised ML-KEM-768. Requesting hybrid against such a peer
+    /// negotiates DOWN to classical, NOT failing.
+    #[test]
+    fn hybrid_requested_against_classical_only_peer_falls_back() {
+        let responder = fresh_recipient();
+        let peer_view = advertise_classical_only(&responder);
+        let (msg, initiator_key) =
+            FederationSession::initiate(&peer_view, KexAlgorithm::Hybrid).expect("initiate");
+        assert_eq!(
+            msg.algorithm(),
+            ALGORITHM_CLASSICAL_V1,
+            "fallback should pick classical"
+        );
+        let responder_key = FederationSession::respond(&responder, &msg).expect("respond");
+        assert_eq!(initiator_key.as_bytes(), responder_key.as_bytes());
+    }
+
+    /// Acceptance criterion 4 — ML-KEM-only mode rejected. A peer view
+    /// that names ML-KEM-768 but defaults X25519 to all-zero (the
+    /// hallmark of a deserialize-skipped or never-published X25519
+    /// half) MUST be refused before any crypto runs.
+    #[test]
+    fn mlkem_only_peer_view_rejected() {
+        let responder = fresh_recipient();
+        let bad_peer_view = PeerKexPubkeys {
+            x25519_pub: [0u8; 32],
+            mlkem768_pub: responder.mlkem768_pub.clone(),
+        };
+        let r = FederationSession::initiate(&bad_peer_view, KexAlgorithm::Hybrid);
+        assert!(
+            matches!(r, Err(SessionError::MlKemOnlyRejected)),
+            "expected MlKemOnlyRejected, got {r:?}"
+        );
+    }
+
+    /// Algorithm-ID downgrade resistance — if a wire message claims the
+    /// hybrid algorithm but its responder-side processing dispatches to
+    /// classical (or vice versa), the underlying `respond_*` primitives
+    /// surface `AlgorithmMismatch`. This dispatch is structural in our
+    /// `SessionHandshakeMsg` enum, so the only way to hit this is to
+    /// hand-craft a message — verify the crypto layer's own check fires
+    /// for that hand-craft.
+    #[test]
+    fn handcrafted_algorithm_downgrade_caught_by_crypto_layer() {
+        let responder = fresh_recipient();
+        // Craft a "classical" responder call with a handshake whose
+        // algorithm string is hybrid. ciris_crypto::hybrid_kex must
+        // reject this.
+        let bogus = ClassicalHandshakeMsg {
+            algorithm: KEX_ALGORITHM_HYBRID_V1.to_string(),
+            x25519_ephemeral_pub: [0u8; 32],
+        };
+        let r = hybrid_kex::respond_classical(&responder.x25519_priv, &bogus);
+        assert!(matches!(
+            r,
+            Err(hybrid_kex::KexError::AlgorithmMismatch { .. })
+        ));
+    }
+
+    /// Hybrid responder with no ML-KEM-768 keys — graceful refusal,
+    /// not a panic or silent classical degradation.
+    #[test]
+    fn hybrid_message_to_classical_responder_refused() {
+        let real = fresh_recipient();
+        let peer_view = advertise(&real);
+        let (msg, _) =
+            FederationSession::initiate(&peer_view, KexAlgorithm::Hybrid).expect("initiate");
+        // Strip the ML-KEM keys from the "responder" we hand to respond().
+        let degraded = OwnKexKeys {
+            x25519_priv: real.x25519_priv,
+            mlkem768_priv: None,
+            mlkem768_pub: None,
+        };
+        let r = FederationSession::respond(&degraded, &msg);
+        assert!(matches!(r, Err(SessionError::HybridResponderMissingMlkem)));
+    }
+
+    /// SessionKey debug output redacts the bytes — no accidental log leaks.
+    #[test]
+    fn session_key_debug_is_redacted() {
+        let responder = fresh_recipient();
+        let peer_view = advertise(&responder);
+        let (_msg, k) =
+            FederationSession::initiate(&peer_view, KexAlgorithm::Hybrid).expect("initiate");
+        let s = format!("{k:?}");
+        assert!(s.contains("<redacted"), "session key leaked in Debug: {s}");
+        assert!(
+            !s.contains(&hex::encode(&k.as_bytes()[..4])),
+            "session key bytes appeared in Debug"
+        );
+    }
+
+    /// OwnKexKeys Debug output redacts the private material — same.
+    #[test]
+    fn own_kex_keys_debug_is_redacted() {
+        let own = fresh_recipient();
+        let s = format!("{own:?}");
+        assert!(s.contains("<redacted>"), "private key leaked: {s}");
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -18,6 +18,18 @@ use chrono::{DateTime, Utc};
 #[cfg(feature = "transport-http")]
 pub mod http;
 
+/// Hybrid X25519 + ML-KEM-768 KEX for federation session-key setup
+/// (CIRISEdge#54 — Fed TM §3.3 Gap C closure). Stateless verbs that
+/// operate on caller-supplied KEX pubkeys / privkeys; pubkey
+/// advertisement + AEAD framing live in the medium-specific transports
+/// that consume the derived session key.
+pub mod federation_session;
+
+/// N1 cryptographic addressing (`destination = sha256(pubkey)[..16]`)
+/// + sliding-window replay protection per peer (CIRISEdge#53). Medium-
+/// agnostic primitives consumed by every transport.
+pub mod addressing;
+
 /// Announce attestation — the authenticated transport-identity ↔
 /// federation-key binding carried in Reticulum announce app-data
 /// (CIRISEdge#15 / AV-42). Feature-gated alongside the Reticulum


### PR DESCRIPTION
Three medium-agnostic federation-transport primitives shipped together — they share the same `ciris-crypto::hybrid_kex` dependency boundary + the same review surface (sealed primitives + property-style tests, no wire-format changes yet).

## Closes CIRISEdge#54 — Hybrid X25519 + ML-KEM-768 KEX (Fed TM §3.3 Gap C)

\`src/transport/federation_session.rs\` exposes \`FederationSession::initiate\` and \`respond\` over \`ciris_crypto::hybrid_kex\`. Closes the **harvest-now-decrypt-later** exposure — an attacker capturing federation ciphertexts today must break both X25519 and ML-KEM-768 (FIPS 203 final) to recover the session key.

All 5 issue acceptance criteria covered by tests:
1. ✅ Algorithm IDs in envelope (\`KexAlgorithm::wire_id\` → \`hybrid-x25519-mlkem768-hkdf-sha256-v1\` / \`classical-x25519-hkdf-sha256-v1\`)
2. ✅ Round-trip initiate→respond yields matching 32-byte session keys, both hybrid + classical
3. ✅ Classical fallback when peer hasn't advertised ML-KEM-768
4. ✅ ML-KEM-only mode rejected at v1 (defense-in-depth)
5. ✅ Algorithm downgrade caught by crypto-layer check

Session keys + KEX private material zeroize on drop; Debug output redacts; structural enums prevent silent classical degradation.

## Partial CIRISEdge#53 — N1 addressing + replay window (Fed TM §3.3 Gap D)

**N1 addressing:** \`addressing::reticulum_destination_for_pubkey\` = \`SHA-256(pubkey)[..16]\` per the spec. 128-bit truncation gives ~2^64 effective collision resistance — eclipse / impersonation against a known target becomes cryptographically uneconomical.

**Sliding-window replay protection (RFC 6479):** \`addressing::ReplayWindow\` — per-peer 1024-bit window (configurable in multiples of 64) over the federation envelope sequence number. Admits out-of-order arrivals once, refuses dupes + stale-below-window envelopes. 128 bytes per peer.

## NOT in this PR (deliberate follow-up scope)

- **#53 N2 multi-medium plug (packet radio):** needs the \`Transport\` trait's address-resolution path to grow a medium-registry shape. This PR ships the addressing primitive (\`destination_from_pubkey_bytes\` slice form) the packet-radio driver will consume but doesn't add the driver itself.
- **#62 realtime A/V mesh profile:** depends on this PR's \`SessionKey\` + reachability (already shipped at \`src/reachability.rs\`) + a per-RNS-Link AEAD framer. Will land as its own PR; the \`SessionKey\` type defined here is the contract.

## Validation

- \`cargo fmt --all -- --check\` ✅
- \`cargo clippy --features "transport-http transport-reticulum pyo3" -- -D warnings\` ✅
- \`cargo clippy --features "... ffi-uniffi" -- -D warnings\` ✅
- \`cargo test --lib transport::\` — **37 passed** (18 new across the two new modules)

## Files

- \`src/transport/federation_session.rs\` (NEW, 464 lines) — KEX verbs + session-key type
- \`src/transport/addressing.rs\` (NEW, 384 lines) — N1 + replay window
- \`src/transport/mod.rs\` — module wiring + docblocks
- \`Cargo.toml\` — adds \`hybrid-kex\` feature on \`ciris-crypto\`, adds \`zeroize = "1"\`