### PR TITLE
replication: PyO3 init wiring — ReplicationRegistry + ReplicationRuntime + PyReplicationHandle (closes #65 v1)

### DIFF
--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -868,6 +868,179 @@ impl PyEdge {
 
         Ok(root.unbind().into_any())
     }
+
+    // ── CIRISEdge#65 v1.6.3 — PyO3 init wiring for replication ──────
+    //
+    // Closes the 8th and final rung of #65's v1 ladder per
+    // FSD/REPLICATION_WIRE_FORMAT_V1.md §3.7. Spawns a
+    // `ReplicationRuntime` (bridge + registry + scheduler) bound to
+    // this PyEdge's federation directory and first transport;
+    // returns a `PyReplicationHandle` the operator holds for the
+    // lifetime of their replication peer set.
+
+    /// Start the replication runtime over this edge's federation
+    /// directory + transport.
+    ///
+    /// `peers` is a list of `(peer_key_id, kind_str)` tuples where
+    /// `kind_str` is one of the 10 wire-stable kinds per FSD §3.3:
+    /// "key" / "attestation" / "revocation" / "identity_occurrence"
+    /// / "family" / "community" / "identity_occurrence_revocation"
+    /// / "family_membership_revocation" /
+    /// "community_membership_revocation" / "location_proof".
+    ///
+    /// `cadence_seconds` overrides the scheduler's default 30 s
+    /// per-round cadence; `None` keeps the default. The round
+    /// timeout stays at the scheduler default (10 s).
+    ///
+    /// Errors:
+    /// - `ValueError("edge has no federation_directory wired")` if
+    ///   the cohabitation init path didn't supply one (the typical
+    ///   test-fixture trap).
+    /// - `ValueError("edge has no transport wired")` if no
+    ///   transport was registered at init.
+    /// - `ValueError("unknown EnvelopeKind: {token}")` if a kind
+    ///   string in `peers` doesn't match the 10 wire tokens.
+    #[pyo3(signature = (peers, cadence_seconds = None))]
+    fn start_replication(
+        &self,
+        py: Python<'_>,
+        peers: Vec<(String, String)>,
+        cadence_seconds: Option<u64>,
+    ) -> PyResult<PyReplicationHandle> {
+        let directory = self
+            .inner
+            .federation_directory()
+            .ok_or_else(|| PyValueError::new_err("edge has no federation_directory wired"))?;
+        let transports = self.inner.transports();
+        let transport = transports
+            .into_iter()
+            .next()
+            .ok_or_else(|| PyValueError::new_err("edge has no transport wired"))?;
+
+        let mut typed_peers = Vec::with_capacity(peers.len());
+        for (peer_key_id, kind_str) in peers {
+            let kind = parse_envelope_kind(&kind_str)?;
+            typed_peers.push(crate::replication::ReplicationPeer { peer_key_id, kind });
+        }
+
+        let mut config = crate::replication::ReplicationRuntimeConfig::default();
+        if let Some(secs) = cadence_seconds {
+            config.scheduler.cadence = std::time::Duration::from_secs(secs);
+        }
+
+        let executor = self.executor.clone();
+        let runtime = py.detach(|| {
+            run_async(&executor, async move {
+                crate::replication::ReplicationRuntime::start(
+                    directory,
+                    transport,
+                    typed_peers,
+                    config,
+                )
+                .await
+            })
+        });
+
+        Ok(PyReplicationHandle {
+            inner: Arc::new(tokio::sync::Mutex::new(Some(runtime))),
+            executor: self.executor.clone(),
+        })
+    }
+}
+
+/// Parse a wire-stable kind string into [`crate::replication::EnvelopeKind`].
+/// The token set is the 10 `#[serde(rename_all = "snake_case")]`
+/// variants per FSD §3.3.
+fn parse_envelope_kind(s: &str) -> PyResult<crate::replication::EnvelopeKind> {
+    use crate::replication::EnvelopeKind;
+    match s {
+        "key" => Ok(EnvelopeKind::Key),
+        "attestation" => Ok(EnvelopeKind::Attestation),
+        "revocation" => Ok(EnvelopeKind::Revocation),
+        "identity_occurrence" => Ok(EnvelopeKind::IdentityOccurrence),
+        "family" => Ok(EnvelopeKind::Family),
+        "community" => Ok(EnvelopeKind::Community),
+        "identity_occurrence_revocation" => Ok(EnvelopeKind::IdentityOccurrenceRevocation),
+        "family_membership_revocation" => Ok(EnvelopeKind::FamilyMembershipRevocation),
+        "community_membership_revocation" => Ok(EnvelopeKind::CommunityMembershipRevocation),
+        "location_proof" => Ok(EnvelopeKind::LocationProof),
+        other => Err(PyValueError::new_err(format!(
+            "unknown EnvelopeKind: {other:?} (valid: key, attestation, revocation, \
+             identity_occurrence, family, community, \
+             identity_occurrence_revocation, family_membership_revocation, \
+             community_membership_revocation, location_proof)"
+        ))),
+    }
+}
+
+/// Python-facing handle for the `ReplicationRuntime`.
+///
+/// Construct via [`PyEdge::start_replication`]; hold for the
+/// lifetime of the application's replication peer set; call
+/// `register_peer` for hot-add; call `stop` for graceful shutdown.
+///
+/// Clones of this handle (Python references) share the same inner
+/// runtime — first `stop` shuts down; subsequent `stop` calls are
+/// no-ops.
+#[pyclass(unsendable)]
+pub struct PyReplicationHandle {
+    inner: Arc<tokio::sync::Mutex<Option<crate::replication::ReplicationRuntime>>>,
+    executor: Arc<ciris_persist::ffi::executor_capsule::AsyncExecutor>,
+}
+
+#[pymethods]
+impl PyReplicationHandle {
+    /// Number of currently registered `(peer_key_id, kind)` pairs.
+    /// Returns 0 after `stop()`.
+    fn registered_count(&self, py: Python<'_>) -> usize {
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                if let Some(rt) = guard.as_ref() {
+                    rt.registry().len().await
+                } else {
+                    0
+                }
+            })
+        })
+    }
+
+    /// Hot-add a `(peer_key_id, kind)` after start. See
+    /// `ReplicationRuntime::register_peer` for the v1 limitation
+    /// (hot-adds default to Responder role; the scheduler's
+    /// Initiator set is fixed at start in v1).
+    fn register_peer(&self, py: Python<'_>, peer_key_id: &str, kind: &str) -> PyResult<()> {
+        let kind = parse_envelope_kind(kind)?;
+        let peer = peer_key_id.to_string();
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                if let Some(rt) = guard.as_ref() {
+                    rt.register_peer(peer, kind).await;
+                }
+            });
+        });
+        Ok(())
+    }
+
+    /// Stop the replication runtime — signals the scheduler to
+    /// exit and awaits its run loop. Idempotent.
+    fn stop(&self, py: Python<'_>) {
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let mut guard = inner.lock().await;
+                if let Some(mut rt) = guard.take() {
+                    rt.shutdown().await;
+                }
+            });
+        });
+    }
 }
 
 /// CIRISEdge#22 Tier 3 (v0.17.0) — Python-side projection of the
