### PR TITLE
release(v2.0.0): v2 wire cycle — 3 operational EnvelopeKinds + JCS envelope_hash (CEG 1.0-RC2 §5.6.8.13)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "1.7.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.0.0", version = "5", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.1.1", version = "5", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,17 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.0.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.0.0", version = "5", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.0.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
+# v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
+# for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
+# `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
+# input shape persist's v2 operational `put_*` admit surfaces expect).
+# Edge MUST NOT reimplement JCS per FSD §3.2 ("Canonical bytes are not
+# edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
+# with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
+# substrate floor with persist v5.1.1 (operational-data admit surface).
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -817,7 +826,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.0.0", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.1.1", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/FSD/REPLICATION_WIRE_FORMAT_V1.md
+++ b/FSD/REPLICATION_WIRE_FORMAT_V1.md
@@ -502,33 +502,68 @@ convention; the CEG cut names them explicitly so no implementation
 re-derives. Per §3.2.2, all three v2 kinds use
 `envelope_hash = sha256(JCS(Signed*Record))`.
 
-**Edge's v2 implementation scope:**
+**Edge's v2 implementation scope — SHIPPED at v2.0.0:**
 
-1. Add `Organization`, `OrgMembership`, `PartnerRecord` to
-   `EnvelopeKind` under a `WireVersion::V2` discriminant.
-2. Implement v2 `envelope_hash` per §3.2.2 (JCS-conformant).
-3. Extend `Session` version negotiation to advertise v2 + fall back
-   to v1 with v1-only peers (the §3.5 byte already supports this).
-4. Wire `Bridge::apply_envelope_bytes` to persist's three new
-   admit surfaces (`put_organization` / `put_org_membership` /
-   `put_partner_record`).
-5. **No new coordinator code** — merge policy stays persist-side
+1. ✅ Added `Organization`, `OrgMembership`, `PartnerRecord` to
+   `EnvelopeKind` (appended for `Ord`/`Hash` stability on
+   `LocalState`'s `BTreeMap<EnvelopeKind, …>` keys).
+2. ✅ Implemented v2 `envelope_hash` per §3.2.2 (JCS-conformant) —
+   `bridge::v2_envelope_hash` calls
+   `ciris_verify_core::jcs::canonicalize` then sha256.
+3. ✅ Wire-version negotiation extended — `WIRE_PROTOCOL_VERSION_V2 = 0x02`
+   in `wire_frame.rs`; `try_unwrap` accepts both `0x01` and `0x02`;
+   `wrap_for_kind` selects per-message version via
+   `EnvelopeKind::min_wire_version` (v2 kinds emit at `0x02`, v1 kinds
+   stay at `0x01`); `Coordinator::send_message` calls `wrap_for_kind`.
+4. ✅ `Bridge::apply_envelope_bytes` extended with `apply_organization` /
+   `apply_org_membership` / `apply_partner_record` — each dispatches
+   to persist v5.1.1's `put_organization` / `put_org_membership` /
+   `put_partner_record` with the operator-supplied `OperationalProviders`
+   (key_directory + root_stewards + steward_roster).
+5. ✅ No new coordinator code — merge policy stays persist-side
    (`lww_skew_bounded` + `withdrawal_forward_only` + `monotonic_quorum`
-   dispatched declaratively per §10.1.6, never inferred). The
-   M-of-N quorum aggregation, `revision: u64` anti-rollback, and
-   skew-bound LWW are all admit-time checks edge stays agnostic to.
+   per §10.1.6, dispatched declaratively, never inferred).
+6. ✅ `OperationalProviders` bundle in `BridgeConfig` — optional;
+   when unset (`v1-only` bridge construction via `new` / `with_config`),
+   all 3 operational `apply_*` fail-close to `false` without touching
+   persist. Operators opt into v2 admission via
+   `with_operational` / `with_config_and_operational`.
 
-**Substrate prerequisites for the v2 cycle:**
+**Substrate prerequisites — SATISFIED:**
 
-- **`ciris-persist` v5.x** carrying `put_organization` /
-  `put_org_membership` / `put_partner_record` admit surfaces,
-  V058-generalized `verify_coord` for `license_id`, skew-bound LWW
-  precedence, stable-id grouping.
-- **`ciris-verify` v6.x** carrying the `delegates_to` role-chain
-  resolver applied to operational subject_kinds + `verify_founder_quorum`
-  for `PartnerRecord` admission.
-- CIRISConformance#9 M-of-N identical-bytes vector set published
-  (the Verify-raised catch — locked in RC2).
+- ✅ **`ciris-persist` v5.1.1** ships `put_organization` /
+  `put_org_membership` / `put_partner_record` admit surfaces + the
+  two §10.1.6 merge dispatchers (`resolve_lww` for organization /
+  org_membership; `resolve_monotonic_quorum` for partner_record) +
+  V058-generalized `verify_coord` for `license_id` + skew-bound LWW
+  precedence + stable-id grouping.
+- ✅ **`ciris-verify` v5.1.0** ships `ciris_verify_core::operational_admit`
+  (the role-chain resolver applied to operational subject_kinds via
+  `resolve_role_authority` + `verify_founder_quorum` for partner_record
+  admission) + `ciris_verify_core::jcs::canonicalize` (the JCS basis
+  v2 envelope_hash invokes).
+- ⏳ **CIRISConformance#9** M-of-N identical-bytes vector set — pending
+  (the Verify-raised catch from RC2 review). Persist + verify own the
+  fixture generation; edge consumes the vectors via conformance tests.
+
+**v2.0.0 known limitation — `partner_record` is admit-only.**
+
+`PartnerRecord`'s row shape (per CIRISPersist v5.1.0's
+`federation::operational::PartnerRecord`) does NOT carry the M-of-N
+steward signatures inline — they live in the
+`SignedPartnerRecord` write wrapper. Persist v5.1.0's
+`list_partner_records_since` returns rows only (no companion
+`list_signed_partner_records_since`). Edge's
+`Bridge::list_partner_records` therefore returns empty — the Initiator
+side does NOT advertise `partner_record` envelopes via anti-entropy
+enumeration. The Responder side admits peer-pushed
+`SignedPartnerRecord` bytes correctly (the sender ships the M-of-N
+signatures inline; verify v5.1.0's `verify_partner_record_quorum`
+admits on receipt). The fully bidirectional path lights up when persist
+ships `list_signed_partner_records_since` (a v5.2 follow-up filed
+upstream). Organization + OrgMembership are fully bidirectional at
+v2.0.0 because their row shapes carry the single-signer Ed25519 +
+ML-DSA-65 signatures inline.
 
 ### 5.3 v2 → v3 (and beyond)
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -77,12 +77,16 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tokio::sync::Mutex;
 
+use ciris_persist::federation::operational::{
+    SignedOrgMembership, SignedOrganization, SignedPartnerRecord,
+};
 use ciris_persist::federation::types::{
     SignedAttestation, SignedCommunity, SignedCommunityMembershipRevocation, SignedFamily,
     SignedFamilyMembershipRevocation, SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation,
     SignedKeyRecord, SignedLocationProof, SignedRevocation,
 };
 use ciris_persist::federation::FederationDirectory;
+use ciris_verify_core::threshold::ThresholdMember;
 
 use super::directory::ReplicationDirectory;
 use super::protocol::{EnvelopeKind, EnvelopeRef};
