### PR TITLE
replication: v1 wire format lock — FSD + 9-variant EnvelopeKind + WIRE_PROTOCOL_VERSION (partial #65)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,20 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
+  # ── Crates.io index resilience ──
+  # Default `CARGO_NET_RETRY` is 3, which has surfaced as a flake
+  # surface on macOS PyO3 cross-compile lanes (the iOS PyO3 sim job on
+  # PR #76 hit "no matching package named `heck` found" — the
+  # non-sim iOS PyO3 lane pulled the identical dep and succeeded
+  # within the same run). Bumping to 10 catches the long-tail of
+  # transient `index.crates.io` resolution flakes without changing
+  # behavior on the happy path. Per cargo-cooldown's
+  # COOLDOWN_HTTP_RETRIES precedent (default 2, max 8 — we go one
+  # above for stateless CI). Cross-process retry (via
+  # nick-fields/retry@v3) wraps the historically-flake-prone
+  # cargo invocations in the iOS / Android cross-compile lanes —
+  # see the matching steps below for the per-step retry policy.
+  CARGO_NET_RETRY: "10"
 
 jobs:
   # ─── linux-x86_64 — feature-combo gauntlet ──────────────────────────
@@ -263,11 +277,22 @@ jobs:
       # UniFFI/JNI) take this artifact; the Chaquopy variant below is
       # for the Python-agent cohabitation case.
       - name: cargo ndk build (${{ matrix.abi }} — plain, no PyO3)
+        # Cross-process retry via nick-fields/retry@v3 — catches
+        # transient `index.crates.io` resolution flakes the in-process
+        # CARGO_NET_RETRY=10 can't (e.g. when cargo gives up but a
+        # fresh process succeeds, which we observed on PR #76's iOS
+        # PyO3 sim lane). 3 attempts × 20 min each = worst-case 60 min
+        # wall-clock, but typical case is 1 attempt at ~5 min. Same
+        # rationale documented at the workflow `env:` block.
+        uses: nick-fields/retry@v3
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
-        run: >-
-          cargo ndk -t ${{ matrix.abi }} build --release
-          --features "$MOBILE_BASE_FEATURES"
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: >-
+            cargo ndk -t ${{ matrix.abi }} build --release
+            --features "$MOBILE_BASE_FEATURES"
       - name: save plain .so
         run: |
           mkdir -p dist/${{ matrix.abi }}
@@ -313,12 +338,17 @@ jobs:
           file "${STUB_DIR}/libpython3.10.so"
 
       - name: cargo ndk build (${{ matrix.abi }} — PyO3 Chaquopy abi3)
+        # Cross-process retry — see plain-build step for rationale.
+        uses: nick-fields/retry@v3
         env:
           ANDROID_NDK_HOME: ${{ steps.setup-ndk.outputs.ndk-path }}
           RUSTFLAGS: "-L ${{ runner.temp }}/python-stub -C link-arg=-Wl,--no-as-needed -C link-arg=-lpython3.10"
-        run: >-
-          cargo ndk -t ${{ matrix.abi }} build --release --lib
-          --features "$MOBILE_PYO3_FEATURES"
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: >-
+            cargo ndk -t ${{ matrix.abi }} build --release --lib
+            --features "$MOBILE_PYO3_FEATURES"
 
       - name: verify DT_NEEDED includes libpython3.10.so
         # AV-NN: the whole point of the stub-link dance is the
@@ -541,17 +571,24 @@ jobs:
         # cohabitation wire (MISSION §1.4). No PyO3 here (see job
         # docblock above for the rationale); no transport-http
         # (cloud fallback, not mobile).
-        run: |
-          # v0.7.1 — `--lib` so the bin target (`emit_edge_extras`,
-          # used only by the build-manifest emitter on the host) isn't
-          # also linked under this RUSTFLAGS. The `-install_name` flag
-          # is `-dynamiclib`-only; applying it to the bin target's
-          # `cc` invocation fails with `invalid argument` because the
-          # bin links as an executable, not a dylib. Verify's lane
-          # doesn't hit this because its repo has no `[[bin]]`.
-          RUSTFLAGS="-C link-arg=-install_name -C link-arg=@rpath/CIRISEdge.framework/CIRISEdge" \
-            cargo build --release --target ${{ matrix.target }} --lib \
-              --features "transport-reticulum"
+        #
+        # v0.7.1 — `--lib` so the bin target (`emit_edge_extras`,
+        # used only by the build-manifest emitter on the host) isn't
+        # also linked under this RUSTFLAGS. The `-install_name` flag
+        # is `-dynamiclib`-only; applying it to the bin target's
+        # `cc` invocation fails with `invalid argument`.
+        #
+        # Cross-process retry via nick-fields/retry@v3 — see Android
+        # lanes for rationale.
+        uses: nick-fields/retry@v3
+        env:
+          RUSTFLAGS: "-C link-arg=-install_name -C link-arg=@rpath/CIRISEdge.framework/CIRISEdge"
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: >-
+            cargo build --release --target ${{ matrix.target }} --lib
+            --features "transport-reticulum"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -772,18 +809,30 @@ jobs:
           echo "✓ Python-Apple-support ${PYTHON_IOS_VER}-${PYTHON_IOS_BUILD} staged for ${{ matrix.target }}"
           ls -la "$STAGE_DIR/"
       - name: cargo build (ios PyO3 — ${{ matrix.target }})
+        # Direct `cargo build` — NOT `maturin build`. Maturin 1.13's
+        # platform check rejects darwin→iOS cross-compile; persist
+        # documented this in v2.0.4 and the constraint persists.
+        #
+        # Cross-process retry via nick-fields/retry@v3 — this is the
+        # lane that observably flaked on PR #76 (`heck` not found in
+        # crates.io index on this specific runner; non-sim iOS PyO3
+        # pulled the same dep and succeeded). Per the env-block
+        # rationale: CARGO_NET_RETRY=10 covers in-process retries;
+        # this wrapper covers the case where cargo gives up but a
+        # fresh process succeeds.
+        uses: nick-fields/retry@v3
         env:
           PYO3_CROSS: "1"
           PYO3_CROSS_PYTHON_VERSION: "3.10"
           PYO3_CROSS_LIB_DIR: ${{ steps.python-ios.outputs.lib_dir }}
-        # Direct `cargo build` — NOT `maturin build`. Maturin 1.13's
-        # platform check rejects darwin→iOS cross-compile; persist
-        # documented this in v2.0.4 and the constraint persists.
-        run: >-
-          cargo build --release
-          --target ${{ matrix.target }}
-          --lib
-          --features "$IOS_PYO3_FEATURES"
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          command: >-
+            cargo build --release
+            --target ${{ matrix.target }}
+            --lib
+            --features "$IOS_PYO3_FEATURES"
       - name: strip + rename + install_name fix
         # Mach-O rename: libciris_edge.dylib → ciris_edge.abi3.so
         # (Python extension naming convention). install_name_tool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1569,38 +1569,36 @@ jobs:
   # workflow — see that repo's README for adding new cases.
   # ─── extract-substrate-pins: Cargo.toml → JSON pin-overrides ────────
   #
-  # Reads edge's actual Cargo.toml pin for ciris-persist and emits a
-  # JSON object that the cohabitation gate feeds into the harness's
-  # `pin-overrides` input.
+  # Reads edge's actual Cargo.toml pins for ciris-persist (Python wheel)
+  # and ciris-keyring (= ciris-verify Python wheel — both come from
+  # CIRISVerify at the same tag) and emits a JSON object that the
+  # cohabitation gate feeds into the harness's `pin-overrides` input.
   #
   # This eliminates the substrate-currency race: edge's own Cargo pin
   # IS the cohabitation contract. The conformance matrix becomes
   # documentation-of-record + nightly drift gate, but is no longer on
-  # the critical path of an edge release. Before this job existed, we
-  # had to force-push a conformance matrix bump in lockstep with every
-  # edge tag (v1.1.9 / v1.1.10 / v1.1.11 / v1.1.12 all hit it).
+  # the critical path of an edge release.
   #
-  # ## Why ciris-verify is NOT pinned here
+  # ## History — why this job briefly stopped emitting ciris-verify
   #
-  # Earlier versions of this job ALSO emitted `ciris-verify==<tag>`,
-  # extracted from edge's ciris-keyring/ciris-crypto Cargo tag. That
-  # was wrong: the Cargo tag is the **Rust-internal** verify crate
-  # (compiled into edge's + persist's cdylib symbol tables), while
-  # the Python `ciris-verify` wheel is a **separate** cdylib at a
-  # **separate** process boundary. Neither edge nor persist (via
-  # PyCapsule cohabitation) imports the Python ciris-verify wheel —
-  # they use Rust-internal cohabitation through their compiled cdylibs.
+  # During the v1.4.0/v1.4.1 cycle, persist v4.8.0's pyproject still
+  # pinned `ciris-verify<5,>=4.4.2` while edge's Cargo pin moved to
+  # ciris-keyring/crypto v5.0.0. Forcing the Python `ciris-verify==5.0.0`
+  # alongside persist 4.8.0 was unresolvable (the Python pin ceiling
+  # and the Cargo pin ceiling diverged). This job temporarily stopped
+  # emitting the ciris-verify override; the v1.4.1 release notes
+  # documented the workaround.
   #
-  # The two pins can legitimately diverge. The v1.4.0 cycle hit
-  # ResolutionImpossible because edge's Cargo pin was v5.0.0 but
-  # persist v4.8.0's PUBLISHED pyproject pins `ciris-verify<5,>=4.4.2`
-  # — forcing the Python wheel to v5.0.0 alongside persist 4.8.0
-  # was unresolvable, even though the Cargo cohabitation worked fine.
+  # **Persist v4.10.0 closes the divergence** — its pyproject bumps
+  # `ciris-verify` to `>=5.0.0,<6` (matching the Rust pin). The
+  # conformance matrix can now install `ciris-verify==5.0.0` alongside
+  # `ciris-persist==4.10.0` without conflict, so this job re-enables
+  # the ciris-verify pin-override extraction.
   #
-  # The fix: let persist's pyproject resolve the Python ciris-verify
-  # wheel transitively. The Cargo-side cohabitation is asserted
-  # independently by edge's wheel-build CI job (which uses the
-  # Cargo pin directly + the cargo deny / clippy gates).
+  # Going forward, if persist's pyproject ciris-verify ceiling lags
+  # again, this job will need to either skip the ciris-verify override
+  # (the v1.4.0 workaround) or persist needs to coordinate the pyproject
+  # bump with its own Cargo bump.
   extract-substrate-pins:
     name: extract substrate pins from Cargo.toml
     runs-on: ubuntu-latest
@@ -1619,16 +1617,12 @@ jobs:
                   raise SystemExit(f'no tag found for {crate} in Cargo.toml')
               return m.group(1)
           persist = find_tag('ciris-persist')
-          # Verify the Cargo-side keyring/crypto pair shares a tag —
-          # they MUST come from CIRISVerify at the same release. The
-          # tag itself is NOT emitted as a Python-side pin-override
-          # (see job docstring); this assertion is purely a sanity
-          # check on edge's own Cargo.toml shape.
           keyring = find_tag('ciris-keyring')
           crypto  = find_tag('ciris-crypto')
           assert keyring == crypto, f'ciris-keyring ({keyring}) and ciris-crypto ({crypto}) must share a tag — both come from CIRISVerify'
           pins = {
               'ciris-persist': f'ciris-persist=={persist}',
+              'ciris-verify':  f'ciris-verify=={keyring}',
           }
           print(f'json={json.dumps(pins)}')
           PYEOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,55 @@ env:
   RUSTFLAGS: -D warnings
 
 jobs:
-  # ─── linux-x86_64 — full features (transport-http + pyo3) ──────────
+  # ─── linux-x86_64 — feature-combo gauntlet ──────────────────────────
   # Mission alignment: the lens cutover (Phase 1) consumes edge from
-  # Python via the pyo3 feature; this job covers that path.
+  # Python via the pyo3 feature; the `pyo3-full` matrix entry covers
+  # that path. The other entries are the lane-isolation gauntlet.
+  #
+  # ## Feature-combo matrix (per persist's `linux-x86_64-test`
+  # substrate-matrix precedent — CIRISPersist v2.0.1)
+  #
+  # Edge's optional features compose orthogonally — a regression in
+  # one transport lane can hide behind another lane being enabled.
+  # Before this matrix, a single full-features invocation masked
+  # `cfg(feature = "transport-reticulum")` breakage that the
+  # `transport-http`-only build would surface immediately. The
+  # matrix catches lane-isolation regressions at PR time, not at
+  # downstream consumer integration.
+  #
+  # Entries:
+  #   - core: minimal — just `transport-http`. Catches any module
+  #     that accidentally requires reticulum / packet-radio / pyo3
+  #     to compile.
+  #   - reticulum: canonical wire (MISSION §1.4). Builds the
+  #     Leviculum-backed stack standalone.
+  #   - packet-radio: CIRISEdge#53 N2 transport. Newer + less
+  #     battle-tested; first-class gauntlet entry.
+  #   - all-transports: all three lanes together. Catches feature-
+  #     interaction breakage.
+  #   - pyo3-full: the wheel-build canonical (transport-http +
+  #     transport-reticulum + pyo3). Runs `cargo test --all-targets`
+  #     so lib tests + integration tests + doctests all exercise.
+  #
+  # `fail-fast: false` so a regression in one entry doesn't mask
+  # regressions in others. Wall-clock = slowest single entry (not
+  # the sum) because matrix entries run in parallel — adopted from
+  # persist's substrate matrix precedent. Web-search-validated
+  # against `cargo-feature-combinations` (the Rust-community
+  # canonical pattern) + `doc.rust-lang.org/cargo/guide/continuous-
+  # integration.html`. Source citations live in the PR description.
   linux-x86_64-test:
-    name: linux-x86_64 (full features)
+    name: linux-x86_64 (${{ matrix.combo.name }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        combo:
+          - { name: core,           features: "transport-http" }
+          - { name: reticulum,      features: "transport-reticulum" }
+          - { name: packet-radio,   features: "transport-packet-radio" }
+          - { name: all-transports, features: "transport-http transport-reticulum transport-packet-radio" }
+          - { name: pyo3-full,      features: "transport-http transport-reticulum pyo3", all_targets: "true" }
     steps:
       - uses: actions/checkout@v4
       # ciris-keyring's `tpm` feature (auto-enabled for Linux targets
@@ -37,11 +80,23 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: cargo test (transport-http + transport-reticulum + pyo3)
-        # transport-reticulum included so the Leviculum-backed Reticulum
-        # transport + the reticulum_loopback acceptance test are exercised
-        # in CI — "full features" must mean all of them (CIRISEdge#14).
-        run: cargo test --features "transport-http transport-reticulum pyo3" --all-targets
+        with:
+          # Per-combo cache key so each matrix entry gets its own
+          # target dir (different feature sets compile to different
+          # artifacts; sharing the cache would cause recompile thrash).
+          key: ${{ matrix.combo.name }}
+      - name: cargo test --features "${{ matrix.combo.features }}"
+        # pyo3-full runs --all-targets to exercise the integration
+        # test suite (transport_http_hardening, reticulum_loopback,
+        # https_per_messagetype_roundtrip, etc.); the transport-lane
+        # entries run --lib only because the integration suites need
+        # the full pyo3 + http stack to link.
+        run: |
+          if [ "${{ matrix.combo.all_targets }}" = "true" ]; then
+            cargo test --features "${{ matrix.combo.features }}" --all-targets
+          else
+            cargo test --features "${{ matrix.combo.features }}" --lib
+          fi
 
   # ─── darwin-aarch64 — Phase 1 macOS dev path ────────────────────────
   # No pyo3 feature here per persist's matrix precedent — the abi3 wheel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1058,8 +1058,18 @@ jobs:
         # All three feature-gates so EVERY bench file compiles in
         # this gate — the feature-gated benches (transport-reticulum,
         # transport-http, pyo3) cannot bit-rot silently.
-        run: |
-          cargo bench --no-run --features "transport-http transport-reticulum pyo3"
+        #
+        # Cross-process retry — same rationale as the iOS/Android
+        # cross-compile lanes. PR #76 observed the `heck` index flake
+        # hitting this lane too (CARGO_NET_RETRY=10 alone wasn't
+        # enough when crates.io has a sustained regional sync hiccup;
+        # a fresh process attempt after a delay clears the cached
+        # negative resolution).
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          command: cargo bench --no-run --features "transport-http transport-reticulum pyo3"
 
   # ─── pyo3-wheel: maturin abi3-py310 wheels ──────────────────────────
   #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v4.9.0", version = "4", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v4.10.0", version = "4", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -811,7 +811,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v4.9.0", version = "4", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v4.10.0", version = "4", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/FSD/REPLICATION_WIRE_FORMAT_V1.md
+++ b/FSD/REPLICATION_WIRE_FORMAT_V1.md
@@ -1,0 +1,385 @@
+# FSD: Replication Wire Format v1 — anti-entropy gossip for federation envelopes
+
+**Status:** Proposed — lands as part of CIRISEdge#65 layer (c-2) production wiring
+**Author:** Eric Moore (CIRIS Team) with Claude Opus 4.7
+**Created:** 2026-06-09
+**Repo:** `~/CIRISEdge` (this document is the spec; code lands in this repo)
+**Anchors:** Path to CIRIS 2.0 — this wire format is the **first version-stable
+contract** for cross-region anti-entropy gossip. Every replication round shipped
+from v1.5.0 forward speaks this wire; protocol breakages going forward bump
+`WIRE_PROTOCOL_VERSION`.
+**Risk:** Wire-stable. Mistakes bake in at the protocol-version level and cost
+a fleet-wide rolling-upgrade tolerance window to escape. Hence: ratify before
+shipping; expand the kind taxonomy now to match persist's surface 1:1.
+
+**Companion documents:**
+- [`CIRIS_EDGE.md`](CIRIS_EDGE.md) — overall edge mission
+- [`../MISSION.md`](../MISSION.md) §3 (canonicalization isn't edge's to define)
+- [`CIRISRegistry#58`](https://github.com/CIRISAI/CIRISRegistry/issues/58) — "remove Spock" epic ("Edge owns propagation")
+- [`CIRISPersist src/federation/types.rs`](https://github.com/CIRISAI/CIRISPersist/blob/main/src/federation/types.rs) — record shapes
+- CEG 0.15 §0.9 canonicalization rules + §0.9.2.1 determinism rules
+
+---
+
+## 1. Why this exists
+
+Cross-region convergence in the CIRIS federation today is split:
+
+- **Trust data** (keys / attestations / revocations / families /
+  communities / identity_occurrences) — replicated CEG-natively via
+  point-to-point signed envelopes. Eventual consistency depends on
+  every region eventually sending to every other.
+- **Cross-region DB state** — replicated via Postgres Spock multi-
+  master, which trusts the DB layer. A compromised node's injected
+  rows replicate silently.
+
+CIRISRegistry#58 ("[Epic] Remove Spock") collapses these into a
+**single CEG-native replication mechanism**: every cross-region state
+change is a signed CEG envelope, propagated via edge's anti-entropy
+gossip, applied with persist's R1/Q1 quorum-merge + anti-rollback.
+
+The decision boundary per #58:
+- **Persist owns** the federation directory + quorum-merge (V058 +
+  generalization to operational data).
+- **Edge owns propagation** — the anti-entropy protocol shape, gossip
+  cadence, peer-set discovery, wire frame.
+- **Registry is consumer** — defines operational-data envelope shapes
+  (orgs/users/licenses/partners) where they don't already exist.
+
+This FSD specifies edge's propagation contract: **what bytes go on
+the wire**, **how envelopes are identified**, **what protocol messages
+the two peers exchange**.
+
+The shape implementations partially landed in #69 (protocol types) →
+#70 (coordinator) → #71 (directory trait + adapters) → #72 (wire-frame
+prefix) → #73 (long-lived Session) → #75 (scheduler glue). This FSD
+locks the **v1 wire-stable shape** and adds the missing piece —
+layer (c-2) production wiring via a `FederationDirectoryReplicationBridge`
+that bridges replication's [`ReplicationDirectory`] trait onto persist's
+existing [`FederationDirectory`] + `ReadEngine` surfaces.
+
+## 2. Scope
+
+In:
+
+- Envelope identity (`envelope_hash`) and wire-byte format
+  (`envelope_bytes`) for every kind of federation envelope
+- Replication kind taxonomy (`EnvelopeKind`) — expanded from the
+  4-variant pre-v1 shape to a **9-variant v1 shape** aligned 1:1
+  with persist's `FederationDirectory` put_* surface
+- Wire-protocol version marker; advancement rules
+- Bridge implementation surface (`FederationDirectoryReplicationBridge`)
+- Hash → bytes cache strategy (persist surface gap; edge mitigation)
+- PyO3 init shape for operator config + runtime registration
+
+Out:
+
+- The R1/Q1 quorum-merge semantics (substrate-side; persist owns)
+- Operational-data CEG envelope shapes (Registry owns)
+- Streaming/multicast (CEG 0.15 §10.5 — separate axis; CIRISEdge#66)
+- Cross-region peer-set discovery (operator config)
+
+## 3. Decision authority — what's locked, what's open
+
+The 5 design questions surfaced during layer (c-2) investigation
+resolve as follows. Citations are by direction (CEG / persist /
+edge MISSION).
+
+### 3.1 envelope_hash semantics — LOCKED (CEG + persist)
+
+The federation envelope identity is **`original_content_hash`**:
+sha256 over the canonical bytes of the inner `*_envelope` JSON
+value carried inside each `Signed*Record`.
+
+Every persist federation record type (`KeyRecord`, `Attestation`,
+`Revocation`, `IdentityOccurrence`, `Family`, `Community`, the V067
+membership-revocation triple from v4.8.0) carries the same shape:
+- A `*_envelope: serde_json::Value` field — the inner CEG envelope
+- An `original_content_hash: String` field — hex sha256 of canonical
+  bytes of that envelope
+- Embedded scrub signatures (Ed25519 classical + ML-DSA-65 hybrid)
+- A server-computed `persist_row_hash: String` over the full record
+
+We use `original_content_hash` (the **content** identity), not
+`persist_row_hash` (the **row** identity). Justification:
+
+- `original_content_hash` is deterministic across nodes; same content
+  claim → same hash regardless of which node observed it. That's the
+  property anti-entropy summary↔diff convergence requires.
+- v4.7.0 `register_public_key` typed return (Registered /
+  AlreadyRegistered / RotationCollision) defines persist's stance:
+  same `key_id` + same pubkey → idempotent; same `key_id` + different
+  pubkey → rotation collision. Content identity is the dedup boundary.
+- CEG §0.9.2.1 (canonical-bytes determinism rules) locks the
+  canonicalization that makes `original_content_hash` reproducible
+  cross-impl.
+
+### 3.2 envelope_bytes wire format — LOCKED (edge MISSION + persist)
+
+The bytes shipped over the replication wire are **canonical(Signed*Record)**
+serialized via persist's `PythonJsonDumpsCanonicalizer` (the V1Python
+canonicalizer today; flips to JCS at the 2.9.6 substrate triple via
+persist v4.6.0's signed-epoch version gate).
+
+Edge does **not** define canonicalization rules. Quoting `MISSION.md`
+§3: *"`sign_envelope` calls `ciris_persist::canonicalize_envelope_for_signing`;
+edge re-implements no canonicalization rule. Canonical bytes are not
+edge's to define."* Layer (c-2) calls persist's canonicalizer directly.
+
+The wire bytes include the embedded scrub signatures + the
+server-computed `persist_row_hash` field — the **full record** as
+persist would re-canonicalize it after `put_*` admit. This means:
+
+- A peer receiving an envelope deserializes the Signed*Record,
+  forwards to the appropriate `put_*` admit on its local persist,
+  and the admit's scrub-signature verification runs against the
+  embedded signatures.
+- `persist_row_hash` is server-computed on receive too — the receiver's
+  persist recomputes it. Edge does not preserve the sender's
+  `persist_row_hash` semantically; it just rides along in the wire
+  bytes and is recomputed downstream.
+
+The shipped canonicalizer (V1Python) flips to JCS by persist v4.6.0's
+`produce_canon_version()` returning `CanonVersion::V2Jcs` (gated by
+the signed-epoch version, NOT by a caller flag). When that flip
+happens, replication wire bytes auto-flip too — edge calls persist's
+canonicalizer at runtime; no edge-side coordination needed.
+
+### 3.3 EnvelopeKind taxonomy — DECISION: expand 4→9
+
+This was the genuinely open question. We resolve it by aligning the
+replication kind discriminator **1:1 with persist's `FederationDirectory`
+put_* surface**. Nine variants:
+
+| `EnvelopeKind` variant      | Persist put_* method                          | Wire tag         |
+|-----------------------------|------------------------------------------------|------------------|
+| `Key`                       | `put_public_key(SignedKeyRecord)`             | `"key"`          |
+| `Attestation`               | `put_attestation(SignedAttestation)`          | `"attestation"`  |
+| `Revocation`                | `put_revocation(SignedRevocation)`            | `"revocation"`   |
+| `IdentityOccurrence`        | `put_identity_occurrence(SignedIdentityOccurrence)` | `"identity_occurrence"` |
+| `Family`                    | `put_family(SignedFamily)`                    | `"family"`       |
+| `Community`                 | `put_community(SignedCommunity)`              | `"community"`    |
+| `IdentityOccurrenceRevocation` | `put_identity_occurrence_revocation(SignedIdentityOccurrenceRevocation)` | `"identity_occurrence_revocation"` |
+| `FamilyMembershipRevocation`   | `put_family_membership_revocation(SignedFamilyMembershipRevocation)`   | `"family_membership_revocation"` |
+| `CommunityMembershipRevocation` | `put_community_membership_revocation(SignedCommunityMembershipRevocation)` | `"community_membership_revocation"` |
+
+The wire tag is the `serde(rename = "snake_case")` form. Tagged via
+`#[serde(tag = "kind")]` at the message layer (Summary / Diff /
+Fetch / Deliver each carry their kind on the wire).
+
+Justification:
+
+- **1:1 with persist** means `apply_envelope_bytes` dispatches via
+  a simple match on `EnvelopeKind` — no JSON shape sniffing, no
+  schema inference. Each branch deserializes the matching Signed*Record
+  and calls the matching put_*.
+- **Forward-secrecy revocations** (the V067 triple from persist v4.8.0)
+  are first-class kinds — they propagate via federation gossip just
+  like the membership puts they revoke, so the wire surface must
+  carry them.
+- **No lumped Community sub-kind** means we don't need a wire-frame
+  discriminator and don't need to invent CEG-spec extensions.
+
+We accept the **wire-format break from the pre-v1 4-variant shape**.
+This is acceptable because:
+- No production fleet runs the pre-v1 shape yet — the protocol PRs
+  shipped to develop, not to a tagged production replication run.
+- v1 stays stable from this version forward; advancing requires
+  bumping `WIRE_PROTOCOL_VERSION` (§3.5).
+
+### 3.4 anti-entropy wire shape — LOCKED (edge-defined, already shipped)
+
+The Summary / Diff / Fetch / Deliver four-message shape (#69) plus
+the CRPL wire-frame prefix (#72) plus the long-lived Session (#73)
+plus the scheduler (#75) constitute the v1 anti-entropy protocol.
+CEG defers to edge per #58.
+
+### 3.5 WIRE_PROTOCOL_VERSION
+
+Replication protocol version is carried in the wire-frame:
+
+```text
+  ┌────┬────┬──────────────────────────────────────────────┐
+  │MAG │VER │  ReplicationMessage::to_bytes() — JSON       │
+  │ 4B │ 1B │                                              │
+  └────┴────┴──────────────────────────────────────────────┘
+```
+
+- `MAG` is `b"CRPL"` (4 bytes; see #72)
+- `VER` is `0x01` for v1 (1 byte; **new in this FSD**)
+
+A receiver with no `VER` byte support (the pre-v1 in-development
+shape) MUST be replaced before any production peer ships replication.
+Going forward, the version byte gates dispatch:
+
+```rust
+match version {
+    0x01 => parse_v1(body),
+    _    => Err(ProtocolError::UnknownVersion(version)),
+}
+```
+
+Future versions:
+- `0x02` — when CEG-native operational-data envelopes (orgs / users /
+  licenses / partners per #58 Phase 2) land and need new
+  `EnvelopeKind`s. Currently expected for CIRIS 2.0.
+- `0x03+` — reserve.
+
+The single-byte version field gives us 255 future versions before
+needing a multi-byte version extension. Plenty.
+
+### 3.6 Layer (c-2) production wiring — DECIDED
+
+Layer (c-2) ships a **`FederationDirectoryReplicationBridge`** that
+implements `ReplicationDirectory` over `Arc<dyn FederationDirectory> +
+Arc<dyn ReadEngine>`:
+
+- **`list_envelope_refs(kind)`** — pages through the matching
+  `ReadEngine::list_*` bulk method (the v4.0+ §I federation
+  observability bulk primitives in `src/ceg/list/federation.rs`),
+  collecting `(envelope_hash, seq)` pairs. The `seq` is the bulk
+  cursor's natural ordering field (`valid_from` for keys,
+  `asserted_at` for attestations, `revoked_at` for revocations,
+  etc.); we project to a `u64` via Unix ms.
+
+- **`fetch_envelope_bytes(kind, hash)`** — looks up the bytes by
+  content hash. **Substrate gap**: persist has no
+  `lookup_*_by_content_hash` point-read. v1 mitigation: an
+  in-memory `HashMap<(EnvelopeKind, [u8; 32]), Vec<u8>>` cache
+  populated as a side effect of `list_envelope_refs`. The cache is
+  bounded (LRU, 4096 entries by default — operator-tunable) and
+  keyed on the `(kind, hash)` pair. Cache miss = "I don't have this
+  envelope" semantically (the responder side returns empty bytes
+  for that hash; the requester re-attempts next round).
+  - Follow-up persist issue to file: `lookup_signed_key_record_by_hash`
+    and friends. v1 ships without; the cache + bulk-list shape is
+    sufficient for federations up to ~10k envelopes per kind
+    (validated by sizing the cache to match steady-state envelope
+    count + round cadence).
+
+- **`apply_envelope_bytes(kind, bytes)`** — deserializes the matching
+  `Signed*Record` (one match arm per kind), routes to the matching
+  persist `put_*` admit. Persist runs scrub-signature verification +
+  R1/Q1 monotonicity; edge returns `bool` for "admitted vs refused"
+  (matching the existing `StateApplier::apply_envelope` shape — #71).
+
+### 3.7 PyO3 init shape
+
+`init_edge_runtime` gains two replication parameters:
+
+```python
+init_edge_runtime(
+    engine,                                # existing
+    transports=...,                         # existing
+    replication_peers: list[tuple[str, str]] = None,  # NEW
+    replication_cadence_seconds: int = 30,  # NEW (matches scheduler default)
+)
+```
+
+`replication_peers` is a list of `(peer_key_id, kind_str)` pairs.
+Each entry constructs a `ReplicationCoordinator` (Initiator role,
+because the operator chose to peer with this remote for this kind),
+registers it with the application-side `ReplicationRegistry` (for
+inbound dispatch), and adds it to the `ReplicationScheduler`'s
+Initiator set.
+
+The Responder side is symmetric: when an unknown remote peer sends
+a Summary, the registry auto-creates a Responder coordinator on
+first contact (subject to operator allowlist policy — out of scope
+here; operator policy lives at the transport layer per existing
+blackhole_rules surface).
+
+Runtime hot-add via `PyEdge.register_replication_peer(peer_key_id, kind_str)`
+gives operators flexibility post-init.
+
+## 4. Acceptance criteria
+
+- [ ] 9-variant `EnvelopeKind` shipped; serde tags match §3.3 table
+- [ ] `WIRE_PROTOCOL_VERSION = 0x01` byte added to wire frame; wrap/try_unwrap updated
+- [ ] `FederationDirectoryReplicationBridge` implements `ReplicationDirectory`
+  over `Arc<dyn FederationDirectory> + Arc<dyn ReadEngine>`
+- [ ] In-memory hash→bytes cache (LRU, 4096 default capacity) populated
+  from bulk-list responses
+- [ ] All 9 kinds round-trip via `apply_envelope_bytes` → persist `put_*`
+  → list_envelope_refs (in-memory sqlite test)
+- [ ] PyO3 init accepts `replication_peers` + `replication_cadence_seconds`;
+  `PyEdge.register_replication_peer` hot-add works
+- [ ] `try_unwrap_replication_frame` rejects unknown version bytes with
+  `ProtocolError::UnknownVersion(u8)`
+- [ ] FSD anchored as `~/CIRISEdge/FSD/REPLICATION_WIRE_FORMAT_V1.md`
+  (this document); cross-linked from `CIRIS_EDGE.md` and `replication/mod.rs`
+
+## 5. Path to CIRIS 2.0
+
+Per #58, the operational-data envelope shape (orgs / users / licenses /
+partners) is the **one genuinely new design lift** for Spock removal.
+That lift introduces new `EnvelopeKind`s — naturally a wire-protocol
+version bump (`0x01` → `0x02`).
+
+This FSD anchors v1 so the path is clear:
+
+1. **CIRIS 1.x replication line** — v1 wire (`VER = 0x01`),
+   nine `EnvelopeKind`s, federation directory + R1/Q1 quorum-merge
+   for trust data. Operational-data still on Spock multi-master.
+2. **CIRIS 2.0 cut** — Spock fully removed. Operational-data envelopes
+   defined by Registry (per #58 Phase 2). Wire bumps to `VER = 0x02`
+   adding `EnvelopeKind::Org`, `User`, `License`, `Partner` (or
+   whatever Registry names them). Edge tolerates both v1 and v2
+   wire during the rolling-upgrade window via the version byte.
+3. **Post-2.0** — Spock-free federation; one CEG-native replication
+   mechanism; single auditable cryptographic-provenance trail across
+   every cross-region state change.
+
+The wire-version byte at the frame layer (§3.5) is the load-bearing
+detail. Without it, the v1 → v2 transition would require a coordinated
+fleet-wide flag day. With it, individual peers can upgrade
+independently and the framing dispatch tells them what they're
+receiving.
+
+## 6. Non-goals (explicit, with linked tracking)
+
+- **Operational-data envelope shapes** — CIRISRegistry#58 Phase 2;
+  not edge's design.
+- **Streaming chunked content (CEG §10.5)** — separate axis;
+  CIRISPersist#142 + CIRISEdge#66 (relay/multicast for large-N).
+- **Adaptive byte-range scheduling** — CIRISEdge#55 / CIRISPersist#145.
+- **`lookup_*_by_content_hash` on persist** — substrate follow-up;
+  v1 mitigates via in-memory cache (§3.6).
+- **Cross-region peer-set discovery cadence** — operator config;
+  not protocol.
+- **Telemetry beyond the existing `StalenessSignal` +
+  `RoundEvent`** — metrics counters land in a follow-up; the
+  `tracing` spans the scheduler emits give the v1 observability
+  surface.
+
+## 7. Threat model considerations
+
+The v1 wire surface adds **no new cryptographic primitives** — it's
+plumbing. The security envelope is unchanged:
+
+- **AV-9** (hybrid Ed25519 + ML-DSA-65 scrub signatures) — enforced
+  at persist's put_* admit. Layer (c-2)'s `apply_envelope_bytes`
+  delegates to the admit; no edge-side verify bypass.
+- **AV-13** (signed envelopes only — refuse unsigned) — same.
+- **R1/Q1 anti-rollback monotonicity** — persist V058 / v4.8.0
+  forward-secrecy; replication just streams envelopes, persist
+  decides admit/refuse.
+- **Frame magic prefix** + **version byte** — these are routing
+  metadata, NOT integrity primitives. A peer that lies about its
+  version causes its envelope to be rejected at parse; the embedded
+  scrub signatures remain the integrity floor.
+
+New attack surface from replication itself:
+
+- **Amplification** — a peer requesting many envelope_hashes triggers
+  large `DeliverMessage`s. Mitigation: round_timeout + scheduler
+  cadence bound total throughput per peer. Operator can tune.
+- **Cache poisoning** — the in-memory hash→bytes cache trusts the
+  bulk-list response from persist. Persist's response is authoritative
+  (it's reading its own local DB), so this is moot.
+- **Replay** — replication doesn't have a freshness window; persist's
+  monotonicity gates handle duplicate-application. Subject to the
+  same anti-rollback guarantees as the put_* surfaces.
+
+No new TM entries; the existing AV-9/AV-13/V058 set covers v1
+replication wire.

--- a/FSD/REPLICATION_WIRE_FORMAT_V1.md
+++ b/FSD/REPLICATION_WIRE_FORMAT_V1.md
@@ -145,27 +145,36 @@ the signed-epoch version, NOT by a caller flag). When that flip
 happens, replication wire bytes auto-flip too — edge calls persist's
 canonicalizer at runtime; no edge-side coordination needed.
 
-### 3.3 EnvelopeKind taxonomy — DECISION: expand 4→9
+### 3.3 EnvelopeKind taxonomy — DECISION: expand 4→10
 
 This was the genuinely open question. We resolve it by aligning the
 replication kind discriminator **1:1 with persist's `FederationDirectory`
-put_* surface**. Nine variants:
+put_* surface**. **Ten variants** as of persist v4.10.0:
 
-| `EnvelopeKind` variant      | Persist put_* method                          | Wire tag         |
-|-----------------------------|------------------------------------------------|------------------|
-| `Key`                       | `put_public_key(SignedKeyRecord)`             | `"key"`          |
-| `Attestation`               | `put_attestation(SignedAttestation)`          | `"attestation"`  |
-| `Revocation`                | `put_revocation(SignedRevocation)`            | `"revocation"`   |
-| `IdentityOccurrence`        | `put_identity_occurrence(SignedIdentityOccurrence)` | `"identity_occurrence"` |
-| `Family`                    | `put_family(SignedFamily)`                    | `"family"`       |
-| `Community`                 | `put_community(SignedCommunity)`              | `"community"`    |
-| `IdentityOccurrenceRevocation` | `put_identity_occurrence_revocation(SignedIdentityOccurrenceRevocation)` | `"identity_occurrence_revocation"` |
-| `FamilyMembershipRevocation`   | `put_family_membership_revocation(SignedFamilyMembershipRevocation)`   | `"family_membership_revocation"` |
-| `CommunityMembershipRevocation` | `put_community_membership_revocation(SignedCommunityMembershipRevocation)` | `"community_membership_revocation"` |
+| `EnvelopeKind` variant      | Persist put_* method                          | Wire tag                          | Substrate ship |
+|-----------------------------|------------------------------------------------|-----------------------------------|----------------|
+| `Key`                       | `put_public_key(SignedKeyRecord)`             | `"key"`                           | v1.0+ |
+| `Attestation`               | `put_attestation(SignedAttestation)`          | `"attestation"`                   | v1.0+ |
+| `Revocation`                | `put_revocation(SignedRevocation)`            | `"revocation"`                    | v1.0+ |
+| `IdentityOccurrence`        | `put_identity_occurrence(SignedIdentityOccurrence)` | `"identity_occurrence"`     | CEG 0.7 |
+| `Family`                    | `put_family(SignedFamily)`                    | `"family"`                        | CEG 0.7 |
+| `Community`                 | `put_community(SignedCommunity)`              | `"community"`                     | CEG 0.8 |
+| `IdentityOccurrenceRevocation` | `put_identity_occurrence_revocation(SignedIdentityOccurrenceRevocation)` | `"identity_occurrence_revocation"` | v4.8.0 (#161) |
+| `FamilyMembershipRevocation`   | `put_family_membership_revocation(SignedFamilyMembershipRevocation)`   | `"family_membership_revocation"`   | v4.8.0 (#161) |
+| `CommunityMembershipRevocation` | `put_community_membership_revocation(SignedCommunityMembershipRevocation)` | `"community_membership_revocation"` | v4.8.0 (#161) |
+| `LocationProof`             | `put_location_proof(SignedLocationProof)`     | `"location_proof"`                | v4.10.0 (#154) |
 
 The wire tag is the `serde(rename = "snake_case")` form. Tagged via
 `#[serde(tag = "kind")]` at the message layer (Summary / Diff /
 Fetch / Deliver each carry their kind on the wire).
+
+The 10th variant `LocationProof` is the CEG 0.8 §0.8.1 normative
+privacy primitive — a geographic claim bounded to H3 resolution ≤ 7,
+enforced at the substrate (CIRISPersist v4.10.0, V068
+`federation_location_proofs` + `validate_location_cell`). The
+substrate's resolution-≤-7 rejection IS the privacy enforcement; a
+producer can't over-share precise location even if client UI gating
+fails.
 
 Justification:
 
@@ -294,13 +303,13 @@ gives operators flexibility post-init.
 
 ## 4. Acceptance criteria
 
-- [ ] 9-variant `EnvelopeKind` shipped; serde tags match §3.3 table
+- [ ] 10-variant `EnvelopeKind` shipped; serde tags match §3.3 table
 - [ ] `WIRE_PROTOCOL_VERSION = 0x01` byte added to wire frame; wrap/try_unwrap updated
 - [ ] `FederationDirectoryReplicationBridge` implements `ReplicationDirectory`
   over `Arc<dyn FederationDirectory> + Arc<dyn ReadEngine>`
 - [ ] In-memory hash→bytes cache (LRU, 4096 default capacity) populated
   from bulk-list responses
-- [ ] All 9 kinds round-trip via `apply_envelope_bytes` → persist `put_*`
+- [ ] All 10 kinds round-trip via `apply_envelope_bytes` → persist `put_*`
   → list_envelope_refs (in-memory sqlite test)
 - [ ] PyO3 init accepts `replication_peers` + `replication_cadence_seconds`;
   `PyEdge.register_replication_peer` hot-add works

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ classifiers = [
 # Persist prelude surface unchanged — pure currency bump, zero API
 # drift on edge's consumed paths.
 dependencies = [
-    "ciris-persist>=4.9.0,<5",
+    "ciris-persist>=4.10.0,<5",
 ]
 dynamic = ["version"]
 

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -115,9 +115,24 @@ pub struct ReplicationCoordinator {
     /// tasks; the mutex serializes them — anti-entropy is sequential
     /// per peer-pair by protocol).
     session: Mutex<Session>,
+    /// Sender half of the inbound-message channel. The application's
+    /// [`Transport::listen`] loop calls
+    /// [`Self::deliver_inbound`] which routes here; the
+    /// [`super::scheduler::ReplicationScheduler`] reads the other
+    /// end via [`Self::recv_inbound`] to step a round between
+    /// `SendThenWait` and the next inbound. Bounded capacity 8 —
+    /// enough to absorb the few in-flight Summary / Diff / Deliver
+    /// messages without blocking the listen loop on a slow round.
+    inbound_tx: tokio::sync::mpsc::Sender<ReplicationMessage>,
+    inbound_rx: Mutex<tokio::sync::mpsc::Receiver<ReplicationMessage>>,
 }
 
 impl ReplicationCoordinator {
+    /// Default inbound mpsc capacity. A round in flight has at most
+    /// 3 messages queued (Summary + Diff + Deliver); 8 gives slack
+    /// for a slightly-late deliver while the scheduler is mid-step.
+    pub const INBOUND_CHANNEL_CAPACITY: usize = 8;
+
     pub fn new(
         transport: Arc<dyn Transport>,
         peer_key_id: impl Into<String>,
@@ -126,6 +141,7 @@ impl ReplicationCoordinator {
         provider: Arc<dyn StateProvider>,
         applier: Arc<Mutex<dyn StateApplier>>,
     ) -> Self {
+        let (inbound_tx, inbound_rx) = tokio::sync::mpsc::channel(Self::INBOUND_CHANNEL_CAPACITY);
         Self {
             transport,
             peer_key_id: peer_key_id.into(),
@@ -134,7 +150,32 @@ impl ReplicationCoordinator {
             provider,
             applier,
             session: Mutex::new(Session::new(role, kind)),
+            inbound_tx,
+            inbound_rx: Mutex::new(inbound_rx),
         }
+    }
+
+    /// Deliver an inbound replication message into this coordinator's
+    /// queue. Called by the application's [`Transport::listen`] loop
+    /// after [`Self::parse_inbound_bytes`] yields a
+    /// [`ReplicationMessage`].
+    ///
+    /// Returns `Err(NoRoundInProgress)` if the inbound channel is full
+    /// (the scheduler isn't keeping up; back-pressure surfaces). The
+    /// listen loop typically logs + drops the frame.
+    pub fn deliver_inbound(&self, msg: ReplicationMessage) -> Result<(), CoordinatorError> {
+        self.inbound_tx
+            .try_send(msg)
+            .map_err(|_| CoordinatorError::NoRoundInProgress)
+    }
+
+    /// Wait for the next inbound replication message from the
+    /// listen-loop-fed queue. Returns `None` if the channel is
+    /// permanently closed (the coordinator is being dropped). The
+    /// scheduler awaits on this between `SendThenWait` and the
+    /// next round step.
+    pub async fn recv_inbound(&self) -> Option<ReplicationMessage> {
+        self.inbound_rx.lock().await.recv().await
     }
 
     /// Step the held [`Session`] one transition forward.

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -308,27 +308,32 @@ impl ReplicationCoordinator {
         super::wire_frame::try_unwrap(bytes).map_err(CoordinatorError::from)
     }
 
-    /// Backward-compatible parser that REQUIRES bytes to be a valid
-    /// replication frame — returns `Err` if not, matching the PR #70
-    /// behavior. New code should prefer [`Self::try_parse_inbound_bytes`]
-    /// for the trichotomy (absent magic = NotAReplicationFrame, not
-    /// an error).
+    /// Strict parser that REQUIRES bytes to be a valid replication
+    /// frame at the locked [`super::wire_frame::WIRE_PROTOCOL_VERSION`]
+    /// (v1). Returns `Err` if the magic prefix is absent, the version
+    /// byte is unrecognized, or the body is malformed. Prefer
+    /// [`Self::try_parse_inbound_bytes`] in new dispatcher code so
+    /// non-replication bytes route cleanly (Ok(None)) without
+    /// surfacing as errors.
     ///
-    /// Tolerates both framed (CRPL-prefixed, the current wire format)
-    /// and bare (legacy, pre-#71-wire-frame) inputs — bare inputs
-    /// route directly to [`ReplicationMessage::from_bytes`]. The
-    /// tolerance ships because the on-wire codec changed between
-    /// PR #70 (bare JSON) and this PR (CRPL-prefixed); a fleet
-    /// running mixed builds during a rolling upgrade can still
-    /// exchange messages. The tolerance can be removed once edge
-    /// v1.3.x reaches end-of-life.
+    /// ## v1 wire-stability — no pre-v1 bare-JSON tolerance
+    ///
+    /// Prior cuts of the replication module (#69 / #70) shipped a
+    /// `parse_inbound_bytes` that tolerated bare-JSON inputs (no
+    /// `CRPL` magic) to ease the rolling-upgrade window when the
+    /// wire-frame prefix landed (#72). v1 LOCKS the wire format
+    /// per `FSD/REPLICATION_WIRE_FORMAT_V1.md` §3.5: every
+    /// replication frame MUST carry the 5-byte preamble (`CRPL` +
+    /// `VER`). Bare-JSON inputs now surface as
+    /// `CoordinatorError::Protocol(Decode(_))`. This is the
+    /// version-stable contract going forward.
     pub fn parse_inbound_bytes(bytes: &[u8]) -> Result<ReplicationMessage, CoordinatorError> {
         match super::wire_frame::try_unwrap(bytes) {
             Ok(Some(msg)) => Ok(msg),
-            Ok(None) => {
-                // Legacy bare-JSON fallback for mid-rolling-upgrade fleets.
-                ReplicationMessage::from_bytes(bytes).map_err(CoordinatorError::from)
-            }
+            Ok(None) => Err(CoordinatorError::Protocol(ProtocolError::Decode(
+                "replication frame magic absent — wire format requires CRPL+VER preamble (v1)"
+                    .into(),
+            ))),
             Err(e) => Err(CoordinatorError::from(e)),
         }
     }
@@ -698,23 +703,26 @@ mod tests {
         assert!(matches!(r, Err(CoordinatorError::Protocol(_))));
     }
 
-    /// Backward-compatible `parse_inbound_bytes` accepts BOTH the
-    /// new framed wire form AND the legacy bare-JSON form — important
-    /// during a rolling fleet upgrade.
+    /// `parse_inbound_bytes` is STRICT at v1: bare-JSON without the
+    /// CRPL+VER preamble surfaces as `Protocol(Decode)`. The pre-v1
+    /// rolling-upgrade tolerance is gone per FSD §3.5.
     #[test]
-    fn parse_inbound_bytes_tolerates_legacy_bare_json() {
+    fn parse_inbound_bytes_strict_v1_rejects_bare_json() {
         let msg = ReplicationMessage::Summary(SummaryMessage {
             kind: EnvelopeKind::Key,
             refs: vec![],
         });
-        // Legacy form (bare JSON, no CRPL magic).
+        // Bare form — refused.
         let bare = msg.to_bytes();
-        let parsed = ReplicationCoordinator::parse_inbound_bytes(&bare).expect("parse");
-        assert_eq!(parsed, msg);
-        // New form (CRPL-prefixed) also parses.
+        let r = ReplicationCoordinator::parse_inbound_bytes(&bare);
+        assert!(
+            matches!(r, Err(CoordinatorError::Protocol(_))),
+            "v1 wire requires CRPL+VER preamble; bare-JSON must refuse"
+        );
+        // Framed form (CRPL+VER+body) — accepted.
         let framed = super::super::wire_frame::wrap(&msg);
-        let parsed2 = ReplicationCoordinator::parse_inbound_bytes(&framed).expect("parse");
-        assert_eq!(parsed2, msg);
+        let parsed = ReplicationCoordinator::parse_inbound_bytes(&framed).expect("parse");
+        assert_eq!(parsed, msg);
     }
 
     /// `parse_inbound_bytes` refuses junk cleanly — defence against

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -72,6 +72,49 @@
 //!   counters for round counts, bytes transferred, diff sizes are
 //!   surfaced via `tracing` spans the binding PR will wire to a
 //!   metric backend.
+//!
+//! ## NAT traversal
+//!
+//! Edge does **not** implement STUN / TURN / ICE — and shouldn't.
+//!
+//! Reticulum (the canonical wire per MISSION §1.4) routes by
+//! **cryptographic destination address** (`sha256(pubkey)[..16]`,
+//! the same shape this crate's `transport::addressing` builds for
+//! the packet-radio plug). Transit nodes carry packets by
+//! destination-hash without decrypt capability — the relay can't
+//! read what it's carrying, can't even tell which CEG namespace
+//! it's in. As long as a NAT'd peer's announce graph reaches *any*
+//! publicly-reachable transport node, mesh routing carries packets
+//! both ways without endpoint-translation gymnastics.
+//!
+//! The federation topology itself supplies that public-side peer
+//! set, by construction:
+//!
+//! - **Registry servers** — substrate of the federation; public by
+//!   definition (CEG 0.15 §0.4, registry-anchored normative refs).
+//! - **CIRISLens (LensCore → edge)** — public observability surface
+//!   per the lens-opt-in model. The opt-in dimension is at the
+//!   policy layer (does lens get to see this peer's CEG envelopes
+//!   for telemetry?); the transit layer (Reticulum relay through
+//!   lens's edge instance) is orthogonal — lens can relay packets
+//!   it can't read.
+//! - **Agent 2.9.6 (CEG/RET-native)** — community-server-opt-in
+//!   instances on public IPs join the transport graph for free.
+//!   Mobile agents behind NAT inherit the same benefit they give
+//!   to other NAT'd peers.
+//! - **Any other CEG 0.15 community peer with a public interface.**
+//!
+//! Practical implication: the only operator-doc bit is "your peer
+//! set should include at least one publicly-reachable CIRIS peer"
+//! — which is *automatically* satisfied if the operator points at
+//! the registry / lens / public-agent set at all.
+//!
+//! **HTTP transport** stays the one exception: its accept-side
+//! still needs port-forward / reverse-proxy to be reachable from
+//! outside the NAT. That's operator config (Cloudflare Tunnel,
+//! nginx reverse proxy, etc.), not edge code. Operators behind
+//! hard NATs should use Reticulum, which is what MISSION §1.4
+//! designates canonical anyway.
 
 pub mod coordinator;
 pub mod directory;

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -76,6 +76,7 @@
 pub mod coordinator;
 pub mod directory;
 pub mod protocol;
+pub mod scheduler;
 pub mod session;
 pub mod summary;
 pub mod wire_frame;
@@ -89,6 +90,8 @@ pub use protocol::{
     DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, ReplicationMessage,
     SummaryMessage,
 };
+#[doc(inline)]
+pub use scheduler::{ReplicationScheduler, RoundEvent, SchedulerConfig};
 #[doc(inline)]
 pub use session::{ReplicationOutcome, Session, SessionRole};
 #[doc(inline)]

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -48,24 +48,25 @@ use serde::{Deserialize, Serialize};
 /// ## v1 wire-stable taxonomy — aligned 1:1 with persist's
 /// `FederationDirectory` `put_*` surface
 ///
-/// Per `FSD/REPLICATION_WIRE_FORMAT_V1.md` §3.3, the nine variants
-/// here match persist's nine put_* admit methods exactly. This means
-/// `apply_envelope_bytes` dispatches via a simple match on
-/// `EnvelopeKind` — no JSON shape sniffing, no schema inference. Each
-/// branch deserializes the matching `Signed*Record` and calls the
-/// matching put_*.
+/// Per `FSD/REPLICATION_WIRE_FORMAT_V1.md` §3.3, the ten variants
+/// here match persist's ten put_* admit methods exactly (as of
+/// persist v4.10.0). `apply_envelope_bytes` dispatches via a simple
+/// match on `EnvelopeKind` — no JSON shape sniffing, no schema
+/// inference. Each branch deserializes the matching `Signed*Record`
+/// and calls the matching put_*.
 ///
-/// | Variant                          | Persist put_*                                 |
-/// |----------------------------------|------------------------------------------------|
-/// | `Key`                            | `put_public_key(SignedKeyRecord)`             |
-/// | `Attestation`                    | `put_attestation(SignedAttestation)`          |
-/// | `Revocation`                     | `put_revocation(SignedRevocation)`            |
-/// | `IdentityOccurrence`             | `put_identity_occurrence(SignedIdentityOccurrence)` |
-/// | `Family`                         | `put_family(SignedFamily)`                    |
-/// | `Community`                      | `put_community(SignedCommunity)`              |
-/// | `IdentityOccurrenceRevocation`   | `put_identity_occurrence_revocation(...)` (v4.8.0) |
-/// | `FamilyMembershipRevocation`     | `put_family_membership_revocation(...)` (v4.8.0) |
-/// | `CommunityMembershipRevocation`  | `put_community_membership_revocation(...)` (v4.8.0) |
+/// | Variant                          | Persist put_*                                       | Substrate ship |
+/// |----------------------------------|------------------------------------------------------|----------------|
+/// | `Key`                            | `put_public_key(SignedKeyRecord)`                   | v1.0+          |
+/// | `Attestation`                    | `put_attestation(SignedAttestation)`                | v1.0+          |
+/// | `Revocation`                     | `put_revocation(SignedRevocation)`                  | v1.0+          |
+/// | `IdentityOccurrence`             | `put_identity_occurrence(SignedIdentityOccurrence)` | CEG 0.7        |
+/// | `Family`                         | `put_family(SignedFamily)`                          | CEG 0.7        |
+/// | `Community`                      | `put_community(SignedCommunity)`                    | CEG 0.8        |
+/// | `IdentityOccurrenceRevocation`   | `put_identity_occurrence_revocation(...)`           | v4.8.0 (#161)  |
+/// | `FamilyMembershipRevocation`     | `put_family_membership_revocation(...)`             | v4.8.0 (#161)  |
+/// | `CommunityMembershipRevocation`  | `put_community_membership_revocation(...)`          | v4.8.0 (#161)  |
+/// | `LocationProof`                  | `put_location_proof(SignedLocationProof)`           | v4.10.0 (#154) |
 ///
 /// Adding a variant going forward bumps `WIRE_PROTOCOL_VERSION` (see
 /// `wire_frame.rs`). Anticipated v2 additions (operational-data CEG
@@ -110,6 +111,16 @@ pub enum EnvelopeKind {
     /// forward-secrecy primitive per CIRISPersist v4.8.0 (#161).
     /// `put_community_membership_revocation(...)`.
     CommunityMembershipRevocation,
+    /// `federation_location_proofs` — CEG 0.8 §0.8.1 normative privacy
+    /// primitive (H3 rough-only geographic claim, resolution ≤ 7).
+    /// CIRISPersist v4.10.0 (#154) ships V068 + `LocationProof` /
+    /// `SignedLocationProof` types + `put_location_proof` on all 3
+    /// backends + the pure-Rust `h3o` validation helpers
+    /// (`validate_location_cell` / `h3_cell_contained`). The substrate's
+    /// resolution-≤-7 rejection IS the privacy enforcement — a producer
+    /// can't over-share precise location even if client UI gating fails.
+    /// `put_location_proof(SignedLocationProof)`.
+    LocationProof,
 }
 
 /// A reference to a single envelope in a peer's local state. The
@@ -291,7 +302,7 @@ mod tests {
         assert!(matches!(r, Err(ProtocolError::Decode(_))));
     }
 
-    /// All nine `EnvelopeKind` variants round-trip via JSON — kind
+    /// All ten `EnvelopeKind` variants round-trip via JSON — kind
     /// values are wire-load-bearing per FSD §3.3.
     #[test]
     fn envelope_kind_wire_values_are_stable() {
@@ -314,6 +325,7 @@ mod tests {
                 EnvelopeKind::CommunityMembershipRevocation,
                 "community_membership_revocation",
             ),
+            (EnvelopeKind::LocationProof, "location_proof"),
         ];
         for (kind, wire) in cases {
             let m = ReplicationMessage::Summary(SummaryMessage { kind, refs: vec![] });
@@ -340,6 +352,7 @@ mod tests {
             EnvelopeKind::IdentityOccurrenceRevocation,
             EnvelopeKind::FamilyMembershipRevocation,
             EnvelopeKind::CommunityMembershipRevocation,
+            EnvelopeKind::LocationProof,
         ];
         let wires: HashSet<String> = kinds
             .iter()

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -43,26 +43,73 @@ use serde::{Deserialize, Serialize};
 
 /// The kinds of envelope the anti-entropy protocol replicates. Each
 /// kind corresponds to a separate sync stream so partitions on one
-/// kind don't gate convergence on others. Extending this enum is
-/// additive (new variant); the receiver gracefully unknowns variants
-/// it doesn't recognize via serde's untagged-fallback behavior. New
-/// variants MUST be appended (not inserted) to preserve serialized
-/// wire order for the explicit JSON-name representation.
+/// kind don't gate convergence on others.
+///
+/// ## v1 wire-stable taxonomy — aligned 1:1 with persist's
+/// `FederationDirectory` `put_*` surface
+///
+/// Per `FSD/REPLICATION_WIRE_FORMAT_V1.md` §3.3, the nine variants
+/// here match persist's nine put_* admit methods exactly. This means
+/// `apply_envelope_bytes` dispatches via a simple match on
+/// `EnvelopeKind` — no JSON shape sniffing, no schema inference. Each
+/// branch deserializes the matching `Signed*Record` and calls the
+/// matching put_*.
+///
+/// | Variant                          | Persist put_*                                 |
+/// |----------------------------------|------------------------------------------------|
+/// | `Key`                            | `put_public_key(SignedKeyRecord)`             |
+/// | `Attestation`                    | `put_attestation(SignedAttestation)`          |
+/// | `Revocation`                     | `put_revocation(SignedRevocation)`            |
+/// | `IdentityOccurrence`             | `put_identity_occurrence(SignedIdentityOccurrence)` |
+/// | `Family`                         | `put_family(SignedFamily)`                    |
+/// | `Community`                      | `put_community(SignedCommunity)`              |
+/// | `IdentityOccurrenceRevocation`   | `put_identity_occurrence_revocation(...)` (v4.8.0) |
+/// | `FamilyMembershipRevocation`     | `put_family_membership_revocation(...)` (v4.8.0) |
+/// | `CommunityMembershipRevocation`  | `put_community_membership_revocation(...)` (v4.8.0) |
+///
+/// Adding a variant going forward bumps `WIRE_PROTOCOL_VERSION` (see
+/// `wire_frame.rs`). Anticipated v2 additions (operational-data CEG
+/// envelopes for CIRISRegistry#58 Phase 2 / CIRIS 2.0): `Org`,
+/// `User`, `License`, `Partner` or whatever Registry settles on.
+///
+/// New variants MUST be appended (not inserted) to preserve `Ord` /
+/// `Hash` stability on the `BTreeMap<EnvelopeKind, …>` keys
+/// `LocalState` uses.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum EnvelopeKind {
-    /// `federation_keys` table — newly-published key registrations.
+    /// `federation_keys` — newly-published key registrations.
+    /// `put_public_key(SignedKeyRecord)`.
     Key,
-    /// `federation_attestations` table — `trust_grant` / `holds_bytes`
-    /// / consent / etc.
+    /// `federation_attestations` — trust grants / scores / withdraws /
+    /// delegates_to / etc. `put_attestation(SignedAttestation)`.
     Attestation,
-    /// `federation_revocations` table — anti-rollback per CIRISPersist
-    /// V058.
+    /// `federation_revocations` — key-level revocations with R1/Q1
+    /// quorum-merge per CIRISPersist V058.
+    /// `put_revocation(SignedRevocation)`.
     Revocation,
-    /// `federation_communities` (CEG 0.8) once shipped — placeholder
-    /// reserved here so the kind enum doesn't have to change when the
-    /// substrate lands.
+    /// `federation_identity_occurrences` — agent / human / partner
+    /// occurrence records per CEG 0.7.
+    /// `put_identity_occurrence(SignedIdentityOccurrence)`.
+    IdentityOccurrence,
+    /// `federation_families` — family roster declarations per CEG 0.7.
+    /// `put_family(SignedFamily)`.
+    Family,
+    /// `federation_communities` — community roster declarations per
+    /// CEG 0.8. `put_community(SignedCommunity)`.
     Community,
+    /// `federation_identity_occurrence_revocations` — Option-A forward-
+    /// secrecy primitive per CIRISPersist v4.8.0 (#161).
+    /// `put_identity_occurrence_revocation(...)`.
+    IdentityOccurrenceRevocation,
+    /// `federation_family_membership_revocations` — Option-A forward-
+    /// secrecy primitive per CIRISPersist v4.8.0 (#161).
+    /// `put_family_membership_revocation(...)`.
+    FamilyMembershipRevocation,
+    /// `federation_community_membership_revocations` — Option-A
+    /// forward-secrecy primitive per CIRISPersist v4.8.0 (#161).
+    /// `put_community_membership_revocation(...)`.
+    CommunityMembershipRevocation,
 }
 
 /// A reference to a single envelope in a peer's local state. The
@@ -154,6 +201,13 @@ impl ReplicationMessage {
 pub enum ProtocolError {
     #[error("replication message decode failed: {0}")]
     Decode(String),
+    /// The wire frame carried a version byte the local code can't
+    /// speak. The frame's MAG prefix asserted it was a replication
+    /// frame, but the version byte was outside the locally-supported
+    /// set (currently only `WIRE_PROTOCOL_VERSION = 0x01`). Surfaced
+    /// by `wire_frame::try_unwrap`; the caller logs + drops.
+    #[error("unknown replication wire-protocol version: {0:#x}")]
+    UnknownVersion(u8),
 }
 
 #[cfg(test)]
@@ -237,15 +291,29 @@ mod tests {
         assert!(matches!(r, Err(ProtocolError::Decode(_))));
     }
 
-    /// All four `EnvelopeKind` variants round-trip via JSON — kind
-    /// values are wire-load-bearing.
+    /// All nine `EnvelopeKind` variants round-trip via JSON — kind
+    /// values are wire-load-bearing per FSD §3.3.
     #[test]
     fn envelope_kind_wire_values_are_stable() {
         let cases = [
             (EnvelopeKind::Key, "key"),
             (EnvelopeKind::Attestation, "attestation"),
             (EnvelopeKind::Revocation, "revocation"),
+            (EnvelopeKind::IdentityOccurrence, "identity_occurrence"),
+            (EnvelopeKind::Family, "family"),
             (EnvelopeKind::Community, "community"),
+            (
+                EnvelopeKind::IdentityOccurrenceRevocation,
+                "identity_occurrence_revocation",
+            ),
+            (
+                EnvelopeKind::FamilyMembershipRevocation,
+                "family_membership_revocation",
+            ),
+            (
+                EnvelopeKind::CommunityMembershipRevocation,
+                "community_membership_revocation",
+            ),
         ];
         for (kind, wire) in cases {
             let m = ReplicationMessage::Summary(SummaryMessage { kind, refs: vec![] });
@@ -254,5 +322,29 @@ mod tests {
             assert!(s.contains(wire), "expected `{wire}` in {s}");
             assert_eq!(ReplicationMessage::from_bytes(&bytes).unwrap(), m);
         }
+    }
+
+    /// Wire-stability sanity: confirm no two kinds collide on their
+    /// serde rename. Catches accidental duplicates if a future
+    /// variant is added with a typo.
+    #[test]
+    fn envelope_kind_wire_values_are_unique() {
+        use std::collections::HashSet;
+        let kinds = [
+            EnvelopeKind::Key,
+            EnvelopeKind::Attestation,
+            EnvelopeKind::Revocation,
+            EnvelopeKind::IdentityOccurrence,
+            EnvelopeKind::Family,
+            EnvelopeKind::Community,
+            EnvelopeKind::IdentityOccurrenceRevocation,
+            EnvelopeKind::FamilyMembershipRevocation,
+            EnvelopeKind::CommunityMembershipRevocation,
+        ];
+        let wires: HashSet<String> = kinds
+            .iter()
+            .map(|k| serde_json::to_string(k).unwrap())
+            .collect();
+        assert_eq!(wires.len(), kinds.len(), "wire-name collision detected");
     }
 }

--- a/src/replication/scheduler.rs
+++ b/src/replication/scheduler.rs
@@ -1,0 +1,662 @@
+//! Periodic round-driver for the anti-entropy protocol.
+//!
+//! Closes the `replication::mod.rs` documented non-goal — "the
+//! decision to run a round every N seconds, per peer, per kind, is
+//! operator policy." This module *is* that operator policy, expressed
+//! as a small composable harness: bind any number of Initiator-side
+//! [`ReplicationCoordinator`]s to a cadence, spawn one tokio task per
+//! coordinator, and the scheduler runs Summary → SendThenWait → recv
+//! inbound → DriveStep loops on each one independently.
+//!
+//! ## Where this fits
+//!
+//! The application's two integration touch points with anti-entropy
+//! are:
+//!
+//! - **Inbound** — [`Transport::listen`](crate::transport::Transport::listen)
+//!   delivers framed bytes; the listen loop calls
+//!   [`ReplicationCoordinator::parse_inbound_bytes`] (or the trichotomy
+//!   variant) and routes the [`ReplicationMessage`] to the matching
+//!   coordinator via [`ReplicationCoordinator::deliver_inbound`].
+//!   That works for BOTH the Initiator-side (mid-round replies) and
+//!   the Responder-side (round-starting Summary from a remote peer).
+//!
+//! - **Outbound timer** — for each Initiator-side coordinator, a
+//!   tokio task fires `interval.tick()` at the configured cadence and
+//!   runs one round to completion (or timeout). That's this module.
+//!
+//! Responder-side rounds need no scheduler: the Responder's
+//! `drive_round_step` runs synchronously inside the listen loop's
+//! dispatch path, returning `SendThenWait { Summary, Diff }` which
+//! the listen loop sends via the coordinator's transport, then
+//! `Deliver` arrives on the inbound channel and the next
+//! `drive_round_step(Some(...))` finishes the round.
+//!
+//! ## Cancellation
+//!
+//! [`ReplicationScheduler::run_until_cancelled`] takes a
+//! [`tokio::sync::watch::Receiver<bool>`] that the caller flips to
+//! `true` to ask the scheduler to stop. Shipping watch (already in
+//! tokio core, no new dep) instead of `CancellationToken` keeps the
+//! dep surface minimal.
+//!
+//! ## Round timeout
+//!
+//! Each in-flight `SendThenWait` wait is bounded by `round_timeout`.
+//! On expiry the scheduler logs the timeout, resets the coordinator's
+//! session (the next interval tick starts fresh), and continues —
+//! anti-entropy is *eventually consistent* by design, so a stuck
+//! round is a missed cadence, not a fault. The next round will pick
+//! up whatever state changed in the meantime.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::watch;
+
+use super::coordinator::{CoordinatorError, DriveStep, ReplicationCoordinator, RoundReport};
+use super::session::SessionRole;
+
+/// Scheduler configuration shared across all coordinators it drives.
+///
+/// `cadence` is how often each Initiator coordinator starts a new
+/// round. `round_timeout` is the max wall-clock time the scheduler
+/// will wait on an inbound message between SendThenWait phases
+/// before giving up on the round.
+///
+/// Defaults are deliberately conservative — small fleets / LAN /
+/// quiet links — so the operator tunes UP for slower mediums (LoRa
+/// packet-radio) and DOWN for hot federations. The
+/// `Default` impl matches the prior `mod.rs` documentation guidance
+/// ("every N seconds, per peer, per kind"; N=30s is the federation
+/// MISSION's "near-realtime convergence" anchor).
+#[derive(Debug, Clone, Copy)]
+pub struct SchedulerConfig {
+    pub cadence: Duration,
+    pub round_timeout: Duration,
+}
+
+impl SchedulerConfig {
+    pub const DEFAULT_CADENCE: Duration = Duration::from_secs(30);
+    pub const DEFAULT_ROUND_TIMEOUT: Duration = Duration::from_secs(10);
+}
+
+impl Default for SchedulerConfig {
+    fn default() -> Self {
+        Self {
+            cadence: Self::DEFAULT_CADENCE,
+            round_timeout: Self::DEFAULT_ROUND_TIMEOUT,
+        }
+    }
+}
+
+/// What the scheduler observed running one round on one coordinator.
+/// Surfaced via the run loop's `tracing` span so metrics / dashboards
+/// see per-round outcome.
+#[derive(Debug, Clone)]
+pub enum RoundEvent {
+    /// Round completed; the report carries admitted / refused /
+    /// staleness for the metrics pipeline.
+    Completed(RoundReport),
+    /// Coordinator rejected the round (peer sent a malformed or
+    /// out-of-state message). The scheduler reset the session and
+    /// will retry on the next cadence tick.
+    Refused,
+    /// `round_timeout` elapsed waiting for an inbound message between
+    /// SendThenWait phases. The scheduler reset the session.
+    TimedOut,
+    /// Transport / protocol error during the round. The scheduler
+    /// logged it; the next interval tick will try fresh.
+    Error(String),
+}
+
+/// Periodically drive anti-entropy rounds on a set of Initiator-side
+/// coordinators.
+///
+/// One scheduler instance can hold many coordinators (one per
+/// `(peer, kind)` pair this node is the initiator for). Each gets its
+/// own tokio task with its own `interval`, so a slow peer's round
+/// doesn't block other peers' cadence.
+///
+/// Constructing the scheduler does NOT spawn any tasks; the caller
+/// chooses when to start the run loop via
+/// [`Self::run_until_cancelled`].
+pub struct ReplicationScheduler {
+    config: SchedulerConfig,
+    coordinators: Vec<Arc<ReplicationCoordinator>>,
+}
+
+impl ReplicationScheduler {
+    pub fn new(config: SchedulerConfig) -> Self {
+        Self {
+            config,
+            coordinators: Vec::new(),
+        }
+    }
+
+    /// Register an Initiator-side coordinator with the scheduler.
+    /// Panics in debug builds if the coordinator's role isn't
+    /// [`SessionRole::Initiator`] — responder rounds are driven by
+    /// the application's listen loop, not the scheduler.
+    pub fn add_initiator(&mut self, coord: Arc<ReplicationCoordinator>) {
+        debug_assert_eq!(
+            coord.role(),
+            SessionRole::Initiator,
+            "scheduler drives Initiator coordinators only; \
+             Responder rounds run inline in the listen loop"
+        );
+        self.coordinators.push(coord);
+    }
+
+    /// Number of registered coordinators.
+    pub fn len(&self) -> usize {
+        self.coordinators.len()
+    }
+
+    /// Whether the scheduler holds zero coordinators.
+    pub fn is_empty(&self) -> bool {
+        self.coordinators.is_empty()
+    }
+
+    /// Drive all registered coordinators until the caller flips
+    /// `cancel` to `true`. Each coordinator runs as an independent
+    /// tokio task; the function returns when all tasks have
+    /// observed the cancel signal + exited their interval loops.
+    ///
+    /// `cancel` is a `tokio::sync::watch::Receiver<bool>`; the
+    /// caller holds the [`tokio::sync::watch::Sender`] and calls
+    /// `.send(true)` to ask for shutdown. The scheduler checks the
+    /// signal on every iteration of every coordinator's loop, so
+    /// shutdown latency is bounded by the slowest coordinator's
+    /// `round_timeout`.
+    ///
+    /// Returns on clean shutdown. The scheduler does NOT propagate
+    /// per-round errors — those are observed via the `tracing` spans
+    /// each round emits (and via the optional `event_sink` channel
+    /// callers can wire in via [`Self::run_with_events`]).
+    pub async fn run_until_cancelled(self, cancel: watch::Receiver<bool>) {
+        self.run_with_events(cancel, None).await;
+    }
+
+    /// Variant of [`Self::run_until_cancelled`] that also routes each
+    /// round's [`RoundEvent`] into a caller-supplied channel. Useful
+    /// for metrics / test assertions / [`crate::replication::summary::StalenessSignal`]
+    /// telemetry consumers. Drop the receiver to stop receiving
+    /// events; the scheduler tolerates a closed sink (the round
+    /// loops continue).
+    pub async fn run_with_events(
+        self,
+        cancel: watch::Receiver<bool>,
+        event_sink: Option<tokio::sync::mpsc::Sender<(String, RoundEvent)>>,
+    ) {
+        let mut handles = Vec::with_capacity(self.coordinators.len());
+        for coord in self.coordinators {
+            let mut cancel_rx = cancel.clone();
+            let event_sink = event_sink.clone();
+            let cadence = self.config.cadence;
+            let round_timeout = self.config.round_timeout;
+            let h = tokio::spawn(async move {
+                run_one_coordinator_forever(
+                    coord,
+                    cadence,
+                    round_timeout,
+                    &mut cancel_rx,
+                    event_sink,
+                )
+                .await;
+            });
+            handles.push(h);
+        }
+        for h in handles {
+            // join_all would be nicer but adds futures-util dep
+            // outside our current set. tokio::join! on a Vec needs
+            // boxing. Sequential .await is fine here — every task
+            // observes the same cancel signal so they all finish
+            // at about the same time anyway.
+            let _ = h.await;
+        }
+    }
+}
+
+async fn run_one_coordinator_forever(
+    coord: Arc<ReplicationCoordinator>,
+    cadence: Duration,
+    round_timeout: Duration,
+    cancel: &mut watch::Receiver<bool>,
+    event_sink: Option<tokio::sync::mpsc::Sender<(String, RoundEvent)>>,
+) {
+    let mut interval = tokio::time::interval(cadence);
+    // `Burst` is the default; with `MissedTickBehavior::Skip` a
+    // long-delayed task wouldn't fire bursts to catch up. We want
+    // Skip — a stuck round eating cadence ticks shouldn't compound
+    // into a burst of rounds the moment it unblocks.
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    let peer_id = coord.peer_key_id().to_string();
+    let kind_str = format!("{:?}", coord.kind());
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancel.changed() => {
+                if *cancel.borrow() {
+                    return;
+                }
+            }
+            _ = interval.tick() => {
+                let span = tracing::info_span!("anti_entropy_round", peer = %peer_id, kind = %kind_str);
+                let _enter = span.enter();
+                let event = match run_one_round(&coord, round_timeout).await {
+                    Ok(DriveStep::Complete(report)) => RoundEvent::Completed(report),
+                    Ok(DriveStep::Refused) => {
+                        tracing::warn!("round refused; resetting session");
+                        RoundEvent::Refused
+                    }
+                    Ok(DriveStep::SendThenWait(_)) => {
+                        // This shouldn't happen — run_one_round loops
+                        // until Complete or Refused. If it did, treat
+                        // as a timeout so the next tick recovers.
+                        tracing::warn!("scheduler returned mid-round; resetting");
+                        RoundEvent::TimedOut
+                    }
+                    Err(RoundError::Timeout) => {
+                        tracing::warn!("round timed out waiting for peer reply");
+                        RoundEvent::TimedOut
+                    }
+                    Err(RoundError::Coordinator(e)) => {
+                        tracing::warn!(error = %e, "coordinator error during round");
+                        RoundEvent::Error(e.to_string())
+                    }
+                    Err(RoundError::InboundClosed) => {
+                        tracing::warn!("inbound channel closed; cannot complete round");
+                        RoundEvent::Error("inbound channel closed".to_string())
+                    }
+                };
+                if let Some(sink) = &event_sink {
+                    // Sink-closed isn't a fault — the metrics consumer
+                    // dropped their receiver. Round loops continue.
+                    let _ = sink.send((peer_id.clone(), event)).await;
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum RoundError {
+    Timeout,
+    InboundClosed,
+    Coordinator(CoordinatorError),
+}
+
+impl From<CoordinatorError> for RoundError {
+    fn from(e: CoordinatorError) -> Self {
+        Self::Coordinator(e)
+    }
+}
+
+/// Drive a single round end-to-end on one coordinator: start_round →
+/// loop { send_outbound; await inbound; drive_round_step } until
+/// Complete or Refused.
+async fn run_one_round(
+    coord: &ReplicationCoordinator,
+    round_timeout: Duration,
+) -> Result<DriveStep, RoundError> {
+    let mut step = coord.drive_round_step(None).await?;
+    loop {
+        let msgs = match step {
+            DriveStep::SendThenWait(ref msgs) => msgs.clone(),
+            _ => return Ok(step),
+        };
+        for m in &msgs {
+            coord.send_message(m).await?;
+        }
+        let next = match tokio::time::timeout(round_timeout, coord.recv_inbound()).await {
+            Ok(Some(msg)) => msg,
+            Ok(None) => return Err(RoundError::InboundClosed),
+            Err(_) => return Err(RoundError::Timeout),
+        };
+        step = coord.drive_round_step(Some(next)).await?;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::replication::coordinator::ReplicationCoordinator;
+    use crate::replication::protocol::{EnvelopeKind, EnvelopeRef};
+    use crate::replication::session::SessionRole;
+    use crate::replication::summary::{LocalState, StalenessSignal, StateApplier, StateProvider};
+    use crate::transport::{
+        InboundFrame, Transport, TransportError, TransportId, TransportSendOutcome,
+    };
+    use async_trait::async_trait;
+    use std::collections::HashMap;
+    use tokio::sync::Mutex;
+
+    fn h(seed: u8) -> [u8; 32] {
+        let mut a = [0u8; 32];
+        a[0] = seed;
+        a
+    }
+
+    /// In-memory transport mirroring the coordinator test fixture.
+    /// Alice-and-Bob share two channels (one each direction); the
+    /// scheduler's listen-loop equivalent here is a small task that
+    /// drains the inbox into the matching coordinator's
+    /// `deliver_inbound`.
+    struct InMemTransport {
+        peer_inbox: HashMap<String, tokio::sync::mpsc::UnboundedSender<Vec<u8>>>,
+    }
+
+    #[async_trait]
+    impl Transport for InMemTransport {
+        fn id(&self) -> TransportId {
+            TransportId::HTTP
+        }
+        async fn send(
+            &self,
+            destination_key_id: &str,
+            envelope_bytes: &[u8],
+        ) -> Result<TransportSendOutcome, TransportError> {
+            self.peer_inbox
+                .get(destination_key_id)
+                .ok_or_else(|| TransportError::Unreachable(destination_key_id.to_string()))?
+                .send(envelope_bytes.to_vec())
+                .map_err(|e| TransportError::Io(format!("inbox closed: {e}")))?;
+            Ok(TransportSendOutcome::Delivered)
+        }
+        async fn listen(
+            &self,
+            _sink: tokio::sync::mpsc::Sender<InboundFrame>,
+        ) -> Result<(), TransportError> {
+            unimplemented!("test fixture drives inbox manually")
+        }
+    }
+
+    struct StaticProvider {
+        state: LocalState,
+        envelopes: HashMap<[u8; 32], Vec<u8>>,
+    }
+    impl StateProvider for StaticProvider {
+        fn local_refs(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+            self.state.refs_for(kind)
+        }
+        fn fetch_envelope(&self, _kind: EnvelopeKind, h: &[u8; 32]) -> Option<Vec<u8>> {
+            self.envelopes.get(h).cloned()
+        }
+    }
+
+    struct RecordingApplier {
+        known: HashMap<Vec<u8>, [u8; 32]>,
+        local_hashes: std::collections::HashSet<[u8; 32]>,
+    }
+    impl StateApplier for RecordingApplier {
+        fn apply_envelope(&mut self, _kind: EnvelopeKind, bytes: &[u8]) -> bool {
+            let Some(hash) = self.known.get(bytes).copied() else {
+                return false;
+            };
+            if self.local_hashes.contains(&hash) {
+                return false;
+            }
+            self.local_hashes.insert(hash);
+            true
+        }
+    }
+
+    /// The scheduler default cadence + timeout are real wall-clock
+    /// numbers; tests use much shorter values. We use real time
+    /// (not `start_paused`) because the lib-test build doesn't pull
+    /// tokio's `test-util` feature; the 10ms/500ms pair completes
+    /// the round-trip tests in well under a second.
+    fn fast_config() -> SchedulerConfig {
+        SchedulerConfig {
+            cadence: Duration::from_millis(10),
+            round_timeout: Duration::from_millis(500),
+        }
+    }
+
+    /// Smoke: register and len/is_empty track.
+    #[test]
+    fn add_initiator_tracks_len() {
+        let mut s = ReplicationScheduler::new(fast_config());
+        assert!(s.is_empty());
+        let (alice_to_bob_tx, _alice_to_bob_rx) = tokio::sync::mpsc::unbounded_channel();
+        let transport = Arc::new(InMemTransport {
+            peer_inbox: HashMap::from([("bob".to_string(), alice_to_bob_tx)]),
+        });
+        let provider = Arc::new(StaticProvider {
+            state: LocalState::new(),
+            envelopes: HashMap::new(),
+        });
+        let applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            known: HashMap::new(),
+            local_hashes: std::collections::HashSet::new(),
+        }));
+        let coord = Arc::new(ReplicationCoordinator::new(
+            transport,
+            "bob",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        ));
+        s.add_initiator(coord);
+        assert_eq!(s.len(), 1);
+        assert!(!s.is_empty());
+    }
+
+    /// Defaults are sane.
+    #[test]
+    fn default_config_pins_30s_and_10s() {
+        let c = SchedulerConfig::default();
+        assert_eq!(c.cadence, Duration::from_secs(30));
+        assert_eq!(c.round_timeout, Duration::from_secs(10));
+    }
+
+    /// End-to-end: scheduler drives Alice (Initiator) through a full
+    /// anti-entropy round against Bob (Responder, driven manually as
+    /// the listen loop would). Asserts the round completes with
+    /// admitted=2 + StalenessSignal::InSync — the long-lived session
+    /// + scheduler + inbound channel are all wired correctly.
+    #[tokio::test]
+    async fn scheduler_drives_initiator_round_to_completion() {
+        // Build Alice-and-Bob channels (transport mailboxes).
+        let (alice_to_bob_tx, mut alice_to_bob_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (bob_to_alice_tx, mut bob_to_alice_rx) = tokio::sync::mpsc::unbounded_channel();
+        let alice_transport = Arc::new(InMemTransport {
+            peer_inbox: HashMap::from([("bob".to_string(), alice_to_bob_tx)]),
+        });
+        let bob_transport = Arc::new(InMemTransport {
+            peer_inbox: HashMap::from([("alice".to_string(), bob_to_alice_tx)]),
+        });
+
+        // Alice has env_1 + env_2; Bob has env_3 + env_4.
+        let mut a_state = LocalState::new();
+        a_state.insert(EnvelopeKind::Key, h(1), 1);
+        a_state.insert(EnvelopeKind::Key, h(2), 2);
+        let alice_provider = Arc::new(StaticProvider {
+            state: a_state,
+            envelopes: HashMap::from([(h(1), b"env_1".to_vec()), (h(2), b"env_2".to_vec())]),
+        });
+        let mut b_state = LocalState::new();
+        b_state.insert(EnvelopeKind::Key, h(3), 3);
+        b_state.insert(EnvelopeKind::Key, h(4), 4);
+        let bob_provider = Arc::new(StaticProvider {
+            state: b_state,
+            envelopes: HashMap::from([(h(3), b"env_3".to_vec()), (h(4), b"env_4".to_vec())]),
+        });
+        let alice_applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            known: HashMap::from([(b"env_3".to_vec(), h(3)), (b"env_4".to_vec(), h(4))]),
+            local_hashes: [h(1), h(2)].into_iter().collect(),
+        }));
+        let bob_applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            known: HashMap::from([(b"env_1".to_vec(), h(1)), (b"env_2".to_vec(), h(2))]),
+            local_hashes: [h(3), h(4)].into_iter().collect(),
+        }));
+
+        let alice_coord = Arc::new(ReplicationCoordinator::new(
+            alice_transport,
+            "bob",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            alice_provider,
+            alice_applier,
+        ));
+        let bob_coord = Arc::new(ReplicationCoordinator::new(
+            bob_transport,
+            "alice",
+            EnvelopeKind::Key,
+            SessionRole::Responder,
+            bob_provider,
+            bob_applier,
+        ));
+
+        // Listen-loop simulation: drain Alice's outgoing mailbox →
+        // parse → Bob.deliver_inbound; drain Bob's outgoing → parse
+        // → Alice.deliver_inbound. Tokio task each.
+        let bob_for_alice_route = bob_coord.clone();
+        tokio::spawn(async move {
+            while let Some(bytes) = alice_to_bob_rx.recv().await {
+                let msg = ReplicationCoordinator::parse_inbound_bytes(&bytes).unwrap();
+                let _ = bob_for_alice_route.deliver_inbound(msg);
+            }
+        });
+        let alice_for_bob_route = alice_coord.clone();
+        tokio::spawn(async move {
+            while let Some(bytes) = bob_to_alice_rx.recv().await {
+                let msg = ReplicationCoordinator::parse_inbound_bytes(&bytes).unwrap();
+                let _ = alice_for_bob_route.deliver_inbound(msg);
+            }
+        });
+
+        // Bob is the Responder; the application's listen-loop calls
+        // drive_round_step(Some(msg)) inline as inbound arrives.
+        // Simulate via a task: pull from Bob's recv_inbound, step
+        // the responder session, send any outbound, repeat.
+        let bob_drive = bob_coord.clone();
+        tokio::spawn(async move {
+            loop {
+                let Some(msg) = bob_drive.recv_inbound().await else {
+                    return;
+                };
+                let step = bob_drive.drive_round_step(Some(msg)).await.unwrap();
+                if let DriveStep::SendThenWait(msgs) = step {
+                    for m in &msgs {
+                        bob_drive.send_message(m).await.unwrap();
+                    }
+                }
+            }
+        });
+
+        // Wire the scheduler with Alice as the Initiator.
+        let mut sched = ReplicationScheduler::new(fast_config());
+        sched.add_initiator(alice_coord.clone());
+
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(16);
+        let sched_handle =
+            tokio::spawn(async move { sched.run_with_events(cancel_rx, Some(event_tx)).await });
+
+        // Real-time wait for the first RoundEvent. The 10ms cadence
+        // + the small async hop chain finishes well under the 5s
+        // bound on any sane host.
+        let (peer, event) = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
+            .await
+            .expect("scheduler round event")
+            .expect("event channel open");
+        assert_eq!(peer, "bob");
+        match event {
+            RoundEvent::Completed(report) => {
+                assert_eq!(report.kind, EnvelopeKind::Key);
+                assert_eq!(report.admitted, 2);
+                assert_eq!(report.refused, 0);
+                assert_eq!(report.staleness, StalenessSignal::InSync);
+            }
+            o => panic!("expected Completed, got {o:?}"),
+        }
+
+        // Shut the scheduler down.
+        cancel_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), sched_handle)
+            .await
+            .expect("scheduler shutdown")
+            .expect("scheduler join");
+    }
+
+    /// Round timeout: the Initiator's peer never replies → the
+    /// scheduler observes `TimedOut`, the session resets, and the
+    /// next cadence tick fires a fresh round.
+    #[tokio::test]
+    async fn scheduler_reports_timeout_when_peer_silent() {
+        let (alice_to_bob_tx, mut alice_to_bob_rx) = tokio::sync::mpsc::unbounded_channel();
+        let alice_transport = Arc::new(InMemTransport {
+            peer_inbox: HashMap::from([("bob".to_string(), alice_to_bob_tx)]),
+        });
+        // Black-hole the outbound traffic — Bob doesn't reply.
+        tokio::spawn(async move { while alice_to_bob_rx.recv().await.is_some() {} });
+
+        let provider = Arc::new(StaticProvider {
+            state: LocalState::new(),
+            envelopes: HashMap::new(),
+        });
+        let applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            known: HashMap::new(),
+            local_hashes: std::collections::HashSet::new(),
+        }));
+        let alice_coord = Arc::new(ReplicationCoordinator::new(
+            alice_transport,
+            "bob",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        ));
+
+        let config = SchedulerConfig {
+            cadence: Duration::from_millis(10),
+            round_timeout: Duration::from_millis(100),
+        };
+        let mut sched = ReplicationScheduler::new(config);
+        sched.add_initiator(alice_coord);
+
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(16);
+        let sched_handle =
+            tokio::spawn(async move { sched.run_with_events(cancel_rx, Some(event_tx)).await });
+
+        // Real-time wait for the first TimedOut event. cadence + round_timeout
+        // is ~110ms so 5s is comfortable headroom.
+        let (peer, event) = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
+            .await
+            .expect("scheduler timeout event")
+            .expect("channel open");
+        assert_eq!(peer, "bob");
+        assert!(
+            matches!(event, RoundEvent::TimedOut),
+            "expected TimedOut, got {event:?}"
+        );
+
+        cancel_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), sched_handle)
+            .await
+            .expect("shutdown")
+            .expect("join");
+    }
+
+    /// Cancellation: the scheduler exits cleanly when `cancel` flips
+    /// to true.
+    #[tokio::test]
+    async fn scheduler_exits_on_cancel() {
+        let sched = ReplicationScheduler::new(fast_config());
+        // Empty scheduler should be a no-op + exit immediately
+        // (no coordinators means no tasks to wait on).
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let h = tokio::spawn(async move { sched.run_until_cancelled(cancel_rx).await });
+        cancel_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), h)
+            .await
+            .expect("exit on cancel")
+            .expect("join");
+    }
+}

--- a/src/replication/wire_frame.rs
+++ b/src/replication/wire_frame.rs
@@ -9,21 +9,27 @@
 //! needs to route by payload kind without parsing every byte as every
 //! possible shape.
 //!
-//! ## Design — magic-prefix dispatch
+//! ## Design — magic-prefix + version-byte dispatch (v1 wire format)
 //!
-//! Replication messages carry a 4-byte magic at the front:
+//! Replication messages carry a 5-byte preamble at the front:
 //!
 //! ```text
-//!   ┌────┬──────────────────────────────────────────────┐
-//!   │MAG │  ReplicationMessage::to_bytes() — JSON       │
-//!   │ 4B │                                              │
-//!   └────┴──────────────────────────────────────────────┘
+//!   ┌────┬────┬──────────────────────────────────────────────┐
+//!   │MAG │VER │  ReplicationMessage::to_bytes() — JSON       │
+//!   │ 4B │ 1B │                                              │
+//!   └────┴────┴──────────────────────────────────────────────┘
 //! ```
 //!
-//! The magic is `b"CRPL"` ("CIRis RePLication") — chosen because no
-//! existing federation envelope shape starts with this prefix (signed
-//! envelopes start with `{` for JSON, `0x80..0xBF` for CBOR map tags,
-//! etc.).
+//! - `MAG` is `b"CRPL"` ("CIRis RePLication") — chosen because no
+//!   existing federation envelope shape starts with this prefix
+//!   (signed envelopes start with `{` for JSON, `0x80..0xBF` for
+//!   CBOR map tags, etc.).
+//! - `VER` is `WIRE_PROTOCOL_VERSION` (currently `0x01`) — locks v1
+//!   wire-stable. See [`FSD/REPLICATION_WIRE_FORMAT_V1.md`](../../FSD/REPLICATION_WIRE_FORMAT_V1.md)
+//!   §3.5. Future versions: `0x02` reserved for the CIRIS 2.0 cut
+//!   when CIRISRegistry#58 Phase 2 operational-data envelopes
+//!   (orgs / users / licenses / partners) need new
+//!   [`super::EnvelopeKind`]s.
 //!
 //! ## Why this and not a top-level FramedKind enum
 //!
@@ -37,7 +43,10 @@
 //!
 //! ```text
 //!   if bytes starts with REPLICATION_FRAME_MAGIC:
-//!       hand to ReplicationCoordinator::feed_inbound_bytes
+//!       version_byte = bytes[4]
+//!       match version_byte:
+//!           0x01 -> hand to ReplicationCoordinator (v1 codec)
+//!           _    -> Err(UnknownVersion)
 //!   else:
 //!       existing signed-envelope dispatch (unchanged)
 //! ```
@@ -48,6 +57,23 @@
 //! `FramedKind` enum approach grows the same number of branches but
 //! requires touching every existing send site to opt in; this approach
 //! only touches the sites that need the new wire kind.
+//!
+//! ## Version-byte rollover (v1 → v2 path)
+//!
+//! Per FSD §5, v2 will introduce operational-data CEG envelopes
+//! (orgs / users / licenses / partners) for Spock removal (CIRISRegistry
+//! #58 Phase 2). A node speaking v2 will:
+//!
+//! - SEND `VER = 0x02` frames carrying the v2 codec (which may add
+//!   message variants, new `EnvelopeKind`s, or change message
+//!   field encodings)
+//! - RECEIVE both `VER = 0x01` (legacy) and `VER = 0x02` frames; the
+//!   `try_unwrap` dispatch routes by version
+//!
+//! v1 nodes that see `VER = 0x02` return `ProtocolError::UnknownVersion(0x02)`
+//! and the round fails — the sender's scheduler observes the failure
+//! and either drops the peer or downgrades. There's no silent
+//! misinterpretation.
 
 use super::protocol::{ProtocolError, ReplicationMessage};
 
@@ -57,33 +83,60 @@ use super::protocol::{ProtocolError, ReplicationMessage};
 /// unambiguously a replication frame.
 pub const REPLICATION_FRAME_MAGIC: [u8; 4] = *b"CRPL";
 
+/// Replication wire-protocol version. Locked to `0x01` for v1 per
+/// `FSD/REPLICATION_WIRE_FORMAT_V1.md` §3.5. Bumps to `0x02` for
+/// the CIRIS 2.0 cut (operational-data envelopes per
+/// CIRISRegistry#58 Phase 2).
+pub const WIRE_PROTOCOL_VERSION: u8 = 0x01;
+
+/// Length of the wire-frame preamble (`MAG` + `VER`). The body
+/// follows starting at offset `PREAMBLE_LEN`.
+pub const PREAMBLE_LEN: usize = REPLICATION_FRAME_MAGIC.len() + 1;
+
 /// Wrap a [`ReplicationMessage`] in the wire frame ready to hand to
 /// [`crate::transport::Transport::send`]. Allocates one `Vec` of
-/// exactly `4 + msg.to_bytes().len()` bytes.
+/// exactly `PREAMBLE_LEN + msg.to_bytes().len()` bytes.
+///
+/// The frame uses the current [`WIRE_PROTOCOL_VERSION`] byte. To wrap
+/// at a specific version (e.g. for cross-version interop testing),
+/// use [`wrap_at_version`].
 pub fn wrap(msg: &ReplicationMessage) -> Vec<u8> {
+    wrap_at_version(msg, WIRE_PROTOCOL_VERSION)
+}
+
+/// Wrap a message at a specific protocol version. Production code
+/// always wraps at `WIRE_PROTOCOL_VERSION` via [`wrap`]; this entry
+/// point exists for tests + future cross-version interop drivers.
+pub fn wrap_at_version(msg: &ReplicationMessage, version: u8) -> Vec<u8> {
     let body = msg.to_bytes();
-    let mut out = Vec::with_capacity(REPLICATION_FRAME_MAGIC.len() + body.len());
+    let mut out = Vec::with_capacity(PREAMBLE_LEN + body.len());
     out.extend_from_slice(&REPLICATION_FRAME_MAGIC);
+    out.push(version);
     out.extend_from_slice(&body);
     out
 }
 
 /// Inverse of [`wrap`]. Returns:
 ///
-/// - `Ok(Some(msg))` — bytes start with [`REPLICATION_FRAME_MAGIC`]
-///   and the JSON body decodes cleanly. The caller routes to the
-///   replication path.
+/// - `Ok(Some(msg))` — bytes start with [`REPLICATION_FRAME_MAGIC`],
+///   the version byte matches [`WIRE_PROTOCOL_VERSION`], and the JSON
+///   body decodes cleanly. The caller routes to the replication path.
 /// - `Ok(None)` — bytes don't start with the magic. The caller falls
 ///   through to its non-replication dispatch (existing signed-envelope
 ///   handler, key_grant handler, etc.).
-/// - `Err(ProtocolError)` — bytes DO start with the magic but the JSON
-///   body is malformed. This is a protocol violation by the sender; the
-///   caller surfaces it (typically: drop the frame + log).
+/// - `Err(ProtocolError::UnknownVersion(v))` — bytes start with the
+///   magic but the version byte is unrecognized. Protocol violation
+///   or a peer running a newer wire codec; the caller drops the
+///   frame + logs.
+/// - `Err(ProtocolError::Decode(_))` — bytes have the magic + a known
+///   version but the JSON body is malformed. Protocol violation by
+///   the sender.
 ///
-/// The trichotomy is deliberate: a non-replication frame is NOT an
-/// error from this function's POV — it's a successful "this isn't
-/// ours" answer. A malformed replication frame IS an error because the
-/// magic prefix promised replication-shaped bytes that didn't deliver.
+/// The four-way distinction is deliberate: a non-replication frame is
+/// NOT an error (it's a successful "this isn't ours" answer); an
+/// unknown-version frame IS an error (the magic promised replication-
+/// shaped bytes but we can't speak that version yet); a malformed body
+/// IS an error (sender broke its own contract).
 pub fn try_unwrap(bytes: &[u8]) -> Result<Option<ReplicationMessage>, ProtocolError> {
     if bytes.len() < REPLICATION_FRAME_MAGIC.len() {
         return Ok(None);
@@ -91,7 +144,19 @@ pub fn try_unwrap(bytes: &[u8]) -> Result<Option<ReplicationMessage>, ProtocolEr
     if bytes[..REPLICATION_FRAME_MAGIC.len()] != REPLICATION_FRAME_MAGIC {
         return Ok(None);
     }
-    let body = &bytes[REPLICATION_FRAME_MAGIC.len()..];
+    if bytes.len() < PREAMBLE_LEN {
+        // Magic present but no version byte — caller's framing is
+        // broken or this is a pre-v1 dev frame. Treat as a protocol
+        // error since the magic asserted "this is replication."
+        return Err(ProtocolError::Decode(
+            "replication frame truncated — magic present but version byte missing".into(),
+        ));
+    }
+    let version = bytes[REPLICATION_FRAME_MAGIC.len()];
+    if version != WIRE_PROTOCOL_VERSION {
+        return Err(ProtocolError::UnknownVersion(version));
+    }
+    let body = &bytes[PREAMBLE_LEN..];
     ReplicationMessage::from_bytes(body).map(Some)
 }
 
@@ -110,6 +175,8 @@ mod tests {
         let framed = wrap(&msg);
         // First 4 bytes are the magic.
         assert_eq!(&framed[..4], &REPLICATION_FRAME_MAGIC);
+        // Fifth byte is the wire-protocol version.
+        assert_eq!(framed[4], WIRE_PROTOCOL_VERSION);
         // try_unwrap recovers the original.
         let unwrapped = try_unwrap(&framed).expect("decode").expect("magic match");
         assert_eq!(unwrapped, msg);
@@ -136,29 +203,86 @@ mod tests {
         }
     }
 
-    /// Bytes with the magic but malformed JSON body yield
-    /// `Err(ProtocolError)` — the sender broke the contract.
+    /// Bytes with the magic + correct version byte but malformed JSON
+    /// body yield `Err(ProtocolError::Decode)` — the sender broke
+    /// the contract.
     #[test]
     fn magic_with_malformed_body_is_protocol_error() {
         let mut bytes = REPLICATION_FRAME_MAGIC.to_vec();
+        bytes.push(WIRE_PROTOCOL_VERSION);
         bytes.extend_from_slice(b"{not valid json");
         let r = try_unwrap(&bytes);
         assert!(matches!(r, Err(ProtocolError::Decode(_))));
     }
 
-    /// Bytes with the magic but with a JSON body that's a valid JSON
-    /// object but NOT a `ReplicationMessage` (unknown tag) — same
-    /// `Err(ProtocolError)` shape per [`ReplicationMessage::from_bytes`].
+    /// Bytes with the magic + correct version but with a JSON body
+    /// that's a valid JSON object but NOT a `ReplicationMessage`
+    /// (unknown tag) — same `Err(ProtocolError::Decode)` shape per
+    /// [`ReplicationMessage::from_bytes`].
     #[test]
     fn magic_with_unknown_replication_tag_is_protocol_error() {
         let mut bytes = REPLICATION_FRAME_MAGIC.to_vec();
+        bytes.push(WIRE_PROTOCOL_VERSION);
         bytes.extend_from_slice(br#"{"type":"hostile_takeover","payload":42}"#);
         let r = try_unwrap(&bytes);
         assert!(matches!(r, Err(ProtocolError::Decode(_))));
     }
 
+    /// Bytes with the magic but an unknown version byte yield
+    /// `Err(ProtocolError::UnknownVersion(v))`. Exercises the v1→v2
+    /// rollover path: a v1 receiver seeing a v2 frame surfaces the
+    /// typed unknown-version error so the scheduler can decide
+    /// whether to drop the peer or downgrade.
+    #[test]
+    fn unknown_version_byte_is_typed_error() {
+        let mut v2_bytes = REPLICATION_FRAME_MAGIC.to_vec();
+        v2_bytes.push(0x02); // v2 — not yet supported
+        v2_bytes.extend_from_slice(br#"{"type":"summary","kind":"key","refs":[]}"#);
+        let r = try_unwrap(&v2_bytes);
+        assert!(matches!(r, Err(ProtocolError::UnknownVersion(0x02))));
+
+        // Same for a future v0xFF — caps at u8 max.
+        let mut vff_bytes = REPLICATION_FRAME_MAGIC.to_vec();
+        vff_bytes.push(0xFF);
+        vff_bytes.extend_from_slice(b"{}");
+        let r = try_unwrap(&vff_bytes);
+        assert!(matches!(r, Err(ProtocolError::UnknownVersion(0xFF))));
+    }
+
+    /// Magic present but truncated before the version byte yields a
+    /// Decode error — magic asserted "this is replication" so the
+    /// caller surfaces the protocol violation instead of silently
+    /// treating it as non-replication.
+    #[test]
+    fn magic_without_version_byte_is_decode_error() {
+        let bytes = REPLICATION_FRAME_MAGIC.to_vec(); // exactly 4 bytes, no VER
+        let r = try_unwrap(&bytes);
+        assert!(matches!(r, Err(ProtocolError::Decode(_))));
+    }
+
+    /// `wrap_at_version` lets test fixtures forge cross-version frames.
+    /// Round-trip via the current version works; forged v2 frames
+    /// surface UnknownVersion.
+    #[test]
+    fn wrap_at_version_forges_cross_version_frames() {
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![],
+        });
+        // Current version — round-trips.
+        let v1 = wrap_at_version(&msg, WIRE_PROTOCOL_VERSION);
+        assert_eq!(try_unwrap(&v1).unwrap().unwrap(), msg);
+        // Forged v2 — surfaces UnknownVersion.
+        let v2 = wrap_at_version(&msg, 0x02);
+        assert!(matches!(
+            try_unwrap(&v2),
+            Err(ProtocolError::UnknownVersion(0x02))
+        ));
+    }
+
     /// All four `ReplicationMessage` variants round-trip through
-    /// wrap/try_unwrap.
+    /// wrap/try_unwrap. Exercises all 9 `EnvelopeKind` variants too
+    /// — one per variant to catch any serde-tag regression.
     #[test]
     fn all_variants_round_trip() {
         use crate::replication::protocol::{
@@ -182,8 +306,28 @@ mod tests {
                 want: vec![h, h],
             }),
             ReplicationMessage::Deliver(DeliverMessage {
-                kind: EnvelopeKind::Community,
+                kind: EnvelopeKind::IdentityOccurrence,
                 envelopes: vec![b"signed_envelope_bytes".to_vec()],
+            }),
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Family,
+                refs: vec![],
+            }),
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Community,
+                refs: vec![],
+            }),
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::IdentityOccurrenceRevocation,
+                refs: vec![],
+            }),
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::FamilyMembershipRevocation,
+                refs: vec![],
+            }),
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::CommunityMembershipRevocation,
+                refs: vec![],
             }),
         ];
         for msg in cases {

--- a/src/replication/wire_frame.rs
+++ b/src/replication/wire_frame.rs
@@ -329,6 +329,10 @@ mod tests {
                 kind: EnvelopeKind::CommunityMembershipRevocation,
                 refs: vec![],
             }),
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::LocationProof,
+                refs: vec![],
+            }),
         ];
         for msg in cases {
             let framed = wrap(&msg);

--- a/tests/replication_wire_proptest.rs
+++ b/tests/replication_wire_proptest.rs
@@ -1,0 +1,183 @@
+//! Property-based invariants for the v1 replication wire format.
+//!
+//! Locks the wire-stable contract from `FSD/REPLICATION_WIRE_FORMAT_V1.md`
+//! against arbitrary inputs — proptest generates thousands of random
+//! `ReplicationMessage` shapes and asserts the invariants hold for
+//! every one.
+//!
+//! ## What's tested
+//!
+//! 1. **Wrap/unwrap round-trip** — for any `ReplicationMessage`,
+//!    `try_unwrap(wrap(m)) == Ok(Some(m))`.
+//! 2. **Magic prefix discriminates** — for any byte string that doesn't
+//!    start with `CRPL`, `try_unwrap` returns `Ok(None)`. (Non-
+//!    replication bytes route to the non-replication dispatcher.)
+//! 3. **Unknown version surfaces typed error** — for any version byte
+//!    other than `WIRE_PROTOCOL_VERSION`, `try_unwrap` returns
+//!    `Err(UnknownVersion(v))`.
+//! 4. **`EnvelopeKind` JSON tag round-trips** — every variant
+//!    serialises + deserialises to itself.
+//!
+//! ## Wall-clock budget
+//!
+//! Default proptest runs 256 cases per `proptest!`. The whole file
+//! finishes in well under a second on CI runners — proportionate to
+//! the value (every PR exercises the v1 wire contract against random
+//! inputs).
+//!
+//! ## Why an integration test, not a #[cfg(test)] mod
+//!
+//! Property-based tests touching the wire contract validate the
+//! **public API surface** — the same shape downstream consumers see.
+//! Integration-test placement means the test links against the
+//! crate's exported `pub` items, catching any accidental
+//! `pub(crate)` regression that would hide a wire-format type.
+
+use ciris_edge::replication::protocol::ProtocolError;
+use ciris_edge::replication::wire_frame::{
+    try_unwrap, wrap, wrap_at_version, WIRE_PROTOCOL_VERSION,
+};
+use ciris_edge::replication::{
+    DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, ReplicationMessage,
+    SummaryMessage, REPLICATION_FRAME_MAGIC,
+};
+use proptest::prelude::*;
+
+// ─── Generators ────────────────────────────────────────────────────
+
+fn arb_envelope_kind() -> impl Strategy<Value = EnvelopeKind> {
+    prop_oneof![
+        Just(EnvelopeKind::Key),
+        Just(EnvelopeKind::Attestation),
+        Just(EnvelopeKind::Revocation),
+        Just(EnvelopeKind::IdentityOccurrence),
+        Just(EnvelopeKind::Family),
+        Just(EnvelopeKind::Community),
+        Just(EnvelopeKind::IdentityOccurrenceRevocation),
+        Just(EnvelopeKind::FamilyMembershipRevocation),
+        Just(EnvelopeKind::CommunityMembershipRevocation),
+    ]
+}
+
+fn arb_envelope_ref() -> impl Strategy<Value = EnvelopeRef> {
+    (any::<[u8; 32]>(), any::<u64>())
+        .prop_map(|(envelope_hash, seq)| EnvelopeRef { envelope_hash, seq })
+}
+
+fn arb_summary() -> impl Strategy<Value = SummaryMessage> {
+    (
+        arb_envelope_kind(),
+        prop::collection::vec(arb_envelope_ref(), 0..16),
+    )
+        .prop_map(|(kind, refs)| SummaryMessage { kind, refs })
+}
+
+fn arb_diff() -> impl Strategy<Value = DiffMessage> {
+    (
+        arb_envelope_kind(),
+        prop::collection::vec(any::<[u8; 32]>(), 0..32),
+    )
+        .prop_map(|(kind, want)| DiffMessage { kind, want })
+}
+
+fn arb_fetch() -> impl Strategy<Value = FetchMessage> {
+    (
+        arb_envelope_kind(),
+        prop::collection::vec(any::<[u8; 32]>(), 0..32),
+    )
+        .prop_map(|(kind, want)| FetchMessage { kind, want })
+}
+
+fn arb_deliver() -> impl Strategy<Value = DeliverMessage> {
+    (
+        arb_envelope_kind(),
+        prop::collection::vec(prop::collection::vec(any::<u8>(), 0..256), 0..8),
+    )
+        .prop_map(|(kind, envelopes)| DeliverMessage { kind, envelopes })
+}
+
+fn arb_replication_message() -> impl Strategy<Value = ReplicationMessage> {
+    prop_oneof![
+        arb_summary().prop_map(ReplicationMessage::Summary),
+        arb_diff().prop_map(ReplicationMessage::Diff),
+        arb_fetch().prop_map(ReplicationMessage::Fetch),
+        arb_deliver().prop_map(ReplicationMessage::Deliver),
+    ]
+}
+
+// ─── Properties ────────────────────────────────────────────────────
+
+proptest! {
+    /// Property 1: any well-formed `ReplicationMessage` round-trips
+    /// through `wrap` → `try_unwrap`. The wire format is bijective on
+    /// the message domain.
+    #[test]
+    fn wrap_unwrap_round_trip_for_any_message(msg in arb_replication_message()) {
+        let framed = wrap(&msg);
+        let parsed = try_unwrap(&framed).expect("decode").expect("magic");
+        prop_assert_eq!(parsed, msg);
+    }
+
+    /// Property 2: bytes that do NOT start with the `CRPL` magic
+    /// always return `Ok(None)` — never an error. The application's
+    /// dispatcher routes non-replication bytes to its other handlers.
+    ///
+    /// We constrain the first byte ≠ b'C' (the first byte of CRPL)
+    /// so the test doesn't accidentally generate a magic prefix.
+    /// That's a strict subset of the property — any byte string whose
+    /// first byte is in `[0..b'C') ∪ (b'C'..=0xFF]` will not match
+    /// magic. (The `[b'C'..b'C']` 1-byte window may match; we exclude
+    /// it explicitly.)
+    #[test]
+    fn non_crpl_bytes_yield_none(
+        bytes in prop::collection::vec(any::<u8>(), 0..512)
+            .prop_filter("first byte is C", |v| v.first() != Some(&b'C'))
+    ) {
+        let r = try_unwrap(&bytes).expect("non-CRPL routing is never an error");
+        prop_assert!(r.is_none());
+    }
+
+    /// Property 3: any version byte other than `WIRE_PROTOCOL_VERSION`
+    /// surfaces as `UnknownVersion(v)`, regardless of body content.
+    /// Anchors the v1→v2 transition story: a v1 receiver seeing a v2
+    /// frame fails cleanly with a typed error the scheduler can act
+    /// on (drop the peer, downgrade, etc.).
+    #[test]
+    fn unknown_version_byte_always_surfaces_typed_error(
+        version in any::<u8>().prop_filter("non-v1 version", |v| *v != WIRE_PROTOCOL_VERSION),
+        body in prop::collection::vec(any::<u8>(), 0..256),
+    ) {
+        let mut frame = REPLICATION_FRAME_MAGIC.to_vec();
+        frame.push(version);
+        frame.extend_from_slice(&body);
+        match try_unwrap(&frame) {
+            Err(ProtocolError::UnknownVersion(v)) => prop_assert_eq!(v, version),
+            other => prop_assert!(
+                false,
+                "expected UnknownVersion({}), got {:?}", version, other
+            ),
+        }
+    }
+
+    /// Property 4: every `EnvelopeKind` variant serialises +
+    /// deserialises to itself through the JSON serde tag. Locks the
+    /// snake_case rename of every variant — if a future commit
+    /// accidentally renames a variant's serde tag, this proptest
+    /// surfaces the regression on every shrink.
+    #[test]
+    fn envelope_kind_json_tag_round_trips(kind in arb_envelope_kind()) {
+        let json = serde_json::to_string(&kind).unwrap();
+        let parsed: EnvelopeKind = serde_json::from_str(&json).unwrap();
+        prop_assert_eq!(parsed, kind);
+    }
+
+    /// Property 5: `wrap_at_version` with the canonical version
+    /// produces the same bytes as `wrap`. (Documents the equivalence
+    /// for test-fixture readers; catches any drift where `wrap`
+    /// accidentally embeds a different version byte than
+    /// `WIRE_PROTOCOL_VERSION`.)
+    #[test]
+    fn wrap_equals_wrap_at_current_version(msg in arb_replication_message()) {
+        prop_assert_eq!(wrap(&msg), wrap_at_version(&msg, WIRE_PROTOCOL_VERSION));
+    }
+}

--- a/tests/replication_wire_proptest.rs
+++ b/tests/replication_wire_proptest.rs
@@ -56,6 +56,7 @@ fn arb_envelope_kind() -> impl Strategy<Value = EnvelopeKind> {
         Just(EnvelopeKind::IdentityOccurrenceRevocation),
         Just(EnvelopeKind::FamilyMembershipRevocation),
         Just(EnvelopeKind::CommunityMembershipRevocation),
+        Just(EnvelopeKind::LocationProof),
     ]
 }
 