@@ -3068,6 +3241,11 @@ fn ciris_edge(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // CIRISEdge#34 (v0.19.0) — per-category network-event AsyncIterator
     // pyclass returned by every `PyEdge::subscribe_*` pymethod.
     m.add_class::<PyNetworkEventSubscription>()?;
+
+    // CIRISEdge#65 v1 (v1.6.3) — replication runtime handle. Returned
+    // by `PyEdge::start_replication`; the operator holds it for the
+    // lifetime of their peer set and calls `register_peer` / `stop`.
+    m.add_class::<PyReplicationHandle>()?;
 
     // init_edge_runtime — the CIRISEdge#16 / CIRIS-3.0 cohabitation
     // constructor. Only registered when the Reticulum transport is

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -120,6 +120,8 @@ pub mod bridge;
 pub mod coordinator;
 pub mod directory;
 pub mod protocol;
+pub mod registry;
+pub mod runtime;
 pub mod scheduler;
 pub mod session;
 pub mod summary;
@@ -136,6 +138,10 @@ pub use protocol::{
     DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, ReplicationMessage,
     SummaryMessage,
 };
+#[doc(inline)]
+pub use registry::{RegistryError, ReplicationRegistry, RouteOutcome};
+#[doc(inline)]
+pub use runtime::{ReplicationPeer, ReplicationRuntime, ReplicationRuntimeConfig};
 #[doc(inline)]
 pub use scheduler::{ReplicationScheduler, RoundEvent, SchedulerConfig};
 #[doc(inline)]

--- a/src/replication/registry.rs
+++ b/src/replication/registry.rs
@@ -1,0 +1,435 @@
+//! `ReplicationRegistry` — application-side dispatch table for the
+//! anti-entropy replication module.
+//!
+//! Closes the 5th of the 5 design questions raised in CIRISEdge#65's
+//! pre-FSD discussion: *"the application's `Transport::listen` loop
+//! receives bytes; the CRPL wire-frame prefix (#72) identifies
+//! replication bytes; but each peer has its own coordinator, so
+//! dispatch is `(remote_key_id, kind) → coordinator`."*
+//!
+//! The registry holds `Arc<ReplicationCoordinator>` indexed by
+//! `(peer_key_id, kind)`, and routes inbound bytes via
+//! [`Self::route_inbound_bytes`]:
+//!
+//! - bytes don't carry the CRPL magic → `Ok(false)` (caller routes to
+//!   its non-replication dispatch — existing signed-envelope handler,
+//!   key_grant handler, etc.)
+//! - bytes carry CRPL + a recognized version + a parseable
+//!   `ReplicationMessage` → look up the matching coordinator,
+//!   `deliver_inbound`, return `Ok(true)`
+//! - bytes carry CRPL but the message is malformed or no coordinator
+//!   is registered for `(peer_key_id, kind)` → `Err(…)` (caller logs +
+//!   drops)
+//!
+//! ## Why a registry, not a flat list
+//!
+//! Anti-entropy is per-peer-per-kind. A federation node may anti-
+//! entropy Keys with one peer, Attestations with another, all kinds
+//! with a third. The registry lets operators register/deregister at
+//! the (peer, kind) granularity without churning the scheduler's
+//! Initiator set.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tokio::sync::RwLock;
+
+use super::coordinator::{CoordinatorError, ReplicationCoordinator};
+use super::protocol::EnvelopeKind;
+use super::wire_frame;
+
+/// Outcome of [`ReplicationRegistry::route_inbound_bytes`].
+#[derive(Debug)]
+pub enum RouteOutcome {
+    /// Bytes were a valid replication frame and were routed to a
+    /// registered coordinator's `deliver_inbound` queue.
+    Routed,
+    /// Bytes did NOT carry the CRPL magic prefix. The caller's
+    /// dispatcher should fall through to its non-replication
+    /// handler.
+    NotAReplicationFrame,
+    /// Bytes carried the CRPL magic but no coordinator is registered
+    /// for the inferred `(peer_key_id, kind)`. The caller typically
+    /// logs + drops. (`peer_key_id` is supplied by the caller from
+    /// the transport's source-identification layer; the wire frame
+    /// itself does NOT carry it — it's transport-medium-identified.)
+    NoCoordinatorRegistered { kind: EnvelopeKind },
+}
+
+/// Errors from registry routing.
+#[derive(Debug, thiserror::Error)]
+pub enum RegistryError {
+    #[error("replication protocol error: {0}")]
+    Protocol(#[from] CoordinatorError),
+    /// The matching coordinator's inbound channel is full — back-
+    /// pressure surfaces. The scheduler isn't keeping up; the caller
+    /// typically logs and drops.
+    #[error("coordinator inbound channel full for peer={peer_key_id} kind={kind:?}")]
+    BackPressure {
+        peer_key_id: String,
+        kind: EnvelopeKind,
+    },
+}
+
+/// Dispatch table for inbound replication messages, indexed by
+/// `(peer_key_id, kind)`.
+///
+/// Thread-safe. Multiple application tasks can call
+/// [`Self::route_inbound_bytes`] concurrently; the underlying
+/// `RwLock` is read-mostly (registration is rare; routing is hot-
+/// path).
+pub struct ReplicationRegistry {
+    by_peer_kind: RwLock<HashMap<(String, EnvelopeKind), Arc<ReplicationCoordinator>>>,
+}
+
+impl ReplicationRegistry {
+    pub fn new() -> Self {
+        Self {
+            by_peer_kind: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Register a coordinator for `(peer_key_id, kind)`. Replaces
+    /// any prior coordinator at that key (the application's
+    /// hot-add / hot-replace surface).
+    pub async fn register(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+        coord: Arc<ReplicationCoordinator>,
+    ) {
+        let key = (peer_key_id.into(), kind);
+        self.by_peer_kind.write().await.insert(key, coord);
+    }
+
+    /// Remove the coordinator at `(peer_key_id, kind)`. Returns
+    /// the removed coordinator if one was registered; `None` if
+    /// no registration existed.
+    pub async fn deregister(
+        &self,
+        peer_key_id: &str,
+        kind: EnvelopeKind,
+    ) -> Option<Arc<ReplicationCoordinator>> {
+        self.by_peer_kind
+            .write()
+            .await
+            .remove(&(peer_key_id.to_string(), kind))
+    }
+
+    /// Lookup the coordinator for `(peer_key_id, kind)`. Returns
+    /// `None` if no registration exists. Useful for telemetry +
+    /// hot-add idempotency checks.
+    pub async fn get(
+        &self,
+        peer_key_id: &str,
+        kind: EnvelopeKind,
+    ) -> Option<Arc<ReplicationCoordinator>> {
+        self.by_peer_kind
+            .read()
+            .await
+            .get(&(peer_key_id.to_string(), kind))
+            .cloned()
+    }
+
+    /// Number of registered `(peer_key_id, kind)` pairs.
+    pub async fn len(&self) -> usize {
+        self.by_peer_kind.read().await.len()
+    }
+
+    /// Whether the registry is empty (no registrations).
+    pub async fn is_empty(&self) -> bool {
+        self.by_peer_kind.read().await.is_empty()
+    }
+
+    /// All registered keys, snapshot at call time. Useful for
+    /// shutdown loops + telemetry.
+    pub async fn registered_keys(&self) -> Vec<(String, EnvelopeKind)> {
+        self.by_peer_kind.read().await.keys().cloned().collect()
+    }
+
+    /// Route inbound bytes from the application's `Transport::listen`
+    /// loop. The transport layer supplies the source-identified
+    /// `peer_key_id` (Reticulum announces carry the source destination
+    /// hash; HTTPS mTLS carries the CN of the client cert verified
+    /// against `federation_keys`; etc.).
+    ///
+    /// Returns:
+    /// - `Ok(RouteOutcome::Routed)` — bytes parsed as a replication
+    ///   frame for the inferred kind; coordinator's `deliver_inbound`
+    ///   queue accepted them.
+    /// - `Ok(RouteOutcome::NotAReplicationFrame)` — no CRPL magic.
+    ///   Caller falls through to non-replication dispatch.
+    /// - `Ok(RouteOutcome::NoCoordinatorRegistered { kind })` —
+    ///   CRPL magic + parseable, but no `(peer_key_id, kind)`
+    ///   registration. Caller logs + drops.
+    /// - `Err(RegistryError::Protocol(_))` — CRPL magic present but
+    ///   body malformed or unknown version. Caller logs + drops.
+    /// - `Err(RegistryError::BackPressure { … })` — matching
+    ///   coordinator's inbound channel is full. Caller logs + drops;
+    ///   the next round picks up.
+    pub async fn route_inbound_bytes(
+        &self,
+        peer_key_id: &str,
+        bytes: &[u8],
+    ) -> Result<RouteOutcome, RegistryError> {
+        let msg = match wire_frame::try_unwrap(bytes) {
+            Ok(Some(m)) => m,
+            Ok(None) => return Ok(RouteOutcome::NotAReplicationFrame),
+            Err(e) => return Err(RegistryError::Protocol(e.into())),
+        };
+        // ReplicationMessage carries a `kind` field on every variant
+        // — that's our dispatch key alongside peer_key_id.
+        let kind = match &msg {
+            super::protocol::ReplicationMessage::Summary(m) => m.kind,
+            super::protocol::ReplicationMessage::Diff(m) => m.kind,
+            super::protocol::ReplicationMessage::Fetch(m) => m.kind,
+            super::protocol::ReplicationMessage::Deliver(m) => m.kind,
+        };
+        let Some(coord) = self.get(peer_key_id, kind).await else {
+            return Ok(RouteOutcome::NoCoordinatorRegistered { kind });
+        };
+        coord
+            .deliver_inbound(msg)
+            .map_err(|_| RegistryError::BackPressure {
+                peer_key_id: peer_key_id.to_string(),
+                kind,
+            })?;
+        Ok(RouteOutcome::Routed)
+    }
+}
+
+impl Default for ReplicationRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::replication::directory::MockReplicationDirectory;
+    use crate::replication::directory::{DirectoryStateAdapter, MutableDirectoryStateAdapter};
+    use crate::replication::protocol::{ReplicationMessage, SummaryMessage};
+    use crate::replication::session::SessionRole;
+    use crate::replication::summary::{StateApplier, StateProvider};
+    use crate::replication::wire_frame::wrap;
+    use crate::transport::{
+        InboundFrame, Transport, TransportError, TransportId, TransportSendOutcome,
+    };
+    use async_trait::async_trait;
+    use tokio::sync::Mutex;
+
+    // ── Test transport (no-op) ──────────────────────────────────────
+
+    struct NoopTransport;
+    #[async_trait]
+    impl Transport for NoopTransport {
+        fn id(&self) -> TransportId {
+            TransportId::HTTP
+        }
+        async fn send(
+            &self,
+            _destination_key_id: &str,
+            _envelope_bytes: &[u8],
+        ) -> Result<TransportSendOutcome, TransportError> {
+            Ok(TransportSendOutcome::Delivered)
+        }
+        async fn listen(
+            &self,
+            _sink: tokio::sync::mpsc::Sender<InboundFrame>,
+        ) -> Result<(), TransportError> {
+            unimplemented!("registry tests don't drive listen")
+        }
+    }
+
+    // ── Test coordinator builder ────────────────────────────────────
+
+    fn make_coord(peer: &str, kind: EnvelopeKind) -> Arc<ReplicationCoordinator> {
+        let mock = Arc::new(MockReplicationDirectory::new());
+        let dir: Arc<dyn crate::replication::directory::ReplicationDirectory> =
+            Arc::clone(&mock) as _;
+        let provider: Arc<dyn StateProvider> =
+            Arc::new(DirectoryStateAdapter::new(Arc::clone(&dir)));
+        let applier: Arc<Mutex<dyn StateApplier>> =
+            Arc::new(Mutex::new(MutableDirectoryStateAdapter::new(dir)));
+        Arc::new(ReplicationCoordinator::new(
+            Arc::new(NoopTransport),
+            peer,
+            kind,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        ))
+    }
+
+    // ── Smoke ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn empty_registry_routes_inbound_bytes_as_not_a_replication_frame() {
+        let registry = ReplicationRegistry::new();
+        assert!(registry.is_empty().await);
+        // Plain JSON without CRPL magic → NotAReplicationFrame.
+        let r = registry
+            .route_inbound_bytes("any_peer", b"{\"hello\":\"world\"}")
+            .await
+            .expect("not an error");
+        assert!(matches!(r, RouteOutcome::NotAReplicationFrame));
+    }
+
+    #[tokio::test]
+    async fn register_then_lookup_round_trips() {
+        let registry = ReplicationRegistry::new();
+        let coord = make_coord("bob", EnvelopeKind::Key);
+        registry
+            .register("bob".to_string(), EnvelopeKind::Key, Arc::clone(&coord))
+            .await;
+        assert_eq!(registry.len().await, 1);
+        let found = registry.get("bob", EnvelopeKind::Key).await;
+        assert!(found.is_some());
+        let keys = registry.registered_keys().await;
+        assert_eq!(keys, vec![("bob".to_string(), EnvelopeKind::Key)]);
+    }
+
+    #[tokio::test]
+    async fn deregister_removes_entry() {
+        let registry = ReplicationRegistry::new();
+        let coord = make_coord("alice", EnvelopeKind::Attestation);
+        registry
+            .register("alice", EnvelopeKind::Attestation, coord)
+            .await;
+        assert_eq!(registry.len().await, 1);
+        let removed = registry
+            .deregister("alice", EnvelopeKind::Attestation)
+            .await;
+        assert!(removed.is_some());
+        assert!(registry.is_empty().await);
+        // Idempotent deregister returns None on second call.
+        let second = registry
+            .deregister("alice", EnvelopeKind::Attestation)
+            .await;
+        assert!(second.is_none());
+    }
+
+    // ── Routing ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn route_inbound_bytes_routes_to_registered_coordinator() {
+        let registry = ReplicationRegistry::new();
+        let coord = make_coord("carol", EnvelopeKind::Key);
+        registry
+            .register("carol", EnvelopeKind::Key, Arc::clone(&coord))
+            .await;
+
+        // Build a Summary message wrapped in the CRPL frame.
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![],
+        });
+        let framed = wrap(&msg);
+
+        let r = registry
+            .route_inbound_bytes("carol", &framed)
+            .await
+            .expect("routed");
+        assert!(matches!(r, RouteOutcome::Routed));
+    }
+
+    #[tokio::test]
+    async fn route_to_unregistered_peer_returns_no_coordinator() {
+        let registry = ReplicationRegistry::new();
+        // Don't register anything; build a valid frame anyway.
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Attestation,
+            refs: vec![],
+        });
+        let framed = wrap(&msg);
+        let r = registry
+            .route_inbound_bytes("ghost", &framed)
+            .await
+            .expect("ok");
+        match r {
+            RouteOutcome::NoCoordinatorRegistered { kind } => {
+                assert_eq!(kind, EnvelopeKind::Attestation);
+            }
+            o => panic!("expected NoCoordinatorRegistered, got {o:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn route_with_correct_peer_wrong_kind_returns_no_coordinator() {
+        let registry = ReplicationRegistry::new();
+        let coord = make_coord("dave", EnvelopeKind::Key);
+        registry.register("dave", EnvelopeKind::Key, coord).await;
+        // Frame for a DIFFERENT kind than what's registered.
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Revocation,
+            refs: vec![],
+        });
+        let framed = wrap(&msg);
+        let r = registry
+            .route_inbound_bytes("dave", &framed)
+            .await
+            .expect("ok");
+        assert!(matches!(
+            r,
+            RouteOutcome::NoCoordinatorRegistered {
+                kind: EnvelopeKind::Revocation
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn route_malformed_replication_frame_is_protocol_error() {
+        let registry = ReplicationRegistry::new();
+        // CRPL magic + version byte + garbage body.
+        let mut bytes = wire_frame::REPLICATION_FRAME_MAGIC.to_vec();
+        bytes.push(wire_frame::WIRE_PROTOCOL_VERSION);
+        bytes.extend_from_slice(b"{not valid json");
+        let r = registry.route_inbound_bytes("anyone", &bytes).await;
+        assert!(matches!(r, Err(RegistryError::Protocol(_))));
+    }
+
+    #[tokio::test]
+    async fn route_unknown_version_is_protocol_error() {
+        let registry = ReplicationRegistry::new();
+        // Forge a v2 frame.
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![],
+        });
+        let v2 = wire_frame::wrap_at_version(&msg, 0x02);
+        let r = registry.route_inbound_bytes("anyone", &v2).await;
+        // UnknownVersion surfaces via the Protocol error.
+        assert!(matches!(r, Err(RegistryError::Protocol(_))));
+    }
+
+    /// Filling the coordinator's inbound channel surfaces as
+    /// BackPressure. The coordinator's channel capacity is 8 (see
+    /// `ReplicationCoordinator::INBOUND_CHANNEL_CAPACITY`); send 9
+    /// messages without anything draining it.
+    #[tokio::test]
+    async fn route_into_full_channel_surfaces_back_pressure() {
+        let registry = ReplicationRegistry::new();
+        let coord = make_coord("eve", EnvelopeKind::Key);
+        registry.register("eve", EnvelopeKind::Key, coord).await;
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![],
+        });
+        let framed = wrap(&msg);
+        // Fill the capacity-8 channel.
+        for _ in 0..ReplicationCoordinator::INBOUND_CHANNEL_CAPACITY {
+            let r = registry.route_inbound_bytes("eve", &framed).await;
+            assert!(matches!(r, Ok(RouteOutcome::Routed)));
+        }
+        // The 9th surfaces BackPressure.
+        let r = registry.route_inbound_bytes("eve", &framed).await;
+        match r {
+            Err(RegistryError::BackPressure {
+                peer_key_id,
+                kind: EnvelopeKind::Key,
+            }) => assert_eq!(peer_key_id, "eve"),
+            o => panic!("expected BackPressure, got {o:?}"),
+        }
+    }
+}

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -1,0 +1,362 @@
+//! `ReplicationRuntime` — the operator-facing entry point that
+//! bundles bridge + registry + scheduler + cohort callback into a
+//! single managed runtime.
+//!
+//! Closes the orchestration concern raised in CIRISEdge#65's
+//! FSD §3.7. Per the FSD:
+//!
+//! > `init_edge_runtime` gains [replication parameters]. Each entry
+//! > constructs a `ReplicationCoordinator` (Initiator role, because
+//! > the operator chose to peer with this remote for this kind),
+//! > registers it with the application-side `ReplicationRegistry`
+//! > (for inbound dispatch), and adds it to the
+//! > `ReplicationScheduler`'s Initiator set.
+//!
+//! This module is the small bit of glue that does all of that
+//! cohesively + exposes a runtime handle the caller can hold for
+//! the lifetime of their application.
+//!
+//! ## Shape
+//!
+//! - [`ReplicationRuntime::start`] constructs the bridge, builds
+//!   coordinators for each peer/kind in the configured set,
+//!   registers them with a shared [`ReplicationRegistry`], hands
+//!   the Initiator set to a [`ReplicationScheduler`], and spawns
+//!   the scheduler's run loop on the current tokio runtime.
+//! - [`ReplicationRuntime::register_peer`] hot-adds a new
+//!   `(peer_key_id, kind)` after start.
+//! - [`ReplicationRuntime::registry`] returns a shared
+//!   `Arc<ReplicationRegistry>` the application's `Transport::listen`
+//!   loop calls `route_inbound_bytes` on. The listen-loop integration
+//!   itself is operator code — when bytes arrive identifying a
+//!   source peer, the operator calls `registry.route_inbound_bytes(
+//!   peer_key_id, bytes)` and that's it.
+//! - [`ReplicationRuntime::shutdown`] flips the scheduler's cancel
+//!   watch to true and awaits the scheduler's run-loop task to
+//!   completion.
+//!
+//! ## Why no auto-routing into transport.listen()
+//!
+//! Edge's `Transport::listen` already runs in the application's
+//! existing dispatch loop. Wiring the registry's `route_inbound_bytes`
+//! INTO that loop is operator code (a one-line addition to the
+//! application's listen-handler), not edge's job. This keeps the
+//! v1 cut clean: the runtime exposes the registry; the operator
+//! wires it. A v1.7 follow-up may add an opt-in
+//! `Edge::install_replication_routing(runtime)` helper.
+
+use std::sync::Arc;
+
+use ciris_persist::federation::FederationDirectory;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+
+use super::bridge::{BridgeConfig, CohortProvider, FederationDirectoryReplicationBridge};
+use super::coordinator::ReplicationCoordinator;
+use super::directory::{DirectoryStateAdapter, MutableDirectoryStateAdapter, ReplicationDirectory};
+use super::protocol::EnvelopeKind;
+use super::registry::ReplicationRegistry;
+use super::scheduler::{ReplicationScheduler, SchedulerConfig};
+use super::session::SessionRole;
+use super::summary::{StateApplier, StateProvider};
+use crate::transport::Transport;
+
+/// A `(peer_key_id, kind)` pair the runtime should anti-entropy with
+/// as the Initiator side. Each pair gets one [`ReplicationCoordinator`]
+/// in the Initiator role.
+#[derive(Debug, Clone)]
+pub struct ReplicationPeer {
+    pub peer_key_id: String,
+    pub kind: EnvelopeKind,
+}
+
+/// Configuration for [`ReplicationRuntime::start`].
+#[derive(Debug, Clone, Default)]
+pub struct ReplicationRuntimeConfig {
+    /// Cadence + round-timeout for the scheduler. Defaults to
+    /// [`SchedulerConfig::default`] (30 s cadence, 10 s round timeout).
+    pub scheduler: SchedulerConfig,
+    /// Cache + paging tuning for the bridge. Defaults to
+    /// [`BridgeConfig::default`].
+    pub bridge: BridgeConfig,
+}
+
+/// Live replication runtime — bridge + registry + scheduler task +
+/// shutdown handle. Construct via [`Self::start`]; hold the returned
+/// handle for the lifetime of the application; call
+/// [`Self::shutdown`] to stop the background scheduler.
+pub struct ReplicationRuntime {
+    transport: Arc<dyn Transport>,
+    registry: Arc<ReplicationRegistry>,
+    bridge: Arc<FederationDirectoryReplicationBridge>,
+    cancel_tx: watch::Sender<bool>,
+    scheduler_task: Option<JoinHandle<()>>,
+    config: ReplicationRuntimeConfig,
+}
+
+impl ReplicationRuntime {
+    /// Start the runtime with the given set of Initiator peers.
+    ///
+    /// `directory` is the persist federation directory (typically
+    /// extracted from a cohabitating `PyEngine` via the
+    /// [`crate::ffi::pyo3::extract_capsule`] helper, or passed as an
+    /// `Arc<dyn FederationDirectory>` from the host code path).
+    ///
+    /// `transport` is the canonical transport for the peer set
+    /// (Reticulum per MISSION §1.4; HTTPS in fallback deployments).
+    /// One transport instance is shared across all coordinators —
+    /// each coordinator addresses its peer by `peer_key_id`.
+    ///
+    /// `peers` is the initial Initiator set. Each entry constructs
+    /// one [`ReplicationCoordinator`] in Initiator role, registers
+    /// it with the registry, and hands it to the scheduler.
+    pub async fn start(
+        directory: Arc<dyn FederationDirectory>,
+        transport: Arc<dyn Transport>,
+        peers: Vec<ReplicationPeer>,
+        config: ReplicationRuntimeConfig,
+    ) -> Self {
+        // Cohort callback: yields the set of peer_key_ids we
+        // anti-entropy with, snapshotted at construction. Hot-adds
+        // via [`Self::register_peer`] don't update the snapshot —
+        // the FSD §3.6 cohort is operator-configured + serves the
+        // bridge's list_envelope_refs path, which can re-read on
+        // each tick. We accept the snapshot model here because v1
+        // hot-add is uncommon; a follow-up patch can swap in a
+        // shared Arc<RwLock<Vec<String>>> if dynamism becomes the
+        // common path.
+        let cohort_snapshot: Vec<String> = peers.iter().map(|p| p.peer_key_id.clone()).collect();
+        let cohort: CohortProvider = Arc::new(move || cohort_snapshot.clone());
+
+        let bridge = Arc::new(FederationDirectoryReplicationBridge::with_config(
+            Arc::clone(&directory),
+            cohort,
+            config.bridge,
+        ));
+
+        let registry = Arc::new(ReplicationRegistry::new());
+
+        // Build coordinators + scheduler. Coordinators share one
+        // bridge instance; provider + applier are split-shape per
+        // session.rs's borrow story (the bridge is the same object
+        // backing both).
+        let mut scheduler = ReplicationScheduler::new(config.scheduler);
+        let coords: Vec<Arc<ReplicationCoordinator>> = peers
+            .iter()
+            .map(|peer| {
+                let bridge_dir: Arc<dyn ReplicationDirectory> = Arc::clone(&bridge) as _;
+                let provider: Arc<dyn StateProvider> =
+                    Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
+                let applier: Arc<tokio::sync::Mutex<dyn StateApplier>> = Arc::new(
+                    tokio::sync::Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)),
+                );
+                Arc::new(ReplicationCoordinator::new(
+                    Arc::clone(&transport),
+                    &peer.peer_key_id,
+                    peer.kind,
+                    SessionRole::Initiator,
+                    provider,
+                    applier,
+                ))
+            })
+            .collect();
+
+        for (peer, coord) in peers.iter().zip(coords.iter()) {
+            scheduler.add_initiator(Arc::clone(coord));
+            // Register so the operator's listen loop can route
+            // inbound replies (the Initiator side receives Summary
+            // / Diff / Deliver back from the peer). Inline await
+            // because `start` is async.
+            registry
+                .register(peer.peer_key_id.clone(), peer.kind, Arc::clone(coord))
+                .await;
+        }
+
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let scheduler_task = tokio::spawn(async move {
+            scheduler.run_until_cancelled(cancel_rx).await;
+        });
+
+        // `directory` is consumed by the bridge above (held inside
+        // `bridge`'s Arc<dyn FederationDirectory>). Drop the local
+        // binding to make the lifecycle explicit.
+        drop(directory);
+
+        Self {
+            transport,
+            registry,
+            bridge,
+            cancel_tx,
+            scheduler_task: Some(scheduler_task),
+            config,
+        }
+    }
+
+    /// Hot-add a new `(peer_key_id, kind)` Initiator. Constructs a
+    /// coordinator, registers it, **but does NOT add to the
+    /// scheduler's Initiator set** for v1 — that requires the
+    /// scheduler to expose dynamic adds (not in the v1 API).
+    ///
+    /// For now hot-add lets the Responder-side route inbound for
+    /// the new peer; the Initiator side would need a runtime
+    /// restart to fire periodic rounds. This is acceptable for the
+    /// hot-add-is-uncommon v1 posture; a v1.x patch will extend
+    /// the scheduler with a dynamic-add API.
+    pub async fn register_peer(&self, peer_key_id: impl Into<String>, kind: EnvelopeKind) {
+        let peer_key_id = peer_key_id.into();
+        let bridge_dir: Arc<dyn ReplicationDirectory> = Arc::clone(&self.bridge) as _;
+        let provider: Arc<dyn StateProvider> =
+            Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
+        let applier: Arc<tokio::sync::Mutex<dyn StateApplier>> = Arc::new(tokio::sync::Mutex::new(
+            MutableDirectoryStateAdapter::new(bridge_dir),
+        ));
+        let coord = Arc::new(ReplicationCoordinator::new(
+            Arc::clone(&self.transport),
+            peer_key_id.clone(),
+            kind,
+            SessionRole::Responder, // hot-add defaults to Responder; cf. doc above
+            provider,
+            applier,
+        ));
+        self.registry.register(peer_key_id, kind, coord).await;
+    }
+
+    /// Shared registry handle. The operator's `Transport::listen`
+    /// loop calls [`ReplicationRegistry::route_inbound_bytes`] on
+    /// this when bytes arrive from an identified source peer.
+    pub fn registry(&self) -> Arc<ReplicationRegistry> {
+        Arc::clone(&self.registry)
+    }
+
+    /// The runtime's bridge. Useful for telemetry or tests that
+    /// want to inspect cache state.
+    pub fn bridge(&self) -> Arc<FederationDirectoryReplicationBridge> {
+        Arc::clone(&self.bridge)
+    }
+
+    /// Returns the active runtime configuration.
+    pub fn config(&self) -> &ReplicationRuntimeConfig {
+        &self.config
+    }
+
+    /// Signal the scheduler to stop and await its run loop to exit
+    /// cleanly. Idempotent — repeated calls return immediately
+    /// after the first stop completes.
+    pub async fn shutdown(&mut self) {
+        let _ = self.cancel_tx.send(true);
+        if let Some(task) = self.scheduler_task.take() {
+            let _ = task.await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciris_persist::store::MemoryBackend;
+    use std::sync::Arc;
+
+    use crate::transport::{InboundFrame, TransportError, TransportId, TransportSendOutcome};
+    use async_trait::async_trait;
+
+    struct NoopTransport;
+    #[async_trait]
+    impl Transport for NoopTransport {
+        fn id(&self) -> TransportId {
+            TransportId::HTTP
+        }
+        async fn send(
+            &self,
+            _destination_key_id: &str,
+            _envelope_bytes: &[u8],
+        ) -> Result<TransportSendOutcome, TransportError> {
+            Ok(TransportSendOutcome::Delivered)
+        }
+        async fn listen(
+            &self,
+            _sink: tokio::sync::mpsc::Sender<InboundFrame>,
+        ) -> Result<(), TransportError> {
+            unimplemented!("runtime tests don't drive listen")
+        }
+    }
+
+    /// `start` with an empty peer list builds the runtime + spawns
+    /// the scheduler task; `shutdown` exits cleanly.
+    #[tokio::test]
+    async fn empty_peer_set_starts_and_shuts_down_cleanly() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        assert!(rt.registry().is_empty().await);
+        rt.shutdown().await;
+    }
+
+    /// `start` with one Initiator peer registers it + holds the
+    /// registry handle the listen loop would use.
+    #[tokio::test]
+    async fn one_initiator_peer_registered_at_start() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let peers = vec![ReplicationPeer {
+            peer_key_id: "agent-alice".to_string(),
+            kind: EnvelopeKind::Key,
+        }];
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            peers,
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        let registry = rt.registry();
+        assert_eq!(registry.len().await, 1);
+        let coord = registry.get("agent-alice", EnvelopeKind::Key).await;
+        assert!(coord.is_some());
+        rt.shutdown().await;
+    }
+
+    /// `register_peer` hot-adds and the registry reflects the
+    /// add immediately.
+    #[tokio::test]
+    async fn register_peer_hot_adds() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        rt.register_peer("agent-bob", EnvelopeKind::Attestation)
+            .await;
+        assert_eq!(rt.registry().len().await, 1);
+        rt.shutdown().await;
+    }
+
+    /// `shutdown` is idempotent.
+    #[tokio::test]
+    async fn shutdown_is_idempotent() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        rt.shutdown().await;
+        rt.shutdown().await; // no panic, no hang
+    }
+}


