### PR TITLE
release(v2.2.1): persist v5.5.5 + verify v5.1.3 + Win7-capable wheel (Tier-3 build-std)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1314,20 +1314,19 @@ jobs:
         # `windows.<N>.<M>.<P>.lib` import libs — under `-Zbuild-std`
         # the linker doesn't auto-discover them.
         shell: bash
-        env:
-          # v2.2.1 — only consumed by the Windows path below, but
-          # GitHub Actions step-level env doesn't support `if:`. Setting
-          # these unconditionally is harmless on non-Windows runners
-          # because the Windows branch is the only one that reads
-          # them.
-          RUSTUP_TOOLCHAIN: ${{ runner.os == 'Windows' && 'nightly' || '' }}
-          CARGO_BUILD_TARGET: ${{ runner.os == 'Windows' && 'x86_64-win7-windows-msvc' || '' }}
-          CARGO_UNSTABLE_BUILD_STD: ${{ runner.os == 'Windows' && 'std,panic_abort' || '' }}
         run: |
           set -euo pipefail
           if [ "${{ runner.os }}" = "Linux" ]; then
             maturin build --release --strip --features "pyo3 extension-module transport-http" --auditwheel=skip
           elif [ "${{ runner.os }}" = "Windows" ]; then
+            # Win7 build-std env vars — scoped to this shell branch so
+            # non-Windows runners never see them. Setting
+            # CARGO_BUILD_TARGET='' at step-level env breaks cargo
+            # ("target was empty"); the empty string is treated as an
+            # explicit (invalid) target rather than as unset.
+            export RUSTUP_TOOLCHAIN=nightly
+            export CARGO_BUILD_TARGET=x86_64-win7-windows-msvc
+            export CARGO_UNSTABLE_BUILD_STD=std,panic_abort
             # Sanity: Tier-3 target must be in nightly's target-list
             # (catches rustc upstream renames before the build runs).
             if ! rustc --print target-list | grep -qx 'x86_64-win7-windows-msvc'; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1123,6 +1123,18 @@ jobs:
           # the OpenSSL install step below. Closes CIRISEdge#90 by
           # validating the full Windows wheel build end-to-end in the
           # gauntlet.
+          #
+          # v2.2.1 (CIRISPersist#205 mirror) — Win7-capable. Built with
+          # the Tier-3 `x86_64-win7-windows-msvc` target via nightly +
+          # `-Zbuild-std`, so std keeps the Win7 fallback paths (keyed
+          # events, GetSystemTimeAsFileTime, RtlGenRandom) instead of
+          # stable ≥1.78's hard-imported Win8/Win10 APIs (WaitOnAddress,
+          # GetSystemTimePreciseAsFileTime, ProcessPrng). The artifact
+          # is the SAME `win_amd64.whl` file (one wheel pip resolves
+          # for any 64-bit Windows) and runs unchanged on Win7 SP1 +
+          # Server 2008 R2 + Win10/11. Built std with persist + verify
+          # whose own wheels do the same thing — full vertical Win7
+          # support across the CIRIS family.
           - { os: windows-latest,   label: windows-x86_64, tag: win_amd64 }
     runs-on: ${{ matrix.os }}
     steps:
@@ -1198,7 +1210,20 @@ jobs:
           echo "::notice::OpenSSL_DIR=${win_root} (vcpkg static x64-windows-static)"
           # Sanity probe — confirm the libs are where openssl-sys looks.
           ls -la "${ROOT}/lib/libssl.lib" "${ROOT}/lib/libcrypto.lib"
+      # v2.2.1 (CIRISPersist#205 mirror) — Windows uses nightly +
+      # rust-src so the Tier-3 `x86_64-win7-windows-msvc` target can
+      # build std from source via `-Zbuild-std`. Tier-3 ships no
+      # precompiled std; without build-std the link fails. Persist
+      # v5.5.4 / v5.5.5 + verify v5.1.3 ship Win7-capable wheels using
+      # this exact pattern; edge v2.2.1 mirrors so the published
+      # `win_amd64.whl` runs on Win7 SP1 + Server 2008 R2 in addition
+      # to Win10/11 (one wheel, broadest support).
       - uses: dtolnay/rust-toolchain@stable
