### PR TITLE
replication: long-lived Session in coordinator (partial #65)

### DIFF
--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -82,22 +82,39 @@ pub enum CoordinatorError {
 }
 
 /// Binds one [`Session`] to one transport peer. The application
-/// constructs one of these per `(peer_key_id, kind)` pair, holds it
-/// across the lifetime of that anti-entropy relationship, and drives
-/// rounds via [`Self::run_initiator_round`] / [`Self::feed_inbound_bytes`].
+/// constructs one of these per `(peer_key_id, kind, role)` triple,
+/// holds it across the lifetime of that anti-entropy relationship,
+/// and drives rounds via [`Self::drive_round_step`] +
+/// [`Self::send_message`] from its scheduler / listen-loop glue.
 ///
-/// Implementation note: the [`Session`] state machine borrows the
-/// provider plus applier; the coordinator holds them as
-/// `Arc<dyn StateProvider>` and `Arc<Mutex<dyn StateApplier>>` so we
-/// can construct a fresh Session per round without lifetime
-/// gymnastics. The mutex on the applier is for `&mut` access during
-/// apply; the provider trait is `&self`-only so no mutex needed.
+/// ## Long-lived session
+///
+/// The [`Session`] is held inside a `Mutex` for the coordinator's
+/// lifetime. The state machine's `last_summary_sent`,
+/// `last_remote_summary`, and `diff_want_count` persist across the
+/// Summary → Diff → Deliver phase boundaries, so the post-Apply
+/// [`StalenessSignal`] computes correctly (`BoundedBy { missing }` /
+/// `InSync`) instead of degrading to `Unknown`. After a round
+/// completes (`DriveStep::Complete` is observed), the coordinator
+/// auto-resets the session so the next round can begin without
+/// caller bookkeeping; the application's scheduler just calls
+/// `drive_round_step(None)` (initiator) again to start the next
+/// round, or `drive_round_step(Some(inbound))` (responder) on the
+/// next inbound Summary.
 pub struct ReplicationCoordinator {
     transport: Arc<dyn Transport>,
     peer_key_id: String,
     kind: EnvelopeKind,
+    role: SessionRole,
     provider: Arc<dyn StateProvider>,
     applier: Arc<Mutex<dyn StateApplier>>,
+    /// The long-lived state machine for this peer-pair anti-entropy
+    /// relationship. Wrapped in `Mutex` so `drive_round_step` can
+    /// take `&self` (matching the existing API + letting the
+    /// scheduler / listen-loop call it concurrently from different
+    /// tasks; the mutex serializes them — anti-entropy is sequential
+    /// per peer-pair by protocol).
+    session: Mutex<Session>,
 }
 
 impl ReplicationCoordinator {
@@ -105,6 +122,7 @@ impl ReplicationCoordinator {
         transport: Arc<dyn Transport>,
         peer_key_id: impl Into<String>,
         kind: EnvelopeKind,
+        role: SessionRole,
         provider: Arc<dyn StateProvider>,
         applier: Arc<Mutex<dyn StateApplier>>,
     ) -> Self {
@@ -112,58 +130,81 @@ impl ReplicationCoordinator {
             transport,
             peer_key_id: peer_key_id.into(),
             kind,
+            role,
             provider,
             applier,
+            session: Mutex::new(Session::new(role, kind)),
         }
     }
 
-    /// Run one initiator-side anti-entropy round with the configured
-    /// peer. Returns the round's report (admitted / refused / staleness)
-    /// or a `CoordinatorError` if the transport or protocol misbehaves.
+    /// Step the held [`Session`] one transition forward.
     ///
-    /// The round drives the full sequence:
+    /// - `msg = None` — start a new round (initiator only). Returns
+    ///   `SendThenWait` with our outbound Summary.
+    /// - `msg = Some(inbound)` — feed an inbound replication message
+    ///   into the session.
     ///
-    /// 1. Build our [`super::protocol::SummaryMessage`] from
-    ///    [`StateProvider::local_refs`].
-    /// 2. Send via [`Transport::send`].
-    /// 3. Wait for the peer's reply messages (delivered via
-    ///    [`Self::feed_inbound_bytes`] from the application's listen
-    ///    loop).
-    /// 4. Apply received envelopes via [`StateApplier::apply_envelope`].
-    /// 5. Return the [`RoundReport`].
+    /// The session is long-lived across the call boundary, so
+    /// `diff_want_count` recorded during the Diff phase carries into
+    /// the Deliver phase — the post-Apply [`StalenessSignal`]
+    /// computes correctly (`BoundedBy` / `InSync`), no longer
+    /// `Unknown`.
     ///
-    /// **For this PR's scope**, the "wait for the peer's reply" step is
-    /// driven by a [`tokio::sync::oneshot`] the application fills from
-    /// its listen loop via [`Self::feed_inbound_bytes`]. Production
-    /// wiring with a real transport would use a multi-message channel
-    /// (the peer sends Summary + Diff + Deliver in three packets); for
-    /// now the coordinator supports one-shot via the caller-driven
-    /// loop test pattern, and we document the multi-message extension
-    /// as the next sub-task.
-    ///
-    /// Test-driver pattern (used in the in-memory tests below) — the
-    /// caller alternates `coordinator.run_initiator_round()` with
-    /// `coordinator.feed_inbound_bytes(...)` to step the round
-    /// through its phases.
+    /// When the session completes (Applied outcome), the coordinator
+    /// auto-resets it so the next `drive_round_step(None)` /
+    /// inbound Summary starts a fresh round without caller
+    /// bookkeeping.
     pub async fn drive_round_step(
         &self,
         msg: Option<ReplicationMessage>,
     ) -> Result<DriveStep, CoordinatorError> {
-        let mut applier = self.applier.lock().await;
-        let mut session = Session::new(
-            match msg {
-                None => SessionRole::Initiator,
-                Some(_) => SessionRole::Responder,
-            },
-            self.kind,
-            self.provider.as_ref(),
-            &mut *applier,
-        );
+        let mut session = self.session.lock().await;
         let outcome = match msg {
-            None => session.start_round(),
-            Some(m) => session.on_message(m),
+            None => session.start_round(self.provider.as_ref()),
+            Some(m) => {
+                let mut applier = self.applier.lock().await;
+                session.on_message(m, self.provider.as_ref(), &mut *applier)
+            }
         };
-        Ok(Self::outcome_to_step(outcome))
+        let step = Self::outcome_to_step(outcome);
+        // Auto-reset on round completion so the next call can drive
+        // a fresh round without the caller threading state.
+        if matches!(step, DriveStep::Complete(_)) {
+            session.reset();
+        }
+        Ok(step)
+    }
+
+    /// Whether this coordinator's session has completed its current
+    /// round (Applied has been observed). Useful for the scheduler
+    /// to decide whether to start a new round or wait. Note that
+    /// `drive_round_step` auto-resets on Complete, so this returns
+    /// `true` only briefly during a `drive_round_step` call that
+    /// observes Applied; in practice the scheduler reads the
+    /// `DriveStep::Complete` return directly.
+    pub async fn is_round_complete(&self) -> bool {
+        self.session.lock().await.is_complete()
+    }
+
+    /// The session's configured role. Fixed at construction; used
+    /// by the scheduler to decide which side calls
+    /// `drive_round_step(None)` to initiate each round.
+    pub fn role(&self) -> SessionRole {
+        self.role
+    }
+
+    /// The envelope kind this coordinator's anti-entropy round
+    /// runs over. Fixed at construction; the scheduler reads this
+    /// when fanning round cadence across (peer × kind) pairs.
+    pub fn kind(&self) -> EnvelopeKind {
+        self.kind
+    }
+
+    /// The peer identity this coordinator is bound to. Fixed at
+    /// construction; metrics + telemetry consumers tag round
+    /// reports with this.
+    pub fn peer_key_id(&self) -> &str {
+        &self.peer_key_id
     }
 
     fn outcome_to_step(outcome: ReplicationOutcome) -> DriveStep {
@@ -382,7 +423,12 @@ mod tests {
     /// Build a peer pair with disjoint state. Each peer holds two
     /// envelopes, none in common. After one anti-entropy round both
     /// should know all four.
+    ///
+    /// `clippy::too_many_lines` allowed because the seven explicit
+    /// phases are the test — collapsing them into helpers obscures
+    /// the round-shape this fixture demonstrates.
     #[tokio::test]
+    #[allow(clippy::too_many_lines)]
     async fn two_coordinators_converge_via_in_memory_transport() {
         let (alice_t, bob_t) = alice_bob_transports();
         let alice_t = Arc::new(alice_t);
@@ -420,6 +466,7 @@ mod tests {
             alice_t.clone(),
             "bob",
             EnvelopeKind::Key,
+            SessionRole::Initiator,
             a_provider.clone(),
             a_applier.clone(),
         );
@@ -427,12 +474,17 @@ mod tests {
             bob_t.clone(),
             "alice",
             EnvelopeKind::Key,
+            SessionRole::Responder,
             b_provider.clone(),
             b_applier.clone(),
         );
 
-        // Step the round manually — this is what the production
-        // scheduler/listen-loop combination automates.
+        // Drive the full anti-entropy round end-to-end across both
+        // coordinators. With the long-lived session refactor, each
+        // coordinator's Session preserves last_summary_sent +
+        // diff_want_count across the Summary → Diff → Deliver phase
+        // boundaries — so the final Applied outcomes carry correct
+        // `StalenessSignal::InSync` instead of degrading to `Unknown`.
 
         // 1. Alice initiates → emits Summary.
         let alice_step1 = alice_coord.drive_round_step(None).await.unwrap();
@@ -443,16 +495,14 @@ mod tests {
             }
             o => panic!("expected SendThenWait, got {o:?}"),
         };
-        // Send via transport (proves the transport binding works).
         alice_coord.send_message(&alice_summary).await.unwrap();
 
-        // 2. Bob receives Alice's Summary from his inbox.
+        // 2. Bob receives Alice's Summary → emits {Summary, Diff}.
         let bob_received_bytes = {
             let mut inbox = bob_t.my_inbox.lock().await;
             inbox.recv().await.expect("bob inbox")
         };
         let bob_inbound = ReplicationCoordinator::parse_inbound_bytes(&bob_received_bytes).unwrap();
-        // Bob processes the message (Responder role).
         let bob_step1 = bob_coord.drive_round_step(Some(bob_inbound)).await.unwrap();
         let (bob_summary, bob_diff) = match bob_step1 {
             DriveStep::SendThenWait(ref msgs) => {
@@ -464,38 +514,113 @@ mod tests {
         bob_coord.send_message(&bob_summary).await.unwrap();
         bob_coord.send_message(&bob_diff).await.unwrap();
 
-        // 3. The protocol from this point is complex enough that
-        // exercising it via drive_round_step iteration would require
-        // a stateful session held across calls. For this PR's scope
-        // — proving the transport binding works — we've shown:
-        //   a. drive_round_step yields the right outcome
-        //   b. send_message serializes + ships
-        //   c. parse_inbound_bytes deserializes
-        // The full multi-step end-to-end orchestration is the next
-        // sub-task (a stateful long-lived session held by the
-        // coordinator across round phases).
-        //
-        // Confirm the bytes arrived in Alice's inbox.
-        let alice_received_summary = {
+        // 3. Alice receives Bob's Summary → emits Diff (recording
+        //    diff_want_count = 2 into the held Session).
+        let alice_recv_summary_bytes = {
             let mut inbox = alice_t.my_inbox.lock().await;
-            inbox.recv().await.expect("alice inbox bob summary")
+            inbox.recv().await.expect("alice recv summary")
         };
-        let parsed =
-            ReplicationCoordinator::parse_inbound_bytes(&alice_received_summary).expect("parse");
-        assert!(
-            matches!(parsed, ReplicationMessage::Summary(_)),
-            "expected Bob's Summary, got {parsed:?}"
-        );
-        let alice_received_diff = {
+        let alice_recv_summary =
+            ReplicationCoordinator::parse_inbound_bytes(&alice_recv_summary_bytes).unwrap();
+        let alice_step2 = alice_coord
+            .drive_round_step(Some(alice_recv_summary))
+            .await
+            .unwrap();
+        let alice_diff = match alice_step2 {
+            DriveStep::SendThenWait(ref msgs) => {
+                assert_eq!(msgs.len(), 1);
+                msgs[0].clone()
+            }
+            o => panic!("expected SendThenWait, got {o:?}"),
+        };
+        alice_coord.send_message(&alice_diff).await.unwrap();
+
+        // 4. Alice receives Bob's Diff → emits Deliver(env_1, env_2).
+        let alice_recv_diff_bytes = {
             let mut inbox = alice_t.my_inbox.lock().await;
-            inbox.recv().await.expect("alice inbox bob diff")
+            inbox.recv().await.expect("alice recv diff")
         };
-        let parsed =
-            ReplicationCoordinator::parse_inbound_bytes(&alice_received_diff).expect("parse");
-        assert!(
-            matches!(parsed, ReplicationMessage::Diff(_)),
-            "expected Bob's Diff, got {parsed:?}"
-        );
+        let alice_recv_diff =
+            ReplicationCoordinator::parse_inbound_bytes(&alice_recv_diff_bytes).unwrap();
+        let alice_step3 = alice_coord
+            .drive_round_step(Some(alice_recv_diff))
+            .await
+            .unwrap();
+        let alice_deliver = match alice_step3 {
+            DriveStep::SendThenWait(ref msgs) => {
+                assert_eq!(msgs.len(), 1);
+                msgs[0].clone()
+            }
+            o => panic!("expected SendThenWait, got {o:?}"),
+        };
+        alice_coord.send_message(&alice_deliver).await.unwrap();
+
+        // 5. Bob receives Alice's Diff → emits Deliver(env_3, env_4).
+        let bob_recv_diff_bytes = {
+            let mut inbox = bob_t.my_inbox.lock().await;
+            inbox.recv().await.expect("bob recv diff")
+        };
+        let bob_recv_diff =
+            ReplicationCoordinator::parse_inbound_bytes(&bob_recv_diff_bytes).unwrap();
+        let bob_step2 = bob_coord
+            .drive_round_step(Some(bob_recv_diff))
+            .await
+            .unwrap();
+        let bob_deliver = match bob_step2 {
+            DriveStep::SendThenWait(ref msgs) => {
+                assert_eq!(msgs.len(), 1);
+                msgs[0].clone()
+            }
+            o => panic!("expected SendThenWait, got {o:?}"),
+        };
+        bob_coord.send_message(&bob_deliver).await.unwrap();
+
+        // 6. Alice receives Bob's Deliver → Applied(admitted=2, InSync).
+        let alice_recv_deliver_bytes = {
+            let mut inbox = alice_t.my_inbox.lock().await;
+            inbox.recv().await.expect("alice recv deliver")
+        };
+        let alice_recv_deliver =
+            ReplicationCoordinator::parse_inbound_bytes(&alice_recv_deliver_bytes).unwrap();
+        let alice_final = alice_coord
+            .drive_round_step(Some(alice_recv_deliver))
+            .await
+            .unwrap();
+        match alice_final {
+            DriveStep::Complete(report) => {
+                assert_eq!(report.kind, EnvelopeKind::Key);
+                assert_eq!(report.admitted, 2);
+                assert_eq!(report.refused, 0);
+                // The long-lived session preserved diff_want_count = 2
+                // from step 3 through to here — both admitted, so InSync.
+                assert_eq!(report.staleness, StalenessSignal::InSync);
+            }
+            o => panic!("expected Complete, got {o:?}"),
+        }
+
+        // 7. Bob receives Alice's Deliver → Applied(admitted=2, InSync).
+        let bob_recv_deliver_bytes = {
+            let mut inbox = bob_t.my_inbox.lock().await;
+            inbox.recv().await.expect("bob recv deliver")
+        };
+        let bob_recv_deliver =
+            ReplicationCoordinator::parse_inbound_bytes(&bob_recv_deliver_bytes).unwrap();
+        let bob_final = bob_coord
+            .drive_round_step(Some(bob_recv_deliver))
+            .await
+            .unwrap();
+        match bob_final {
+            DriveStep::Complete(report) => {
+                assert_eq!(report.admitted, 2);
+                assert_eq!(report.staleness, StalenessSignal::InSync);
+            }
+            o => panic!("expected Complete, got {o:?}"),
+        }
+
+        // Both coordinators auto-reset on completion (the round is
+        // ready to begin again on the next scheduler tick).
+        assert!(!alice_coord.is_round_complete().await);
+        assert!(!bob_coord.is_round_complete().await);
     }
 
     /// `try_parse_inbound_bytes` returns `Ok(None)` for non-replication
@@ -594,6 +719,7 @@ mod tests {
             alice_t,
             "nobody_home",
             EnvelopeKind::Key,
+            SessionRole::Initiator,
             a_provider,
             a_applier,
         );
@@ -628,6 +754,7 @@ mod tests {
             Arc::new(alice_t),
             "bob",
             EnvelopeKind::Key,
+            SessionRole::Initiator,
             provider,
             applier,
         );
@@ -665,6 +792,7 @@ mod tests {
             Arc::new(alice_t),
             "bob",
             EnvelopeKind::Key,
+            SessionRole::Responder,
             provider,
             applier,
         );
@@ -691,9 +819,13 @@ mod tests {
         }
     }
 
-    /// Round terminates on Deliver (Applied → Complete report).
+    /// Deliver fed directly into a session that never saw a prior
+    /// Diff yields `StalenessSignal::Unknown` — the session's
+    /// `diff_want_count` is `None`, the honest signal is "I don't
+    /// know how stale I am." NOT the same as the prior (pre-long-
+    /// lived) `Unknown` bug; here it's correct.
     #[tokio::test]
-    async fn applied_outcome_maps_to_complete_step() {
+    async fn deliver_without_prior_diff_yields_unknown_staleness() {
         let (alice_t, _bob_t) = alice_bob_transports();
         let provider = Arc::new(StaticProvider {
             state: LocalState::new(),
@@ -708,16 +840,10 @@ mod tests {
             Arc::new(alice_t),
             "bob",
             EnvelopeKind::Key,
+            SessionRole::Initiator,
             provider,
             applier,
         );
-        // Feed an Initiator session: start_round then a Diff back.
-        // Then a Deliver. Because the Session is built fresh per
-        // drive_round_step call (single-shot for this PR), the
-        // diff_want_count from the Diff phase doesn't carry into the
-        // Deliver phase. So Applied here will report Unknown
-        // staleness — that's the v1 limitation; the long-lived
-        // session is the layer-(b)-extension followup.
         let deliver_msg = ReplicationMessage::Deliver(DeliverMessage {
             kind: EnvelopeKind::Key,
             envelopes: vec![b"e1".to_vec()],
@@ -728,11 +854,139 @@ mod tests {
                 assert_eq!(report.kind, EnvelopeKind::Key);
                 assert_eq!(report.admitted, 1);
                 assert_eq!(report.refused, 0);
-                // Single-shot session loses diff_want_count → Unknown.
+                // No prior Diff → diff_want_count is None → honest
+                // Unknown. (Contrast with the full-round path in
+                // `two_coordinators_converge_via_in_memory_transport`
+                // where the long-lived session carries diff_want_count
+                // through and reports InSync.)
                 assert_eq!(report.staleness, StalenessSignal::Unknown);
             }
             o => panic!("expected Complete, got {o:?}"),
         }
+    }
+
+    /// Long-lived Session: driving the full Initiator-side phase
+    /// chain (Summary → recv remote Summary → recv Diff → recv
+    /// Deliver) through a single coordinator yields the correct
+    /// post-Apply staleness — the held session preserves
+    /// `diff_want_count` across the call boundaries.
+    #[tokio::test]
+    async fn long_lived_session_preserves_diff_want_count_across_calls() {
+        let (alice_t, _bob_t) = alice_bob_transports();
+        // Alice has env_1; will learn env_3 + env_4 from "bob"
+        // (synthesized via direct drive_round_step calls).
+        let mut alice_state = LocalState::new();
+        alice_state.insert(EnvelopeKind::Key, h(1), 1);
+        let provider = Arc::new(StaticProvider {
+            state: alice_state,
+            envelopes: HashMap::from([(h(1), b"env_1".to_vec())]),
+        });
+        let applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            admitted_bytes: Vec::new(),
+            known: HashMap::from([(b"env_3".to_vec(), h(3)), (b"env_4".to_vec(), h(4))]),
+            local_hashes: [h(1)].into_iter().collect(),
+        }));
+        let coord = ReplicationCoordinator::new(
+            Arc::new(alice_t),
+            "bob",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        );
+
+        // Phase 1: Initiator starts a round → Summary out.
+        let _ = coord.drive_round_step(None).await.unwrap();
+
+        // Phase 2: Synthesize Bob's Summary (advertising env_3 + env_4)
+        // and feed it. Session computes Diff (want = [h(3), h(4)],
+        // diff_want_count = 2) and stores it.
+        let bob_summary = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![
+                EnvelopeRef {
+                    envelope_hash: h(3),
+                    seq: 3,
+                },
+                EnvelopeRef {
+                    envelope_hash: h(4),
+                    seq: 4,
+                },
+            ],
+        });
+        let step2 = coord.drive_round_step(Some(bob_summary)).await.unwrap();
+        match step2 {
+            DriveStep::SendThenWait(msgs) => {
+                if let ReplicationMessage::Diff(d) = &msgs[0] {
+                    assert_eq!(d.want, vec![h(3), h(4)]);
+                } else {
+                    panic!("expected Diff");
+                }
+            }
+            o => panic!("expected SendThenWait, got {o:?}"),
+        }
+
+        // Phase 3: Synthesize Bob's Diff (asking for env_1) → Deliver out.
+        let bob_diff = ReplicationMessage::Diff(DiffMessage {
+            kind: EnvelopeKind::Key,
+            want: vec![h(1)],
+        });
+        let _ = coord.drive_round_step(Some(bob_diff)).await.unwrap();
+
+        // Phase 4: Synthesize Bob's Deliver (env_3 + env_4).
+        // The session's diff_want_count = 2 from phase 2 is still set;
+        // both envelopes admit; staleness should be InSync.
+        let bob_deliver = ReplicationMessage::Deliver(DeliverMessage {
+            kind: EnvelopeKind::Key,
+            envelopes: vec![b"env_3".to_vec(), b"env_4".to_vec()],
+        });
+        let step4 = coord.drive_round_step(Some(bob_deliver)).await.unwrap();
+        match step4 {
+            DriveStep::Complete(report) => {
+                assert_eq!(report.admitted, 2);
+                assert_eq!(report.refused, 0);
+                assert_eq!(report.staleness, StalenessSignal::InSync);
+            }
+            o => panic!("expected Complete, got {o:?}"),
+        }
+    }
+
+    /// After a round completes, the coordinator auto-resets the
+    /// session so the next call begins a fresh round — the
+    /// scheduler doesn't have to track per-peer "in flight" state.
+    #[tokio::test]
+    async fn round_auto_resets_after_complete() {
+        let (alice_t, _bob_t) = alice_bob_transports();
+        let provider = Arc::new(StaticProvider {
+            state: LocalState::new(),
+            envelopes: HashMap::new(),
+        });
+        let applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            admitted_bytes: Vec::new(),
+            known: HashMap::from([(b"e1".to_vec(), h(1))]),
+            local_hashes: std::collections::HashSet::new(),
+        }));
+        let coord = ReplicationCoordinator::new(
+            Arc::new(alice_t),
+            "bob",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        );
+        // Drive into Applied (degenerate path: Deliver without Diff).
+        let deliver = ReplicationMessage::Deliver(DeliverMessage {
+            kind: EnvelopeKind::Key,
+            envelopes: vec![b"e1".to_vec()],
+        });
+        let step = coord.drive_round_step(Some(deliver)).await.unwrap();
+        assert!(matches!(step, DriveStep::Complete(_)));
+        // After Complete, the session auto-reset; is_complete is false.
+        assert!(!coord.is_round_complete().await);
+        // The next drive_round_step(None) starts a fresh round
+        // (would otherwise be a debug_assert panic if the session
+        // were still mid-round).
+        let _ = coord.drive_round_step(None).await.unwrap();
     }
 
     /// Mismatched-kind inbound message produces `DriveStep::Refused`
@@ -753,6 +1007,7 @@ mod tests {
             Arc::new(alice_t),
             "bob",
             EnvelopeKind::Key, // ← session is for Key
+            SessionRole::Responder,
             provider,
             applier,
         );

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -78,14 +78,26 @@ pub enum ReplicationOutcome {
 }
 
 /// One direction of an anti-entropy round. The caller creates one
-/// session per `(peer, kind)` pair, drives it via `start_round`
+/// session per `(peer, kind, role)` triple, drives it via `start_round`
 /// (initiator) / `on_message` (either role), and reads the
 /// `ReplicationOutcome` to decide what to send next.
-pub struct Session<'a> {
+///
+/// ## Lifetime model
+///
+/// The session is fully **owned** — it carries no borrows. The
+/// [`StateProvider`] and [`StateApplier`] are passed as method
+/// parameters on each call, so a session can live across multiple
+/// calls without lifetime gymnastics. This enables a long-lived
+/// session inside [`super::ReplicationCoordinator`] that preserves
+/// `diff_want_count` across the Diff and Deliver phases — the
+/// documented `Unknown`-staleness gap closes.
+///
+/// After a round completes (`Applied` outcome), call [`Self::reset`]
+/// to clear the per-round state and prepare for the next round with
+/// the same peer.
+pub struct Session {
     role: SessionRole,
     kind: EnvelopeKind,
-    provider: &'a dyn StateProvider,
-    applier: &'a mut dyn StateApplier,
     /// What we sent the peer in our most recent Summary — used to
     /// fulfill their Diff against our state.
     last_summary_sent: Option<SummaryMessage>,
@@ -98,23 +110,20 @@ pub struct Session<'a> {
     /// to get residual missing — works regardless of whether the
     /// Provider sees the Applier's writes, since the count is
     /// already known).
+    ///
+    /// The long-lived session preserves this across the Diff →
+    /// Deliver phase boundary, so [`Self::on_deliver`] computes
+    /// `BoundedBy { missing }` / `InSync` instead of `Unknown`.
     diff_want_count: Option<usize>,
     /// Whether the round has completed from this side's view.
     completed: bool,
 }
 
-impl<'a> Session<'a> {
-    pub fn new(
-        role: SessionRole,
-        kind: EnvelopeKind,
-        provider: &'a dyn StateProvider,
-        applier: &'a mut dyn StateApplier,
-    ) -> Self {
+impl Session {
+    pub fn new(role: SessionRole, kind: EnvelopeKind) -> Self {
         Self {
             role,
             kind,
-            provider,
-            applier,
             last_summary_sent: None,
             last_remote_summary: None,
             diff_want_count: None,
@@ -122,14 +131,32 @@ impl<'a> Session<'a> {
         }
     }
 
+    /// Clear per-round state so the session can drive a new round
+    /// with the same peer. Preserves `role` + `kind`. Idempotent —
+    /// calling on a fresh session is a no-op.
+    pub fn reset(&mut self) {
+        self.last_summary_sent = None;
+        self.last_remote_summary = None;
+        self.diff_want_count = None;
+        self.completed = false;
+    }
+
+    pub fn role(&self) -> SessionRole {
+        self.role
+    }
+
+    pub fn kind(&self) -> EnvelopeKind {
+        self.kind
+    }
+
     /// Start a round. Only valid for [`SessionRole::Initiator`] —
     /// responders wait for an inbound Summary via [`Self::on_message`].
-    pub fn start_round(&mut self) -> ReplicationOutcome {
+    pub fn start_round(&mut self, provider: &dyn StateProvider) -> ReplicationOutcome {
         debug_assert!(
             matches!(self.role, SessionRole::Initiator),
             "start_round() is initiator-only"
         );
-        let refs = self.provider.local_refs(self.kind);
+        let refs = provider.local_refs(self.kind);
         let summary = SummaryMessage {
             kind: self.kind,
             refs,
@@ -146,24 +173,35 @@ impl<'a> Session<'a> {
     ///   also sends our Summary at this point.
     /// - Inbound Diff → Send Deliver (envelopes from our state matching
     ///   their wants).
-    /// - Inbound Deliver → Apply envelopes via StateApplier; mark the
-    ///   round complete from our side.
+    /// - Inbound Deliver → Apply envelopes via [`StateApplier`]; mark
+    ///   the round complete from our side.
     /// - Inbound Fetch → Same as Diff (responder fulfills the request).
-    pub fn on_message(&mut self, msg: ReplicationMessage) -> ReplicationOutcome {
+    pub fn on_message(
+        &mut self,
+        msg: ReplicationMessage,
+        provider: &dyn StateProvider,
+        applier: &mut dyn StateApplier,
+    ) -> ReplicationOutcome {
         match msg {
-            ReplicationMessage::Summary(remote_summary) => self.on_summary(&remote_summary),
-            ReplicationMessage::Diff(diff) => self.on_diff(&diff),
-            ReplicationMessage::Deliver(deliver) => self.on_deliver(&deliver),
-            ReplicationMessage::Fetch(fetch) => self.on_fetch(&fetch),
+            ReplicationMessage::Summary(remote_summary) => {
+                self.on_summary(&remote_summary, provider)
+            }
+            ReplicationMessage::Diff(diff) => self.on_diff(&diff, provider),
+            ReplicationMessage::Deliver(deliver) => self.on_deliver(&deliver, applier),
+            ReplicationMessage::Fetch(fetch) => self.on_fetch(&fetch, provider),
         }
     }
 
-    fn on_summary(&mut self, remote: &SummaryMessage) -> ReplicationOutcome {
+    fn on_summary(
+        &mut self,
+        remote: &SummaryMessage,
+        provider: &dyn StateProvider,
+    ) -> ReplicationOutcome {
         if remote.kind != self.kind {
             return ReplicationOutcome::UnexpectedMessage;
         }
         self.last_remote_summary = Some(remote.clone());
-        let local = self.provider.local_refs(self.kind);
+        let local = provider.local_refs(self.kind);
         let want = diff_refs(&local, &remote.refs);
         let mut outbound = Vec::new();
         // Responder ALSO needs to send its Summary so the
@@ -172,7 +210,7 @@ impl<'a> Session<'a> {
         // (matching the initiator's sequence). For initiators, we
         // already sent our Summary in start_round; skip resending.
         if matches!(self.role, SessionRole::Responder) && self.last_summary_sent.is_none() {
-            let my_refs = self.provider.local_refs(self.kind);
+            let my_refs = provider.local_refs(self.kind);
             let my_summary = SummaryMessage {
                 kind: self.kind,
                 refs: my_refs,
@@ -188,14 +226,14 @@ impl<'a> Session<'a> {
         ReplicationOutcome::Send(outbound)
     }
 
-    fn on_diff(&mut self, diff: &DiffMessage) -> ReplicationOutcome {
+    fn on_diff(&mut self, diff: &DiffMessage, provider: &dyn StateProvider) -> ReplicationOutcome {
         if diff.kind != self.kind {
             return ReplicationOutcome::UnexpectedMessage;
         }
         let envelopes: Vec<Vec<u8>> = diff
             .want
             .iter()
-            .filter_map(|h| self.provider.fetch_envelope(self.kind, h))
+            .filter_map(|h| provider.fetch_envelope(self.kind, h))
             .collect();
         ReplicationOutcome::Send(vec![ReplicationMessage::Deliver(DeliverMessage {
             kind: self.kind,
@@ -203,23 +241,34 @@ impl<'a> Session<'a> {
         })])
     }
 
-    fn on_fetch(&mut self, fetch: &FetchMessage) -> ReplicationOutcome {
+    fn on_fetch(
+        &mut self,
+        fetch: &FetchMessage,
+        provider: &dyn StateProvider,
+    ) -> ReplicationOutcome {
         // Fetch is structurally identical to Diff on the responder
         // side — both ask "give me these specific envelopes."
-        self.on_diff(&DiffMessage {
-            kind: fetch.kind,
-            want: fetch.want.clone(),
-        })
+        self.on_diff(
+            &DiffMessage {
+                kind: fetch.kind,
+                want: fetch.want.clone(),
+            },
+            provider,
+        )
     }
 
-    fn on_deliver(&mut self, deliver: &DeliverMessage) -> ReplicationOutcome {
+    fn on_deliver(
+        &mut self,
+        deliver: &DeliverMessage,
+        applier: &mut dyn StateApplier,
+    ) -> ReplicationOutcome {
         if deliver.kind != self.kind {
             return ReplicationOutcome::UnexpectedMessage;
         }
         let mut admitted = 0usize;
         let mut refused = 0usize;
         for env_bytes in &deliver.envelopes {
-            if self.applier.apply_envelope(self.kind, env_bytes) {
+            if applier.apply_envelope(self.kind, env_bytes) {
                 admitted += 1;
             } else {
                 refused += 1;
@@ -355,21 +404,11 @@ mod tests {
         let mut a_applier = applier_for(&[(h(3), b"env_3".to_vec()), (h(4), b"env_4".to_vec())]);
         let mut b_applier = applier_for(&[(h(1), b"env_1".to_vec()), (h(2), b"env_2".to_vec())]);
 
-        let mut alice = Session::new(
-            SessionRole::Initiator,
-            EnvelopeKind::Key,
-            &a_provider,
-            &mut a_applier,
-        );
-        let mut bob = Session::new(
-            SessionRole::Responder,
-            EnvelopeKind::Key,
-            &b_provider,
-            &mut b_applier,
-        );
+        let mut alice = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
+        let mut bob = Session::new(SessionRole::Responder, EnvelopeKind::Key);
 
         // 1. Alice starts → sends Summary.
-        let alice_step1 = alice.start_round();
+        let alice_step1 = alice.start_round(&a_provider);
         let alice_summary = match alice_step1 {
             ReplicationOutcome::Send(ref msgs) => {
                 assert_eq!(msgs.len(), 1);
@@ -379,7 +418,7 @@ mod tests {
         };
 
         // 2. Bob receives Alice's Summary → emits {Summary, Diff}.
-        let bob_step1 = bob.on_message(alice_summary);
+        let bob_step1 = bob.on_message(alice_summary, &b_provider, &mut b_applier);
         let (bob_summary, bob_diff) = match bob_step1 {
             ReplicationOutcome::Send(ref msgs) => {
                 assert_eq!(msgs.len(), 2);
@@ -390,7 +429,7 @@ mod tests {
 
         // 3. Alice receives Bob's Summary → emits Diff. (Then
         //    receives Bob's Diff → emits Deliver.)
-        let alice_step2 = alice.on_message(bob_summary);
+        let alice_step2 = alice.on_message(bob_summary, &a_provider, &mut a_applier);
         let alice_diff = match alice_step2 {
             ReplicationOutcome::Send(ref msgs) => {
                 assert_eq!(msgs.len(), 1);
@@ -400,7 +439,7 @@ mod tests {
         };
 
         // 4. Bob receives Alice's Diff → emits Deliver(env_1, env_2).
-        let bob_step2 = bob.on_message(alice_diff);
+        let bob_step2 = bob.on_message(alice_diff, &b_provider, &mut b_applier);
         let bob_deliver = match bob_step2 {
             ReplicationOutcome::Send(ref msgs) => {
                 assert_eq!(msgs.len(), 1);
@@ -410,7 +449,7 @@ mod tests {
         };
 
         // 5. Alice receives Bob's Diff → emits Deliver(env_3, env_4).
-        let alice_step3 = alice.on_message(bob_diff);
+        let alice_step3 = alice.on_message(bob_diff, &a_provider, &mut a_applier);
         let alice_deliver = match alice_step3 {
             ReplicationOutcome::Send(ref msgs) => {
                 assert_eq!(msgs.len(), 1);
@@ -420,7 +459,7 @@ mod tests {
         };
 
         // 6. Alice applies Bob's Deliver → admitted env_3 + env_4.
-        let alice_final = alice.on_message(bob_deliver);
+        let alice_final = alice.on_message(bob_deliver, &a_provider, &mut a_applier);
         match alice_final {
             ReplicationOutcome::Applied {
                 admitted,
@@ -436,7 +475,7 @@ mod tests {
         }
 
         // 7. Bob applies Alice's Deliver → admitted env_1 + env_2.
-        let bob_final = bob.on_message(alice_deliver);
+        let bob_final = bob.on_message(alice_deliver, &b_provider, &mut b_applier);
         match bob_final {
             ReplicationOutcome::Applied {
                 admitted,
@@ -478,45 +517,36 @@ mod tests {
         let mut a_applier = applier_for(&[(h(4), b"e4".to_vec())]);
         let mut b_applier = applier_for(&[(h(1), b"e1".to_vec())]);
 
-        let mut alice = Session::new(
-            SessionRole::Initiator,
-            EnvelopeKind::Attestation,
-            &a_provider,
-            &mut a_applier,
-        );
-        let mut bob = Session::new(
-            SessionRole::Responder,
-            EnvelopeKind::Attestation,
-            &b_provider,
-            &mut b_applier,
-        );
+        let mut alice = Session::new(SessionRole::Initiator, EnvelopeKind::Attestation);
+        let mut bob = Session::new(SessionRole::Responder, EnvelopeKind::Attestation);
 
         // Mechanical round-drive (same as full_sync above).
-        let m_alice_summary = match alice.start_round() {
+        let m_alice_summary = match alice.start_round(&a_provider) {
             ReplicationOutcome::Send(m) => m[0].clone(),
             _ => panic!(),
         };
-        let (m_bob_summary, m_bob_diff) = match bob.on_message(m_alice_summary) {
-            ReplicationOutcome::Send(m) => (m[0].clone(), m[1].clone()),
-            _ => panic!(),
-        };
-        let m_alice_diff = match alice.on_message(m_bob_summary) {
+        let (m_bob_summary, m_bob_diff) =
+            match bob.on_message(m_alice_summary, &b_provider, &mut b_applier) {
+                ReplicationOutcome::Send(m) => (m[0].clone(), m[1].clone()),
+                _ => panic!(),
+            };
+        let m_alice_diff = match alice.on_message(m_bob_summary, &a_provider, &mut a_applier) {
             ReplicationOutcome::Send(m) => m[0].clone(),
             _ => panic!(),
         };
-        let m_bob_deliver = match bob.on_message(m_alice_diff) {
+        let m_bob_deliver = match bob.on_message(m_alice_diff, &b_provider, &mut b_applier) {
             ReplicationOutcome::Send(m) => m[0].clone(),
             _ => panic!(),
         };
-        let m_alice_deliver = match alice.on_message(m_bob_diff) {
+        let m_alice_deliver = match alice.on_message(m_bob_diff, &a_provider, &mut a_applier) {
             ReplicationOutcome::Send(m) => m[0].clone(),
             _ => panic!(),
         };
-        match alice.on_message(m_bob_deliver) {
+        match alice.on_message(m_bob_deliver, &a_provider, &mut a_applier) {
             ReplicationOutcome::Applied { admitted, .. } => assert_eq!(admitted, 1),
             o => panic!("unexpected: {o:?}"),
         }
-        match bob.on_message(m_alice_deliver) {
+        match bob.on_message(m_alice_deliver, &b_provider, &mut b_applier) {
             ReplicationOutcome::Applied { admitted, .. } => assert_eq!(admitted, 1),
             o => panic!("unexpected: {o:?}"),
         }
@@ -537,35 +567,26 @@ mod tests {
         let mut a_applier = applier_for(&[]);
         let mut b_applier = applier_for(&[]);
 
-        let mut alice = Session::new(
-            SessionRole::Initiator,
-            EnvelopeKind::Key,
-            &a_provider,
-            &mut a_applier,
-        );
-        let mut bob = Session::new(
-            SessionRole::Responder,
-            EnvelopeKind::Key,
-            &b_provider,
-            &mut b_applier,
-        );
+        let mut alice = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
+        let mut bob = Session::new(SessionRole::Responder, EnvelopeKind::Key);
 
         // Drive round.
-        let alice_summary = match alice.start_round() {
+        let alice_summary = match alice.start_round(&a_provider) {
             ReplicationOutcome::Send(m) => m[0].clone(),
             _ => panic!(),
         };
-        let (bob_summary_resp, bob_diff_msg) = match bob.on_message(alice_summary) {
-            ReplicationOutcome::Send(m) => (m[0].clone(), m[1].clone()),
-            _ => panic!(),
-        };
-        let alice_diff_msg = match alice.on_message(bob_summary_resp) {
+        let (bob_summary_resp, bob_diff_msg) =
+            match bob.on_message(alice_summary, &b_provider, &mut b_applier) {
+                ReplicationOutcome::Send(m) => (m[0].clone(), m[1].clone()),
+                _ => panic!(),
+            };
+        let alice_diff_msg = match alice.on_message(bob_summary_resp, &a_provider, &mut a_applier) {
             ReplicationOutcome::Send(m) => m[0].clone(),
             _ => panic!(),
         };
         // Bob's Deliver from Alice's Diff should be empty (Alice has
         // everything Bob has).
-        let bob_deliver_msg = match bob.on_message(alice_diff_msg) {
+        let bob_deliver_msg = match bob.on_message(alice_diff_msg, &b_provider, &mut b_applier) {
             ReplicationOutcome::Send(m) => m[0].clone(),
             _ => panic!(),
         };
@@ -573,7 +594,7 @@ mod tests {
             assert!(d.envelopes.is_empty(), "bob should deliver nothing");
         }
         // Same for Alice's Deliver from Bob's Diff.
-        let alice_deliver_msg = match alice.on_message(bob_diff_msg) {
+        let alice_deliver_msg = match alice.on_message(bob_diff_msg, &a_provider, &mut a_applier) {
             ReplicationOutcome::Send(m) => m[0].clone(),
             _ => panic!(),
         };
@@ -581,7 +602,7 @@ mod tests {
             assert!(d.envelopes.is_empty(), "alice should deliver nothing");
         }
         // Applied with 0 admitted, InSync staleness.
-        match alice.on_message(bob_deliver_msg) {
+        match alice.on_message(bob_deliver_msg, &a_provider, &mut a_applier) {
             ReplicationOutcome::Applied {
                 admitted,
                 staleness,
@@ -600,16 +621,15 @@ mod tests {
     fn mismatched_kind_refused() {
         let provider = provider_with(&[]);
         let mut applier = applier_for(&[]);
-        let mut s = Session::new(
-            SessionRole::Responder,
-            EnvelopeKind::Key,
+        let mut s = Session::new(SessionRole::Responder, EnvelopeKind::Key);
+        let r = s.on_message(
+            ReplicationMessage::Diff(DiffMessage {
+                kind: EnvelopeKind::Revocation, // ← wrong kind for this session
+                want: vec![],
+            }),
             &provider,
             &mut applier,
         );
-        let r = s.on_message(ReplicationMessage::Diff(DiffMessage {
-            kind: EnvelopeKind::Revocation, // ← wrong kind for this session
-            want: vec![],
-        }));
         assert_eq!(r, ReplicationOutcome::UnexpectedMessage);
     }
 
@@ -623,16 +643,15 @@ mod tests {
             (EnvelopeKind::Attestation, h(2), b"e2".to_vec(), 2),
         ]);
         let mut applier = applier_for(&[]);
-        let mut s = Session::new(
-            SessionRole::Responder,
-            EnvelopeKind::Attestation,
+        let mut s = Session::new(SessionRole::Responder, EnvelopeKind::Attestation);
+        let r = s.on_message(
+            ReplicationMessage::Fetch(FetchMessage {
+                kind: EnvelopeKind::Attestation,
+                want: vec![h(1), h(99)], // h(99) doesn't exist
+            }),
             &provider,
             &mut applier,
         );
-        let r = s.on_message(ReplicationMessage::Fetch(FetchMessage {
-            kind: EnvelopeKind::Attestation,
-            want: vec![h(1), h(99)], // h(99) doesn't exist
-        }));
         match r {
             ReplicationOutcome::Send(msgs) => {
                 assert_eq!(msgs.len(), 1);
@@ -657,12 +676,7 @@ mod tests {
         // refused).
         let a_provider = provider_with(&[]);
         let mut a_applier = applier_for(&[(h(1), b"e1".to_vec())]);
-        let mut alice = Session::new(
-            SessionRole::Initiator,
-            EnvelopeKind::Key,
-            &a_provider,
-            &mut a_applier,
-        );
+        let mut alice = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
         // Skip the wire dance — drive on_message directly.
         let bob_summary = ReplicationMessage::Summary(SummaryMessage {
             kind: EnvelopeKind::Key,
@@ -681,8 +695,8 @@ mod tests {
                 },
             ],
         });
-        alice.start_round();
-        let _ = alice.on_message(bob_summary);
+        alice.start_round(&a_provider);
+        let _ = alice.on_message(bob_summary, &a_provider, &mut a_applier);
         let bob_deliver = ReplicationMessage::Deliver(DeliverMessage {
             kind: EnvelopeKind::Key,
             envelopes: vec![
@@ -691,7 +705,7 @@ mod tests {
                 b"unknown_e3".to_vec(),
             ],
         });
-        match alice.on_message(bob_deliver) {
+        match alice.on_message(bob_deliver, &a_provider, &mut a_applier) {
             ReplicationOutcome::Applied {
                 admitted,
                 refused,


### PR DESCRIPTION
## Summary

Closes the `Unknown`-staleness limitation called out in the prior
coordinator PR (#70): the `Session` was constructed FRESH on every
`drive_round_step` call, so `diff_want_count` recorded during the Diff
phase was lost before the Deliver phase observed it.

The Session is now long-lived inside the coordinator (`Mutex<Session>`
held for the coordinator's lifetime), so the state machine's
`last_summary_sent` + `last_remote_summary` + `diff_want_count` all
carry across phase boundaries. Post-Apply `StalenessSignal` computes
correctly (`InSync` / `BoundedBy { missing }` / honest `Unknown`).

### Shape of the change

- `Session<'a>` → `Session` (no lifetime). Provider + applier moved
  from struct fields (with borrows) to method parameters on
  `start_round` and `on_message`. Session is fully owned, Send-safe.
- Coordinator takes `role: SessionRole` at construction (was inferred
  per-call from `msg.is_none()` — broken for initiators receiving
  messages after their Summary out). Each (peer, kind, role) triple
  gets one coordinator.
- After `DriveStep::Complete`, the coordinator auto-resets the
  session so the next call starts a fresh round without caller
  bookkeeping.

### API additions

- `Session::new(role, kind)`, `Session::reset()`, `Session::role() / kind()`
- `ReplicationCoordinator::new(..., role, ...)` (new role parameter)
- `ReplicationCoordinator::is_round_complete() / role() / kind() / peer_key_id()`

### Tests

46 → 48 replication tests:

- `two_coordinators_converge_via_in_memory_transport` rewritten to
  drive the FULL end-to-end round across both peers (was truncated
  in #70 at \"the rest needs a stateful long-lived session, deferred\").
  Asserts both sides Apply with `StalenessSignal::InSync`.
- `long_lived_session_preserves_diff_want_count_across_calls` — direct
  test of the refactor's invariant: drives an Initiator through
  Summary → recv Bob's Summary → recv Bob's Diff → recv Bob's Deliver,
  asserts InSync staleness. This test could not exist before this PR.
- `round_auto_resets_after_complete` — post-Complete reset works.
- `deliver_without_prior_diff_yields_unknown_staleness` (renamed) —
  Unknown is the HONEST signal when no prior Diff happened.

### Out of scope (still pending for #65)

- Layer (c-2) production wiring (FederationDirectory blanket impl +
  cohort callback + hash→bytes cache + PyO3 init path).
- Scheduler glue (\`tokio::time::interval\` per (peer, kind) pair).
- End-to-end across a live ReticulumTransport.

## Test plan

- [x] \`cargo check\` clean across all 4 CI feature combos under -D warnings
- [x] \`cargo clippy --all-targets\` clean on both CI clippy combos
  (\`transport-http transport-reticulum pyo3\` ± \`ffi-uniffi\`)
- [x] \`cargo fmt --check\` clean
- [x] 209 lib tests pass (was 207; +2 long-lived-session tests)
- [ ] CI green on the PR

The replication ladder for #65 now stands at: protocol (#69) →
coordinator (#70) → directory trait + adapters (#71) → wire-frame
prefix (#72) → long-lived session (this PR). Production wiring +
scheduler glue remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)