### PR TITLE
release(v2.2.2): expose local_dest_hash() — RNS destination accessor (closes #97)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1108,6 +1108,20 @@ jobs:
     #   2. vcpkg static x64-windows-static — openssl-sys link
     #   3. CIRISPersist v5.5.1 — Unix-only code paths cfg-gated (#200)
     # A regression in any of the three fails the gauntlet.
+    #
+    # v2.2.2 (CIRISPersist#208 mirror) — Windows nightly pinned via
+    # NIGHTLY_PIN. rust-cache's key includes the rustc version, so a
+    # daily-rotating `dtolnay/rust-toolchain@nightly` would bust the
+    # build-std cache every day (Windows wheel went 21.9m → cold every
+    # run). Pinning + per-(os,label) cache key drops Windows wheel to
+    # ~10-12m warm projected. Bump NIGHTLY_PIN deliberately when a
+    # std/build-std fix lands; tracks the known-good nightly the wheel
+    # last shipped against. KEEP IN SYNC with the toolchain step's
+    # `toolchain:` AND the maturin-build step's `RUSTUP_TOOLCHAIN:` —
+    # divergence causes `-Zbuild-std` to look for std source in a
+    # toolchain that has no rust-src installed.
+    env:
+      NIGHTLY_PIN: nightly-2026-06-12
     strategy:
       fail-fast: false
       matrix:
@@ -1220,17 +1234,35 @@ jobs:
       # to Win10/11 (one wheel, broadest support).
       - uses: dtolnay/rust-toolchain@stable
         if: runner.os != 'Windows'
-      - uses: dtolnay/rust-toolchain@nightly
+      # v2.2.2 (CIRISPersist#208 mirror) — pinned nightly via
+      # `@master + toolchain:` instead of `@nightly` (rolling). Rolling
+      # nightly busts rust-cache every day since the cache key includes
+      # rustc version. NIGHTLY_PIN is set at job-level env above.
+      - uses: dtolnay/rust-toolchain@master
         if: runner.os == 'Windows'
         with:
+          toolchain: ${{ env.NIGHTLY_PIN }}
           components: rust-src
       # v0.7.0 (CIRISEdge#17) — cache-bin: false on macOS to defang the
       # rustup-init shadow that the Repair-toolchain heal step below
       # actively corrects. CIRISVerify v2.1.4+ pattern; persist v0.7.2's
       # original work + verify's follow-up active-heal step.
+      #
+      # v2.2.2 (CIRISPersist#208 mirror) — `key: wheel-${{ matrix.label }}`
+      # gives each matrix entry its own cache slot. Without this, all
+      # 4 wheel jobs (linux x86_64, linux aarch64, darwin aarch64,
+      # windows x86_64) thrash a SINGLE shared cache slot — the last
+      # one written wins, every other entry hits an unusable cache
+      # (different target triple, different artifacts) and recompiles
+      # from scratch. Per-label keying drops the Windows wheel from
+      # ~21.9m cold to ~10-12m warm projected. Zero quality impact:
+      # cargo fingerprints on Cargo.lock+rustc and always recompiles
+      # edge's own (changed) crate; the published wheel is identical
+      # to a clean build.
       - uses: Swatinem/rust-cache@v2
         with:
           cache-bin: false
+          key: wheel-${{ matrix.label }}
         continue-on-error: true
       - name: Repair toolchain if rustup-init shadow (cache-poison heal)
         # v0.7.0 (CIRISEdge#17) — CIRISVerify v2.1.4+ pattern verbatim.
@@ -1254,8 +1286,10 @@ jobs:
           fi
           # v2.2.1 — Windows needs nightly (Tier-3 build-std); other
           # OSes use stable.
+          # v2.2.2 — Windows uses the pinned NIGHTLY_PIN, not rolling
+          # nightly (cache-warmth preservation; see job-level env block).
           if [ "${{ runner.os }}" = "Windows" ]; then
-            rustup default nightly
+            rustup default "${NIGHTLY_PIN}"
           else
             rustup default stable
           fi
@@ -1324,7 +1358,12 @@ jobs:
             # CARGO_BUILD_TARGET='' at step-level env breaks cargo
             # ("target was empty"); the empty string is treated as an
             # explicit (invalid) target rather than as unset.
-            export RUSTUP_TOOLCHAIN=nightly
+            # v2.2.2 — RUSTUP_TOOLCHAIN tracks the pinned NIGHTLY_PIN
+            # the toolchain step + Repair-toolchain step also use.
+            # Divergence between RUSTUP_TOOLCHAIN here and the actually-
+            # installed toolchain causes -Zbuild-std to look for std
+            # source in a toolchain that has no rust-src.
+            export RUSTUP_TOOLCHAIN="${NIGHTLY_PIN}"
             export CARGO_BUILD_TARGET=x86_64-win7-windows-msvc
             export CARGO_UNSTABLE_BUILD_STD=std,panic_abort
             # Sanity: Tier-3 target must be in nightly's target-list

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -2483,6 +2483,25 @@ impl Edge {
             .map(|t| t.local_transport_pubkey())
     }
 
+    /// v2.2.2 (CIRISEdge#97) — return edge's announced RNS destination
+    /// hash when a Reticulum transport is wired: the 16-byte
+    /// `*dest.hash()` value peers resolve to dial this node.
+    /// Cohabiting cdylibs (CIRISLensCore v1.4.0+'s `install_ret_relay`)
+    /// read this to surface the dialable RNS address alongside the
+    /// pubkeys from [`Self::local_transport_pubkey`].
+    ///
+    /// Returns `None` for HTTPS-only / transport-less Edge builds
+    /// (`disable_reticulum=True` at `init_edge_runtime`, or a wheel
+    /// built without the `_reticulum-module` feature) — same posture
+    /// as [`Self::local_transport_pubkey`].
+    #[cfg(feature = "_reticulum-module")]
+    #[must_use]
+    pub fn local_dest_hash(&self) -> Option<[u8; 16]> {
+        self.reticulum_transport
+            .as_ref()
+            .map(|t| t.local_dest_hash())
+    }
+
     /// Pub-crate variant of [`Self::run_speak_pipeline`] reachable
     /// from `crate::ffi::pyo3`. The Python `send_inline_text` /
     /// `send_durable_inline_text` wrappers need to run the pipeline

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -426,6 +426,34 @@ impl PyEdge {
         }
     }
 