### PR DESCRIPTION
Closes the 8th and final rung of CIRISEdge#65's v1 ladder per FSD/REPLICATION_WIRE_FORMAT_V1.md §3.7. After this PR, #65's v1 implementation is feature-complete: edge ships the orchestration glue the operator wires into their application.

## What's in this PR

### `src/replication/registry.rs` (new module)

`ReplicationRegistry` — application-side dispatch table indexed by `(peer_key_id, kind)`. Closes the 5th of the 5 design questions raised in #65's pre-FSD discussion: how to dispatch CRPL-framed inbound bytes to the matching coordinator.

- `register(peer_key_id, kind, coord)` / `deregister(...)` / `get(...)` / `len()` / `is_empty()` / `registered_keys()` — standard map ops, RwLock-backed (read-mostly).
- `route_inbound_bytes(peer_key_id, bytes)` — the hot-path call from the operator's `Transport::listen` loop. Trichotomy:
  - `Ok(Routed)` — bytes parsed as a CRPL+VER replication frame for a registered (peer, kind); coordinator's `deliver_inbound` accepted
  - `Ok(NotAReplicationFrame)` — no CRPL magic; caller routes to its non-replication dispatch
  - `Ok(NoCoordinatorRegistered { kind })` — CRPL present + parseable but no `(peer, kind)` registration; caller logs + drops
  - `Err(Protocol(_))` — malformed body or unknown wire version
  - `Err(BackPressure { … })` — coordinator's inbound channel full

