### PR TITLE
release(v2.3.1): persist v5.6.0 → v5.8.0 catch-up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.6.0", version = "5", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.8.0", version = "5", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -861,7 +861,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.6.0", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.8.0", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=5.6.0,<6",
+    "ciris-persist>=5.8.0,<6",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

- Bumps `ciris-persist` v5.6.0 → v5.8.0 across all three pin sites: main dep, dev-deps, pyproject.
- Picks up CIRISPersist#146's consent-observability surface (v5.7.0 + v5.8.0): `hard_case` emission, `resolve_consent_state`, the consent-SLA watcher.
- No edge code changes. Surface-compatible bump.

## Why bump when edge doesn't consume the new APIs

Cohabiting cdylibs share one persist engine via the OnceLock singleton (`CIRISPersist#85` discipline). If lens / agent / registry ship wheels pinned to persist 5.8.x while edge keeps 5.6.x, co-resident deployments hit a version-mismatch panic at `Engine::install` time. Pin parity > unused-surface efficiency.

## Verification

- `-D warnings` clean across the 4 CI feature combos (core / reticulum / packet-radio / all-transports)
- `cargo clippy -D warnings` clean on pyo3-full --all-targets
- `cargo test --lib` (pyo3-full): 255 / 255 pass

## Test plan

- [ ] Tag CI green
- [ ] PyPI publish lands `ciris_edge-2.3.1` (4 wheels)
- [ ] `pip install ciris-edge==2.3.1` resolves with `ciris-persist>=5.8.0,<6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)