@@ -101,16 +105,27 @@ pub struct BridgeConfig {
     /// covers federations up to ~thousands of envelopes per kind.
     /// FIFO eviction.
     pub cache_capacity: usize,
+    /// Page size for the v2 operational kinds' bulk-list sweep
+    /// (`list_organizations_since` / `list_org_memberships_since` /
+    /// `list_partner_records_since`). v2.0.0 ships unlimited single-page
+    /// (`u32::MAX`) by default — federations of operational records are
+    /// O(orgs × partners), far below the wire MTU concern that motivated
+    /// pagination. Operators with very large operational rosters tune
+    /// this downward and accept multiple round trips per round.
+    pub operational_page_limit: u32,
 }
 
 impl BridgeConfig {
     pub const DEFAULT_CACHE_CAPACITY: usize = 4096;
+    /// Default for [`Self::operational_page_limit`].
+    pub const DEFAULT_OPERATIONAL_PAGE_LIMIT: u32 = u32::MAX;
 }
 
 impl Default for BridgeConfig {
     fn default() -> Self {
         Self {
             cache_capacity: Self::DEFAULT_CACHE_CAPACITY,
+            operational_page_limit: Self::DEFAULT_OPERATIONAL_PAGE_LIMIT,
         }
     }
 }
@@ -121,6 +136,51 @@ impl Default for BridgeConfig {
 /// so the bridge observes peer-set evolution without restart.
 pub type CohortProvider = Arc<dyn Fn() -> Vec<String> + Send + Sync>;
 
+/// Type alias for the v2 key-directory provider — an operator-configured
+/// callback yielding the current federation key_directory
+/// (`Vec<ThresholdMember>`). Re-invoked on each operational admit so
+/// admission sees the live directory. Used by persist's
+/// `put_organization` / `put_org_membership` admit surfaces for the
+/// single-signer role-chain authority check (Verify v5.1.0's
+/// `resolve_role_authority`). When `None`, the bridge refuses to admit
+/// operational-kind envelopes (returns `false` from `apply_*`) —
+/// fail-closed.
+pub type KeyDirectoryProvider = Arc<dyn Fn() -> Vec<ThresholdMember> + Send + Sync>;
+
+/// Type alias for the v2 root-stewards provider — an operator-configured
+/// callback yielding the federation's bootstrap steward `member_id`s.
+/// Used by persist's `put_organization` / `put_org_membership` admit
+/// surfaces to anchor the role-chain at trust root (the founder set
+/// per CEG §9.1). When `None`, the bridge refuses to admit operational-
+/// kind envelopes — fail-closed.
+pub type RootStewardsProvider = Arc<dyn Fn() -> Vec<String> + Send + Sync>;
+
+/// Type alias for the v2 steward-roster provider — an operator-configured
+/// callback yielding the current federation steward roster
+/// (`Vec<ThresholdMember>`). Used by persist's `put_partner_record`
+/// admit surface for the M-of-N steward quorum verification. When
+/// `None`, the bridge refuses to admit `partner_record` envelopes —
+/// fail-closed.
+pub type StewardRosterProvider = Arc<dyn Fn() -> Vec<ThresholdMember> + Send + Sync>;
+
+/// v2 (CEG 1.0-RC2 §5.6.8.13 / FSD §5.2) — operational-data admission
+/// providers bundle. Operators set this at bridge construction time to
+/// enable v2 operational-kind admission; leaving it `None` keeps the
+/// bridge v1-only (operational `apply_*` returns `false`, gracefully
+/// declining to admit).
+#[derive(Clone)]
+pub struct OperationalProviders {
+    /// The federation key_directory — `Vec<ThresholdMember>`. See
+    /// [`KeyDirectoryProvider`].
+    pub key_directory: KeyDirectoryProvider,
+    /// The federation bootstrap stewards' `member_id`s. See
+    /// [`RootStewardsProvider`].
+    pub root_stewards: RootStewardsProvider,
+    /// The federation steward roster — `Vec<ThresholdMember>`. See
+    /// [`StewardRosterProvider`].
+    pub steward_roster: StewardRosterProvider,
+}
+
 // ─── The bridge ──────────────────────────────────────────────────────
 
 /// Production-grade [`ReplicationDirectory`] implementation over
@@ -129,15 +189,23 @@ pub struct FederationDirectoryReplicationBridge {
     directory: Arc<dyn FederationDirectory>,
     cohort: CohortProvider,
     cache: Mutex<BridgeCache>,
+    config: BridgeConfig,
+    /// v2 operational-data admission providers. `None` = v2 admission
+    /// fail-closed; operational kinds' `apply_*` returns `false` without
+    /// touching persist. Set via [`Self::with_operational`] or
+    /// [`Self::with_config_and_operational`].
+    operational: Option<OperationalProviders>,
 }
 
 impl FederationDirectoryReplicationBridge {
-    /// Construct with default [`BridgeConfig`].
+    /// Construct with default [`BridgeConfig`], **v1-only** (no v2
+    /// operational-kind admission). For v2 operational admission, use
+    /// [`Self::with_operational`].
     pub fn new(directory: Arc<dyn FederationDirectory>, cohort: CohortProvider) -> Self {
         Self::with_config(directory, cohort, BridgeConfig::default())
     }
 
-    /// Construct with explicit configuration.
+    /// Construct with explicit configuration, **v1-only**.
     pub fn with_config(
         directory: Arc<dyn FederationDirectory>,
         cohort: CohortProvider,
@@ -148,6 +216,40 @@ impl FederationDirectoryReplicationBridge {
             directory,
             cohort,
             cache,
+            config,
+            operational: None,
+        }
+    }
+
+    /// Construct with default [`BridgeConfig`] **+ v2 operational
+    /// admission enabled**. The operational providers (key_directory /
+    /// root_stewards / steward_roster) are required for the bridge to
+    /// admit `organization` / `org_membership` / `partner_record`
+    /// envelopes; without them, the operational-kind `apply_*` returns
+    /// `false` (fail-closed; v1 kinds remain unaffected).
+    pub fn with_operational(
+        directory: Arc<dyn FederationDirectory>,
+        cohort: CohortProvider,
+        operational: OperationalProviders,
+    ) -> Self {
+        Self::with_config_and_operational(directory, cohort, BridgeConfig::default(), operational)
+    }
+
+    /// Construct with explicit configuration **+ v2 operational
+    /// admission enabled**.
+    pub fn with_config_and_operational(
+        directory: Arc<dyn FederationDirectory>,
+        cohort: CohortProvider,
+        config: BridgeConfig,
+        operational: OperationalProviders,
+    ) -> Self {
+        let cache = Mutex::new(BridgeCache::with_capacity(config.cache_capacity));
+        Self {
+            directory,
+            cohort,
+            cache,
+            config,
+            operational: Some(operational),
         }
     }
 
@@ -224,6 +326,9 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
             EnvelopeKind::IdentityOccurrence => self.list_identity_occurrences().await,
             EnvelopeKind::Family => self.list_families().await,
             EnvelopeKind::Community => self.list_communities().await,
+            EnvelopeKind::Organization => self.list_organizations().await,
+            EnvelopeKind::OrgMembership => self.list_org_memberships().await,
+            EnvelopeKind::PartnerRecord => self.list_partner_records().await,
             EnvelopeKind::IdentityOccurrenceRevocation => {
                 self.list_identity_occurrence_revocations().await
             }
@@ -255,6 +360,9 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
             }
             EnvelopeKind::Family => self.apply_family(envelope_bytes).await,
             EnvelopeKind::Community => self.apply_community(envelope_bytes).await,
+            EnvelopeKind::Organization => self.apply_organization(envelope_bytes).await,
+            EnvelopeKind::OrgMembership => self.apply_org_membership(envelope_bytes).await,
+            EnvelopeKind::PartnerRecord => self.apply_partner_record(envelope_bytes).await,
             EnvelopeKind::IdentityOccurrenceRevocation => {
                 self.apply_identity_occurrence_revocation(envelope_bytes)
                     .await
@@ -570,6 +678,111 @@ impl FederationDirectoryReplicationBridge {
         }
         refs
     }
+
+    // ── v2 operational-data list_* ─────────────────────────────────
+    //
+    // v2 operational kinds enumerate via persist's
+    // `list_organizations_since` / `list_org_memberships_since` /
+    // `list_partner_records_since` (cursor + limit; CIRISPersist v5.1.0
+    // shipped these explicitly "for CIRISEdge#65 v2 bridge"). Each row's
+    // wire `envelope_hash` is `sha256(JCS(Signed*Record))` per FSD §3.2.2
+    // — JCS-conformant, edge-defined, reproducible by any non-persist
+    // CEG implementer (the §3.2.1 deferred-interop fix).
+    //
+    // The page limit is operator-tunable via [`BridgeConfig::operational_page_limit`];
+    // default `u32::MAX` covers federations whose operational rosters
+    // (orgs × memberships × licenses) fit in a single page.
+    //
+    // Skipping with `continue` on a row whose JCS hash can't be computed
+    // is safe: the row exists in persist but won't be advertised on the
+    // wire this round; the next round retries. Logging that skip is a
+    // v2.0.x follow-up (matches the v1 trust-kinds' silent-skip on
+    // decode_hash failure).
+
+    async fn list_organizations(&self) -> Vec<EnvelopeRef> {
+        let mut refs = Vec::new();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        let limit = self.config.operational_page_limit;
+        if let Ok(rows) = self.directory.list_organizations_since(None, limit).await {
+            for row in rows {
+                let signed = SignedOrganization {
+                    organization: row.clone(),
+                };
+                let Some(hash) = v2_envelope_hash(&signed) else {
+                    continue;
+                };
+                if !seen.insert(hash) {
+                    continue;
+                }
+                let bytes = serde_json::to_vec(&signed).unwrap_or_default();
+                self.cache_insert(EnvelopeKind::Organization, hash, bytes)
+                    .await;
+                refs.push(EnvelopeRef {
+                    envelope_hash: hash,
+                    seq: Self::ms_seq(row.asserted_at),
+                });
+            }
+        }
+        refs
+    }
+
+    async fn list_org_memberships(&self) -> Vec<EnvelopeRef> {
+        let mut refs = Vec::new();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        let limit = self.config.operational_page_limit;
+        if let Ok(rows) = self.directory.list_org_memberships_since(None, limit).await {
+            for row in rows {
+                let signed = SignedOrgMembership {
+                    org_membership: row.clone(),
+                };
+                let Some(hash) = v2_envelope_hash(&signed) else {
+                    continue;
+                };
+                if !seen.insert(hash) {
+                    continue;
+                }
+                let bytes = serde_json::to_vec(&signed).unwrap_or_default();
+                self.cache_insert(EnvelopeKind::OrgMembership, hash, bytes)
+                    .await;
+                refs.push(EnvelopeRef {
+                    envelope_hash: hash,
+                    seq: Self::ms_seq(row.asserted_at),
+                });
+            }
+        }
+        refs
+    }
+
+    async fn list_partner_records(&self) -> Vec<EnvelopeRef> {
+        // v2.0.0 — `partner_record` is **admit-only**, not emit.
+        //
+        // `partner_record` is the one operational kind whose row shape
+        // (`PartnerRecord`) does NOT carry its M distinct steward
+        // signatures inline. The signatures live in the
+        // [`SignedPartnerRecord`] write wrapper (a `Vec<ThresholdSignature>`
+        // alongside the row + threshold). Persist v5.1.0's
+        // `list_partner_records_since` returns `PartnerRecord` rows
+        // only — no companion `list_signed_partner_records_since` exists
+        // yet. Returning empty here means edge does NOT emit
+        // `partner_record` envelopes via anti-entropy enumeration.
+        //
+        // What still works in v2.0.0: `apply_partner_record` admits
+        // peer-pushed [`SignedPartnerRecord`] envelopes (the sender's
+        // wire bytes carry the steward signature set, persist verifies
+        // M-of-N via verify v5.1.0's `verify_partner_record_quorum`).
+        // What's blocked until persist v5.2: peer-initiated *Summary*
+        // round-trips for this kind. The Initiator side advertises an
+        // empty ref set; the Responder doesn't know we have rows.
+        //
+        // Tracking: a CIRISPersist follow-up issue
+        // (`list_signed_partner_records_since`) will return the signed
+        // wrapper directly; once it lands, this method enumerates with
+        // a real ref set + JCS hash basis matching admission identity.
+        // Organization + OrgMembership are fully functional in v2.0.0
+        // because their row shape carries the single signer's
+        // Ed25519/ML-DSA-65 signatures inline.
+        Vec::new()
+    }
 }
 
 // ─── apply_envelope_bytes — per-kind dispatch ───────────────────────
