### PR TITLE
release(v2.0.2): pyproject ciris-persist ceiling fix — align with Cargo (>=5.2.0,<6)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,16 +39,20 @@ classifiers = [
 # Pin to <2 because we expect persist to follow semver-major on
 # breaking changes; v0.2.x edge consumes v1.x persist. Bump the
 # upper bound when v0.3.x edge coordinates with v2.x persist.
-# v0.2.8 — pin floor bumped to >=1.11.0, currency catch-up on the
-# CIRIS 3.0 cohabitation convergence point. All co-resident consumers
-# (agent + NodeCore + LensCore + edge) must link one identical
-# ciris-persist version to share the OnceLock-backed Engine
-# process-singleton (CIRISPersist#85 EPIC). v1.11.0 pins CIRISVerify
-# v2.8.0; edge's keyring/crypto pins move v2.7.0 → v2.8.0 in lockstep.
-# Persist prelude surface unchanged — pure currency bump, zero API
-# drift on edge's consumed paths.
+# v2.0.2 — Cargo↔pyproject skew fix. Cargo.toml has linked persist
+# v5.x since v1.7.0 (currently v5.2.0), but pyproject's
+# `ciris-persist>=4.15.0,<5` carried over from the v4.x line and was
+# never bumped in lockstep. Net effect on PyPI: edge 1.7.0 / 2.0.0 /
+# 2.0.1 wheels published with Requires-Dist asking for persist <5
+# while their bundled cdylib expects persist 5 — ResolutionImpossible
+# when a downstream consumer (e.g. CIRISLensCore 1.0.0, which pins
+# `ciris-persist==5.2.0`) tries to co-install with edge. Flagged by
+# the lens-core maintainer. v2.0.2 is a metadata-only cut that aligns
+# the pyproject ceiling with what Cargo actually links. All co-resident
+# consumers must still share one ciris-persist version process-wide
+# (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=4.15.0,<5",
+    "ciris-persist>=5.2.0,<6",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## The bug

Edge's wheel metadata on PyPI for v1.7.0 / v2.0.0 / v2.0.1 carries `Requires-Dist: ciris-persist<5,>=4.15.0`, while the bundled cdylib links persist v5.x (5.0.0 in v1.7.0; 5.1.1 in v2.0.0; 5.2.0 in v2.0.1). Net effect: pip refuses to co-install edge with the persist version its cdylib actually expects — every downstream consumer hitting `pip install ciris-edge ciris-persist==5.x` gets ResolutionImpossible, because the wheel claims it wants persist <5.

The bug crept in across the v1.7.0 → v2.0.x cascade: Cargo.toml's persist pin moved through v4.15.0 → v5.0.0 → v5.1.1 → v5.2.0, but the parallel pyproject.toml `dependencies` constraint stayed at the v4.x ceiling. The wheel-build path doesn't validate the pyproject ceiling against what Cargo links — the skew compiled and published cleanly three times.

**Flagged by the CIRISLensCore maintainer** while attempting the conformance matrix re-add after CIRISLensCore 1.0.0 (which pins `ciris-persist==5.2.0` correctly) shipped — lens-core's resolver tries the floor (persist 5.2.0 + edge 2.0.1 + lens-core 1.0.0) and chokes on edge's stale ceiling. Same Cargo↔pyproject skew class as lens-core's own v0.4.6 (which they caught + fixed).

## The fix

Metadata-only cut. One line in `pyproject.toml`:

```diff
- "ciris-persist>=4.15.0,<5"
+ "ciris-persist>=5.2.0,<6"
```

The Rust side is unchanged at v2.0.1's surface (Cargo.toml's persist v5.2.0 pin was already correct). 253 lib tests green; CI's full wheel build path is where the new metadata surfaces.

## Co-resident-singleton invariant unchanged

All co-resident consumers (agent + NodeCore + LensCore + edge) must still link one identical `ciris-persist` version to share the OnceLock-backed Engine process-singleton (CIRISPersist#85 EPIC). v2.0.2 just allows the resolver to actually find a matching version under the v5 line; the singleton enforcement is unaffected.

## What this does NOT fix

v1.7.0 / v2.0.0 / v2.0.1 wheels are already published with the broken ceiling. They stay on PyPI as-is — yanking them would be heavier than warranted (downstream consumers who pinned them work fine as long as they ALSO pin persist <5). v2.0.2 is the version forward consumers resolve to from `pip install ciris-edge` once it propagates.

## CI guard for this class — follow-up

The wheel-build CI lane could grep pyproject's `Requires-Dist:` against Cargo.toml's `[dependencies]` table for the CIRIS family pins and fail on skew. Worth filing as a v2.0.x test-hardening follow-up — not in this hotfix's scope.

## Test plan

- [x] `cargo test --lib --features transport-http,transport-reticulum,pyo3` green (253 tests)
- [ ] Full CI gauntlet green on PR (verifies wheel build emits the corrected `Requires-Dist`)
- [ ] PyPI v2.0.2 wheel metadata shows `ciris-persist<6,>=5.2.0` (verified post-tag)
- [ ] Downstream `pip install ciris-edge==2.0.2 ciris-persist==5.2.0` resolves (verified by CIRISLensCore matrix re-add)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