### PR DESCRIPTION
## Summary

Locks the v1 replication wire format. Anchors the path to **CIRIS 2.0**:
the wire-version byte at the frame layer makes the v1→v2 transition
peer-by-peer instead of fleet-wide flag-day.

### FSD/REPLICATION_WIRE_FORMAT_V1.md

Five design questions answered (citations in the FSD):

| Q | Status | Lock source |
|---|---|---|
| envelope_hash identity | LOCKED | \`original_content_hash\` per persist record types + CEG §0.9.2.1 |
| envelope_bytes format | LOCKED | canonical(Signed*Record) via persist's canonicalizer (MISSION.md §3 — \"Canonical bytes are not edge's to define\") |
| EnvelopeKind taxonomy | EXPAND 4→9 | aligned 1:1 with persist's \`FederationDirectory::put_*\` surface |
| Anti-entropy protocol | LOCKED | Summary/Diff/Fetch/Deliver per CIRISRegistry#58 \"Edge owns propagation\" |
| Version-byte rollover | NEW | \`VER\` byte in frame preamble; v1=0x01, v2 reserved for CIRIS 2.0 |

### 9-variant EnvelopeKind (FSD §3.3)

\`\`\`
Key                              -> put_public_key
Attestation                      -> put_attestation
Revocation                       -> put_revocation
IdentityOccurrence               -> put_identity_occurrence
Family                           -> put_family
Community                        -> put_community
IdentityOccurrenceRevocation     -> put_identity_occurrence_revocation (v4.8.0)
FamilyMembershipRevocation       -> put_family_membership_revocation (v4.8.0)
CommunityMembershipRevocation    -> put_community_membership_revocation (v4.8.0)
\`\`\`

Layer (c-2)'s \`apply_envelope_bytes\` dispatches via simple match on
\`EnvelopeKind\` — no JSON shape sniffing.

### Wire-frame preamble (FSD §3.5)

\`\`\`
  ┌────┬────┬──────────────────────────────────────────────┐
  │CRPL│VER │  ReplicationMessage::to_bytes() — JSON       │
  │ 4B │ 1B │                                              │
  └────┴────┴──────────────────────────────────────────────┘
\`\`\`

\`WIRE_PROTOCOL_VERSION = 0x01\` locks v1. \`wrap_at_version\` lets test
fixtures forge cross-version frames; \`try_unwrap\` surfaces typed
\`ProtocolError::UnknownVersion(u8)\` on future v2 frames so a v1
receiver fails cleanly + the scheduler reports the mismatch as
\`RoundEvent::Error\`.

### Strict v1 parser

\`coordinator::parse_inbound_bytes\` no longer tolerates bare-JSON
(the pre-v1 rolling-upgrade tolerance). Wire-stable contract going
forward.

## Tests

218 lib tests pass (was 214):
- \`unknown_version_byte_is_typed_error\` — v1→v2 rollover surface
- \`magic_without_version_byte_is_decode_error\` — truncated preamble
- \`wrap_at_version_forges_cross_version_frames\` — interop driver
- \`envelope_kind_wire_values_are_unique\` — no serde-tag collisions
- \`envelope_kind_wire_values_are_stable\` updated for 9 variants
- \`parse_inbound_bytes_strict_v1_rejects_bare_json\` (renamed from
  the legacy tolerance test)

cargo clippy clean on both CI combos; fmt clean.

## Path to CIRIS 2.0 (FSD §5)

- **1.x replication line** — v1 wire (\`VER=0x01\`), 9 EnvelopeKinds,
  federation directory + R1/Q1 quorum-merge for trust data
- **2.0 cut** — Spock fully removed (CIRISRegistry#58 Phase 2).
  Operational-data envelopes defined by Registry (orgs/users/
  licenses/partners). Wire bumps to \`VER=0x02\` with new
  EnvelopeKinds. Edge tolerates v1+v2 during rolling upgrade

## Test plan

- [x] 4 CI feature combos clean under -D warnings
- [x] cargo clippy clean on both CI clippy combos
- [x] cargo fmt clean
- [x] 218 lib tests pass
- [ ] CI green

## Follow-ups stacked on this

- Layer (c-2) \`FederationDirectoryReplicationBridge\` over persist
- PyO3 init wiring (\`init_edge_runtime\` + \`PyEdge::register_replication_peer\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)