### PR TITLE
release(v2.2.0): Python surface re-exports — unblocks CIRISLens#18 §2 + #20 Reticulum-half

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.1.2"
+version = "2.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -364,6 +364,16 @@ x509-parser    = { version = "0.16", optional = true }
 # dev-dependency surface; lifted to optional-runtime here so the
 # init path can reach it. Apache-2.0 / MIT.
 rcgen          = { version = "0.13", optional = true, default-features = false, features = ["pem", "ring"] }
+# v2.2.0 — pin time <0.3.48 to dodge a transitive incompatibility. time
+# 0.3.48 (published 2026-06-12) added a generic `Into<String>` impl that
+# conflicts with rcgen 0.13.x and 0.14.x's blanket `impl<T: Into<String>>
+# From<T>` for OtherNameValue / DnValue (E0119 — "conflicting
+# implementations"). Both rcgen versions fail with this time version;
+# the fix has to land in rcgen upstream. Edge doesn't use the `time`
+# API surface directly — this constraint is pure transitive resolution
+# control. Drop when rcgen upstream ships the fix (track via
+# https://github.com/rustls/rcgen/issues).
+time           = { version = ">=0.3, <0.3.48", default-features = false }
 rustls-pki-types = { version = "1", optional = true }
 # v0.19.3 (CIRISEdge#49) — the `init_edge_runtime`
 # `https_dev_self_signed=True` path needs a tempdir that outlives the

--- a/python/ciris_edge/__init__.py
+++ b/python/ciris_edge/__init__.py
@@ -5,13 +5,27 @@ wrapper over the Rust crate; the lens FastAPI cutover (Phase 1) and
 the agent Python pipeline (Phase 2) call into ``Edge`` from Python
 during their alongside-window cutovers.
 
-Phase 1 surface (lens cutover):
+Phase 1 surface (lens cutover) — v2.2.0:
 
 >>> import ciris_edge
 >>> import ciris_persist as cp
 >>> engine = cp.Engine(dsn="postgres://lens:lens@localhost:5432/cirislens")
->>> # Edge construction lands as the Rust surface stabilizes.
->>> # See FSD/CIRIS_EDGE.md §3.2 for the call shape.
+>>> edge = ciris_edge.init_edge_runtime(
+...     engine=engine,
+...     identity_path="/var/lib/ciris/edge/identity",
+...     listen_addr="0.0.0.0:4242",
+...     bootstrap_peers=["public-relay.example.org:4242"],
+...     announce_interval_seconds=300,
+...     local_epoch=0,
+...     hybrid_policy="soft_freshness",
+...     soft_freshness_window_seconds=86400,
+...     agent_mode="client",
+... )
+>>> pubkeys = edge.transport_identity_pubkeys()
+>>> # {"x25519_pub_base64": "...", "ed25519_pub_base64": "..."}
+
+See ``FSD/CIRIS_EDGE.md`` §3.2 for the full call shape (including the
+``https_*`` / ``hybrid_policy`` / ``agent_mode`` parameter set).
 
 Trust model (OQ-11 closure): hybrid Ed25519 + ML-DSA-65 verify is the
 day-1 v0.1.0 posture. Edge calls
@@ -29,12 +43,34 @@ middle-ground. ``send()`` ships ephemeral messages with caller-owned
 retry; ``send_durable()`` ships through ``cirislens.edge_outbound_queue``
 with edge-owned persistent retry. Delivery class lives on the message
 type, not the call site — caller can't pick wrong.
