### PR TITLE
release(v2.1.2): leviculum 4c15dfd → ded96ee (123-commit upstream catch-up) + persist 5.5.2 → 5.5.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.1.1"
+version = "2.1.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.2", version = "5", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.3", version = "5", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -411,8 +411,22 @@ tempfile       = { version = "3", optional = true }
 # downstream pyo3 consumer (CIRISLensCore Windows wheel, agent 2.9.6
 # Windows surface). Edge v2.1.1 adds a windows-latest wheel build to
 # its own CI matrix to fence the unblock.
-reticulum-core = { git = "https://github.com/CIRISAI/leviculum", rev = "4c15dfd5ce2585ca4814303db8cd80daff78d231", version = "0.6", optional = true }
-reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", rev = "4c15dfd5ce2585ca4814303db8cd80daff78d231", version = "0.6", optional = true }
+#
+# v2.1.2 — bumped to ded96ee (rc-main HEAD). This is the 123-commit
+# catch-up to teranos/leviculum's upstream master (2af13f1) plus the
+# 6 CIRIS catch-up bug fixes (macOS gating, Windows clock, interop
+# JSON, CLI receiver, advisories). Full upstream matrix green (linux
+# musl + darwin + windows MSVC + rnsd 1.3.x interop + clippy + cargo
+# deny + thumbv6m M0 + thumbv7em M4 + android ×3 + iOS cross-check).
+# One API-shape change at the call site `node.take_event_receiver()`:
+# returns `tokio::sync::mpsc::UnboundedReceiver<NodeEvent>` (was
+# `Receiver`); edge's `events` field at `src/transport/reticulum.rs`
+# already typed this as UnboundedReceiver, so the bump is pure pin
+# currency with zero source-side changes on edge's side. `.recv().await`
+# unchanged. Future leviculum upstream releases land via the one-command
+# `scripts/ciris-sync-upstream.sh` rebase upstream-side now.
+reticulum-core = { git = "https://github.com/CIRISAI/leviculum", rev = "ded96eeb3b4dd7b8b6774c28c7fb30c51acf714d", version = "0.6", optional = true }
+reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", rev = "ded96eeb3b4dd7b8b6774c28c7fb30c51acf714d", version = "0.6", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in
@@ -837,7 +851,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.2", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.3", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## leviculum bump — upstream catch-up

Leviculum maintainer synced `CIRISAI/leviculum` to `teranos/leviculum` upstream master (`2af13f1`) — a **123-commit jump** — plus 6 CIRIS catch-up bug fixes (macOS test-gating, Windows clock, interop JSON, CLI receiver, two advisories). All landed at `rc-main` HEAD `ded96ee`.

Full upstream-side matrix green on real runners:

| Status | Job |
|---|---|
| ✓ | linux-x86_64 (musl) · darwin-aarch64 · windows-x86_64 (MSVC) |
| ✓ | rnsd interop (RNS 1.3.x) · clippy + fmt · cargo deny |
| ✓ | thumbv6m (M0) · thumbv7em (M4) · android ×3 + iOS cross-check |

**One API change** at the call site `node.take_event_receiver()`: now returns `tokio::sync::mpsc::UnboundedReceiver<NodeEvent>` (was `Receiver`). Edge's `events` field at `src/transport/reticulum.rs:865` already typed this as `UnboundedReceiver` (since edge expected the unbounded shape for its event loop), so the bump is **pure pin currency with zero source-side changes**. `.recv().await` unchanged.

This positions edge for future leviculum upstream releases via the one-command `scripts/ciris-sync-upstream.sh` rebase — each new upstream release becomes a single-rev bump on edge's side.

## persist bump — small Postgres resilience fix

CIRISPersist v5.5.3 — `get_client` (every PG op's chokepoint) retries a transient `pool.get()` up to 4× with short backoff (50/100/150ms). Pure resilience improvement; pure pin currency for edge.

## Substrate pin currency

- `ciris-persist`: v5.5.2 → v5.5.3 (Postgres connection-pool retry resilience)
- `leviculum` (reticulum-core + reticulum-std): `4c15dfd` → `ded96ee` (upstream catch-up + 6 CIRIS bug fixes; full matrix green)
- `ciris-verify` family: unchanged at v5.1.0

## Verification

- 255 lib tests green (unchanged from v2.1.1)
- All 4 `RUSTFLAGS=-D warnings` combos green (core / reticulum / packet-radio / all-transports / pyo3-full)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Test plan

- [x] `cargo test --lib --features transport-http,transport-reticulum,pyo3` green (255 tests)
- [x] All 4 CI feature combos clean under `RUSTFLAGS=-D warnings`
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI gauntlet green on PR

## Coordination note

This PR is the authoritative downstream compat check for leviculum's 123-commit upstream jump. Per the maintainer: once edge CI is green here, they force-update `CIRISAI/leviculum`'s `main` to `rc-main` (rewriting history to the upstream-tracking base). Future upstream releases become one-command rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
