### PR TITLE
release(v1.7.0): substrate floor major persist v5.0.0 + FSD §3.2.2 / §5.2 amendment (CEG 1.0-RC2 lock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,24 @@ jobs:
           - { name: pyo3-full,      features: "transport-http transport-reticulum pyo3", all_targets: "true" }
     steps:
       - uses: actions/checkout@v4
+      # pyo3-full builds the largest target set (--all-targets: lib +
+      # integration tests + benches + doctests against persist + verify
+      # + criterion). At persist v5.0.0 + verify v5.0.0 the cumulative
+      # compile artifact set exceeds the default GitHub runner's 14GB
+      # disk. jlumbroso/free-disk-space frees ~30GB by removing the
+      # preinstalled Android SDK / .NET / GHC / dotnet toolchains we
+      # don't use — keeps the leaner --lib lanes (core / reticulum /
+      # packet-radio / all-transports) from paying the ~60s setup cost.
+      - name: free disk space (pyo3-full only — large compile footprint)
+        if: matrix.combo.name == 'pyo3-full'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          swap-storage: false
       # ciris-keyring's `tpm` feature (auto-enabled for Linux targets
       # by ciris-persist v1.10.0+, CIRISPersist#87) builds tss-esapi,
       # which links libtss2. Cargo unions the feature across the graph

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "1.6.3"
+version = "1.7.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v4.15.0", version = "4", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.0.0", version = "5", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -817,7 +817,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v4.15.0", version = "4", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.0.0", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/FSD/REPLICATION_WIRE_FORMAT_V1.md
+++ b/FSD/REPLICATION_WIRE_FORMAT_V1.md
@@ -211,7 +211,44 @@ flag-day required.
 
 **v1 stays unchanged** — `persist_row_hash` uniformly, all-persist
 federations only. Documented as an explicit interop boundary, not a
-silent caveat.
+silent caveat. **The deferred path resolves in §3.2.2.**
+
+#### 3.2.2 v2 envelope_hash basis — LOCKED (CEG 1.0-RC2)
+
+**Resolution of the §3.2.1 deferred-interop path.** CEG 1.0-RC2
+(`v-ceg-1.0-rc2`, commit `b21fe84`) closed blocker A as **JCS**
+(RFC 8785 — not TupleHash128); CEG 1.0-RC1 (`v-ceg-1.0-rc1`, commit
+`8872bfe`) shipped the canonical-bytes redesign. CIRISRegistry#70
+review (Edge ✅ · Verify ✅ · Persist ✅) locked the v2 wire surface
+in the same RC2 cut.
+
+**v2 `envelope_hash` = `sha256(JCS(Signed*Record))`**, uniformly
+across all v2-emitting kinds. Edge-defined; reproducible by any
+CEG-§0.9-conformant implementation; non-persist CEG implementers
+gain full interop with v2-capable peers.
+
+The architectural shift from v1:
+
+- **v1**: `envelope_hash = persist_row_hash` (V1Python, persist-internal).
+  All-persist federations only; an explicit interop boundary per §3.2.1.
+- **v2**: `envelope_hash = sha256(JCS(Signed*Record))` (CEG-§0.9-conformant,
+  edge-defined). Any CEG implementation reproduces it.
+
+Per §3.5, peer-by-peer transition: v2-capable peers exchange v2
+envelopes with v2-capable peers and v1 envelopes with v1-only peers.
+The version byte negotiates; no flag-day.
+
+**`PartnerRecord` admission depends on JCS basis.** Per the Verify
+review catch locked in RC2 §5.6.8.13: M distinct stewards must sign
+**byte-identical JCS canonical bytes** for the M-of-N steward quorum
+to admit. The §0.9.2.1 rule 1 set-semantics declaration on
+`capabilities_granted[]` / `capabilities_denied[]` /
+unordered-list-inside-`constraints` (lexicographic sort) is what
+makes M-of-N convergence possible — without it, two stewards
+emitting the same grant in different field order produce different
+canonical bytes and the quorum silently fails to admit. Edge's v2
+wire surfaces these arrays via the same JCS pass that produces
+`envelope_hash`; consistency by construction.
 
 The wire bytes include the embedded scrub signatures + the
 server-computed `persist_row_hash` field — the **full record** as
@@ -424,9 +461,10 @@ This FSD anchors v1 so the path is clear:
    for trust data. Operational-data still on Spock multi-master.
 2. **CIRIS 2.0 cut** — Spock fully removed. Operational-data envelopes
    defined by Registry (per #58 Phase 2). Wire bumps to `VER = 0x02`
-   adding `EnvelopeKind::Org`, `User`, `License`, `Partner` (or
-   whatever Registry names them). Edge tolerates both v1 and v2
-   wire during the rolling-upgrade window via the version byte.
+   adding **three** new `EnvelopeKind`s (per §5.2 below — locked at
+   RC2, narrower than the four originally anticipated). Edge tolerates
+   both v1 and v2 wire during the rolling-upgrade window via the
+   version byte.
 3. **Post-2.0** — Spock-free federation; one CEG-native replication
    mechanism; single auditable cryptographic-provenance trail across
    every cross-region state change.
@@ -436,6 +474,71 @@ detail. Without it, the v1 → v2 transition would require a coordinated
 fleet-wide flag day. With it, individual peers can upgrade
 independently and the framing dispatch tells them what they're
 receiving.
+
+### 5.2 v2 EnvelopeKind additions — LOCKED (CEG 1.0-RC2 §5.6.8.13)
+
+CIRISRegistry#70 specified the operational-data envelope shape;
+three-sided federation review (Edge ✅ · Verify ✅ · Persist ✅)
+locked decisions; CEG 1.0-RC2 codified at §5.6.8.13. The v2
+`EnvelopeKind` additions are **three**, not the four originally
+forecast:
+
+| v2 `EnvelopeKind` | wire token | merge intent (§10.1.6) | rationale |
+|---|---|---|---|
+| `Organization` | `organization` | `lww_skew_bounded` | public org identity federates; PII (`tax_id`, contacts, `metadata`) stays region-local |
+| `OrgMembership` | `org_membership` | `lww_skew_bounded` + `withdrawal_forward_only` | authz binding (`user_id`/`org_id`/`role`) federates; **User PII never federates** |
+| `PartnerRecord` | `partner_record` | `monotonic_quorum` (V058-generalized) | combines old `License`+`Partner`; M-of-N steward quorum + monotonic-fail-secure (more-restrictive wins) |
+
+**`User` is explicitly dropped from the wire.** The original §5
+forecast anticipated four kinds (`Org`/`User`/`License`/`Partner`);
+the federate-the-trust/authz-minimal-projection principle keeps PII
+per-region — only the `OrgMembership` role binding crosses. The old
+`License`+`Partner` pair collapses into the existing combined
+`PartnerRecord` shape (already hybrid-signed today; CEG-native just
+means it propagates by envelope instead of Spock).
+
+**Wire tokens are normative** — snake_case per the §3.3 v1
+convention; the CEG cut names them explicitly so no implementation
+re-derives. Per §3.2.2, all three v2 kinds use
+`envelope_hash = sha256(JCS(Signed*Record))`.
+
+**Edge's v2 implementation scope:**
+
+1. Add `Organization`, `OrgMembership`, `PartnerRecord` to
+   `EnvelopeKind` under a `WireVersion::V2` discriminant.
+2. Implement v2 `envelope_hash` per §3.2.2 (JCS-conformant).
+3. Extend `Session` version negotiation to advertise v2 + fall back
+   to v1 with v1-only peers (the §3.5 byte already supports this).
+4. Wire `Bridge::apply_envelope_bytes` to persist's three new
+   admit surfaces (`put_organization` / `put_org_membership` /
+   `put_partner_record`).
+5. **No new coordinator code** — merge policy stays persist-side
+   (`lww_skew_bounded` + `withdrawal_forward_only` + `monotonic_quorum`
+   dispatched declaratively per §10.1.6, never inferred). The
+   M-of-N quorum aggregation, `revision: u64` anti-rollback, and
+   skew-bound LWW are all admit-time checks edge stays agnostic to.
+
+**Substrate prerequisites for the v2 cycle:**
+
+- **`ciris-persist` v5.x** carrying `put_organization` /
+  `put_org_membership` / `put_partner_record` admit surfaces,
+  V058-generalized `verify_coord` for `license_id`, skew-bound LWW
+  precedence, stable-id grouping.
+- **`ciris-verify` v6.x** carrying the `delegates_to` role-chain
+  resolver applied to operational subject_kinds + `verify_founder_quorum`
+  for `PartnerRecord` admission.
+- CIRISConformance#9 M-of-N identical-bytes vector set published
+  (the Verify-raised catch — locked in RC2).
+
+### 5.3 v2 → v3 (and beyond)
+
+CEG 1.0-RC2 declares the **design surface complete** — #70 was the
+one scheduled addition; RC2→1.0 changes are found defects, not
+design additions. Edge's v3+ surface area is therefore expected to
+be either (a) optimization-driven (e.g., O(log N) MLS rekey tree
+when the relay/multicast 1.x cycle drives it — currently CIRISEdge#66)
+or (b) reactive to defect-driven CEG amendments. No further forecast
+EnvelopeKinds expected.
 
 ## 6. Non-goals (explicit, with linked tracking)
 


### PR DESCRIPTION
Two coupled changes for the v2 wire prep cycle: persist v5 substrate-floor major + FSD amendment locking the v2 envelope shape per CEG 1.0-RC2.

## 1. Substrate floor major — persist v4.15.0 → v5.0.0

CIRISPersist v5.0.0 — the agent-2.9.6 / CEG-1.0 substrate line (CIRISPersist#186; #171 / CIRISAgent#840). Persist shipped the v5 major FIRST to break the #840 chicken-and-egg: the agent's `graph_nodes → attestations` hard cut migrates against persist's complete local-tier attestation surface.

Edge-side this is **pure pin currency** — the surfaces persist v5 adds are agent-facing (`attestation_upsert_local_many` / `insert_local_many` PyO3 batch surfaces); edge consumes additively. Zero source-side changes.

- `Cargo.toml`: tag v4.15.0 → v5.0.0 + version "4" → "5" (both occurrences)
- Lockstep with `ciris-verify` already at v5.0.0

## 2. FSD §3.2.2 + §5.2 amendment — CEG 1.0-RC2 v2 lock

CEG 1.0-RC2 (tag `v-ceg-1.0-rc2`, commit `b21fe84`) landed today carrying every locked resolution from the three-sided CIRISRegistry#70 review (Edge / Verify / Persist all green). The design surface is declared **complete** — #70 was the one scheduled addition; RC2→1.0 changes are found defects only.

Edge's review (CIRISRegistry#70 issuecomment-4671567455) committed to filing this FSD amendment concurrent with the CEG cut.

### §3.2.2 — v2 envelope_hash basis (closes §3.2.1 deferred path)

| basis | v1 | v2 |
|---|---|---|
| envelope_hash | `persist_row_hash` (V1Python, persist-internal) | `sha256(JCS(Signed*Record))` (CEG-§0.9-conformant) |
| interop | all-persist federations only | any CEG implementation |

JCS is the §0.9 basis (RFC 8785). §3.2.2 also pins **PartnerRecord admission's dependency on JCS basis** — M distinct stewards must sign byte-identical JCS canonical bytes for the M-of-N quorum to admit.

### §5.2 — v2 EnvelopeKind additions LOCKED

| `EnvelopeKind` | wire token | merge intent (§10.1.6) |
|---|---|---|
| `Organization` | `organization` | `lww_skew_bounded` |
| `OrgMembership` | `org_membership` | `lww_skew_bounded` + `withdrawal_forward_only` |
| `PartnerRecord` | `partner_record` | `monotonic_quorum` (V058-generalized) |

**`User` drops** — PII federate-the-minimal-projection principle: only the `OrgMembership` role binding crosses. **`License`+`Partner` collapse** into combined `PartnerRecord`.

## Verification

- 4 RUSTFLAGS=-D warnings combos green
- 244 lib tests green vs persist v5
- cargo clippy clean
- cargo fmt clean

## What's NOT in this cut

- **CIRISConformance matrix bump** held until persist 5.0.0 PyPI propagation
- **v2 EnvelopeKind code** blocked on persist v5.x admit surfaces + verify v6.x role-chain resolver + CIRISConformance#9 vector set

## Test plan

- [x] cargo test --lib green (244 tests)
- [x] All 4 CI feature combos clean under RUSTFLAGS=-D warnings
- [x] cargo clippy clean / cargo fmt clean
- [ ] Full CI gauntlet green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