+    /// v2.2.2 (CIRISEdge#97) — return edge's announced RNS destination
+    /// hash as a lowercase hex string: the 16-byte `*dest.hash()` value
+    /// Reticulum computes at `Destination` construction time over the
+    /// identity + app aspects (NOT `sha256(pubkey)[..16]` — consumers
+    /// can't safely re-derive it from
+    /// [`Self::transport_identity_pubkeys`] alone).
+    ///
+    /// This is the destination peers resolve to dial this node. RNS
+    /// shows destinations conventionally as hex strings; CIRISLensCore
+    /// v1.4.0+'s `install_ret_relay` (CIRISLensCore#43) calls this to
+    /// surface the dialable RNS address alongside the transport
+    /// pubkeys.
+    ///
+    /// Returns `None` for HTTPS-only or transport-less Edge builds
+    /// (`disable_reticulum=True`, or a wheel built without the
+    /// `_reticulum-module` feature). Returns the 32-character lowercase
+    /// hex string otherwise.
+    fn reticulum_dest_hash_hex(&self) -> Option<String> {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            self.inner.local_dest_hash().map(hex::encode)
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            None
+        }
+    }
+
     /// Local agent's federation `key_id` — the identity peers seed
     /// into their `federation_keys` directory to root inbound traffic
     /// from this agent. CIRISAgent 2.9.4 displays this on the

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1277,6 +1277,27 @@ impl ReticulumTransport {
         self.local_transport_pubkey
     }
 