+
+Cohabitation accessors (v2.1.0+): ``Edge.engine()`` returns the host
+persist Engine PyObject (CIRISLensCore#43 P0 — reach the same engine
+the host wired in); ``Edge.transport_identity_pubkeys()`` returns the
+X25519 + Ed25519 dual-key bytes for persist's LocalIdentityAggregate
+RET-transport role (CIRISPersist#199).
 """
 
-from .ciris_edge import SUPPORTED_SCHEMA_VERSIONS, __version__
+from .ciris_edge import (
+    SUPPORTED_SCHEMA_VERSIONS,
+    DurableHandle,
+    Edge,
+    NetworkEventSubscription,
+    ReplicationHandle,
+    SubscriptionHandle,
+    VerifiedFeedSubscription,
+    __version__,
+    init_edge_runtime,
+)
 
-# Edge, DurableHandle, HybridPolicy, etc. register here as the Rust
-# surface comes online in subsequent commits. Public re-export list
-# below tracks what's actually available.
-
-__all__ = ["SUPPORTED_SCHEMA_VERSIONS", "__version__"]
+__all__ = [
+    "SUPPORTED_SCHEMA_VERSIONS",
+    "DurableHandle",
+    "Edge",
+    "NetworkEventSubscription",
+    "ReplicationHandle",
+    "SubscriptionHandle",
+    "VerifiedFeedSubscription",
+    "__version__",
+    "init_edge_runtime",
+]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1105,7 +1105,7 @@ fn parse_envelope_kind(s: &str) -> PyResult<crate::replication::EnvelopeKind> {
 /// Clones of this handle (Python references) share the same inner
 /// runtime — first `stop` shuts down; subsequent `stop` calls are
 /// no-ops.
-#[pyclass(unsendable)]
+#[pyclass(name = "ReplicationHandle", module = "ciris_edge", unsendable)]
 pub struct PyReplicationHandle {
     inner: Arc<tokio::sync::Mutex<Option<crate::replication::ReplicationRuntime>>>,
     executor: Arc<ciris_persist::ffi::executor_capsule::AsyncExecutor>,


### PR DESCRIPTION
The lens-core 1.0.1 cohabitation surface lands, but it can't construct Edge from Python because `python/ciris_edge/__init__.py` only re-exported `SUPPORTED_SCHEMA_VERSIONS + __version__`. The Rust crate + PyO3 bindings have been feature-complete since v2.1.0 (`PyEdge` + `init_edge_runtime` + `transport_identity_pubkeys` + `engine` all registered via `#[pyclass]` / `#[pyfunction]` in the pymodule), but the Python wrapper never surfaced them.

This is a pure Python-wrapper fix: re-export the symbols the cdylib already registers.

## What ships

`python/ciris_edge/__init__.py` now re-exports the full Phase 1 lens-cutover surface:

```python
from .ciris_edge import (
    SUPPORTED_SCHEMA_VERSIONS,
    DurableHandle,
    Edge,
    NetworkEventSubscription,
    ReplicationHandle,
    SubscriptionHandle,
    VerifiedFeedSubscription,
    __version__,
    init_edge_runtime,
)
```

Lens-core's CIRISLens#18 §2 + #20 Reticulum-half pattern works as documented:

```python
import ciris_edge, ciris_persist as cp
engine = cp.Engine(dsn="postgres://lens:lens@localhost:5432/cirislens")
edge = ciris_edge.init_edge_runtime(engine=engine, ...)
pubkeys = edge.transport_identity_pubkeys()
install_relay(edge)  # lens-core 1.0.1's frozen hook
```

## Naming consistency — PyReplicationHandle → ReplicationHandle

`PyReplicationHandle` shipped at v1.6.3 with no explicit `#[pyclass(name = "...")]` attribute, so its Python class name defaulted to the Rust struct name (`PyReplicationHandle`). The five other Edge-family pyclasses (`Edge`, `DurableHandle`, `SubscriptionHandle`, `VerifiedFeedSubscription`, `NetworkEventSubscription`) all carry `#[pyclass(name = "X", module = "ciris_edge")]` with the `Py` prefix stripped. `ReplicationHandle` joins the pattern.

Safe: `PyReplicationHandle` was never re-exported through `__init__.py` in any prior release, so no Python consumer can be referencing `ciris_edge.PyReplicationHandle` today. Rust struct name unchanged (internal callers + `m.add_class::<PyReplicationHandle>()` still work).

## What's NOT in this cut

The pyo3 0.28 → 0.29 lockstep + persist v5.5.3 → v6.0.0 currency (originally planned as v2.2.0) is **deferred**. The upstream pyo3 ecosystem isn't ready:

- `pyo3-async-runtimes` latest is 0.28.0 ([PyO3/pyo3-async-runtimes#85](https://github.com/PyO3/pyo3-async-runtimes/pull/85) open for 0.29 bump, not merged)
- `pyo3-stub-gen` latest is 0.22.3 (no 0.29 work started upstream)

Edge depends on both; can't move to pyo3 0.29 alone. Persist's ceiling-firewall (`ciris-persist<6` in our pyproject) keeps edge 2.x from accidentally pulling persist 6.0.0 in the meantime — lens-core, agent, and edge stay coherent on the persist 5.x line until edge is g2g for pyo3 0.29.

When the ecosystem catches up, the lockstep cuts as v3.0.0 (or v2.3.0 if minor is sufficient) with pyo3 0.29 + persist 6.0.0 together, per the persist team's coordinated-publish handoff.

## Substrate pin currency

- `ciris-persist`: unchanged at v5.5.3
- `ciris-verify` family: unchanged at v5.1.0
- `leviculum`: unchanged at `ded96ee`

## Verification

- 255 lib tests green
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Test plan

- [x] `cargo test --lib --features transport-http,transport-reticulum,pyo3` green (255 tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI gauntlet green on PR — including `python/ciris_edge/__init__.py` re-exports surviving the wheel build + `from ciris_edge import Edge, init_edge_runtime` round-trip on the cohabitation conformance cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)
