### PR TITLE
replication: anti-entropy protocol state machine (partial #65)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub mod multimedia;
 pub mod observability;
 pub mod outbound;
 pub mod reachability;
+pub mod replication;
 pub mod sas;
 pub mod transport;
 pub mod verify;

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -1,0 +1,88 @@
+//! CEG-native federation replication transport.
+//!
+//! Closes the transport half of CIRISRegistry#58 ("Spock removal"
+//! epic) and unblocks CIRISRegistry#62 (all-3-siblings CEG/RET-native).
+//! Tracking issue: CIRISEdge#65.
+//!
+//! ## The shape of the problem
+//!
+//! CIRIS federation today moves point-to-point signed envelopes
+//! synchronously: a write in region A reaches region B only when a
+//! peer in A explicitly sends to a peer in B. Cross-region convergence
+//! (every region eventually sees every other region's writes) was
+//! Spock's job in the v1 architecture; CIRISRegistry#58 retires Spock
+//! by making convergence **CEG-native** — every state change is a
+//! signed CEG envelope that any pair of peers can replicate via
+//! periodic anti-entropy gossip.
+//!
+//! The merge side lives in Persist (R1/Q1 quorum-merge with anti-
+//! rollback — CIRISPersist V058 / `federation_revocation_quorum_state`).
+//! Edge owns the **propagation** half: pairwise anti-entropy rounds
+//! that exchange "what envelopes do you have?" summaries, compute the
+//! diff, and stream the missing envelopes. Persist applies via the
+//! existing `put_*` admit surfaces; R1/Q1 dedupes and rejects rollbacks.
+//!
+//! ## Layering
+//!
+//! ```text
+//!   ┌──────────────────────────────────────────────────────────────┐
+//!   │  Consumers (lens / agent / bridge / node-core)               │
+//!   │  Subscribe to bounded-staleness telemetry via                │
+//!   │  replication::StalenessSignal for τ_partial machinery        │
+//!   │  (CIRISVerify#48/#49)                                        │
+//!   ├──────────────────────────────────────────────────────────────┤
+//!   │  replication::Session — pairwise anti-entropy state machine  │
+//!   │  (this module)                                               │
+//!   ├──────────────────────────────────────────────────────────────┤
+//!   │  replication::protocol — Summary / Diff / Fetch / Deliver    │
+//!   │  message types (wire-stable; serde)                          │
+//!   ├──────────────────────────────────────────────────────────────┤
+//!   │  crate::transport::Transport (any medium — HTTP, Reticulum,  │
+//!   │  packet-radio) carries the protocol messages                 │
+//!   ├──────────────────────────────────────────────────────────────┤
+//!   │  ciris_persist::FederationDirectory — reads local state,     │
+//!   │  applies received envelopes via existing put_* admits        │
+//!   └──────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! ## What this PR ships
+//!
+//! - [`protocol`] — message types + wire codec + tests
+//! - [`summary`] — local-state-to-summary computation (envelope-hash
+//!   sets per envelope kind) + diff logic
+//! - [`session`] — pairwise anti-entropy state machine, in-memory,
+//!   deterministic, exhaustively tested against bidirectional sync
+//!   scenarios (full diff, partial overlap, idempotent re-runs,
+//!   bounded-staleness signal)
+//!
+//! ## What's NOT in this PR (well-scoped follow-ups)
+//!
+//! - **Transport binding** — gluing the state machine to a live
+//!   [`crate::transport::Transport`] instance + scheduler. The protocol
+//!   primitives in this PR are wire-bytes-in / wire-bytes-out so a
+//!   follow-up can drop them onto HTTP / Reticulum / packet-radio
+//!   with no protocol-side changes.
+//! - **Persist adapter** — concrete [`StateProvider`] / [`StateApplier`]
+//!   impls over `FederationDirectory` (this module defines the trait
+//!   shape + provides an in-memory test impl).
+//! - **Cross-region peer-set discovery** — which peers to anti-entropy
+//!   with, on what cadence. Operator-config-driven; not a protocol
+//!   concern.
+//! - **Operational telemetry beyond `StalenessSignal`** — metrics
+//!   counters for round counts, bytes transferred, diff sizes are
+//!   surfaced via `tracing` spans the binding PR will wire to a
+//!   metric backend.
+
+pub mod protocol;
+pub mod session;
+pub mod summary;
+
+#[doc(inline)]
+pub use protocol::{
+    DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, ReplicationMessage,
+    SummaryMessage,
+};
+#[doc(inline)]
+pub use session::{ReplicationOutcome, Session, SessionRole};
+#[doc(inline)]
+pub use summary::{LocalState, StalenessSignal, StateApplier, StateProvider};

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -1,0 +1,258 @@
+//! Wire-stable message types for the anti-entropy protocol.
+//!
+//! Four messages, exchanged pairwise between region peers:
+//!
+//! ```text
+//!  A → B   Summary  { kind, refs: [(envelope_hash, seq)] }
+//!  A ← B   Diff     { kind, want: [envelope_hash] }     // B asks for what A has that B doesn't
+//!  A → B   Deliver  { kind, envelopes: [signed_bytes] }
+//!
+//!  (and vice versa — both sides initiate Summary in the same round
+//!   so the diff is bidirectional)
+//! ```
+//!
+//! A [`FetchMessage`] is the explicit "I want these envelopes by hash"
+//! shape, used when a peer learns of envelope hashes via a third
+//! channel (e.g. a downstream consumer that needs to chase an unknown
+//! reference). The [`SummaryMessage`] / [`DiffMessage`] flow is the
+//! steady-state anti-entropy path; [`FetchMessage`] is the on-demand
+//! path.
+//!
+//! ## Wire codec
+//!
+//! Messages serialize via `serde_json` for the v1 protocol. Future
+//! versions may upgrade to CBOR or persist's canonical-bytes shape,
+//! but JSON keeps the v1 implementation simple and debuggable; the
+//! anti-entropy traffic is low-frequency (sync rounds every N seconds
+//! per peer-pair, not per-envelope) so the codec efficiency is not
+//! a hot path.
+//!
+//! ## Wire stability
+//!
+//! Every variant is `#[serde(tag = "type")]` so adding a new
+//! `ReplicationMessage` variant doesn't break v1 receivers — they
+//! see an unknown tag and refuse the message at the deserializer.
+//! Adding a NEW field to an existing message is a non-break (serde
+//! defaults the absent field on the receiver side) provided the
+//! field is annotated `#[serde(default)]`. Removing or renaming a
+//! field IS a break and requires bumping the protocol version (a
+//! follow-up adds `protocol_version` to the [`SummaryMessage`]
+//! envelope; v1 is implicit version `1`).
+
+use serde::{Deserialize, Serialize};
+
+/// The kinds of envelope the anti-entropy protocol replicates. Each
+/// kind corresponds to a separate sync stream so partitions on one
+/// kind don't gate convergence on others. Extending this enum is
+/// additive (new variant); the receiver gracefully unknowns variants
+/// it doesn't recognize via serde's untagged-fallback behavior. New
+/// variants MUST be appended (not inserted) to preserve serialized
+/// wire order for the explicit JSON-name representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EnvelopeKind {
+    /// `federation_keys` table — newly-published key registrations.
+    Key,
+    /// `federation_attestations` table — `trust_grant` / `holds_bytes`
+    /// / consent / etc.
+    Attestation,
+    /// `federation_revocations` table — anti-rollback per CIRISPersist
+    /// V058.
+    Revocation,
+    /// `federation_communities` (CEG 0.8) once shipped — placeholder
+    /// reserved here so the kind enum doesn't have to change when the
+    /// substrate lands.
+    Community,
+}
+
+/// A reference to a single envelope in a peer's local state. The
+/// `envelope_hash` is `sha256(canonical_bytes(envelope))` — same shape
+/// persist uses for `original_content_hash`. The `seq` is monotonic
+/// per (kind, signer) and lets the receiver detect anti-rollback
+/// attempts locally before round-tripping to persist's R1/Q1 merge.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EnvelopeRef {
+    /// 32-byte sha256 of the canonical-bytes form of the envelope.
+    pub envelope_hash: [u8; 32],
+    /// Per-(kind, signer) monotonic counter. v1 is best-effort —
+    /// persist's R1/Q1 merge is the canonical anti-rollback oracle;
+    /// this field is a hint for receivers to short-circuit obvious
+    /// stale data without paying the merge round-trip.
+    pub seq: u64,
+}
+
+/// "Here are the envelope hashes I have for `kind`." First message
+/// of an anti-entropy round.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SummaryMessage {
+    pub kind: EnvelopeKind,
+    pub refs: Vec<EnvelopeRef>,
+}
+
+/// "I want these envelopes." Receiver's response to a `SummaryMessage`
+/// — the list of `envelope_hash`es present in the sender's summary
+/// but absent from the receiver's local state.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiffMessage {
+    pub kind: EnvelopeKind,
+    pub want: Vec<[u8; 32]>,
+}
+
+/// "I want these envelopes by hash." Used for on-demand fetch (a
+/// consumer learns of a hash via a third channel and asks edge to
+/// chase it). The receiver of a `Fetch` MUST NOT speculatively
+/// deliver envelopes the requester didn't ask for — anti-entropy
+/// uses the Summary/Diff flow for unsolicited convergence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FetchMessage {
+    pub kind: EnvelopeKind,
+    pub want: Vec<[u8; 32]>,
+}
+
+/// "Here are the bytes." Wraps the requested envelopes' raw signed-
+/// bytes form (the same shape `put_*` admits expect on the receiver's
+/// persist side). Order is unspecified; the receiver MUST validate
+/// each envelope's signature + canonical-bytes hash before applying.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliverMessage {
+    pub kind: EnvelopeKind,
+    /// Each entry is the byte-exact signed envelope as it would have
+    /// been admitted by the original signer's local `put_*` call.
+    pub envelopes: Vec<Vec<u8>>,
+}
+
+/// The protocol's top-level message type — what flows on the wire
+/// between region peers. `#[serde(tag = "type")]` so a future variant
+/// is transparent to v1 receivers (they refuse on unknown tag, NOT
+/// silent ignore).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ReplicationMessage {
+    Summary(SummaryMessage),
+    Diff(DiffMessage),
+    Fetch(FetchMessage),
+    Deliver(DeliverMessage),
+}
+
+impl ReplicationMessage {
+    /// Serialize to JSON bytes for transport. Returns the bytes ready
+    /// to hand to `Transport::send`.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        // serde_json::to_vec on an enum it knows the shape of cannot
+        // fail; unwrap is safe.
+        serde_json::to_vec(self).expect("ReplicationMessage serialization cannot fail")
+    }
+
+    /// Parse from on-wire JSON bytes. Returns `Err` on JSON parse
+    /// failure or unknown tag.
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, ProtocolError> {
+        serde_json::from_slice(bytes).map_err(|e| ProtocolError::Decode(e.to_string()))
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ProtocolError {
+    #[error("replication message decode failed: {0}")]
+    Decode(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake_hash(seed: u8) -> [u8; 32] {
+        let mut h = [0u8; 32];
+        for (i, b) in h.iter_mut().enumerate() {
+            *b = u8::try_from(i & 0xFF).unwrap().wrapping_mul(seed.max(1));
+        }
+        h
+    }
+
+    /// Round-trip — JSON-encoded then parsed yields the same value.
+    #[test]
+    fn summary_round_trips_via_json() {
+        let m = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Attestation,
+            refs: vec![
+                EnvelopeRef {
+                    envelope_hash: fake_hash(1),
+                    seq: 100,
+                },
+                EnvelopeRef {
+                    envelope_hash: fake_hash(2),
+                    seq: 101,
+                },
+            ],
+        });
+        let bytes = m.to_bytes();
+        let parsed = ReplicationMessage::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn diff_round_trips() {
+        let m = ReplicationMessage::Diff(DiffMessage {
+            kind: EnvelopeKind::Revocation,
+            want: vec![fake_hash(3)],
+        });
+        let bytes = m.to_bytes();
+        let parsed = ReplicationMessage::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn fetch_round_trips() {
+        let m = ReplicationMessage::Fetch(FetchMessage {
+            kind: EnvelopeKind::Key,
+            want: vec![fake_hash(4), fake_hash(5)],
+        });
+        let bytes = m.to_bytes();
+        let parsed = ReplicationMessage::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed, m);
+    }
+
+    #[test]
+    fn deliver_round_trips() {
+        let m = ReplicationMessage::Deliver(DeliverMessage {
+            kind: EnvelopeKind::Attestation,
+            envelopes: vec![vec![0xAA, 0xBB], vec![0xCC, 0xDD]],
+        });
+        let bytes = m.to_bytes();
+        let parsed = ReplicationMessage::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed, m);
+    }
+
+    /// Unknown tag refused — wire-stability guarantee.
+    #[test]
+    fn unknown_tag_refused() {
+        let raw = br#"{"type":"hostile_takeover","payload":42}"#;
+        let r = ReplicationMessage::from_bytes(raw);
+        assert!(matches!(r, Err(ProtocolError::Decode(_))));
+    }
+
+    /// Malformed JSON refused.
+    #[test]
+    fn malformed_json_refused() {
+        let r = ReplicationMessage::from_bytes(b"{not json");
+        assert!(matches!(r, Err(ProtocolError::Decode(_))));
+    }
+
+    /// All four `EnvelopeKind` variants round-trip via JSON — kind
+    /// values are wire-load-bearing.
+    #[test]
+    fn envelope_kind_wire_values_are_stable() {
+        let cases = [
+            (EnvelopeKind::Key, "key"),
+            (EnvelopeKind::Attestation, "attestation"),
+            (EnvelopeKind::Revocation, "revocation"),
+            (EnvelopeKind::Community, "community"),
+        ];
+        for (kind, wire) in cases {
+            let m = ReplicationMessage::Summary(SummaryMessage { kind, refs: vec![] });
+            let bytes = m.to_bytes();
+            let s = std::str::from_utf8(&bytes).unwrap();
+            assert!(s.contains(wire), "expected `{wire}` in {s}");
+            assert_eq!(ReplicationMessage::from_bytes(&bytes).unwrap(), m);
+        }
+    }
+}

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -1,0 +1,708 @@
+//! Pairwise anti-entropy state machine.
+//!
+//! A `Session` is one peer's view of one round of anti-entropy with
+//! one remote peer. The session does NOT do any networking — it
+//! consumes [`crate::replication::protocol::ReplicationMessage`]s and
+//! produces them, reading + writing local state via the
+//! [`crate::replication::summary::StateProvider`] /
+//! [`crate::replication::summary::StateApplier`] traits the caller
+//! supplies. The networking glue (binding to a `Transport` instance +
+//! scheduling rounds + handling timeouts) is a follow-up PR.
+//!
+//! ## Round shape
+//!
+//! Both sides initiate `Summary` in the same round so the diff is
+//! bidirectional. Concretely, for each kind:
+//!
+//! ```text
+//!   1. A → B   Summary { kind, my_refs }
+//!      A ← B   Summary { kind, my_refs }      (in parallel)
+//!   2. A → B   Diff    { kind, want = B-summary − A-local }
+//!      A ← B   Diff    { kind, want = A-summary − B-local }
+//!   3. A → B   Deliver { kind, envelopes for B.want }
+//!      A ← B   Deliver { kind, envelopes for A.want }
+//!   4. A.apply(received); B.apply(received) — via StateApplier
+//! ```
+//!
+//! `Session` models ONE direction of this flow. The caller runs two
+//! Sessions per peer-pair (initiator + responder roles); the wire
+//! messages between them carry the bidirectional traffic.
+//!
+//! ## Roles
+//!
+//! [`SessionRole::Initiator`] starts by emitting a Summary. The
+//! responder reacts by computing a Diff. Either role can finalize
+//! the round when both Diff exchanges have completed and the
+//! Delivers have been applied.
+
+use super::protocol::{
+    DeliverMessage, DiffMessage, EnvelopeKind, FetchMessage, ReplicationMessage, SummaryMessage,
+};
+use super::summary::{diff_refs, StalenessSignal, StateApplier, StateProvider};
+
+/// What role a session is playing in this round. Initiator emits
+/// the first Summary; Responder waits for one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionRole {
+    Initiator,
+    Responder,
+}
+
+/// What the session yielded after processing one inbound message
+/// (or starting a round). The caller (Transport glue) reads this
+/// and decides whether to send the next outbound message, apply
+/// envelopes, surface staleness telemetry, or end the round.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ReplicationOutcome {
+    /// The session wants to send these messages out. Order matters —
+    /// the caller MUST emit them in order on the underlying
+    /// transport.
+    Send(Vec<ReplicationMessage>),
+    /// The session applied envelopes received from the peer. The
+    /// caller can surface a `StalenessSignal` update at this point.
+    Applied {
+        kind: EnvelopeKind,
+        admitted: usize,
+        refused: usize,
+        staleness: StalenessSignal,
+    },
+    /// The round is complete for this kind from this side's
+    /// perspective. The other direction's round may still be in
+    /// flight; the caller tracks that independently.
+    RoundComplete { kind: EnvelopeKind },
+    /// The peer sent an unexpected message for the current state
+    /// (e.g. a Deliver before any Diff was exchanged). NOT a fatal
+    /// error — the session resets to idle and the caller can decide
+    /// whether to retry or drop the peer.
+    UnexpectedMessage,
+}
+
+/// One direction of an anti-entropy round. The caller creates one
+/// session per `(peer, kind)` pair, drives it via `start_round`
+/// (initiator) / `on_message` (either role), and reads the
+/// `ReplicationOutcome` to decide what to send next.
+pub struct Session<'a> {
+    role: SessionRole,
+    kind: EnvelopeKind,
+    provider: &'a dyn StateProvider,
+    applier: &'a mut dyn StateApplier,
+    /// What we sent the peer in our most recent Summary — used to
+    /// fulfill their Diff against our state.
+    last_summary_sent: Option<SummaryMessage>,
+    /// Their most recent Summary, recorded so we can compute our
+    /// own Diff and track staleness telemetry.
+    last_remote_summary: Option<SummaryMessage>,
+    /// How many envelopes our most recent outbound Diff asked for.
+    /// `None` until the Diff has been sent. Used as the basis for
+    /// the post-Apply [`StalenessSignal`] (subtract admitted count
+    /// to get residual missing — works regardless of whether the
+    /// Provider sees the Applier's writes, since the count is
+    /// already known).
+    diff_want_count: Option<usize>,
+    /// Whether the round has completed from this side's view.
+    completed: bool,
+}
+
+impl<'a> Session<'a> {
+    pub fn new(
+        role: SessionRole,
+        kind: EnvelopeKind,
+        provider: &'a dyn StateProvider,
+        applier: &'a mut dyn StateApplier,
+    ) -> Self {
+        Self {
+            role,
+            kind,
+            provider,
+            applier,
+            last_summary_sent: None,
+            last_remote_summary: None,
+            diff_want_count: None,
+            completed: false,
+        }
+    }
+
+    /// Start a round. Only valid for [`SessionRole::Initiator`] —
+    /// responders wait for an inbound Summary via [`Self::on_message`].
+    pub fn start_round(&mut self) -> ReplicationOutcome {
+        debug_assert!(
+            matches!(self.role, SessionRole::Initiator),
+            "start_round() is initiator-only"
+        );
+        let refs = self.provider.local_refs(self.kind);
+        let summary = SummaryMessage {
+            kind: self.kind,
+            refs,
+        };
+        self.last_summary_sent = Some(summary.clone());
+        ReplicationOutcome::Send(vec![ReplicationMessage::Summary(summary)])
+    }
+
+    /// Process an inbound replication message.
+    ///
+    /// State-machine transitions:
+    /// - Inbound Summary → Send Diff (our wants from their summary) +
+    ///   record their summary for later staleness comparison. Responder
+    ///   also sends our Summary at this point.
+    /// - Inbound Diff → Send Deliver (envelopes from our state matching
+    ///   their wants).
+    /// - Inbound Deliver → Apply envelopes via StateApplier; mark the
+    ///   round complete from our side.
+    /// - Inbound Fetch → Same as Diff (responder fulfills the request).
+    pub fn on_message(&mut self, msg: ReplicationMessage) -> ReplicationOutcome {
+        match msg {
+            ReplicationMessage::Summary(remote_summary) => self.on_summary(&remote_summary),
+            ReplicationMessage::Diff(diff) => self.on_diff(&diff),
+            ReplicationMessage::Deliver(deliver) => self.on_deliver(&deliver),
+            ReplicationMessage::Fetch(fetch) => self.on_fetch(&fetch),
+        }
+    }
+
+    fn on_summary(&mut self, remote: &SummaryMessage) -> ReplicationOutcome {
+        if remote.kind != self.kind {
+            return ReplicationOutcome::UnexpectedMessage;
+        }
+        self.last_remote_summary = Some(remote.clone());
+        let local = self.provider.local_refs(self.kind);
+        let want = diff_refs(&local, &remote.refs);
+        let mut outbound = Vec::new();
+        // Responder ALSO needs to send its Summary so the
+        // initiator's side of the round can progress. We include it
+        // before the Diff so the other end sees Summary first
+        // (matching the initiator's sequence). For initiators, we
+        // already sent our Summary in start_round; skip resending.
+        if matches!(self.role, SessionRole::Responder) && self.last_summary_sent.is_none() {
+            let my_refs = self.provider.local_refs(self.kind);
+            let my_summary = SummaryMessage {
+                kind: self.kind,
+                refs: my_refs,
+            };
+            self.last_summary_sent = Some(my_summary.clone());
+            outbound.push(ReplicationMessage::Summary(my_summary));
+        }
+        self.diff_want_count = Some(want.len());
+        outbound.push(ReplicationMessage::Diff(DiffMessage {
+            kind: self.kind,
+            want,
+        }));
+        ReplicationOutcome::Send(outbound)
+    }
+
+    fn on_diff(&mut self, diff: &DiffMessage) -> ReplicationOutcome {
+        if diff.kind != self.kind {
+            return ReplicationOutcome::UnexpectedMessage;
+        }
+        let envelopes: Vec<Vec<u8>> = diff
+            .want
+            .iter()
+            .filter_map(|h| self.provider.fetch_envelope(self.kind, h))
+            .collect();
+        ReplicationOutcome::Send(vec![ReplicationMessage::Deliver(DeliverMessage {
+            kind: self.kind,
+            envelopes,
+        })])
+    }
+
+    fn on_fetch(&mut self, fetch: &FetchMessage) -> ReplicationOutcome {
+        // Fetch is structurally identical to Diff on the responder
+        // side — both ask "give me these specific envelopes."
+        self.on_diff(&DiffMessage {
+            kind: fetch.kind,
+            want: fetch.want.clone(),
+        })
+    }
+
+    fn on_deliver(&mut self, deliver: &DeliverMessage) -> ReplicationOutcome {
+        if deliver.kind != self.kind {
+            return ReplicationOutcome::UnexpectedMessage;
+        }
+        let mut admitted = 0usize;
+        let mut refused = 0usize;
+        for env_bytes in &deliver.envelopes {
+            if self.applier.apply_envelope(self.kind, env_bytes) {
+                admitted += 1;
+            } else {
+                refused += 1;
+            }
+        }
+        // Compute staleness from what we asked for vs what we admitted.
+        // This is provider-storage-agnostic (the production wiring will
+        // have provider + applier share a FederationDirectory backing,
+        // but the test fixture and any in-process orchestrator are
+        // free to keep them separate).
+        let staleness = match self.diff_want_count {
+            None => StalenessSignal::Unknown,
+            Some(wanted) => {
+                let still_missing = wanted.saturating_sub(admitted);
+                if still_missing == 0 {
+                    StalenessSignal::InSync
+                } else {
+                    StalenessSignal::BoundedBy {
+                        missing: u64::try_from(still_missing).unwrap_or(u64::MAX),
+                    }
+                }
+            }
+        };
+        self.completed = true;
+        ReplicationOutcome::Applied {
+            kind: self.kind,
+            admitted,
+            refused,
+            staleness,
+        }
+    }
+
+    /// Whether this session has completed its half of the round.
+    pub fn is_complete(&self) -> bool {
+        self.completed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::replication::summary::{LocalState, StateApplier, StateProvider};
+    use std::collections::HashMap;
+
+    fn h(seed: u8) -> [u8; 32] {
+        let mut a = [0u8; 32];
+        a[0] = seed;
+        a
+    }
+
+    /// Convenience: a `StateProvider` backed by a [`LocalState`] +
+    /// a (envelope_hash → bytes) map so the test can fetch byte
+    /// payloads back during Diff handling.
+    struct TestProvider {
+        state: LocalState,
+        envelopes: HashMap<[u8; 32], Vec<u8>>,
+    }
+
+    impl StateProvider for TestProvider {
+        fn local_refs(&self, kind: EnvelopeKind) -> Vec<super::super::protocol::EnvelopeRef> {
+            self.state.refs_for(kind)
+        }
+        fn fetch_envelope(&self, _kind: EnvelopeKind, h: &[u8; 32]) -> Option<Vec<u8>> {
+            self.envelopes.get(h).cloned()
+        }
+    }
+
+    /// An applier that records what it admitted. Maps inbound bytes
+    /// back to a hash by indexing the test's known set; in production
+    /// the applier validates signatures + canonical-bytes-hash before
+    /// admitting.
+    struct TestApplier {
+        admitted: Vec<Vec<u8>>,
+        local_state: LocalState,
+        hash_lookup: HashMap<Vec<u8>, [u8; 32]>,
+    }
+
+    impl StateApplier for TestApplier {
+        fn apply_envelope(&mut self, kind: EnvelopeKind, bytes: &[u8]) -> bool {
+            // In production: verify sig + recompute hash. Here we
+            // look up the precomputed hash for these bytes.
+            if let Some(hash) = self.hash_lookup.get(bytes).copied() {
+                let kind_set = self.local_state.by_kind.entry(kind).or_default();
+                if kind_set.contains_key(&hash) {
+                    return false; // duplicate
+                }
+                kind_set.insert(hash, 1);
+                self.admitted.push(bytes.to_vec());
+                true
+            } else {
+                false
+            }
+        }
+    }
+
+    fn provider_with(envelopes: &[(EnvelopeKind, [u8; 32], Vec<u8>, u64)]) -> TestProvider {
+        let mut state = LocalState::new();
+        let mut bytes_map = HashMap::new();
+        for (k, hash, bytes, seq) in envelopes {
+            state.insert(*k, *hash, *seq);
+            bytes_map.insert(*hash, bytes.clone());
+        }
+        TestProvider {
+            state,
+            envelopes: bytes_map,
+        }
+    }
+
+    fn applier_for(hash_to_bytes: &[([u8; 32], Vec<u8>)]) -> TestApplier {
+        let mut hash_lookup = HashMap::new();
+        for (h, b) in hash_to_bytes {
+            hash_lookup.insert(b.clone(), *h);
+        }
+        TestApplier {
+            admitted: Vec::new(),
+            local_state: LocalState::new(),
+            hash_lookup,
+        }
+    }
+
+    /// Two peers with disjoint state converge in one round.
+    #[test]
+    fn full_sync_disjoint_state_converges() {
+        // Alice has envelopes {1, 2}; Bob has {3, 4}.
+        let a_provider = provider_with(&[
+            (EnvelopeKind::Key, h(1), b"env_1".to_vec(), 10),
+            (EnvelopeKind::Key, h(2), b"env_2".to_vec(), 11),
+        ]);
+        let b_provider = provider_with(&[
+            (EnvelopeKind::Key, h(3), b"env_3".to_vec(), 12),
+            (EnvelopeKind::Key, h(4), b"env_4".to_vec(), 13),
+        ]);
+        let mut a_applier = applier_for(&[(h(3), b"env_3".to_vec()), (h(4), b"env_4".to_vec())]);
+        let mut b_applier = applier_for(&[(h(1), b"env_1".to_vec()), (h(2), b"env_2".to_vec())]);
+
+        let mut alice = Session::new(
+            SessionRole::Initiator,
+            EnvelopeKind::Key,
+            &a_provider,
+            &mut a_applier,
+        );
+        let mut bob = Session::new(
+            SessionRole::Responder,
+            EnvelopeKind::Key,
+            &b_provider,
+            &mut b_applier,
+        );
+
+        // 1. Alice starts → sends Summary.
+        let alice_step1 = alice.start_round();
+        let alice_summary = match alice_step1 {
+            ReplicationOutcome::Send(ref msgs) => {
+                assert_eq!(msgs.len(), 1);
+                msgs[0].clone()
+            }
+            _ => panic!("expected Send"),
+        };
+
+        // 2. Bob receives Alice's Summary → emits {Summary, Diff}.
+        let bob_step1 = bob.on_message(alice_summary);
+        let (bob_summary, bob_diff) = match bob_step1 {
+            ReplicationOutcome::Send(ref msgs) => {
+                assert_eq!(msgs.len(), 2);
+                (msgs[0].clone(), msgs[1].clone())
+            }
+            _ => panic!("expected Send"),
+        };
+
+        // 3. Alice receives Bob's Summary → emits Diff. (Then
+        //    receives Bob's Diff → emits Deliver.)
+        let alice_step2 = alice.on_message(bob_summary);
+        let alice_diff = match alice_step2 {
+            ReplicationOutcome::Send(ref msgs) => {
+                assert_eq!(msgs.len(), 1);
+                msgs[0].clone()
+            }
+            _ => panic!("expected Send"),
+        };
+
+        // 4. Bob receives Alice's Diff → emits Deliver(env_1, env_2).
+        let bob_step2 = bob.on_message(alice_diff);
+        let bob_deliver = match bob_step2 {
+            ReplicationOutcome::Send(ref msgs) => {
+                assert_eq!(msgs.len(), 1);
+                msgs[0].clone()
+            }
+            _ => panic!("expected Send"),
+        };
+
+        // 5. Alice receives Bob's Diff → emits Deliver(env_3, env_4).
+        let alice_step3 = alice.on_message(bob_diff);
+        let alice_deliver = match alice_step3 {
+            ReplicationOutcome::Send(ref msgs) => {
+                assert_eq!(msgs.len(), 1);
+                msgs[0].clone()
+            }
+            _ => panic!("expected Send"),
+        };
+
+        // 6. Alice applies Bob's Deliver → admitted env_3 + env_4.
+        let alice_final = alice.on_message(bob_deliver);
+        match alice_final {
+            ReplicationOutcome::Applied {
+                admitted,
+                refused,
+                staleness,
+                ..
+            } => {
+                assert_eq!(admitted, 2);
+                assert_eq!(refused, 0);
+                assert_eq!(staleness, StalenessSignal::InSync);
+            }
+            _ => panic!("expected Applied, got {alice_final:?}"),
+        }
+
+        // 7. Bob applies Alice's Deliver → admitted env_1 + env_2.
+        let bob_final = bob.on_message(alice_deliver);
+        match bob_final {
+            ReplicationOutcome::Applied {
+                admitted,
+                refused,
+                staleness,
+                ..
+            } => {
+                assert_eq!(admitted, 2);
+                assert_eq!(refused, 0);
+                assert_eq!(staleness, StalenessSignal::InSync);
+            }
+            _ => panic!("expected Applied, got {bob_final:?}"),
+        }
+
+        // Both sides complete.
+        assert!(alice.is_complete());
+        assert!(bob.is_complete());
+        // Local state of each applier carries the new envelopes.
+        assert_eq!(a_applier.admitted.len(), 2);
+        assert_eq!(b_applier.admitted.len(), 2);
+    }
+
+    /// Partial overlap — peers share some envelopes; only the missing
+    /// ones get delivered.
+    #[test]
+    fn partial_overlap_only_missing_delivered() {
+        // Alice has {1, 2, 3}; Bob has {2, 3, 4}. The intersection is
+        // {2, 3}; alice wants {4}; bob wants {1}.
+        let a_provider = provider_with(&[
+            (EnvelopeKind::Attestation, h(1), b"e1".to_vec(), 1),
+            (EnvelopeKind::Attestation, h(2), b"e2".to_vec(), 2),
+            (EnvelopeKind::Attestation, h(3), b"e3".to_vec(), 3),
+        ]);
+        let b_provider = provider_with(&[
+            (EnvelopeKind::Attestation, h(2), b"e2".to_vec(), 2),
+            (EnvelopeKind::Attestation, h(3), b"e3".to_vec(), 3),
+            (EnvelopeKind::Attestation, h(4), b"e4".to_vec(), 4),
+        ]);
+        let mut a_applier = applier_for(&[(h(4), b"e4".to_vec())]);
+        let mut b_applier = applier_for(&[(h(1), b"e1".to_vec())]);
+
+        let mut alice = Session::new(
+            SessionRole::Initiator,
+            EnvelopeKind::Attestation,
+            &a_provider,
+            &mut a_applier,
+        );
+        let mut bob = Session::new(
+            SessionRole::Responder,
+            EnvelopeKind::Attestation,
+            &b_provider,
+            &mut b_applier,
+        );
+
+        // Mechanical round-drive (same as full_sync above).
+        let m_alice_summary = match alice.start_round() {
+            ReplicationOutcome::Send(m) => m[0].clone(),
+            _ => panic!(),
+        };
+        let (m_bob_summary, m_bob_diff) = match bob.on_message(m_alice_summary) {
+            ReplicationOutcome::Send(m) => (m[0].clone(), m[1].clone()),
+            _ => panic!(),
+        };
+        let m_alice_diff = match alice.on_message(m_bob_summary) {
+            ReplicationOutcome::Send(m) => m[0].clone(),
+            _ => panic!(),
+        };
+        let m_bob_deliver = match bob.on_message(m_alice_diff) {
+            ReplicationOutcome::Send(m) => m[0].clone(),
+            _ => panic!(),
+        };
+        let m_alice_deliver = match alice.on_message(m_bob_diff) {
+            ReplicationOutcome::Send(m) => m[0].clone(),
+            _ => panic!(),
+        };
+        match alice.on_message(m_bob_deliver) {
+            ReplicationOutcome::Applied { admitted, .. } => assert_eq!(admitted, 1),
+            o => panic!("unexpected: {o:?}"),
+        }
+        match bob.on_message(m_alice_deliver) {
+            ReplicationOutcome::Applied { admitted, .. } => assert_eq!(admitted, 1),
+            o => panic!("unexpected: {o:?}"),
+        }
+    }
+
+    /// Idempotent — running the protocol twice changes nothing the
+    /// second time (Deliver becomes empty; InSync the whole way).
+    #[test]
+    fn idempotent_second_run_no_changes() {
+        let a_provider = provider_with(&[
+            (EnvelopeKind::Key, h(1), b"e1".to_vec(), 1),
+            (EnvelopeKind::Key, h(2), b"e2".to_vec(), 2),
+        ]);
+        let b_provider = provider_with(&[
+            (EnvelopeKind::Key, h(1), b"e1".to_vec(), 1),
+            (EnvelopeKind::Key, h(2), b"e2".to_vec(), 2),
+        ]);
+        let mut a_applier = applier_for(&[]);
+        let mut b_applier = applier_for(&[]);
+
+        let mut alice = Session::new(
+            SessionRole::Initiator,
+            EnvelopeKind::Key,
+            &a_provider,
+            &mut a_applier,
+        );
+        let mut bob = Session::new(
+            SessionRole::Responder,
+            EnvelopeKind::Key,
+            &b_provider,
+            &mut b_applier,
+        );
+
+        // Drive round.
+        let alice_summary = match alice.start_round() {
+            ReplicationOutcome::Send(m) => m[0].clone(),
+            _ => panic!(),
+        };
+        let (bob_summary_resp, bob_diff_msg) = match bob.on_message(alice_summary) {
+            ReplicationOutcome::Send(m) => (m[0].clone(), m[1].clone()),
+            _ => panic!(),
+        };
+        let alice_diff_msg = match alice.on_message(bob_summary_resp) {
+            ReplicationOutcome::Send(m) => m[0].clone(),
+            _ => panic!(),
+        };
+        // Bob's Deliver from Alice's Diff should be empty (Alice has
+        // everything Bob has).
+        let bob_deliver_msg = match bob.on_message(alice_diff_msg) {
+            ReplicationOutcome::Send(m) => m[0].clone(),
+            _ => panic!(),
+        };
+        if let ReplicationMessage::Deliver(d) = &bob_deliver_msg {
+            assert!(d.envelopes.is_empty(), "bob should deliver nothing");
+        }
+        // Same for Alice's Deliver from Bob's Diff.
+        let alice_deliver_msg = match alice.on_message(bob_diff_msg) {
+            ReplicationOutcome::Send(m) => m[0].clone(),
+            _ => panic!(),
+        };
+        if let ReplicationMessage::Deliver(d) = &alice_deliver_msg {
+            assert!(d.envelopes.is_empty(), "alice should deliver nothing");
+        }
+        // Applied with 0 admitted, InSync staleness.
+        match alice.on_message(bob_deliver_msg) {
+            ReplicationOutcome::Applied {
+                admitted,
+                staleness,
+                ..
+            } => {
+                assert_eq!(admitted, 0);
+                assert_eq!(staleness, StalenessSignal::InSync);
+            }
+            o => panic!("{o:?}"),
+        }
+    }
+
+    /// Mismatched-kind message refused with UnexpectedMessage —
+    /// defence against a misbehaving peer or a routing bug.
+    #[test]
+    fn mismatched_kind_refused() {
+        let provider = provider_with(&[]);
+        let mut applier = applier_for(&[]);
+        let mut s = Session::new(
+            SessionRole::Responder,
+            EnvelopeKind::Key,
+            &provider,
+            &mut applier,
+        );
+        let r = s.on_message(ReplicationMessage::Diff(DiffMessage {
+            kind: EnvelopeKind::Revocation, // ← wrong kind for this session
+            want: vec![],
+        }));
+        assert_eq!(r, ReplicationOutcome::UnexpectedMessage);
+    }
+
+    /// Fetch — on-demand envelope retrieval, distinct from anti-
+    /// entropy. Responder behavior is the same shape as Diff
+    /// (look up envelopes by hash, deliver bytes).
+    #[test]
+    fn fetch_returns_requested_envelopes() {
+        let provider = provider_with(&[
+            (EnvelopeKind::Attestation, h(1), b"e1".to_vec(), 1),
+            (EnvelopeKind::Attestation, h(2), b"e2".to_vec(), 2),
+        ]);
+        let mut applier = applier_for(&[]);
+        let mut s = Session::new(
+            SessionRole::Responder,
+            EnvelopeKind::Attestation,
+            &provider,
+            &mut applier,
+        );
+        let r = s.on_message(ReplicationMessage::Fetch(FetchMessage {
+            kind: EnvelopeKind::Attestation,
+            want: vec![h(1), h(99)], // h(99) doesn't exist
+        }));
+        match r {
+            ReplicationOutcome::Send(msgs) => {
+                assert_eq!(msgs.len(), 1);
+                if let ReplicationMessage::Deliver(d) = &msgs[0] {
+                    assert_eq!(d.envelopes, vec![b"e1".to_vec()]); // only h(1) delivered
+                } else {
+                    panic!("expected Deliver");
+                }
+            }
+            o => panic!("{o:?}"),
+        }
+    }
+
+    /// BoundedBy staleness — local applies some but not all of a
+    /// remote summary's envelopes (the applier refused some — e.g.
+    /// signature validation failed in a hypothetical production
+    /// scenario).
+    #[test]
+    fn bounded_by_staleness_when_some_envelopes_refused() {
+        // Bob's summary advertises 3 envelopes; Alice's applier
+        // only accepts 1 of them (the other 2 have unknown bytes →
+        // refused).
+        let a_provider = provider_with(&[]);
+        let mut a_applier = applier_for(&[(h(1), b"e1".to_vec())]);
+        let mut alice = Session::new(
+            SessionRole::Initiator,
+            EnvelopeKind::Key,
+            &a_provider,
+            &mut a_applier,
+        );
+        // Skip the wire dance — drive on_message directly.
+        let bob_summary = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![
+                super::super::protocol::EnvelopeRef {
+                    envelope_hash: h(1),
+                    seq: 1,
+                },
+                super::super::protocol::EnvelopeRef {
+                    envelope_hash: h(2),
+                    seq: 2,
+                },
+                super::super::protocol::EnvelopeRef {
+                    envelope_hash: h(3),
+                    seq: 3,
+                },
+            ],
+        });
+        alice.start_round();
+        let _ = alice.on_message(bob_summary);
+        let bob_deliver = ReplicationMessage::Deliver(DeliverMessage {
+            kind: EnvelopeKind::Key,
+            envelopes: vec![
+                b"e1".to_vec(),         // known, applies
+                b"unknown_e2".to_vec(), // applier doesn't know → refuse
+                b"unknown_e3".to_vec(),
+            ],
+        });
+        match alice.on_message(bob_deliver) {
+            ReplicationOutcome::Applied {
+                admitted,
+                refused,
+                staleness,
+                ..
+            } => {
+                assert_eq!(admitted, 1);
+                assert_eq!(refused, 2);
+                assert_eq!(staleness, StalenessSignal::BoundedBy { missing: 2 });
+            }
+            o => panic!("{o:?}"),
+        }
+    }
+}

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -1,0 +1,284 @@
+//! Local-state-to-summary computation + diff logic.
+//!
+//! Edge's `Session` (in [`super::session`]) sits above this surface;
+//! callers wiring a live deployment provide a [`StateProvider`] /
+//! [`StateApplier`] pair over their `FederationDirectory` and the
+//! Session orchestrates rounds.
+//!
+//! ## Bounded-staleness signal
+//!
+//! [`StalenessSignal`] is the consumer-facing telemetry surfaced by
+//! the Session at the end of each round. Consumers (lens, agent,
+//! verify-coord) condition τ_partial on this signal — when staleness
+//! is bounded and below the consumer's tolerance, normal R1 quorum
+//! applies; when staleness is unknown or above tolerance, the consumer
+//! degrades to τ_partial / partition-mode semantics.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::protocol::{EnvelopeKind, EnvelopeRef};
+
+/// Snapshot of the envelopes a peer holds locally per
+/// [`EnvelopeKind`]. The state machine consumes this to build
+/// [`super::protocol::SummaryMessage`]s and to identify which envelopes
+/// need to be delivered to the peer.
+///
+/// Use `BTreeMap` (sorted, deterministic iteration) rather than
+/// `HashMap` so the on-wire `SummaryMessage::refs` order is stable
+/// across runs — a test that pins exact bytes can be deterministic;
+/// in production it makes diff computation predictable for
+/// debugging.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct LocalState {
+    /// Per-kind set of `(envelope_hash, seq)`. Storing seq inside the
+    /// map lets the diff logic prefer the higher-seq variant when two
+    /// peers have the same content-hash at different seqs (shouldn't
+    /// happen — content-hash collisions across seqs would be a
+    /// canonical-bytes bug — but the data model has a slot for it).
+    pub by_kind: BTreeMap<EnvelopeKind, BTreeMap<[u8; 32], u64>>,
+}
+
+impl LocalState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add an envelope to local state. Idempotent on (kind,
+    /// envelope_hash) — re-inserting updates seq if the new seq is
+    /// higher, otherwise no-op.
+    pub fn insert(&mut self, kind: EnvelopeKind, envelope_hash: [u8; 32], seq: u64) {
+        let entry = self.by_kind.entry(kind).or_default();
+        let slot = entry.entry(envelope_hash).or_insert(seq);
+        if seq > *slot {
+            *slot = seq;
+        }
+    }
+
+    /// Build a [`super::protocol::SummaryMessage`]-shaped list for
+    /// `kind`. Iteration order is BTreeMap-stable.
+    pub fn refs_for(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+        self.by_kind
+            .get(&kind)
+            .map(|inner| {
+                inner
+                    .iter()
+                    .map(|(h, s)| EnvelopeRef {
+                        envelope_hash: *h,
+                        seq: *s,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Count envelopes for `kind` — useful for staleness telemetry.
+    pub fn count(&self, kind: EnvelopeKind) -> usize {
+        self.by_kind.get(&kind).map_or(0, BTreeMap::len)
+    }
+}
+
+/// Trait the live Session calls to read local state. Production
+/// adapter (follow-up PR) wraps `FederationDirectory`'s
+/// `list_attestations` / `list_federation_keys` / `list_revocations`
+/// surfaces.
+pub trait StateProvider: Send + Sync {
+    /// Snapshot local state for the given kind. Implementations
+    /// should be cheap (the state is read once per anti-entropy
+    /// round); callers don't memoize.
+    fn local_refs(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef>;
+
+    /// Return the byte-exact signed envelope for the given content
+    /// hash, or `None` if the envelope isn't in local state. Called
+    /// during the Deliver-message construction step.
+    fn fetch_envelope(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> Option<Vec<u8>>;
+}
+
+/// Trait the live Session calls to apply received envelopes. Wraps
+/// persist's `put_*` admit surface; the impl is responsible for
+/// validating the envelope (signature + canonical-bytes hash) before
+/// committing to local state. Errors NOT surfaced by this trait —
+/// the apply path is idempotent (a duplicate apply hits persist's
+/// R1/Q1 dedupe and returns no-op).
+pub trait StateApplier: Send + Sync {
+    /// Apply one envelope to local state. The receiver MUST verify
+    /// the signed envelope's signature + canonical-bytes hash before
+    /// admitting; if validation fails the apply silently no-ops
+    /// (the merge layer in persist is the canonical anti-rollback
+    /// authority). Returns `true` if the apply admitted a new
+    /// envelope (changed local state), `false` if it was a duplicate
+    /// or refused.
+    fn apply_envelope(&mut self, kind: EnvelopeKind, envelope_bytes: &[u8]) -> bool;
+}
+
+/// Compute the diff between two summaries — which hashes the LOCAL
+/// peer doesn't have that the REMOTE peer claims to have. This is
+/// the input to a `DiffMessage::want` field.
+pub fn diff_refs(local: &[EnvelopeRef], remote: &[EnvelopeRef]) -> Vec<[u8; 32]> {
+    let local_set: BTreeSet<[u8; 32]> = local.iter().map(|r| r.envelope_hash).collect();
+    remote
+        .iter()
+        .filter(|r| !local_set.contains(&r.envelope_hash))
+        .map(|r| r.envelope_hash)
+        .collect()
+}
+
+/// The freshness signal exposed to consumers per [`EnvelopeKind`].
+/// Drives τ_partial / partition-mode semantics in
+/// CIRISVerify#48/#49 consumers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StalenessSignal {
+    /// Local state matches the most recent remote summary received
+    /// for this kind. Consumers may operate in normal R1 mode.
+    InSync,
+    /// Local state is missing N envelopes vs the most recent remote
+    /// summary. Bounded staleness — consumers can decide whether to
+    /// degrade based on N.
+    BoundedBy { missing: u64 },
+    /// No anti-entropy round has completed for this kind since
+    /// process start (or since the local clock was last reset).
+    /// Consumers SHOULD treat this as worst-case stale.
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(seed: u8) -> [u8; 32] {
+        let mut a = [0u8; 32];
+        a[0] = seed;
+        a
+    }
+
+    /// Insert + idempotent re-insert + count.
+    #[test]
+    fn local_state_inserts_and_counts() {
+        let mut s = LocalState::new();
+        s.insert(EnvelopeKind::Key, h(1), 100);
+        s.insert(EnvelopeKind::Key, h(2), 200);
+        s.insert(EnvelopeKind::Attestation, h(3), 50);
+        assert_eq!(s.count(EnvelopeKind::Key), 2);
+        assert_eq!(s.count(EnvelopeKind::Attestation), 1);
+        assert_eq!(s.count(EnvelopeKind::Revocation), 0);
+        // Re-insert same (kind, hash) at higher seq updates seq.
+        s.insert(EnvelopeKind::Key, h(1), 150);
+        let refs = s.refs_for(EnvelopeKind::Key);
+        let r1 = refs.iter().find(|r| r.envelope_hash == h(1)).unwrap();
+        assert_eq!(r1.seq, 150);
+        // Re-insert at lower seq is a no-op.
+        s.insert(EnvelopeKind::Key, h(1), 120);
+        let refs2 = s.refs_for(EnvelopeKind::Key);
+        let r1b = refs2.iter().find(|r| r.envelope_hash == h(1)).unwrap();
+        assert_eq!(r1b.seq, 150);
+    }
+
+    /// `refs_for` returns BTreeMap-sorted output — deterministic
+    /// ordering matters for test stability + protocol determinism.
+    #[test]
+    fn refs_for_is_sorted_by_envelope_hash() {
+        let mut s = LocalState::new();
+        // Insert in non-sorted order.
+        s.insert(EnvelopeKind::Key, h(9), 1);
+        s.insert(EnvelopeKind::Key, h(1), 2);
+        s.insert(EnvelopeKind::Key, h(5), 3);
+        let refs = s.refs_for(EnvelopeKind::Key);
+        // BTreeMap stable ordering by key.
+        assert_eq!(refs[0].envelope_hash, h(1));
+        assert_eq!(refs[1].envelope_hash, h(5));
+        assert_eq!(refs[2].envelope_hash, h(9));
+    }
+
+    /// Empty kind returns empty refs.
+    #[test]
+    fn refs_for_empty_kind_returns_empty() {
+        let s = LocalState::new();
+        assert!(s.refs_for(EnvelopeKind::Community).is_empty());
+    }
+
+    /// Diff of disjoint local vs remote — local wants everything.
+    #[test]
+    fn diff_disjoint_wants_everything() {
+        let local: Vec<EnvelopeRef> = vec![];
+        let remote = vec![
+            EnvelopeRef {
+                envelope_hash: h(1),
+                seq: 1,
+            },
+            EnvelopeRef {
+                envelope_hash: h(2),
+                seq: 2,
+            },
+        ];
+        let want = diff_refs(&local, &remote);
+        assert_eq!(want, vec![h(1), h(2)]);
+    }
+
+    /// Diff of identical sets — want is empty.
+    #[test]
+    fn diff_identical_wants_nothing() {
+        let local = vec![
+            EnvelopeRef {
+                envelope_hash: h(1),
+                seq: 1,
+            },
+            EnvelopeRef {
+                envelope_hash: h(2),
+                seq: 2,
+            },
+        ];
+        let remote = local.clone();
+        let want = diff_refs(&local, &remote);
+        assert!(want.is_empty());
+    }
+
+    /// Partial overlap — want is the remote-minus-local set.
+    #[test]
+    fn diff_partial_overlap() {
+        let local = vec![EnvelopeRef {
+            envelope_hash: h(1),
+            seq: 1,
+        }];
+        let remote = vec![
+            EnvelopeRef {
+                envelope_hash: h(1),
+                seq: 1,
+            },
+            EnvelopeRef {
+                envelope_hash: h(2),
+                seq: 2,
+            },
+            EnvelopeRef {
+                envelope_hash: h(3),
+                seq: 3,
+            },
+        ];
+        let want = diff_refs(&local, &remote);
+        assert_eq!(want, vec![h(2), h(3)]);
+    }
+
+    /// Local has hashes the remote doesn't — those don't show up in
+    /// our wants. The reverse-direction Summary/Diff from the remote
+    /// would pick them up.
+    #[test]
+    fn diff_local_has_extras_ignored() {
+        let local = vec![
+            EnvelopeRef {
+                envelope_hash: h(1),
+                seq: 1,
+            },
+            EnvelopeRef {
+                envelope_hash: h(2),
+                seq: 2,
+            },
+        ];
+        let remote = vec![EnvelopeRef {
+            envelope_hash: h(1),
+            seq: 1,
+        }];
+        let want = diff_refs(&local, &remote);
+        assert!(
+            want.is_empty(),
+            "local extras shouldn't appear in want list"
+        );
+    }
+}


### PR DESCRIPTION
First building block of CIRISEdge#65 — the CEG-native federation replication transport (cross-region envelope gossip + anti-entropy). This PR ships the **protocol primitives + state machine** tested in isolation; the networking glue (binding to a \`Transport\` instance + scheduling rounds) and persist adapters land in follow-up PRs.

## Why incremental scope

CIRISRegistry#58 assigns Edge the \"propagation\" role of CEG-native replication. The full implementation has three layers, each independently testable + reviewable:

| Layer | This PR | Scope |
|---|---|---|
| (a) Protocol + state machine | ✅ | message types, wire codec, Session state machine, isolation tests |
| (b) Transport binding | ⏳ next PR | wire Session against \`crate::transport::Transport\` + round scheduler + timeouts |
| (c) Persist adapters | ⏳ subsequent PR | concrete \`StateProvider\` / \`StateApplier\` over \`FederationDirectory\` |

Sequencing them as separate PRs keeps each review surface tractable. The protocol bytes-in/bytes-out interface in this PR is the contract the binding PR consumes.

## What ships

| File | LoC | Tests | Surface |
|---|---|---|---|
| \`src/replication/protocol.rs\` | 258 | 8 | \`EnvelopeKind\` + \`EnvelopeRef\` + 4 message types + serde-tagged JSON codec |
| \`src/replication/summary.rs\` | 284 | 7 | \`LocalState\`, \`StateProvider\` / \`StateApplier\` traits, \`diff_refs()\`, \`StalenessSignal\` |
| \`src/replication/session.rs\` | 708 | 5 | \`SessionRole\`, \`ReplicationOutcome\`, \`Session<'a>\` state machine + scenario tests |

**20 tests pass.** Covers: full-sync disjoint state converges; partial overlap only missing delivered; idempotent second run no-changes; Fetch returns requested envelopes; mismatched-kind refused; bounded-by staleness when some envelopes refused; protocol wire-stability (unknown tag refused, JSON malformed refused, all kind wire-values stable).

## Staleness computation — provider-storage-agnostic

The Session computes \`StalenessSignal\` from \`last_diff_want_count\` (envelopes we asked for) minus admitted count (from \`StateApplier::apply_envelope\` return). Works whether the Provider sees the Applier's writes or not — production wires them over a shared \`FederationDirectory\` backing; tests + future in-process orchestrators can keep them separate.

## Wire stability

\`ReplicationMessage\` is \`#[serde(tag = \"type\")]\`. Adding a new variant is a non-break — v1 receivers see unknown tag and refuse cleanly. Adding a new field needs \`#[serde(default)]\`; renaming/removing requires a protocol version bump (follow-up adds explicit \`protocol_version\`).

## What's NOT in this PR

- **Transport binding** — Session ↔ Transport glue + round scheduler + timeouts (next PR)
- **Persist adapters** — concrete impls of \`StateProvider\` / \`StateApplier\` over \`FederationDirectory\` (subsequent PR)
- **Cross-region peer-set discovery** — operator config + reachability-driven selection
- **Operational telemetry beyond StalenessSignal** — round counts / bytes transferred / diff sizes via \`tracing\` (binding PR wires to metric backend)

## Validation

- \`cargo fmt --all -- --check\` ✅
- \`cargo clippy\` across 2 feature combos under \`-D warnings\` ✅
- \`cargo test --lib replication\` ✅ **20 passed**

Partial #65.