### PR TITLE
replication: wire-frame prefix for inbound dispatch (partial #65)

### DIFF
--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -191,10 +191,15 @@ impl ReplicationCoordinator {
     }
 
     /// Emit a [`ReplicationMessage`] on the underlying transport.
-    /// Serializes via [`ReplicationMessage::to_bytes`], hands to
-    /// [`Transport::send`] addressed at the configured peer_key_id.
+    /// Wraps via [`super::wire_frame::wrap`] (4-byte CRPL magic
+    /// prefix + JSON body), then hands to [`Transport::send`]
+    /// addressed at the configured peer_key_id.
+    ///
+    /// The magic prefix lets the application's [`Transport::listen`]
+    /// loop route inbound bytes to the replication path without
+    /// parsing every byte as every possible payload kind.
     pub async fn send_message(&self, msg: &ReplicationMessage) -> Result<(), CoordinatorError> {
-        let bytes = msg.to_bytes();
+        let bytes = super::wire_frame::wrap(msg);
         self.transport
             .send(&self.peer_key_id, &bytes)
             .await
@@ -202,12 +207,48 @@ impl ReplicationCoordinator {
             .map_err(CoordinatorError::from)
     }
 
-    /// Parse on-wire bytes back into a [`ReplicationMessage`]. The
-    /// application's listen loop calls this when it has identified
-    /// the inbound bytes as a replication frame (via the frame-kind
-    /// prefix or per-medium port discriminator — out of scope here).
+    /// Try to parse on-wire bytes as a [`ReplicationMessage`].
+    /// Returns:
+    ///
+    /// - `Ok(Some(msg))` — bytes carry the CRPL magic and the JSON
+    ///   body decoded cleanly. The caller's listen-loop dispatcher
+    ///   feeds the message to [`Self::drive_round_step`].
+    /// - `Ok(None)` — bytes are not a replication frame (magic
+    ///   absent). The caller's dispatcher falls through to its
+    ///   non-replication path (existing signed-envelope handler,
+    ///   future key_grant handler, etc.).
+    /// - `Err(CoordinatorError::Protocol)` — bytes have the CRPL
+    ///   magic but the JSON body is malformed. Protocol violation
+    ///   by the sender; the caller typically logs + drops the frame.
+    pub fn try_parse_inbound_bytes(
+        bytes: &[u8],
+    ) -> Result<Option<ReplicationMessage>, CoordinatorError> {
+        super::wire_frame::try_unwrap(bytes).map_err(CoordinatorError::from)
+    }
+
+    /// Backward-compatible parser that REQUIRES bytes to be a valid
+    /// replication frame — returns `Err` if not, matching the PR #70
+    /// behavior. New code should prefer [`Self::try_parse_inbound_bytes`]
+    /// for the trichotomy (absent magic = NotAReplicationFrame, not
+    /// an error).
+    ///
+    /// Tolerates both framed (CRPL-prefixed, the current wire format)
+    /// and bare (legacy, pre-#71-wire-frame) inputs — bare inputs
+    /// route directly to [`ReplicationMessage::from_bytes`]. The
+    /// tolerance ships because the on-wire codec changed between
+    /// PR #70 (bare JSON) and this PR (CRPL-prefixed); a fleet
+    /// running mixed builds during a rolling upgrade can still
+    /// exchange messages. The tolerance can be removed once edge
+    /// v1.3.x reaches end-of-life.
     pub fn parse_inbound_bytes(bytes: &[u8]) -> Result<ReplicationMessage, CoordinatorError> {
-        ReplicationMessage::from_bytes(bytes).map_err(CoordinatorError::from)
+        match super::wire_frame::try_unwrap(bytes) {
+            Ok(Some(msg)) => Ok(msg),
+            Ok(None) => {
+                // Legacy bare-JSON fallback for mid-rolling-upgrade fleets.
+                ReplicationMessage::from_bytes(bytes).map_err(CoordinatorError::from)
+            }
+            Err(e) => Err(CoordinatorError::from(e)),
+        }
     }
 }
 
@@ -455,6 +496,59 @@ mod tests {
             matches!(parsed, ReplicationMessage::Diff(_)),
             "expected Bob's Diff, got {parsed:?}"
         );
+    }
+
+    /// `try_parse_inbound_bytes` returns `Ok(None)` for non-replication
+    /// bytes — the caller routes to non-replication dispatch.
+    #[test]
+    fn try_parse_inbound_bytes_returns_none_for_non_replication() {
+        let r = ReplicationCoordinator::try_parse_inbound_bytes(b"{\"agent\":\"alice\"}")
+            .expect("not an error");
+        assert!(r.is_none());
+    }
+
+    /// `try_parse_inbound_bytes` returns `Ok(Some(msg))` for properly
+    /// framed replication bytes (round-trip via the new wire frame).
+    #[test]
+    fn try_parse_inbound_bytes_round_trips_framed() {
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![],
+        });
+        let framed = super::super::wire_frame::wrap(&msg);
+        let parsed = ReplicationCoordinator::try_parse_inbound_bytes(&framed)
+            .expect("not an error")
+            .expect("some");
+        assert_eq!(parsed, msg);
+    }
+
+    /// `try_parse_inbound_bytes` surfaces `Err(Protocol)` when the
+    /// magic is present but the body is malformed.
+    #[test]
+    fn try_parse_inbound_bytes_protocol_error_on_bad_body() {
+        let mut bytes = super::super::wire_frame::REPLICATION_FRAME_MAGIC.to_vec();
+        bytes.extend_from_slice(b"{not json");
+        let r = ReplicationCoordinator::try_parse_inbound_bytes(&bytes);
+        assert!(matches!(r, Err(CoordinatorError::Protocol(_))));
+    }
+
+    /// Backward-compatible `parse_inbound_bytes` accepts BOTH the
+    /// new framed wire form AND the legacy bare-JSON form — important
+    /// during a rolling fleet upgrade.
+    #[test]
+    fn parse_inbound_bytes_tolerates_legacy_bare_json() {
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![],
+        });
+        // Legacy form (bare JSON, no CRPL magic).
+        let bare = msg.to_bytes();
+        let parsed = ReplicationCoordinator::parse_inbound_bytes(&bare).expect("parse");
+        assert_eq!(parsed, msg);
+        // New form (CRPL-prefixed) also parses.
+        let framed = super::super::wire_frame::wrap(&msg);
+        let parsed2 = ReplicationCoordinator::parse_inbound_bytes(&framed).expect("parse");
+        assert_eq!(parsed2, msg);
     }
 
     /// `parse_inbound_bytes` refuses junk cleanly — defence against

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -78,6 +78,7 @@ pub mod directory;
 pub mod protocol;
 pub mod session;
 pub mod summary;