9 new tests cover all paths.

### `src/replication/runtime.rs` (new module)

`ReplicationRuntime` — bundles bridge + registry + scheduler task + shutdown handle into a single managed runtime. Closes the orchestration concern from FSD §3.7.

- `ReplicationRuntime::start(directory, transport, peers, config)` — async. Constructs the FederationDirectoryReplicationBridge, builds one ReplicationCoordinator per (peer_key_id, kind) in Initiator role, registers them with a shared ReplicationRegistry, hands the Initiator set to a ReplicationScheduler, and spawns the scheduler's run loop on the current tokio runtime.
- `register_peer(peer_key_id, kind)` — hot-add. Defaults to Responder role; the scheduler's Initiator set is fixed at start in v1 (a v1.x patch will extend the scheduler with a dynamic-add API).
- `registry()` / `bridge()` — shared handles for operator integration + telemetry.
- `shutdown()` — flips the scheduler's cancel watch and awaits the run-loop task to completion. Idempotent.

4 new tests cover construction, hot-add, and shutdown.

### `src/ffi/pyo3.rs` — PyO3 surface

- `PyEdge::start_replication(peers, cadence_seconds=None)` — Python method on PyEdge. Pulls the federation_directory + first transport from the cohabitation Edge, parses the kind strings, dispatches to `ReplicationRuntime::start` via persist's executor capsule, and returns a `PyReplicationHandle`. Surfaces clear `ValueError`s on missing directory / missing transport / unknown kind string.
- `parse_envelope_kind(s)` — strict parser for the 10 wire-stable kind tokens (key / attestation / revocation / identity_occurrence / family / community / identity_occurrence_revocation / family_membership_revocation / community_membership_revocation / location_proof). Same `serde(rename_all = "snake_case")` tokens the wire frame uses; FSD §3.3 table.
- `PyReplicationHandle` — Python-facing handle wrapping the ReplicationRuntime. Methods: `registered_count` / `register_peer(peer_key_id, kind)` / `stop()`. `Arc<Mutex<Option<…>>>` inner pattern lets clones share state + makes `stop` idempotent (post-stop, the handle is dead but cloning works).