@@ -656,6 +869,91 @@ impl FederationDirectoryReplicationBridge {
             Err(_) => false,
         }
     }
+
+    // ── v2 operational-data apply_* ────────────────────────────────
+    //
+    // The 3 v2 operational kinds (CEG 1.0-RC2 §5.6.8.13) gate on the
+    // [`OperationalProviders`] callbacks being set at bridge
+    // construction. Without them, admission fail-closes (returns
+    // `false`); persist is not touched. With them, the bridge resolves
+    // the live `key_directory` / `root_stewards` / `steward_roster` via
+    // the operator-supplied closures and passes them to persist's
+    // `put_*` admit surface. Persist + verify perform the 4-check
+    // admission pipeline (skew-bound, no-payment-processor identifiers,
+    // authority, set-semantics) — edge stays agnostic per the FSD §5.2
+    // commitment "merge policy stays persist-side per §10.1.6 declared
+    // intents."
+
+    async fn apply_organization(&self, bytes: &[u8]) -> bool {
+        let Some(ops) = self.operational.as_ref() else {
+            return false;
+        };
+        let Ok(signed) = serde_json::from_slice::<SignedOrganization>(bytes) else {
+            return false;
+        };
+        let key_directory = (ops.key_directory)();
+        let root_stewards = (ops.root_stewards)();
+        self.directory
+            .put_organization(signed, &key_directory, &root_stewards)
+            .await
+            .is_ok()
+    }
+
+    async fn apply_org_membership(&self, bytes: &[u8]) -> bool {
+        let Some(ops) = self.operational.as_ref() else {
+            return false;
+        };
+        let Ok(signed) = serde_json::from_slice::<SignedOrgMembership>(bytes) else {
+            return false;
+        };
+        let key_directory = (ops.key_directory)();
+        let root_stewards = (ops.root_stewards)();
+        self.directory
+            .put_org_membership(signed, &key_directory, &root_stewards)
+            .await
+            .is_ok()
+    }
+
+    async fn apply_partner_record(&self, bytes: &[u8]) -> bool {
+        let Some(ops) = self.operational.as_ref() else {
+            return false;
+        };
+        let Ok(signed) = serde_json::from_slice::<SignedPartnerRecord>(bytes) else {
+            return false;
+        };
+        let steward_roster = (ops.steward_roster)();
+        self.directory
+            .put_partner_record(signed, &steward_roster)
+            .await
+            .is_ok()
+    }
+}
+
+// ─── v2 envelope_hash basis — JCS (FSD §3.2.2) ──────────────────────
+//
+// v2 closes the §3.2.1 deferred-interop path: operational-kind
+// `envelope_hash` is `sha256(JCS(Signed*Record))`, edge-defined +
+// CEG-§0.9-conformant. This is the SAME computation any non-persist
+// CEG implementation can reproduce — no `persist_row_hash` dependency.
+//
+// The function lives at module scope rather than as a method so the
+// `list_organizations` / `list_org_memberships` / `list_partner_records`
+// sweeps can call it without borrowing `self`.
+
+/// Compute the v2 envelope_hash for a serde-`Serialize`-able value.
+/// Per FSD §3.2.2: `sha256(JCS(value))`. Edge calls
+/// [`ciris_verify_core::jcs::canonicalize`] for the JCS step — the
+/// canonical-bytes encoding is not edge's to define (FSD §3.2). Returns
+/// `None` if either step fails (serialization → JSON Value, JCS
+/// canonicalization); the caller skips the envelope rather than emit a
+/// non-reproducible hash.
+fn v2_envelope_hash<T: serde::Serialize>(value: &T) -> Option<[u8; 32]> {
+    use sha2::{Digest, Sha256};
+    let json_value = serde_json::to_value(value).ok()?;
+    let canonical = ciris_verify_core::jcs::canonicalize(&json_value).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(&canonical);
+    Some(hasher.finalize().into())
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────
@@ -969,5 +1267,151 @@ mod tests {
         assert!(cache.get(EnvelopeKind::Key, &h1).is_some());
         // The value is the FIRST inserted (no overwrite on dup).
         assert_eq!(cache.get(EnvelopeKind::Key, &h1).unwrap(), b"v1");
+    }
+
+    // ── v2 operational-data (FSD §5.2 / CEG 1.0-RC2 §5.6.8.13) ──────
+
+    /// JCS envelope_hash is deterministic: hashing the same serializable
+    /// value twice yields identical bytes. The federation invariant —
+    /// peer A and peer B both compute the same `envelope_hash` from the
+    /// same on-wire bytes — depends on this.
+    #[test]
+    fn v2_envelope_hash_is_deterministic() {
+        let value = serde_json::json!({
+            "organization": {
+                "attestation_id": "att-1",
+                "org_id": "org-acme",
+                "name": "ACME",
+                "status": "active",
+            }
+        });
+        let h1 = v2_envelope_hash(&value).expect("hash 1");
+        let h2 = v2_envelope_hash(&value).expect("hash 2");
+        assert_eq!(h1, h2);
+    }
+
+    /// JCS canonicalization sorts keys lexicographically — different
+    /// key ordering in the input value produces identical canonical
+    /// bytes and thus identical hashes. This is what makes M-of-N
+    /// steward quorum admission converge per RC2 §5.6.8.13 (the
+    /// Verify-raised "byte-identical JCS" catch).
+    #[test]
+    fn v2_envelope_hash_is_key_order_invariant() {
+        let a = serde_json::json!({
+            "alpha": 1,
+            "beta": 2,
+            "gamma": 3,
+        });
+        let b = serde_json::json!({
+            "gamma": 3,
+            "alpha": 1,
+            "beta": 2,
+        });
+        let ha = v2_envelope_hash(&a).expect("hash a");
+        let hb = v2_envelope_hash(&b).expect("hash b");
+        assert_eq!(
+            ha, hb,
+            "JCS sorts keys — same logical object MUST hash identically"
+        );
+    }
+
+    /// JCS canonicalization distinguishes different values — two
+    /// envelopes with different content MUST hash to different bytes.
+    /// Sanity check that v2_envelope_hash isn't degenerate.
+    #[test]
+    fn v2_envelope_hash_differentiates_distinct_values() {
+        let a = serde_json::json!({"org_id": "alice"});
+        let b = serde_json::json!({"org_id": "bob"});
+        let ha = v2_envelope_hash(&a).expect("hash a");
+        let hb = v2_envelope_hash(&b).expect("hash b");
+        assert_ne!(ha, hb);
+    }
+
+    /// Without `OperationalProviders` configured, `apply_organization`
+    /// fail-closes (returns `false`) — v2 admission requires the
+    /// operator to wire up `key_directory` + `root_stewards`. Verifies
+    /// the v1-bridge constructors don't accidentally admit v2 envelopes.
+    #[tokio::test]
+    async fn apply_organization_fail_closes_without_operational_providers() {
+        let (_backend, bridge) = make_bridge(&["k1".into()]);
+        // Bridge constructed via `new` (no operational providers).
+        // Even if the bytes happen to deserialize cleanly, admission
+        // must refuse.
+        let bytes = br#"{"organization": {
+            "attestation_id": "att-1",
+            "org_id": "org-acme",
+            "name": "ACME",
+            "org_type": "internal",
+            "status": "active",
+            "asserted_at": "2026-06-10T20:00:00Z",
+            "attesting_key_id": "k1",
+            "signed_envelope": {},
+            "ed25519_signature_base64": ""
+        }}"#;
+        let admitted = bridge
+            .apply_envelope_bytes(EnvelopeKind::Organization, bytes)
+            .await;
+        assert!(
+            !admitted,
+            "v2 operational admission MUST fail-close without OperationalProviders"
+        );
+    }
+
+    /// Same fail-closed invariant for `org_membership`.
+    #[tokio::test]
+    async fn apply_org_membership_fail_closes_without_operational_providers() {
+        let (_backend, bridge) = make_bridge(&["k1".into()]);
+        let bytes = br#"{"org_membership": {
+            "attestation_id": "att-1",
+            "user_id": "u1",
+            "org_id": "org-acme",
+            "role": "viewer",
+            "status": "active",
+            "asserted_at": "2026-06-10T20:00:00Z",
+            "attesting_key_id": "k1",
+            "signed_envelope": {},
+            "ed25519_signature_base64": ""
+        }}"#;
+        let admitted = bridge
+            .apply_envelope_bytes(EnvelopeKind::OrgMembership, bytes)
+            .await;
+        assert!(!admitted);
+    }
+
+    /// Same fail-closed invariant for `partner_record`.
+    #[tokio::test]
+    async fn apply_partner_record_fail_closes_without_operational_providers() {
+        let (_backend, bridge) = make_bridge(&["k1".into()]);
+        let bytes = br#"{
+            "partner_record": {
+                "attestation_id":"att-1","license_id":"lic-1","partner_id":"p-1","org_id":"org-1",
+                "license_type":"community","max_autonomy_tier":"A0","requires_supervisor":false,
+                "deployment_limit":1,"offline_grace_hours":24,"status":"active","revision":1,
+                "issued_at":"2026-06-10T20:00:00Z","expires_at":"2027-06-10T20:00:00Z",
+                "asserted_at":"2026-06-10T20:00:00Z","signed_envelope":{}
+            },
+            "steward_signatures": [],
+            "threshold": 0
+        }"#;
+        let admitted = bridge
+            .apply_envelope_bytes(EnvelopeKind::PartnerRecord, bytes)
+            .await;
+        assert!(!admitted);
+    }
+
+    /// v2.0.0 known limitation: `list_partner_records` returns empty
+    /// pending CIRISPersist v5.2's `list_signed_partner_records_since`
+    /// (PartnerRecord's row shape doesn't carry the M-of-N steward
+    /// signatures inline, so naive reconstruction would break
+    /// convergence). Fence the docs-vs-code contract so the empty Vec
+    /// is intentional, not a regression.
+    #[tokio::test]
+    async fn v2_list_partner_records_returns_empty_for_v2_0() {
+        let (_backend, bridge) = make_bridge(&[]);
+        let refs = bridge.list_envelope_refs(EnvelopeKind::PartnerRecord).await;
+        assert!(
+            refs.is_empty(),
+            "v2.0.0 ships PartnerRecord admit-only; emit blocked on persist v5.2"
+        );
     }
 }

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -281,7 +281,12 @@ impl ReplicationCoordinator {
     /// loop route inbound bytes to the replication path without
     /// parsing every byte as every possible payload kind.
     pub async fn send_message(&self, msg: &ReplicationMessage) -> Result<(), CoordinatorError> {
-        let bytes = super::wire_frame::wrap(msg);
+        // v2.0.0 (FSD §3.7) — pick the wire version automatically from
+        // the message's EnvelopeKind. v1 trust kinds emit at 0x01; v2
+        // operational kinds emit at 0x02. The receiver's try_unwrap
+        // accepts both, so v2-capable peers exchange both versions and
+        // v1-only peers reject 0x02 frames at UnknownVersion (FSD §3.5).
+        let bytes = super::wire_frame::wrap_for_kind(msg);
         self.transport
             .send(&self.peer_key_id, &bytes)
             .await

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -128,7 +128,10 @@ pub mod summary;
 pub mod wire_frame;
 
 #[doc(inline)]
-pub use bridge::{BridgeConfig, CohortProvider, FederationDirectoryReplicationBridge};
+pub use bridge::{
+    BridgeConfig, CohortProvider, FederationDirectoryReplicationBridge, KeyDirectoryProvider,
+    OperationalProviders, RootStewardsProvider, StewardRosterProvider,
+};
 #[doc(inline)]
 pub use coordinator::{CoordinatorError, DriveStep, ReplicationCoordinator, RoundReport};
 #[doc(inline)]
@@ -151,5 +154,6 @@ pub use summary::{LocalState, StalenessSignal, StateApplier, StateProvider};
 #[doc(inline)]
 pub use wire_frame::{
     try_unwrap as try_unwrap_replication_frame, wrap as wrap_replication_frame,
-    REPLICATION_FRAME_MAGIC,
+    wrap_for_kind as wrap_replication_frame_for_kind, REPLICATION_FRAME_MAGIC,
+    WIRE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION_V2,
 };

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -121,6 +121,59 @@ pub enum EnvelopeKind {
     /// can't over-share precise location even if client UI gating fails.
     /// `put_location_proof(SignedLocationProof)`.
     LocationProof,
+    /// v2 wire (CEG 1.0-RC2 §5.6.8.13 / FSD §5.2) — operational-data
+    /// envelope: an `organization` row (public org identity, LWW +
+    /// withdrawal-forward-only). PII (`tax_id`, contacts, `metadata`)
+    /// stays region-local; never federates. CIRISPersist v5.1.0 ships
+    /// `put_organization(SignedOrganization, key_directory, root_stewards)`.
+    /// REQUIRES `WIRE_PROTOCOL_VERSION = 0x02`.
+    Organization,
+    /// v2 wire (CEG 1.0-RC2 §5.6.8.13 / FSD §5.2) — operational-data
+    /// envelope: an `org_membership` row (the authz binding —
+    /// `user_id`/`org_id`/`role`/`status`; LWW + withdrawal-forward-only).
+    /// User PII NEVER federates: only the role binding crosses. CIRISPersist
+    /// v5.1.0 ships `put_org_membership(SignedOrgMembership, key_directory,
+    /// root_stewards)`. REQUIRES `WIRE_PROTOCOL_VERSION = 0x02`.
+    OrgMembership,
+    /// v2 wire (CEG 1.0-RC2 §5.6.8.13 / FSD §5.2) — operational-data
+    /// envelope: a `partner_record` row (combines old License+Partner;
+    /// M-of-N steward quorum + monotonic-fail-secure merge — `revoked` >
+    /// `suspended` > `active`). CIRISPersist v5.1.0 ships
+    /// `put_partner_record(SignedPartnerRecord, steward_roster)`.
+    /// REQUIRES `WIRE_PROTOCOL_VERSION = 0x02`.
+    PartnerRecord,
+}
+
+impl EnvelopeKind {
+    /// The minimum [`crate::replication::wire_frame::WIRE_PROTOCOL_VERSION`]
+    /// at which this kind can be exchanged on the wire.
+    ///
+    /// The 10 v1 kinds (Key through LocationProof) ride at `0x01`. The
+    /// 3 v2 operational kinds (Organization / OrgMembership /
+    /// PartnerRecord — CEG 1.0-RC2 §5.6.8.13) require `0x02` framing
+    /// because v1-only peers don't recognize the new tags and would
+    /// reject the body at serde-decode time. Used by
+    /// [`crate::replication::wire_frame::wrap_for_kind`] to pick the
+    /// outbound version automatically per the FSD §3.7 peer-by-peer
+    /// transition path.
+    #[must_use]
+    pub fn min_wire_version(self) -> u8 {
+        match self {
+            Self::Key
+            | Self::Attestation
+            | Self::Revocation
+            | Self::IdentityOccurrence
+            | Self::Family
+            | Self::Community
+            | Self::IdentityOccurrenceRevocation
+            | Self::FamilyMembershipRevocation
+            | Self::CommunityMembershipRevocation
+            | Self::LocationProof => crate::replication::wire_frame::WIRE_PROTOCOL_VERSION,
+            Self::Organization | Self::OrgMembership | Self::PartnerRecord => {
+                crate::replication::wire_frame::WIRE_PROTOCOL_VERSION_V2
+            }
+        }
+    }
 }
 
 /// A reference to a single envelope in a peer's local state. The
@@ -193,6 +246,22 @@ pub enum ReplicationMessage {
 }
 
 impl ReplicationMessage {
+    /// The `EnvelopeKind` this message is about. All four message
+    /// variants (Summary / Diff / Fetch / Deliver) carry an inner
+    /// `kind` field — used by
+    /// [`crate::replication::wire_frame::wrap_for_kind`] to pick the
+    /// outbound wire-protocol version (v1 for the 10 trust kinds, v2
+    /// for the 3 v2 operational kinds per FSD §3.7 / §5.2).
+    #[must_use]
+    pub fn kind(&self) -> EnvelopeKind {
+        match self {
+            Self::Summary(m) => m.kind,
+            Self::Diff(m) => m.kind,
+            Self::Fetch(m) => m.kind,
+            Self::Deliver(m) => m.kind,
+        }
+    }
+
     /// Serialize to JSON bytes for transport. Returns the bytes ready
     /// to hand to `Transport::send`.
     pub fn to_bytes(&self) -> Vec<u8> {

--- a/src/replication/registry.rs
+++ b/src/replication/registry.rs
@@ -392,13 +392,14 @@ mod tests {
     #[tokio::test]
     async fn route_unknown_version_is_protocol_error() {
         let registry = ReplicationRegistry::new();
-        // Forge a v2 frame.
+        // Forge a v3 frame (v1 and v2 are both recognized as of
+        // CIRISEdge v2.0.0; v3 is reserved for a future cut).
         let msg = ReplicationMessage::Summary(SummaryMessage {
             kind: EnvelopeKind::Key,
             refs: vec![],
         });
-        let v2 = wire_frame::wrap_at_version(&msg, 0x02);
-        let r = registry.route_inbound_bytes("anyone", &v2).await;
+        let v3 = wire_frame::wrap_at_version(&msg, 0x03);
+        let r = registry.route_inbound_bytes("anyone", &v3).await;
         // UnknownVersion surfaces via the Protocol error.
         assert!(matches!(r, Err(RegistryError::Protocol(_))));
     }

--- a/src/replication/wire_frame.rs
+++ b/src/replication/wire_frame.rs
@@ -58,22 +58,40 @@
 //! requires touching every existing send site to opt in; this approach
 //! only touches the sites that need the new wire kind.
 //!
-//! ## Version-byte rollover (v1 → v2 path)
+//! ## Version-byte rollover (v1 → v2 path — ACTIVE per v2.0.0)
 //!
-//! Per FSD §5, v2 will introduce operational-data CEG envelopes
-//! (orgs / users / licenses / partners) for Spock removal (CIRISRegistry
-//! #58 Phase 2). A node speaking v2 will:
+//! v2 introduces 3 operational-data CEG envelopes per CEG 1.0-RC2
+//! §5.6.8.13 (CIRISRegistry#70): `organization` / `org_membership` /
+//! `partner_record` (User PII never federates; License+Partner collapse
+//! into PartnerRecord per FSD §5.2). A v2 node:
 //!
-//! - SEND `VER = 0x02` frames carrying the v2 codec (which may add
-//!   message variants, new `EnvelopeKind`s, or change message
-//!   field encodings)
-//! - RECEIVE both `VER = 0x01` (legacy) and `VER = 0x02` frames; the
-//!   `try_unwrap` dispatch routes by version
+//! - SENDS `VER = 0x02` frames carrying messages whose `kind` is one
+//!   of the 3 operational variants. The v1 message shapes
+//!   (Summary/Diff/Fetch/Deliver) are unchanged — v2 reuses them.
+//! - SENDS `VER = 0x01` frames for the 10 v1 kinds (Key through
+//!   LocationProof) — preserves v1 peer interop without a flag-day.
+//!   The version selection is per-message, keyed off the message's
+//!   `EnvelopeKind`. See [`wrap_for_kind`].
+//! - RECEIVES both `VER = 0x01` and `VER = 0x02` frames; [`try_unwrap`]
+//!   dispatches both. Body decode is identical for both versions —
+//!   the version byte's purpose is the kind-tag namespace it permits.
 //!
 //! v1 nodes that see `VER = 0x02` return `ProtocolError::UnknownVersion(0x02)`
-//! and the round fails — the sender's scheduler observes the failure
-//! and either drops the peer or downgrades. There's no silent
-//! misinterpretation.
+//! and drop the frame. v1 nodes that receive a `VER = 0x01` frame
+//! carrying an unknown kind tag (one of the 3 v2 variants) return
+//! `ProtocolError::Decode` at serde — this can't happen if the sender
+//! routes via [`wrap_for_kind`] (it never emits v2 kinds at v1
+//! framing), but the receiver's defense-in-depth catches a
+//! misconfigured peer.
+//!
+//! ## v2 envelope_hash basis is JCS — at the bridge layer, not here
+//!
+//! Per FSD §3.2.2, v2's `envelope_hash` is `sha256(JCS(Signed*Record))`
+//! for the 3 operational kinds — closes the §3.2.1 deferred-interop
+//! path. This module is wire-layer plumbing; the JCS computation lives
+//! in the bridge (`bridge::v2_envelope_hash`). The v1 trust kinds
+//! continue to use `persist_row_hash` per FSD §3.1 (v1 wire stays
+//! unchanged, peer-by-peer compatible).
 
 use super::protocol::{ProtocolError, ReplicationMessage};
 
@@ -83,11 +101,29 @@ use super::protocol::{ProtocolError, ReplicationMessage};
 /// unambiguously a replication frame.
 pub const REPLICATION_FRAME_MAGIC: [u8; 4] = *b"CRPL";
 
-/// Replication wire-protocol version. Locked to `0x01` for v1 per
-/// `FSD/REPLICATION_WIRE_FORMAT_V1.md` §3.5. Bumps to `0x02` for
-/// the CIRIS 2.0 cut (operational-data envelopes per
-/// CIRISRegistry#58 Phase 2).
+/// Replication wire-protocol version for v1 — the 10 trust-data kinds
+/// (Key / Attestation / Revocation / IdentityOccurrence / Family /
+/// Community / IdentityOccurrenceRevocation / FamilyMembershipRevocation /
+/// CommunityMembershipRevocation / LocationProof). Locked per
+/// `FSD/REPLICATION_WIRE_FORMAT_V1.md` §3.5; remains wire-stable
+/// indefinitely so v1 peers stay interoperable across the v1→v2
+/// transition (FSD §3.7).
 pub const WIRE_PROTOCOL_VERSION: u8 = 0x01;
+
+/// Replication wire-protocol version for v2 — adds the 3 operational-
+/// data kinds (Organization / OrgMembership / PartnerRecord) per CEG
+/// 1.0-RC2 §5.6.8.13 (CIRISRegistry#70). v2 reuses the v1 message
+/// shapes (Summary / Diff / Fetch / Deliver) but extends the
+/// [`super::EnvelopeKind`] tag namespace; the version byte's role is
+/// to gate which tags the receiver expects.
+///
+/// FSD §3.2.2 also flips the `envelope_hash` basis for v2-emitted
+/// envelopes from `persist_row_hash` to `sha256(JCS(Signed*Record))`
+/// — the JCS computation lives in
+/// [`crate::replication::bridge`] (the v2 hash basis is a bridge
+/// concern, not a wire-frame concern; this module just routes the
+/// version byte).
+pub const WIRE_PROTOCOL_VERSION_V2: u8 = 0x02;
 
 /// Length of the wire-frame preamble (`MAG` + `VER`). The body
 /// follows starting at offset `PREAMBLE_LEN`.
@@ -97,11 +133,31 @@ pub const PREAMBLE_LEN: usize = REPLICATION_FRAME_MAGIC.len() + 1;
 /// [`crate::transport::Transport::send`]. Allocates one `Vec` of
 /// exactly `PREAMBLE_LEN + msg.to_bytes().len()` bytes.
 ///
-/// The frame uses the current [`WIRE_PROTOCOL_VERSION`] byte. To wrap
-/// at a specific version (e.g. for cross-version interop testing),
-/// use [`wrap_at_version`].
+/// **Defaults to v1 framing.** For v2.0.0+ correct outbound version
+/// selection (per the FSD §3.7 peer-by-peer transition), use
+/// [`wrap_for_kind`] — it picks the wire version automatically based
+/// on the message's [`super::EnvelopeKind`]. Direct use of `wrap` is
+/// safe for code that knows it's exchanging v1-only kinds.
 pub fn wrap(msg: &ReplicationMessage) -> Vec<u8> {
     wrap_at_version(msg, WIRE_PROTOCOL_VERSION)
+}
+
+/// Wrap a [`ReplicationMessage`] at the wire version appropriate for
+/// its [`super::EnvelopeKind`].
+///
+/// The 10 v1 kinds emit at `0x01`; the 3 v2 operational kinds
+/// (Organization / OrgMembership / PartnerRecord) emit at `0x02`. The
+/// version selection is per-message — a sender freely mixes v1 frames
+/// and v2 frames within the same peer connection, and the receiver's
+/// [`try_unwrap`] dispatch handles both. This is the FSD §3.7 peer-by-
+/// peer transition mechanism: v1-only peers reject v2-framed messages
+/// at the UnknownVersion error, but continue to handle v1 frames
+/// from the same v2-capable sender.
+///
+/// All `ReplicationMessage` variants carry their `kind` in their inner
+/// payload; this helper extracts it via [`ReplicationMessage::kind`].
+pub fn wrap_for_kind(msg: &ReplicationMessage) -> Vec<u8> {
+    wrap_at_version(msg, msg.kind().min_wire_version())
 }
 
 /// Wrap a message at a specific protocol version. Production code
@@ -153,7 +209,13 @@ pub fn try_unwrap(bytes: &[u8]) -> Result<Option<ReplicationMessage>, ProtocolEr
         ));
     }
     let version = bytes[REPLICATION_FRAME_MAGIC.len()];
-    if version != WIRE_PROTOCOL_VERSION {
+    // v2.0.0 (CEG 1.0-RC2 §5.6.8.13 / FSD §5.2) — accept both v1 and v2
+    // framing. The message body decode is version-agnostic; the version
+    // byte gates which kind-tag namespace the receiver expects. A
+    // mismatched body (e.g. a v2 kind tag in a v1 frame, which a
+    // well-behaved sender never emits but a misconfigured peer might)
+    // surfaces as `ProtocolError::Decode` at the serde layer below.
+    if version != WIRE_PROTOCOL_VERSION && version != WIRE_PROTOCOL_VERSION_V2 {
         return Err(ProtocolError::UnknownVersion(version));
     }
     let body = &bytes[PREAMBLE_LEN..];
@@ -229,17 +291,19 @@ mod tests {
     }
 
     /// Bytes with the magic but an unknown version byte yield
-    /// `Err(ProtocolError::UnknownVersion(v))`. Exercises the v1→v2
-    /// rollover path: a v1 receiver seeing a v2 frame surfaces the
+    /// `Err(ProtocolError::UnknownVersion(v))`. Exercises the v2→v3+
+    /// rollover path: a v2 receiver seeing a v3 frame surfaces the
     /// typed unknown-version error so the scheduler can decide
-    /// whether to drop the peer or downgrade.
+    /// whether to drop the peer or downgrade. v1 + v2 are both
+    /// recognized as of v2.0.0 (FSD §3.7 peer-by-peer transition).
     #[test]
     fn unknown_version_byte_is_typed_error() {
-        let mut v2_bytes = REPLICATION_FRAME_MAGIC.to_vec();
-        v2_bytes.push(0x02); // v2 — not yet supported
-        v2_bytes.extend_from_slice(br#"{"type":"summary","kind":"key","refs":[]}"#);
-        let r = try_unwrap(&v2_bytes);
-        assert!(matches!(r, Err(ProtocolError::UnknownVersion(0x02))));
+        // v3 — reserved for a future cut beyond CEG 1.0-RC2.
+        let mut v3_bytes = REPLICATION_FRAME_MAGIC.to_vec();
+        v3_bytes.push(0x03);
+        v3_bytes.extend_from_slice(br#"{"type":"summary","kind":"key","refs":[]}"#);
+        let r = try_unwrap(&v3_bytes);
+        assert!(matches!(r, Err(ProtocolError::UnknownVersion(0x03))));
 
         // Same for a future v0xFF — caps at u8 max.
         let mut vff_bytes = REPLICATION_FRAME_MAGIC.to_vec();
@@ -261,28 +325,35 @@ mod tests {
     }
 
     /// `wrap_at_version` lets test fixtures forge cross-version frames.
-    /// Round-trip via the current version works; forged v2 frames
-    /// surface UnknownVersion.
+    /// Round-trip via either recognized version works; forged v3+
+    /// frames surface UnknownVersion.
     #[test]
     fn wrap_at_version_forges_cross_version_frames() {
         let msg = ReplicationMessage::Summary(SummaryMessage {
             kind: EnvelopeKind::Key,
             refs: vec![],
         });
-        // Current version — round-trips.
+        // v1 — round-trips (v1 trust kind on v1 framing).
         let v1 = wrap_at_version(&msg, WIRE_PROTOCOL_VERSION);
         assert_eq!(try_unwrap(&v1).unwrap().unwrap(), msg);
-        // Forged v2 — surfaces UnknownVersion.
-        let v2 = wrap_at_version(&msg, 0x02);
+        // v2 — also round-trips (v2 receiver accepts v1 kinds at v2
+        // framing too; the version byte gates which tags are
+        // permitted, not which message shapes).
+        let v2 = wrap_at_version(&msg, WIRE_PROTOCOL_VERSION_V2);
+        assert_eq!(try_unwrap(&v2).unwrap().unwrap(), msg);
+        // Forged v3 — surfaces UnknownVersion.
+        let v3 = wrap_at_version(&msg, 0x03);
         assert!(matches!(
-            try_unwrap(&v2),
-            Err(ProtocolError::UnknownVersion(0x02))
+            try_unwrap(&v3),
+            Err(ProtocolError::UnknownVersion(0x03))
         ));
     }
 
     /// All four `ReplicationMessage` variants round-trip through
-    /// wrap/try_unwrap. Exercises all 9 `EnvelopeKind` variants too
-    /// — one per variant to catch any serde-tag regression.
+    /// wrap/try_unwrap. Exercises all 13 `EnvelopeKind` variants (10 v1
+    /// trust kinds + 3 v2 operational kinds) — one per variant to catch
+    /// any serde-tag regression. v2 kinds wrap via `wrap_for_kind`
+    /// (auto-selects 0x02 framing per their `min_wire_version`).
     #[test]
     fn all_variants_round_trip() {
         use crate::replication::protocol::{
@@ -333,9 +404,25 @@ mod tests {
                 kind: EnvelopeKind::LocationProof,
                 refs: vec![],
             }),
+            // v2 kinds — round-trip via wrap_for_kind (selects 0x02).
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Organization,
+                refs: vec![EnvelopeRef {
+                    envelope_hash: h,
+                    seq: 1,
+                }],
+            }),
+            ReplicationMessage::Diff(DiffMessage {
+                kind: EnvelopeKind::OrgMembership,
+                want: vec![h],
+            }),
+            ReplicationMessage::Deliver(DeliverMessage {
+                kind: EnvelopeKind::PartnerRecord,
+                envelopes: vec![b"signed_partner_bytes".to_vec()],
+            }),
         ];
         for msg in cases {
-            let framed = wrap(&msg);
+            let framed = wrap_for_kind(&msg);
             let unwrapped = try_unwrap(&framed).expect("decode").expect("magic");
             assert_eq!(unwrapped, msg);
         }
@@ -358,5 +445,68 @@ mod tests {
         let bytes = REPLICATION_FRAME_MAGIC.to_vec();
         let r = try_unwrap(&bytes);
         assert!(matches!(r, Err(ProtocolError::Decode(_))));
+    }
+
+    /// v2.0.0 / FSD §3.7 — `wrap_for_kind` selects the version byte
+    /// per the message's [`EnvelopeKind::min_wire_version`]: 0x01 for
+    /// the 10 v1 trust kinds, 0x02 for the 3 v2 operational kinds.
+    #[test]
+    fn wrap_for_kind_selects_version_per_kind() {
+        // v1 trust kind → 0x01 framing.
+        let msg_v1 = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![],
+        });
+        let framed = wrap_for_kind(&msg_v1);
+        assert_eq!(framed[REPLICATION_FRAME_MAGIC.len()], WIRE_PROTOCOL_VERSION);
+
+        // v2 operational kind → 0x02 framing.
+        let msg_v2 = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Organization,
+            refs: vec![],
+        });
+        let framed = wrap_for_kind(&msg_v2);
+        assert_eq!(
+            framed[REPLICATION_FRAME_MAGIC.len()],
+            WIRE_PROTOCOL_VERSION_V2
+        );
+
+        // OrgMembership → 0x02.
+        let msg_v2 = ReplicationMessage::Diff(crate::replication::protocol::DiffMessage {
+            kind: EnvelopeKind::OrgMembership,
+            want: vec![],
+        });
+        let framed = wrap_for_kind(&msg_v2);
+        assert_eq!(
+            framed[REPLICATION_FRAME_MAGIC.len()],
+            WIRE_PROTOCOL_VERSION_V2
+        );
+
+        // PartnerRecord → 0x02.
+        let msg_v2 = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::PartnerRecord,
+            refs: vec![],
+        });
+        let framed = wrap_for_kind(&msg_v2);
+        assert_eq!(
+            framed[REPLICATION_FRAME_MAGIC.len()],
+            WIRE_PROTOCOL_VERSION_V2
+        );
+    }
+
+    /// v2.0.0 acceptance: v2 framing also round-trips the v1 trust
+    /// kinds (the version byte gates which tags are *permitted*, not
+    /// which message *shapes*). This guarantees a v2-capable sender
+    /// can address a v2-capable peer with v1-kind messages under v2
+    /// framing without spec drift.
+    #[test]
+    fn v2_framing_accepts_v1_kinds() {
+        let msg = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![],
+        });
+        let v2 = wrap_at_version(&msg, WIRE_PROTOCOL_VERSION_V2);
+        let unwrapped = try_unwrap(&v2).expect("decode").expect("magic");
+        assert_eq!(unwrapped, msg);
     }
 }