+        if: runner.os != 'Windows'
+      - uses: dtolnay/rust-toolchain@nightly
+        if: runner.os == 'Windows'
+        with:
+          components: rust-src
       # v0.7.0 (CIRISEdge#17) — cache-bin: false on macOS to defang the
       # rustup-init shadow that the Repair-toolchain heal step below
       # actively corrects. CIRISVerify v2.1.4+ pattern; persist v0.7.2's
@@ -1227,7 +1252,13 @@ jobs:
               sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path
             export PATH="$HOME/.cargo/bin:$PATH"
           fi
-          rustup default stable
+          # v2.2.1 — Windows needs nightly (Tier-3 build-std); other
+          # OSes use stable.
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            rustup default nightly
+          else
+            rustup default stable
+          fi
           cargo --version
           cargo build --help >/dev/null
       - uses: actions/setup-python@v5
@@ -1268,10 +1299,58 @@ jobs:
         # v2.1.1 (CIRISEdge#87 / leviculum#10) — `shell: bash` forces Git
         # Bash on windows-latest so the `if [ ... ]` shell test resolves
         # (default Windows shell is pwsh; pwsh chokes on POSIX `[`).
+        #
+        # v2.2.1 (CIRISPersist#205 mirror) — Windows build now targets
+        # the Tier-3 `x86_64-win7-windows-msvc` triple via
+        # `-Zbuild-std`. nightly compiles std from source for the Win7
+        # target (no precompiled std exists). The resulting wheel is
+        # ABI-compatible with Win7 SP1 + Server 2008 R2 in addition to
+        # Win10/11. Maturin tags it `win_amd64` (same wheel filename;
+        # x86_64 + windows is the only thing pip platform-tag-matches
+        # against), and the published wheel runs unchanged across the
+        # whole Win7→Win11 range. The LNK1181 workaround augments LIB
+        # with the per-version `windows_x86_64_msvc-*/lib` directories
+        # the `windows-targets` crate ships for its own
+        # `windows.<N>.<M>.<P>.lib` import libs — under `-Zbuild-std`
+        # the linker doesn't auto-discover them.
         shell: bash
+        env:
+          # v2.2.1 — only consumed by the Windows path below, but
+          # GitHub Actions step-level env doesn't support `if:`. Setting
+          # these unconditionally is harmless on non-Windows runners
+          # because the Windows branch is the only one that reads
+          # them.
+          RUSTUP_TOOLCHAIN: ${{ runner.os == 'Windows' && 'nightly' || '' }}
+          CARGO_BUILD_TARGET: ${{ runner.os == 'Windows' && 'x86_64-win7-windows-msvc' || '' }}
+          CARGO_UNSTABLE_BUILD_STD: ${{ runner.os == 'Windows' && 'std,panic_abort' || '' }}
         run: |
+          set -euo pipefail
           if [ "${{ runner.os }}" = "Linux" ]; then
             maturin build --release --strip --features "pyo3 extension-module transport-http" --auditwheel=skip
+          elif [ "${{ runner.os }}" = "Windows" ]; then
+            # Sanity: Tier-3 target must be in nightly's target-list
+            # (catches rustc upstream renames before the build runs).
+            if ! rustc --print target-list | grep -qx 'x86_64-win7-windows-msvc'; then
+              echo "::error::x86_64-win7-windows-msvc not in nightly target-list — target may have been renamed; check rustc release notes"
+              exit 1
+            fi
+            # LNK1181 workaround: pre-fetch the dep graph (so the
+            # windows_x86_64_msvc-* crates land under ~/.cargo/registry/src),
+            # then add each version's /lib subdir to LIB so link.exe finds
+            # the `windows.<N>.<M>.<P>.lib` import libraries
+            # `windows-targets` references inline.
+            cargo fetch
+            extra=""
+            while IFS= read -r d; do
+              extra="${extra};$(cygpath -w "$d")"
+            done < <(find "$HOME/.cargo/registry/src" -type d -path '*windows_x86_64_msvc-*/lib' 2>/dev/null | sort -u)
+            if [ -n "$extra" ]; then
+              export LIB="${LIB:-}${extra}"
+              echo "::notice::LIB augmented with windows_x86_64_msvc import-lib dirs:${extra}"
+            else
+              echo "::warning::no windows_x86_64_msvc import-lib dirs found under cargo registry"
+            fi
+            maturin build --release --strip --features "pyo3 extension-module transport-http"
           else
             maturin build --release --strip --features "pyo3 extension-module transport-http"
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.2.0"
+version = "2.2.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.3", version = "5", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.5", version = "5", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.3
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.0", version = "5" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -861,7 +861,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.3", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.5.5", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=5.2.0,<6",
+    "ciris-persist>=5.5.5,<6",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
**HOLD — tag held until persist v5.5.5 lands on PyPI** (per your "I'll give you the final go once I see 5.5.5 live on PyPI").