### Why no auto-routing into `Transport::listen`

Edge's `Transport::listen` already runs in the application's existing dispatch loop. Wiring the registry's `route_inbound_bytes` INTO that loop is operator code (a one-line addition to the application's listen-handler), not edge's job. This keeps the v1 cut clean: the runtime exposes the registry; the operator wires it. A v1.7 follow-up may add an opt-in `Edge::install_replication_routing(runtime)` helper if operator demand surfaces.

## Verification

- 4 CI feature combos clean under `RUSTFLAGS="-D warnings"`
- `cargo clippy` clean on both CI clippy combos
- `cargo fmt` clean
- 244 lib tests green (was 231; +9 registry + +4 runtime)
- 5 proptest properties green

## #65 ladder status — v1 feature complete

All 8 rungs landed:
1. ✓ Protocol state machine (#69)
2. ✓ Coordinator (#70)
3. ✓ Directory adapters (#71)
4. ✓ Wire-frame prefix (#72)
5. ✓ Long-lived Session (#73)
6. ✓ Scheduler + wire-format lock (#75 / #76)
7. ✓ Layer (c-2) production bridge (#78 / v1.6.0)
8. ✓ **PyO3 init wiring + registry + runtime (this PR)**

#65 closes as v1 feature complete after this merges. v2 cycles (PyO3 listen-loop integration helper, ReadEngine bulk optimization, persist-side `lookup_*_by_content_hash`, scheduler dynamic-add API) become v1.7+ patch follow-ups.

## Test plan

- [x] `cargo test --lib` green (244 tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean on the two CI feature combos
- [x] `cargo fmt --check` clean
- [ ] Full CI matrix green on the 4 feature combos under `RUSTFLAGS="-D warnings"`

## Path to CIRIS 2.0 (FSD §5) unchanged

- v1 wire LOCKED at 10 variants (`WIRE_PROTOCOL_VERSION = 0x01`)
- v2 cut gated on CIRISRegistry#58 Phase 2 (operational-data envelopes)
- v2 will be the natural moment to switch envelope_hash to a CEG-§0.9-conformant basis (per §3.2.1's deferred interop path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)