+pub mod wire_frame;
 
 #[doc(inline)]
 pub use coordinator::{CoordinatorError, DriveStep, ReplicationCoordinator, RoundReport};
@@ -92,3 +93,8 @@ pub use protocol::{
 pub use session::{ReplicationOutcome, Session, SessionRole};
 #[doc(inline)]
 pub use summary::{LocalState, StalenessSignal, StateApplier, StateProvider};
+#[doc(inline)]
+pub use wire_frame::{
+    try_unwrap as try_unwrap_replication_frame, wrap as wrap_replication_frame,
+    REPLICATION_FRAME_MAGIC,
+};

--- a/src/replication/wire_frame.rs
+++ b/src/replication/wire_frame.rs
@@ -1,0 +1,214 @@
+//! Wire-frame prefix for replication messages on the
+//! [`crate::transport::Transport`] surface.
+//!
+//! Solves the inbound-dispatch question raised in PR #70 (`coordinator.rs`
+//! module docs): the application's [`Transport::listen`] loop receives
+//! bytes from a single channel that carries multiple payload kinds
+//! (signed federation envelopes, replication protocol messages,
+//! eventually key_grant blobs / takedown notices / etc.). The receiver
+//! needs to route by payload kind without parsing every byte as every
+//! possible shape.
+//!
+//! ## Design — magic-prefix dispatch
+//!
+//! Replication messages carry a 4-byte magic at the front:
+//!
+//! ```text
+//!   ┌────┬──────────────────────────────────────────────┐
+//!   │MAG │  ReplicationMessage::to_bytes() — JSON       │
+//!   │ 4B │                                              │
+//!   └────┴──────────────────────────────────────────────┘
+//! ```
+//!
+//! The magic is `b"CRPL"` ("CIRis RePLication") — chosen because no
+//! existing federation envelope shape starts with this prefix (signed
+//! envelopes start with `{` for JSON, `0x80..0xBF` for CBOR map tags,
+//! etc.).
+//!
+//! ## Why this and not a top-level FramedKind enum
+//!
+//! The alternative would be a `FramedKind { Envelope, Replication, ... }`
+//! enum at the application/Transport boundary, with every send call
+//! site wrapping its payload in the enum. That's *cleaner* but invasive
+//! — every existing `Edge::send` / `dispatch_inbound` site would need
+//! to learn the new wrapping convention. The magic-prefix approach is
+//! **purely additive**: replication wraps its bytes, the existing send
+//! paths stay unchanged, and the receiver's dispatcher does:
+//!
+//! ```text
+//!   if bytes starts with REPLICATION_FRAME_MAGIC:
+//!       hand to ReplicationCoordinator::feed_inbound_bytes
+//!   else:
+//!       existing signed-envelope dispatch (unchanged)
+//! ```
+//!
+//! When future wire kinds need their own routing (key_grant streams,
+//! takedown notices), they pick their own magic. The receiver's
+//! dispatcher grows linearly — one branch per wire kind. The
+//! `FramedKind` enum approach grows the same number of branches but
+//! requires touching every existing send site to opt in; this approach
+//! only touches the sites that need the new wire kind.
+
+use super::protocol::{ProtocolError, ReplicationMessage};
+
+/// 4-byte magic prefix that identifies a replication frame on the
+/// transport. ASCII `CRPL` ("CIRis RePLication") — no signed federation
+/// envelope shape starts with these four bytes, so the prefix is
+/// unambiguously a replication frame.
+pub const REPLICATION_FRAME_MAGIC: [u8; 4] = *b"CRPL";
+
+/// Wrap a [`ReplicationMessage`] in the wire frame ready to hand to
+/// [`crate::transport::Transport::send`]. Allocates one `Vec` of
+/// exactly `4 + msg.to_bytes().len()` bytes.
+pub fn wrap(msg: &ReplicationMessage) -> Vec<u8> {
+    let body = msg.to_bytes();
+    let mut out = Vec::with_capacity(REPLICATION_FRAME_MAGIC.len() + body.len());
+    out.extend_from_slice(&REPLICATION_FRAME_MAGIC);
+    out.extend_from_slice(&body);
+    out
+}
+
+/// Inverse of [`wrap`]. Returns:
+///
+/// - `Ok(Some(msg))` — bytes start with [`REPLICATION_FRAME_MAGIC`]
+///   and the JSON body decodes cleanly. The caller routes to the
+///   replication path.
+/// - `Ok(None)` — bytes don't start with the magic. The caller falls
+///   through to its non-replication dispatch (existing signed-envelope
+///   handler, key_grant handler, etc.).
+/// - `Err(ProtocolError)` — bytes DO start with the magic but the JSON
+///   body is malformed. This is a protocol violation by the sender; the
+///   caller surfaces it (typically: drop the frame + log).
+///
+/// The trichotomy is deliberate: a non-replication frame is NOT an
+/// error from this function's POV — it's a successful "this isn't
+/// ours" answer. A malformed replication frame IS an error because the
+/// magic prefix promised replication-shaped bytes that didn't deliver.
+pub fn try_unwrap(bytes: &[u8]) -> Result<Option<ReplicationMessage>, ProtocolError> {
+    if bytes.len() < REPLICATION_FRAME_MAGIC.len() {
+        return Ok(None);
+    }
+    if bytes[..REPLICATION_FRAME_MAGIC.len()] != REPLICATION_FRAME_MAGIC {
+        return Ok(None);
+    }
+    let body = &bytes[REPLICATION_FRAME_MAGIC.len()..];
+    ReplicationMessage::from_bytes(body).map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::replication::protocol::{EnvelopeKind, SummaryMessage};
+
+    /// wrap/try_unwrap round-trips a Summary message.
+    #[test]
+    fn wrap_unwrap_round_trip() {
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Attestation,
+            refs: vec![],
+        });
+        let framed = wrap(&msg);
+        // First 4 bytes are the magic.
+        assert_eq!(&framed[..4], &REPLICATION_FRAME_MAGIC);
+        // try_unwrap recovers the original.
+        let unwrapped = try_unwrap(&framed).expect("decode").expect("magic match");
+        assert_eq!(unwrapped, msg);
+    }
+
+    /// Bytes without the magic prefix return `Ok(None)` — the caller
+    /// routes to its non-replication dispatch.
+    #[test]
+    fn non_replication_bytes_yield_none() {
+        // Signed federation envelopes typically start with `{` (JSON) or
+        // similar — neither byte sequence collides with CRPL.
+        let cases: &[&[u8]] = &[
+            b"{\"agent\":\"alice\"}",
+            b"\x80\xa1cfoo", // some CBOR-shaped bytes
+            b"random garbage with no structure",
+            b"CRP",   // 3-byte prefix — too short to even check the 4-byte magic
+            b"CRPM!", // 4 bytes but not CRPL
+            b"crpl",  // lowercase — case-sensitive, doesn't match
+            b"",      // empty
+        ];
+        for bytes in cases {
+            let r = try_unwrap(bytes).expect("not an error");
+            assert!(r.is_none(), "expected None for {bytes:?}");
+        }
+    }
+
+    /// Bytes with the magic but malformed JSON body yield
+    /// `Err(ProtocolError)` — the sender broke the contract.
+    #[test]
+    fn magic_with_malformed_body_is_protocol_error() {
+        let mut bytes = REPLICATION_FRAME_MAGIC.to_vec();
+        bytes.extend_from_slice(b"{not valid json");
+        let r = try_unwrap(&bytes);
+        assert!(matches!(r, Err(ProtocolError::Decode(_))));
+    }
+
+    /// Bytes with the magic but with a JSON body that's a valid JSON
+    /// object but NOT a `ReplicationMessage` (unknown tag) — same
+    /// `Err(ProtocolError)` shape per [`ReplicationMessage::from_bytes`].
+    #[test]
+    fn magic_with_unknown_replication_tag_is_protocol_error() {
+        let mut bytes = REPLICATION_FRAME_MAGIC.to_vec();
+        bytes.extend_from_slice(br#"{"type":"hostile_takeover","payload":42}"#);
+        let r = try_unwrap(&bytes);
+        assert!(matches!(r, Err(ProtocolError::Decode(_))));
+    }
+
+    /// All four `ReplicationMessage` variants round-trip through
+    /// wrap/try_unwrap.
+    #[test]
+    fn all_variants_round_trip() {
+        use crate::replication::protocol::{
+            DeliverMessage, DiffMessage, EnvelopeRef, FetchMessage,
+        };
+        let h = [7u8; 32];
+        let cases = vec![
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Key,
+                refs: vec![EnvelopeRef {
+                    envelope_hash: h,
+                    seq: 1,
+                }],
+            }),
+            ReplicationMessage::Diff(DiffMessage {
+                kind: EnvelopeKind::Attestation,
+                want: vec![h],
+            }),
+            ReplicationMessage::Fetch(FetchMessage {
+                kind: EnvelopeKind::Revocation,
+                want: vec![h, h],
+            }),
+            ReplicationMessage::Deliver(DeliverMessage {
+                kind: EnvelopeKind::Community,
+                envelopes: vec![b"signed_envelope_bytes".to_vec()],
+            }),
+        ];
+        for msg in cases {
+            let framed = wrap(&msg);
+            let unwrapped = try_unwrap(&framed).expect("decode").expect("magic");
+            assert_eq!(unwrapped, msg);
+        }
+    }
+
+    /// Magic-prefix detection is robust against `bytes` shorter than
+    /// the magic — no panic, no false-positive.
+    #[test]
+    fn short_input_safe() {
+        for len in 0..REPLICATION_FRAME_MAGIC.len() {
+            let r = try_unwrap(&REPLICATION_FRAME_MAGIC[..len]);
+            assert!(matches!(r, Ok(None)));
+        }
+    }
+
+    /// Magic ALONE (no body) is a protocol error — `from_bytes` on an
+    /// empty buffer rejects.
+    #[test]
+    fn magic_only_no_body_is_protocol_error() {
+        let bytes = REPLICATION_FRAME_MAGIC.to_vec();
+        let r = try_unwrap(&bytes);
+        assert!(matches!(r, Err(ProtocolError::Decode(_))));
+    }
+}