+    /// v2.2.2 (CIRISEdge#97) — return edge's announced RNS destination
+    /// hash: the 16-byte `*dest.hash()` value Reticulum computes at
+    /// `Destination` construction time over the identity + app aspects
+    /// (NOT a plain `sha256(pubkey)[..16]` — that's why consumers need
+    /// this accessor; they can't re-derive it from
+    /// [`Self::local_transport_pubkey`] safely).
+    ///
+    /// This is the destination peers resolve to dial this node:
+    /// announces carry it as `self.local_dest_hash`, the routing
+    /// table keys on it, and a peer's path lookup returns it.
+    /// Cohabiting cdylibs (CIRISLensCore v1.4.0+'s `install_ret_relay`
+    /// per CIRISLensCore#43) call this to surface the dialable RNS
+    /// address alongside the transport pubkeys.
+    #[must_use]
+    pub fn local_dest_hash(&self) -> [u8; 16] {
+        let bytes = self.local_dest_hash.as_bytes();
+        let mut out = [0u8; 16];
+        out.copy_from_slice(bytes);
+        out
+    }
+
     /// spec. Returns a `Vec<TransportSpec>` of `(handle, kind)` pairs.
     /// Order matches the registration order in
     /// [`ReticulumTransportConfig::interfaces`] (or the legacy


### PR DESCRIPTION
[CIRISLensCore#43](https://github.com/CIRISAI/CIRISLensCore/issues/43)'s `install_ret_relay` (v1.4.0+) needs the announced RNS destination hash to surface a dialable address, but `local_transport_pubkey() -> [u8; 64]` (v2.1.0) wasn't enough — RNS's `Destination.hash()` is computed over identity + app aspects internally, not derivable from the pubkey alone. Lens-core filed [#97](https://github.com/CIRISAI/CIRISEdge/issues/97) per the federation principle "ask upstream, don't compose around a missing API."

The `local_dest_hash: DestinationHash` field already exists on `ReticulumTransport` (captured at `Destination` registration time per v1.6); this cut just exposes it through three layers matching the existing pubkey-accessor pattern.

## Three layers

1. **`ReticulumTransport::local_dest_hash(&self) -> [u8; 16]`** — reads the existing private field via `DestinationHash::as_bytes()`, copies to a stable `[u8; 16]` shape. Mirrors `local_transport_pubkey() -> [u8; 64]` from CIRISEdge#85.

2. **`Edge::local_dest_hash(&self) -> Option<[u8; 16]>`** — `Some(buf)` when a Reticulum transport is wired; `None` for HTTPS-only / transport-less builds. Gated under `_reticulum-module`.

3. **`PyEdge::reticulum_dest_hash_hex(&self) -> Option<String>`** — Python surface returning the canonical RNS 32-char lowercase hex string (`hex::encode([u8; 16])`). Lens-core's `install_ret_relay` will pass this verbatim to peers.

## Cohabitation contract

Read-direction matches every other PyEdge accessor (`engine`, `edge_handle`, `signer_key_id`, `transport_identity_pubkeys`). Lens-core's `RetRelay` will call `edge.reticulum_dest_hash_hex()` alongside `edge.transport_identity_pubkeys()` to publish both the dialable address AND the federation identity pubkeys. Pure additive surface — no new lifecycle, no new state.

## Verification

- 255 lib tests green
- All 4 `RUSTFLAGS=-D warnings` combos clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt --check` clean

## Substrate pins unchanged

- ciris-persist: v5.5.5
- ciris-verify family: v5.1.3
- leviculum: ded96ee

Closes #97.

## Test plan

- [x] `cargo test --lib --features transport-http,transport-reticulum,pyo3` green (255 tests)
- [x] 4 RUSTFLAGS=-D warnings combos clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Full CI gauntlet green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
