### PR TITLE
ci: promote draft → published after release-asset upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1882,6 +1882,19 @@ jobs:
             "dist/ciris-edge-v${VERSION}-swift-bindings.tar.gz" \
             "dist/SHA256SUMS"
 
+          # Promote draft → published. Idempotent on already-published
+          # releases. Closes the v1.2.0 regression where a prior failed
+          # tag-CI run had created the release in draft state; the
+          # follow-up successful run uploaded assets to the existing
+          # release but never flipped it published, so consumers couldn't
+          # see iOS / Android assets via the Release page even though
+          # PyPI was green. `gh release edit` is no-op on a non-draft
+          # release, so unconditional invocation is the simplest fix.
+          gh release edit "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false
+          echo "✓ ensured ${TAG} is published (draft → false)"
+
           echo "✓ uploaded mobile + native assets to ${TAG}"
           {
             echo "## Mobile + native release assets"


### PR DESCRIPTION
## Why

v1.2.0 shipped with PyPI green but the GitHub Release stuck in **draft** state — iOS / Android XCFramework / AAB assets were uploaded but not visible to consumers via the Release page.

## Root cause

\`.github/workflows/ci.yml:1860-1869\` only invokes \`gh release create\` if no release exists for the tag. The first (failed) v1.2.0 tag-CI run created the release in draft state before failing; the subsequent successful re-tagged run saw \"release already exists\" and just uploaded assets without flipping draft → published.

\`v1.1.x\` didn't hit this because each had a single tag-CI run. v1.2.0's re-tag (after the conformance/persist-v4 migration) is what caught the edge case.

## Fix

Unconditional \`gh release edit \"$TAG\" --draft=false\` after the upload step. No-op on already-published releases, so safe to always run. Closes the rerun-after-failed-tag-CI hole permanently.

## Validation note

v1.2.0 was unstuck manually:

\`\`\`
gh release edit v1.2.0 -R CIRISAI/CIRISEdge --draft=false
\`\`\`

This PR ensures future re-tagged releases self-promote.

## Test plan

- [ ] CI green on this PR
- [ ] Next release that goes through a fix-then-retag cycle ships as published, not draft