Coupled substrate + wheel upgrade.

## Substrate floor — security + Win7 capability

- `ciris-persist`: v5.5.3 → v5.5.5 (rust-postgres security floors + Win7 build-std fixes from CIRISPersist#205)
- `ciris-keyring` + `ciris-crypto`: v5.1.0 → v5.1.3 ([CIRISVerify](https://github.com/CIRISAI/CIRISVerify) v5.1.3 ships the `dirs 5→6` bump that drops `windows-targets 0.48.5` — closes the Tier-3 LNK1181 link-fix v5.1.2 left open)

## pyproject ceiling — floor raise, ceiling held

```diff
- "ciris-persist>=5.2.0,<6"
+ "ciris-persist>=5.5.5,<6"
```

- **floor** at `>=5.5.5` picks up the rust-postgres security fix + the Win7-capable wheel line (5.5.4+)
- **ceiling** at `<6` retains the pyo3-0.29 firewall — persist v6.0.0 is already on PyPI but uses pyo3 0.29 internals; edge stays on pyo3 0.28 until upstream ecosystem (`PyO3/pyo3-async-runtimes#85` + `pyo3-stub-gen` 0.29) catches up. Persist team's coordinated handoff design

## Win7-capable wheel — CIRISPersist#205 mirror

Edge's published `win_amd64.whl` now runs on **Win7 SP1 + Server 2008 R2** in addition to Win10/11. Same wheel filename — `pip` platform-tag-matches on `x86_64+windows` only; the broadened ABI is invisible to consumers.

CI's `pyo3-wheel` matrix Windows entry switches:

| | v2.1.x | v2.2.1 |
|---|---|---|
| toolchain | stable | **nightly** (+ `rust-src`) |
| target | `x86_64-pc-windows-msvc` | **`x86_64-win7-windows-msvc` (Tier-3)** |
| env | — | `CARGO_UNSTABLE_BUILD_STD=std,panic_abort` |

Nightly compiles `std` from source, retaining Win7 fallback paths (keyed events, `GetSystemTimeAsFileTime`, `RtlGenRandom`) instead of stable ≥1.78's hard-imported Win8/Win10 APIs (`WaitOnAddress`, `GetSystemTimePreciseAsFileTime`, `ProcessPrng`).

**LNK1181 workaround**: under `-Zbuild-std` the linker doesn't auto-discover the per-version `windows.<N>.<M>.<P>.lib` import libraries that `windows-targets` references inline. Pre-fetches the dep graph, then walks `~/.cargo/registry/src` for every `windows_x86_64_msvc-*/lib` directory and prepends them to `LIB`. Same pattern persist v5.5.4 / v5.5.5 ship.

Non-Windows runners stay on stable. Linux + darwin wheels unchanged.

## Verification (local)

- 255 lib tests green
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean
- Cargo.lock auto-updated: `tokio-postgres v0.7.17 → v0.7.18` + transitive `zeroize` / `wasip2` minor bumps

## Holds + follow-ups

- Tag held until **persist v5.5.5 lands on PyPI** (matrix bump to 5.5.5 pushes simultaneously with the tag)
- `time = ">=0.3, <0.3.48"` pin kept — rcgen ↔ time upstream conflict unresolved
- pyo3 0.28 → 0.29 lockstep + persist v6.0.0 cuts as v3.0.0 once `PyO3/pyo3-async-runtimes#85` merges + pyo3-stub-gen 0.29-compatible release ships

## Test plan

- [x] `cargo test --lib --features transport-http,transport-reticulum,pyo3` green (255)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI gauntlet green on PR — Windows wheel proves the Win7 build-std path works end-to-end
- [ ] Confirm `ciris_edge-2.2.1-cp310-abi3-win_amd64.whl` installs + imports cleanly post-publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
