### PR TITLE
release(v2.0.1): persist v5.2.0 lights up bidirectional partner_record (CIRISPersist#194 / V072)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.1.1", version = "5", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.2.0", version = "5", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -826,7 +826,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.1.1", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.2.0", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/FSD/REPLICATION_WIRE_FORMAT_V1.md
+++ b/FSD/REPLICATION_WIRE_FORMAT_V1.md
@@ -546,24 +546,18 @@ re-derives. Per §3.2.2, all three v2 kinds use
   (the Verify-raised catch from RC2 review). Persist + verify own the
   fixture generation; edge consumes the vectors via conformance tests.
 
-**v2.0.0 known limitation — `partner_record` is admit-only.**
+**v2.0.1 — `partner_record` is bidirectional (CLOSED LIMITATION).**
 
-`PartnerRecord`'s row shape (per CIRISPersist v5.1.0's
-`federation::operational::PartnerRecord`) does NOT carry the M-of-N
-steward signatures inline — they live in the
-`SignedPartnerRecord` write wrapper. Persist v5.1.0's
-`list_partner_records_since` returns rows only (no companion
-`list_signed_partner_records_since`). Edge's
-`Bridge::list_partner_records` therefore returns empty — the Initiator
-side does NOT advertise `partner_record` envelopes via anti-entropy
-enumeration. The Responder side admits peer-pushed
-`SignedPartnerRecord` bytes correctly (the sender ships the M-of-N
-signatures inline; verify v5.1.0's `verify_partner_record_quorum`
-admits on receipt). The fully bidirectional path lights up when persist
-ships `list_signed_partner_records_since` (a v5.2 follow-up filed
-upstream). Organization + OrgMembership are fully bidirectional at
-v2.0.0 because their row shapes carry the single-signer Ed25519 +
-ML-DSA-65 signatures inline.
+CIRISPersist v5.2.0 (CIRISPersist#194) shipped V072 + the
+`list_signed_partner_records_since` surface that returns the full
+`SignedPartnerRecord` wrapper — row + `steward_signatures` + threshold —
+straight from the new V072 storage. Edge v2.0.1 wires
+`Bridge::list_partner_records` to it. A peer-cached envelope re-emits as
+the same bytes the original sender hashed, so anti-entropy convergence
+for `partner_record` is complete in both directions.
+
+All 3 v2 operational kinds are now fully bidirectional. The v2 cycle is
+feature-complete.
 
 ### 5.3 v2 → v3 (and beyond)
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -683,10 +683,12 @@ impl FederationDirectoryReplicationBridge {
     //
     // v2 operational kinds enumerate via persist's
     // `list_organizations_since` / `list_org_memberships_since` /
-    // `list_partner_records_since` (cursor + limit; CIRISPersist v5.1.0
-    // shipped these explicitly "for CIRISEdge#65 v2 bridge"). Each row's
-    // wire `envelope_hash` is `sha256(JCS(Signed*Record))` per FSD §3.2.2
-    // — JCS-conformant, edge-defined, reproducible by any non-persist
+    // `list_signed_partner_records_since` (cursor + limit; CIRISPersist
+    // v5.1.0 shipped the first two and v5.2.0 / #194 shipped the third
+    // explicitly "for CIRISEdge#65 v2 bidirectional partner_record"
+    // — closes the v2.0.0 admit-only carve-out). Each row's wire
+    // `envelope_hash` is `sha256(JCS(Signed*Record))` per FSD §3.2.2 —
+    // JCS-conformant, edge-defined, reproducible by any non-persist
     // CEG implementer (the §3.2.1 deferred-interop fix).
     //
     // The page limit is operator-tunable via [`BridgeConfig::operational_page_limit`];
@@ -754,34 +756,42 @@ impl FederationDirectoryReplicationBridge {
     }
 
     async fn list_partner_records(&self) -> Vec<EnvelopeRef> {
-        // v2.0.0 — `partner_record` is **admit-only**, not emit.
+        // v2.0.1 — `partner_record` is now **bidirectional**.
         //
-        // `partner_record` is the one operational kind whose row shape
-        // (`PartnerRecord`) does NOT carry its M distinct steward
-        // signatures inline. The signatures live in the
-        // [`SignedPartnerRecord`] write wrapper (a `Vec<ThresholdSignature>`
-        // alongside the row + threshold). Persist v5.1.0's
-        // `list_partner_records_since` returns `PartnerRecord` rows
-        // only — no companion `list_signed_partner_records_since` exists
-        // yet. Returning empty here means edge does NOT emit
-        // `partner_record` envelopes via anti-entropy enumeration.
-        //
-        // What still works in v2.0.0: `apply_partner_record` admits
-        // peer-pushed [`SignedPartnerRecord`] envelopes (the sender's
-        // wire bytes carry the steward signature set, persist verifies
-        // M-of-N via verify v5.1.0's `verify_partner_record_quorum`).
-        // What's blocked until persist v5.2: peer-initiated *Summary*
-        // round-trips for this kind. The Initiator side advertises an
-        // empty ref set; the Responder doesn't know we have rows.
-        //
-        // Tracking: a CIRISPersist follow-up issue
-        // (`list_signed_partner_records_since`) will return the signed
-        // wrapper directly; once it lands, this method enumerates with
-        // a real ref set + JCS hash basis matching admission identity.
-        // Organization + OrgMembership are fully functional in v2.0.0
-        // because their row shape carries the single signer's
-        // Ed25519/ML-DSA-65 signatures inline.
-        Vec::new()
+        // CIRISPersist v5.2.0 (CIRISPersist#194) shipped the
+        // `list_signed_partner_records_since` surface that returns the
+        // full `SignedPartnerRecord` wrapper — row + steward_signatures
+        // + threshold — straight from persist's V072 storage. That
+        // closes the admit-only carve-out v2.0.0 documented: edge can
+        // now enumerate locally-held partner_records with a JCS hash
+        // that reproduces on every peer, completing the anti-entropy
+        // convergence loop for this kind.
+        let mut refs = Vec::new();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        let limit = self.config.operational_page_limit;
+        if let Ok(signed_rows) = self
+            .directory
+            .list_signed_partner_records_since(None, limit)
+            .await
+        {
+            for signed in signed_rows {
+                let Some(hash) = v2_envelope_hash(&signed) else {
+                    continue;
+                };
+                if !seen.insert(hash) {
+                    continue;
+                }
+                let asserted_at = signed.partner_record.asserted_at;
+                let bytes = serde_json::to_vec(&signed).unwrap_or_default();
+                self.cache_insert(EnvelopeKind::PartnerRecord, hash, bytes)
+                    .await;
+                refs.push(EnvelopeRef {
+                    envelope_hash: hash,
+                    seq: Self::ms_seq(asserted_at),
+                });
+            }
+        }
+        refs
     }
 }
 
@@ -1399,19 +1409,24 @@ mod tests {
         assert!(!admitted);
     }
 
-    /// v2.0.0 known limitation: `list_partner_records` returns empty
-    /// pending CIRISPersist v5.2's `list_signed_partner_records_since`
-    /// (PartnerRecord's row shape doesn't carry the M-of-N steward
-    /// signatures inline, so naive reconstruction would break
-    /// convergence). Fence the docs-vs-code contract so the empty Vec
-    /// is intentional, not a regression.
+    /// v2.0.1 — bidirectional `partner_record` replication lights up.
+    /// Persist v5.2.0's `list_signed_partner_records_since` returns the
+    /// full `SignedPartnerRecord` wrapper with `steward_signatures`
+    /// inline (CIRISPersist#194 / V072), so a peer-cached envelope
+    /// re-emits as the same bytes the original sender hashed. Tests
+    /// against an empty backend (no rows) confirms the no-rows path
+    /// returns an empty ref set without panic. The deeper convergence
+    /// (sender's hash = receiver's hash from peer's
+    /// `list_signed_partner_records_since` output) is fenced by the
+    /// JCS-determinism + key-order-invariance tests above + persist's
+    /// own V072 cohabitation convergence_roundtrip test.
     #[tokio::test]
-    async fn v2_list_partner_records_returns_empty_for_v2_0() {
+    async fn v2_list_partner_records_handles_empty_backend() {
         let (_backend, bridge) = make_bridge(&[]);
         let refs = bridge.list_envelope_refs(EnvelopeKind::PartnerRecord).await;
         assert!(
             refs.is_empty(),
-            "v2.0.0 ships PartnerRecord admit-only; emit blocked on persist v5.2"
+            "empty backend yields empty ref set (no panics, no errors)"
         );
     }
 }


### PR DESCRIPTION
CIRISPersist v5.2.0 (CIRISPersist#194) shipped V072 + the `list_signed_partner_records_since` surface that returns the full `SignedPartnerRecord` wrapper — row + steward_signatures + threshold — straight from V072 storage. v5.1.x verified the M-of-N steward quorum at admit then discarded the signature set, so Edge's v2.0.0 bridge shipped `partner_record` as admit-only (Initiator couldn't re-emit a byte-reproducible envelope_hash). v5.2.0 closes that carve-out by persisting the signatures alongside the envelope; this cut wires edge to the new surface.

## What v2.0.1 delivers

- **`Bridge::list_partner_records` now bidirectional.** Calls persist's `list_signed_partner_records_since(None, limit)` and yields one `EnvelopeRef` per row (JCS-hashed `SignedPartnerRecord` wrapper). A peer-cached envelope re-emits as the SAME bytes the original sender hashed — anti-entropy convergence completes for this kind in both directions.
- **Retired the v2.0.0 fence test.** `v2_list_partner_records_returns_empty_for_v2_0` is gone; replaced with `v2_list_partner_records_handles_empty_backend` which just asserts the empty-backend path returns an empty ref set cleanly. The deeper convergence properties (sender's hash = receiver's hash from peer's list_signed_partner_records_since output) are fenced by the existing JCS-determinism + key-order-invariance tests + persist V072's own `convergence_roundtrip` cohabitation test.
- **FSD §5.2 closed limitation.** The v2.0.0 "PartnerRecord is admit-only" paragraph is replaced with the v2.0.1 bidirectional-complete note. The v2 cycle is feature-complete.

## Substrate pin currency

- `ciris-persist`: v5.1.1 → v5.2.0 (operational partner_record V072 + `list_signed_partner_records_since`)
- `ciris-verify` family: unchanged at v5.1.0
- `ciris-verify-core`: unchanged at v5.1.0

## Verification

- 253 lib tests green (unchanged count — fence test renamed, not added)
- All 4 `RUSTFLAGS=-D warnings` combos green (core / reticulum / packet-radio / all-transports / pyo3-full)
- `cargo clippy` clean
- `cargo fmt` clean

## v2 wire taxonomy — feature complete

All 3 v2 operational kinds (Organization / OrgMembership / PartnerRecord) are fully bidirectional as of v2.0.1. v3+ is optimization or defect-driven only per FSD §5.3.

## Test plan

- [x] `cargo test --lib --features transport-http,transport-reticulum,pyo3` green (253 tests)
- [x] All 4 CI feature combos clean under `RUSTFLAGS=-D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI gauntlet green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