--- a/tests/replication_wire_proptest.rs
+++ b/tests/replication_wire_proptest.rs
@@ -35,7 +35,7 @@
 
 use ciris_edge::replication::protocol::ProtocolError;
 use ciris_edge::replication::wire_frame::{
-    try_unwrap, wrap, wrap_at_version, WIRE_PROTOCOL_VERSION,
+    try_unwrap, wrap, wrap_at_version, WIRE_PROTOCOL_VERSION, WIRE_PROTOCOL_VERSION_V2,
 };
 use ciris_edge::replication::{
     DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, ReplicationMessage,
@@ -138,14 +138,18 @@ proptest! {
         prop_assert!(r.is_none());
     }
 
-    /// Property 3: any version byte other than `WIRE_PROTOCOL_VERSION`
-    /// surfaces as `UnknownVersion(v)`, regardless of body content.
-    /// Anchors the v1→v2 transition story: a v1 receiver seeing a v2
-    /// frame fails cleanly with a typed error the scheduler can act
-    /// on (drop the peer, downgrade, etc.).
+    /// Property 3: any version byte other than the recognized set
+    /// (`WIRE_PROTOCOL_VERSION` = 0x01, `WIRE_PROTOCOL_VERSION_V2` =
+    /// 0x02 as of CIRISEdge v2.0.0 per CEG 1.0-RC2 §5.6.8.13) surfaces
+    /// as `UnknownVersion(v)`, regardless of body content. Anchors the
+    /// v2→v3+ transition story: a v2 receiver seeing a v3 frame fails
+    /// cleanly with a typed error the scheduler can act on (drop the
+    /// peer, downgrade, etc.).
     #[test]
     fn unknown_version_byte_always_surfaces_typed_error(
-        version in any::<u8>().prop_filter("non-v1 version", |v| *v != WIRE_PROTOCOL_VERSION),
+        version in any::<u8>().prop_filter("unrecognized version", |v| {
+            *v != WIRE_PROTOCOL_VERSION && *v != WIRE_PROTOCOL_VERSION_V2
+        }),
         body in prop::collection::vec(any::<u8>(), 0..256),
     ) {
         let mut frame = REPLICATION_FRAME_MAGIC.to_vec();


### PR DESCRIPTION
CIRISEdge#65's v2 cycle ships. Closes the wire side of CIRISRegistry#58 Phase 2 (operational-data envelopes for Spock removal). Built atop the v1.7.0 substrate floor (persist v4.15.0 → v5.0.0 → v5.1.1 + verify v5.0.0 → v5.1.0).

## What v2.0.0 delivers

### 3 new EnvelopeKind variants (FSD §5.2 / CEG 1.0-RC2 §5.6.8.13)

| `EnvelopeKind` | wire token | merge intent (§10.1.6) |
|---|---|---|
| `Organization`  | `organization`   | `lww_skew_bounded` + `withdrawal_forward_only` |
| `OrgMembership` | `org_membership` | `lww_skew_bounded` + `withdrawal_forward_only` |
| `PartnerRecord` | `partner_record` | `monotonic_quorum` (V058-generalized)         |

- **`User` drops out** — PII federate-the-minimal-projection: only the `OrgMembership` role binding crosses.
- **`License`+`Partner` collapse** into combined `PartnerRecord`.
- **Wire tokens snake_case** matching v1's `serde(rename_all)` convention.

### v2 envelope_hash basis = `sha256(JCS(Signed*Record))`

Closes the FSD §3.2.1 deferred-interop path:

| basis | v1 | v2 |
|---|---|---|
| envelope_hash | `persist_row_hash` (V1Python, persist-internal) | `sha256(JCS(Signed*Record))` (CEG-§0.9-conformant) |
| interop | all-persist federations only | any CEG implementation |

`bridge::v2_envelope_hash` calls `ciris_verify_core::jcs::canonicalize` then SHA-256s — edge doesn't reimplement JCS (FSD §3.2). Tests cover key-order invariance (the RC2 set-semantics catch), determinism, and distinct-value differentiation.

### `WIRE_PROTOCOL_VERSION` 0x01 → 0x02 (peer-by-peer transition)

- `WIRE_PROTOCOL_VERSION_V2 = 0x02` constant in `wire_frame.rs`.
- `try_unwrap` accepts both `0x01` and `0x02` — no flag day.
- `wrap_for_kind(msg)` selects framing per the message's `EnvelopeKind::min_wire_version`: v1 kinds emit at `0x01`, v2 kinds emit at `0x02`. `Coordinator::send_message` calls `wrap_for_kind`.
- v1-only peers reject `0x02` frames at `ProtocolError::UnknownVersion` per FSD §3.5; v2-capable peers exchange both versions transparently.

### Bridge integration

- `OperationalProviders` bundle: 3 operator-supplied callbacks (`key_directory` / `root_stewards` / `steward_roster`) yielding live federation state for persist's admit-time checks.
- `with_operational` / `with_config_and_operational` constructors opt in to v2 admission. Without them (legacy `new` / `with_config`), all 3 operational `apply_*` fail-close to `false` — v1 path unaffected.
- `apply_organization` / `apply_org_membership` / `apply_partner_record` dispatch to persist's `put_*` admit surfaces. Edge stays agnostic to the 4-check admission pipeline.
- `list_organizations` / `list_org_memberships` walk persist's new `list_*_since` sweep surfaces.

### Known v2.0.0 limitation — `partner_record` is admit-only

`PartnerRecord`'s row shape doesn't carry the M-of-N steward signatures inline (they live in `SignedPartnerRecord`). Persist v5.1.0's `list_partner_records_since` returns rows only. Edge's `list_partner_records` returns empty — the Initiator side does NOT advertise `partner_record` envelopes. The Responder side admits peer-pushed `SignedPartnerRecord` bytes correctly. Bidirectional path lights up when persist ships `list_signed_partner_records_since` (a v5.2 follow-up).

## Substrate pin currency

- `ciris-persist`: v5.0.0 → v5.1.1 (operational admit surfaces + agent-2.9.6 substrate line)
- `ciris-verify` family (keyring / crypto / verify-core): v5.0.0 → v5.1.0 (operational_admit module — role-chain + partner_record quorum)
- New direct dep: `ciris-verify-core` (was transitive; now explicit for `jcs::canonicalize` + `threshold::ThresholdMember`)

## Verification

- 253 lib tests green (+9 from 244: 2 wire_frame, 7 bridge)
- All 4 `RUSTFLAGS=-D warnings` combos green (core / reticulum / packet-radio / all-transports / pyo3-full)
- `cargo clippy` clean
- `cargo fmt` clean

## What's NOT in this cut

- **CIRISConformance matrix bump to persist 5.1.1 + edge 2.0.0** — follows on the conformance repo (pinned PyPI versions; persist 5.1.1 is live, edge 2.0.0 publishes on tag).
- **PartnerRecord emit path** — blocked on persist v5.2's `list_signed_partner_records_since` (admit-only at v2.0.0).
- **CIRISConformance#9 M-of-N vector set** — persist + verify own fixture generation; edge consumes once published.

## Test plan

- [x] `cargo test --lib --features transport-http,transport-reticulum,pyo3` green (253 tests)
- [x] All 4 CI feature combos clean under `RUSTFLAGS=-D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI gauntlet green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