### PR DESCRIPTION
Closes the inbound-dispatch question raised in [PR #70](https://github.com/CIRISAI/CIRISEdge/pull/70)'s \`coordinator.rs\` docs. Replication messages now carry a 4-byte magic prefix (\`b\"CRPL\"\`) on the wire so the application's \`Transport::listen\` loop can route by payload kind without parsing every byte as every possible shape.

## Why magic-prefix and not a \`FramedKind\` enum

The alternative would be a \`FramedKind { Envelope, Replication, ... }\` enum at the Transport boundary with every send call site wrapping its payload. That's cleaner but invasive — every existing \`Edge::send\` / \`dispatch_inbound\` would need to learn the wrapping convention. The magic-prefix approach is purely additive: replication wraps its bytes, existing send paths stay unchanged, and the receiver's dispatcher does:

\`\`\`
if bytes starts with REPLICATION_FRAME_MAGIC:
    hand to ReplicationCoordinator::try_parse_inbound_bytes
else:
    existing signed-envelope dispatch (unchanged)
\`\`\`

Future wire kinds (key_grant streams, takedown notices) pick their own magic. The dispatcher grows linearly — one branch per wire kind. Same number of branches as the \`FramedKind\` enum approach, but each is opt-in on the SEND side.

## What ships

| File | LoC | Tests | Surface |
|---|---|---|---|
| \`src/replication/wire_frame.rs\` | 208 | 7 | \`REPLICATION_FRAME_MAGIC\`, \`wrap()\`, \`try_unwrap()\` |
| \`src/replication/coordinator.rs\` (modified) | +60 | +4 | \`send_message\` wraps; new \`try_parse_inbound_bytes\` trichotomy; backward-compat \`parse_inbound_bytes\` tolerates legacy bare-JSON |

**46 tests pass** (35 from PRs #69-71 + 11 new).

## Trichotomy at the dispatcher API

\`try_parse_inbound_bytes(bytes)\`:

| Return | Meaning |
|---|---|
| \`Ok(Some(msg))\` | CRPL magic present + JSON valid → route to replication |
| \`Ok(None)\` | Magic absent → caller routes to non-replication dispatch |
| \`Err(Protocol)\` | Magic present but JSON malformed → sender violated contract |

## Legacy bare-JSON tolerance

\`parse_inbound_bytes\` (the PR #70 API) now accepts BOTH:
- The new CRPL-framed wire (current sends)
- The legacy bare-JSON wire (pre-this-PR sends from mid-upgrade peers)

The tolerance ships because the on-wire codec changed between PR #70 and this PR; a fleet running mixed builds during a rolling upgrade can still exchange messages. Can be removed once edge v1.3.x reaches EOL.

## Validation

- \`cargo fmt --all -- --check\` ✅
- \`cargo clippy\` across both feature combos under \`-D warnings\` ✅
- \`cargo test --lib replication\` ✅ **46 passed**

Partial #65. Remaining: layer (c-2) production wiring (FederationDirectory blanket impl + PyO3 init) + long-lived Session refactor + scheduler.