### PR TITLE
release(v2.4.0): KEX getter + lease cleanup + CI skew guard (closes #95 #103 + adds #84)

### DIFF
--- a/.github/scripts/check_cargo_pyproject_skew.py
+++ b/.github/scripts/check_cargo_pyproject_skew.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Cargo.toml <-> pyproject.toml version-skew guard (CIRISEdge#84).
+
+Reads the Cargo.toml pinned tag for `ciris-persist` and the pyproject.toml
+PEP 440 constraint for the matching Python wheel; fails CI with a clear
+diff if the Cargo pin does not satisfy the pyproject constraint.
+
+Background: the v1.7.0 -> v2.0.1 cascade shipped three wheels with
+`Requires-Dist: ciris-persist<5,>=4.15.0` while the bundled cdylib linked
+persist v5.x. `pip install ciris-edge ciris-persist==5.x` ->
+ResolutionImpossible. Caught downstream by CIRISLensCore; fixed at v2.0.2.
+This guard would have caught it pre-merge.
+
+Exits 0 on satisfied; non-zero with a human-readable diff otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+
+CARGO_TOML = Path("Cargo.toml")
+PYPROJECT_TOML = Path("pyproject.toml")
+
+# (Cargo crate name, pyproject Python package name) pairs to check.
+# Only crates that ship as standalone Python wheels are checkable; the
+# verify family (ciris-keyring / ciris-crypto) ride statically inside the
+# cdylib and have no Python wheel to skew against.
+PAIRS = [
+    ("ciris-persist", "ciris-persist"),
+]
+
+
+def cargo_pinned_tag(crate: str, text: str) -> str:
+    """Return the SemVer string Cargo.toml pins `crate` to (via `tag =`).
+
+    Picks the FIRST matching line; tolerant of comments preceding the
+    line. Edge pins persist twice (main deps + dev-deps) but on the same
+    tag — taking the first is fine.
+    """
+    pattern = rf'^\s*{re.escape(crate)}\s*=\s*\{{[^}}]*tag\s*=\s*"v(\d+\.\d+\.\d+)"'
+    match = re.search(pattern, text, re.M)
+    if not match:
+        raise SystemExit(
+            f"check_cargo_pyproject_skew: no `tag = \"vX.Y.Z\"` entry for {crate} in Cargo.toml"
+        )
+    return match.group(1)
+
+
+def pyproject_constraint(package: str, text: str) -> str:
+    """Return the PEP 440 constraint pyproject.toml applies to `package`.
+
+    Looks at `[project.dependencies]` entries of the form
+    `"ciris-persist>=5.5.5,<6"`.
+    """
+    pattern = rf'"{re.escape(package)}\s*([^"]+)"'
+    match = re.search(pattern, text)
+    if not match:
+        raise SystemExit(
+            f"check_cargo_pyproject_skew: no dependency line for {package} in pyproject.toml"
+        )
+    return match.group(1).strip()
+
+
+def main() -> int:
+    cargo_text = CARGO_TOML.read_text()
+    pyproject_text = PYPROJECT_TOML.read_text()
+
+    failures: list[str] = []
+    successes: list[str] = []
+
+    for crate, package in PAIRS:
+        cargo_version = cargo_pinned_tag(crate, cargo_text)
+        constraint = pyproject_constraint(package, pyproject_text)
+        spec = SpecifierSet(constraint)
+        v = Version(cargo_version)
+        if v in spec:
+            successes.append(
+                f"  OK   {crate}: Cargo v{cargo_version} satisfies pyproject {constraint!r}"
+            )
+        else:
+            failures.append(
+                f"  FAIL {crate}: Cargo v{cargo_version} does NOT satisfy pyproject {constraint!r}"
+            )
+
+    if failures:
+        print("Cargo.toml <-> pyproject.toml version skew detected:", file=sys.stderr)
+        for line in failures:
+            print(line, file=sys.stderr)
+        if successes:
+            print("\nOther pairs (ok):", file=sys.stderr)
+            for line in successes:
+                print(line, file=sys.stderr)
+        print(
+            "\nFix: bump pyproject.toml's `dependencies` constraint to include the "
+            "Cargo-pinned version, or roll back the Cargo tag.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("Cargo.toml <-> pyproject.toml version pins consistent:")
+    for line in successes:
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1100,8 +1100,29 @@ jobs:
   # Each matrix entry runs on a NATIVE runner for that target so we
   # avoid cross-compile drama (sysroot, linkers, vendored crypto
   # quirks).
+  # v2.4.0 (CIRISEdge#84) — pre-wheel Cargo<->pyproject pin-skew guard.
+  # The v1.7.0 -> v2.0.1 cascade shipped three wheels with
+  # `Requires-Dist: ciris-persist<5,>=4.15.0` while the bundled cdylib
+  # linked persist v5.x; downstream `pip install` hit ResolutionImpossible.
+  # This job parses both files and fails fast if the Cargo-pinned tag
+  # does not satisfy the pyproject PEP 440 constraint, before any wheel
+  # is built. ~10s job; gates pyo3-wheel via `needs:`.
+  cargo-pyproject-skew-check:
+    name: cargo <-> pyproject pin-skew check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: install packaging
+        run: python -m pip install --quiet "packaging>=23"
+      - name: check skew
+        run: python3 .github/scripts/check_cargo_pyproject_skew.py
+
   pyo3-wheel:
     name: maturin abi3-py310 wheel (${{ matrix.label }})
+    needs: [cargo-pyproject-skew-check]
     # v2.1.1 — windows-x86_64 wheel is now REQUIRED (closes
     # CIRISEdge#90). All three layers landed:
     #   1. leviculum 4c15dfd — reticulum-std Windows port (leviculum#10/#11)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.3.1"
+version = "2.4.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1208,6 +1208,69 @@ impl Edge {
         }
     }
 
+    /// v2.4.0 (CIRISEdge#95) — resolve a remote peer's hybrid KEM
+    /// pubkeys (x25519 + ML-KEM-768) from persist's federation
+    /// directory for `FederationSession::initiate` consumers.
+    ///
+    /// `occurrence_key_id` is the per-device occurrence key (NOT the
+    /// identity key) — content KEM keys live at the occurrence level
+    /// per CEG §5.6.8.4.
+    ///
+    /// Returns:
+    /// - `Ok(Some(PeerKexPubkeys))` when persist has both halves
+    ///   registered for the occurrence
+    /// - `Ok(None)` when the occurrence is unknown, expired
+    ///   (`valid_until` in the past), or has no `encryption_pubkeys`
+    ///   block
+    /// - `Err(EdgeError::Persist)` on persist-backend error
+    ///
+    /// Delegates to
+    /// [`FederationDirectory::resolve_encryption_keys`](ciris_persist::federation::FederationDirectory::resolve_encryption_keys)
+    /// (persist v4.13.0+, `EncryptionPubkeys { x25519_base64,
+    /// ml_kem_768_base64 }`) and base64-decodes the two halves into
+    /// the wire-byte shape `PeerKexPubkeys` carries. A decode failure
+    /// or wrong byte count surfaces as `Err(EdgeError::Persist)`
+    /// rather than silent `Ok(None)` — a malformed row in persist
+    /// must be operator-visible.
+    pub async fn resolve_peer_kex_pubkeys(
+        &self,
+        occurrence_key_id: &str,
+    ) -> Result<Option<crate::transport::federation_session::PeerKexPubkeys>, EdgeError> {
+        use base64::Engine as _;
+        let Some(directory) = self.federation_directory.as_ref() else {
+            return Ok(None);
+        };
+        let encryption_pubkeys = directory
+            .resolve_encryption_keys(occurrence_key_id)
+            .await
+            .map_err(|e| EdgeError::Persist(format!("resolve_encryption_keys: {e}")))?;
+        let Some(pk) = encryption_pubkeys else {
+            return Ok(None);
+        };
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let x25519_raw = b64.decode(&pk.x25519_base64).map_err(|e| {
+            EdgeError::Persist(format!(
+                "resolve_peer_kex_pubkeys({occurrence_key_id}): x25519 base64 decode: {e}"
+            ))
+        })?;
+        let x25519_pub: [u8; 32] = x25519_raw.as_slice().try_into().map_err(|_| {
+            EdgeError::Persist(format!(
+                "resolve_peer_kex_pubkeys({occurrence_key_id}): x25519 wrong length \
+                 ({}; expected 32)",
+                x25519_raw.len()
+            ))
+        })?;
+        let mlkem768_pub = b64.decode(&pk.ml_kem_768_base64).map_err(|e| {
+            EdgeError::Persist(format!(
+                "resolve_peer_kex_pubkeys({occurrence_key_id}): ml-kem-768 base64 decode: {e}"
+            ))
+        })?;
+        Ok(Some(crate::transport::federation_session::PeerKexPubkeys {
+            x25519_pub,
+            mlkem768_pub: Some(mlkem768_pub),
+        }))
+    }
+
     /// CIRISEdge#48-A (v0.19.1) accessor — current enforcement
     /// posture.
     #[must_use]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -268,6 +268,103 @@ pub struct PyEdge {
     /// (operator-supplied cert paths persist independently).
     #[cfg(feature = "transport-http")]
     _dev_cert_tmpdir: Option<Arc<tempfile::TempDir>>,
+    /// v2.4.0 (CIRISEdge#103) — shared-instance lease cleanup state.
+    /// When `init_edge_runtime` won the SharedInstanceDirectory
+    /// election (auto role) and spawned the heartbeat task, this
+    /// carries the parts [`Self::close`] needs to release the lease
+    /// cleanly: a shutdown signal for the heartbeat loop + the
+    /// `(name, owner_pid, lease)` triple for
+    /// `release_shared_instance_lease`.
+    ///
+    /// `Mutex` because `close()` takes `&self` (PyO3 / pyclass — no
+    /// `&mut self` from Python without `pyclass(unsendable)`) and we
+    /// need interior mutability to `take()` the contents on the
+    /// first close. Idempotent across multiple close calls.
+    ///
+    /// `None` when:
+    /// - shared-instance was not configured (`local_instance_name=None`)
+    /// - the operator pinned `local_instance_role="client"` (no lease
+    ///   held)
+    /// - `local_instance_role="auto"` lost the election (sibling is
+    ///   server; no lease held)
+    /// - this is a `for_test` constructor
+    #[cfg(feature = "transport-reticulum-local")]
+    shared_instance_cleanup: std::sync::Mutex<Option<SharedInstanceCleanup>>,
+}
+
+/// v2.4.0 (CIRISEdge#103) — best-effort cleanup if the Python caller
+/// let `PyEdge` get GC'd without calling [`PyEdge::close`]
+/// explicitly. Mirrors the close() path: signal the heartbeat to
+/// stop + release the lease, this time WITHOUT `py.detach` (Drop
+/// runs without the GIL anyway). On any error path, the lease ages
+/// out via the staleness window — Drop never panics.
+#[cfg(feature = "transport-reticulum-local")]
+impl Drop for PyEdge {
+    fn drop(&mut self) {
+        // Lock the cleanup state. If poisoned (a prior call panicked
+        // inside the lock), or empty (already closed), skip.
+        let Ok(mut guard) = self.shared_instance_cleanup.lock() else {
+            return;
+        };
+        let Some(mut cleanup) = guard.take() else {
+            return;
+        };
+        // Signal heartbeat task to stop. `send(()) -> Err(_)` only
+        // when the receiver already dropped (task exited early); fine
+        // to ignore.
+        if let Some(tx) = cleanup.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        // Best-effort release. Errors logged (no propagation possible
+        // from Drop). The persist Engine's tokio runtime is reached
+        // via the executor capsule we still hold an Arc to — it lives
+        // for as long as the host engine's PyObject does, which the
+        // `self.engine` field still references.
+        let directory = cleanup.directory;
+        let lease = cleanup.lease;
+        let instance_name_for_log = lease.instance_name.clone();
+        let release_result = run_async(&self.executor, async move {
+            directory.release_shared_instance_lease(&lease).await
+        });
+        match release_result {
+            Ok(()) => {
+                tracing::info!(
+                    instance_name = %instance_name_for_log,
+                    "PyEdge::drop: shared-instance lease released (no explicit close() called)"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    instance_name = %instance_name_for_log,
+                    error = %e,
+                    "PyEdge::drop: shared-instance lease release failed; \
+                     lease will age out via staleness window"
+                );
+            }
+        }
+    }
+}
+
+/// v2.4.0 (CIRISEdge#103) — auto-elected server's lease state, held
+/// by [`PyEdge::shared_instance_cleanup`] from `init_edge_runtime`
+/// until [`PyEdge::close`] runs the release path. See the field doc
+/// for when this is populated vs `None`.
+#[cfg(feature = "transport-reticulum-local")]
+struct SharedInstanceCleanup {
+    /// Shutdown signal for the heartbeat task; the loop `tokio::select!`s
+    /// on the matching `Receiver`. Sending `()` (via
+    /// [`tokio::sync::oneshot::Sender::send`]) breaks the loop on its
+    /// next iteration. `Option` so [`PyEdge::close`] can `take()` it
+    /// and `send` once; subsequent calls observe `None` and skip.
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    /// The lease as last seen by `init_edge_runtime`. Stored so the
+    /// close path's `release_shared_instance_lease` ownership check
+    /// can match the row.
+    lease: ciris_persist::federation::SharedInstanceLease,
+    /// The federation directory handle the close path uses to call
+    /// `release_shared_instance_lease`. Clone of the same Arc the
+    /// heartbeat task holds.
+    directory: Arc<dyn ciris_persist::federation::FederationDirectory>,
 }
 
 impl PyEdge {
@@ -317,6 +414,8 @@ impl PyEdge {
             engine: None,
             #[cfg(feature = "transport-http")]
             _dev_cert_tmpdir: None,
+            #[cfg(feature = "transport-reticulum-local")]
+            shared_instance_cleanup: std::sync::Mutex::new(None),
         }
     }
 }
@@ -329,6 +428,122 @@ impl PyEdge {
     #[staticmethod]
     fn crate_version() -> &'static str {
         VERSION
+    }
+
+    /// v2.4.0 (CIRISEdge#103) — graceful close. Idempotent; safe to
+    /// call from `__del__`, `atexit` hooks, FastAPI shutdown handlers,
+    /// `try/finally` blocks, etc.
+    ///
+    /// When this Edge owns a Reticulum shared-instance lease (auto-
+    /// elected server), close():
+    ///
+    /// 1. Signals the heartbeat task to stop (oneshot — the loop's
+    ///    `tokio::select!` preempts the 10s sleep on the next
+    ///    iteration).
+    /// 2. Calls `FederationDirectory::release_shared_instance_lease`
+    ///    to free the lease row immediately (ownership-checked; safe
+    ///    if the lease was already stolen by a sibling, in which case
+    ///    persist returns `false` and we treat it as a no-op).
+    ///
+    /// Without close(), a worker exit leaves the lease row populated
+    /// until the 30s staleness window elapses — sibling re-election
+    /// then takes that full window. With close() the handoff is
+    /// hundreds of milliseconds (one persist roundtrip), matching the
+    /// orchestrator's expectations on `kubectl rollout restart` /
+    /// `systemd reload`.
+    ///
+    /// For Edges with no shared-instance lease (no `local_instance_name`
+    /// supplied, `local_instance_role="client"`, or election lost),
+    /// close() is a no-op — the surface is present on every Edge so
+    /// callers don't need to introspect.
+    ///
+    /// Errors from the persist release call are LOGGED but NOT
+    /// raised: at process-shutdown time, a backend error doesn't
+    /// help the caller (they're already exiting), and the lease will
+    /// age out via the staleness window as a fallback.
+    #[cfg(feature = "transport-reticulum-local")]
+    #[allow(clippy::unnecessary_wraps)] // Keep PyResult for future-proofing the pymethod shape
+    fn close(&self, py: Python<'_>) -> PyResult<()> {
+        let Ok(mut guard) = self.shared_instance_cleanup.lock() else {
+            // PoisonError: a prior caller panicked inside the lock.
+            // Treat as already-closed and return Ok — re-panicking from
+            // close() is worse than tolerating the poison.
+            tracing::warn!(
+                "PyEdge::close: shared_instance_cleanup mutex poisoned; \
+                 skipping release path"
+            );
+            return Ok(());
+        };
+        let Some(mut cleanup) = guard.take() else {
+            // Already closed, or never had a lease in the first place.
+            return Ok(());
+        };
+        // Signal the heartbeat task FIRST so it stops touching the
+        // lease before our release call lands. The receiver-side
+        // `tokio::select!` is `biased` to preempt the 10s sleep.
+        if let Some(tx) = cleanup.shutdown_tx.take() {
+            let _ = tx.send(()); // err only if the receiver already dropped (task exited).
+        }
+        // Release the lease via run_async. Errors logged + swallowed.
+        let directory = cleanup.directory;
+        let lease = cleanup.lease;
+        let instance_name_for_log = lease.instance_name.clone();
+        py.detach(|| {
+            let release_result = run_async(&self.executor, async move {
+                directory.release_shared_instance_lease(&lease).await
+            });
+            match release_result {
+                Ok(()) => {
+                    tracing::info!(
+                        instance_name = %instance_name_for_log,
+                        "Reticulum shared-instance lease released on close"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        instance_name = %instance_name_for_log,
+                        error = %e,
+                        "Reticulum shared-instance lease release failed; \
+                         lease will age out via staleness window \
+                         (ownership-checked release is a no-op when a \
+                         sibling already stole the lease)"
+                    );
+                }
+            }
+        });
+        Ok(())
+    }
+
+    /// v2.4.0 (CIRISEdge#103) — `close()` shim for wheels built
+    /// without `transport-reticulum-local`. Always Ok; provided so the
+    /// Python API surface is feature-invariant (callers don't need to
+    /// `hasattr(edge, "close")` based on the wheel's feature set).
+    #[cfg(not(feature = "transport-reticulum-local"))]
+    fn close(&self, _py: Python<'_>) -> PyResult<()> {
+        Ok(())
+    }
+
+    /// v2.4.0 (CIRISEdge#103) — context-manager support so callers
+    /// can write `with init_edge_runtime(...) as edge: ...` and have
+    /// close() fire automatically on the with-block exit. Mirrors the
+    /// `contextlib.contextmanager` shape (`__enter__` returns self,
+    /// `__exit__` calls close()).
+    fn __enter__(slf: PyRef<'_, Self>) -> PyRef<'_, Self> {
+        slf
+    }
+
+    /// v2.4.0 (CIRISEdge#103) — context-manager exit. Always calls
+    /// close(); never suppresses the exception (returns `None`
+    /// implicitly — Python's `with` semantics).
+    #[pyo3(signature = (_exc_type=None, _exc_value=None, _traceback=None))]
+    fn __exit__(
+        &self,
+        py: Python<'_>,
+        _exc_type: Option<Bound<'_, PyAny>>,
+        _exc_value: Option<Bound<'_, PyAny>>,
+        _traceback: Option<Bound<'_, PyAny>>,
+    ) -> PyResult<()> {
+        self.close(py)
     }
 
     /// v2.1.0 (CIRISEdge#85 / CIRISLensCore#43) — return the host
@@ -464,6 +679,58 @@ impl PyEdge {
     /// One-line wrapper over [`Edge::signer_key_id`]; no new state.
     fn signer_key_id(&self) -> String {
         self.inner.signer_key_id().to_string()
+    }
+
+    /// v2.4.0 (CIRISEdge#95) — fetch a remote peer's hybrid KEM
+    /// pubkeys (x25519 + ML-KEM-768) from persist's federation
+    /// directory for `FederationSession::initiate` consumers
+    /// (CIRISLensCore#34 RET-native relay).
+    ///
+    /// `occurrence_key_id` is the per-device occurrence key; content-
+    /// KEM keys live at the occurrence level per CEG §5.6.8.4.
+    ///
+    /// ```python
+    /// edge.resolve_peer_kex_pubkeys(peer_occurrence_key_id) == {
+    ///     "x25519_pub_base64":     "...",  # 32 raw bytes, base64 standard
+    ///     "ml_kem_768_pub_base64": "...",  # 1184 raw bytes, base64 standard
+    /// }
+    /// # OR None if the occurrence is unknown / has no registered
+    /// # encryption_pubkeys block / has expired (valid_until in past).
+    /// ```
+    ///
+    /// Returns `None` for: occurrence not in directory, occurrence
+    /// expired, occurrence has no `encryption_pubkeys` block, or an
+    /// Edge built without a federation directory wired (test
+    /// constructors). Raises `RuntimeError` only on persist-backend
+    /// failure or malformed base64 / wrong byte length in the
+    /// stored row (operator-visible substrate corruption).
+    fn resolve_peer_kex_pubkeys<'py>(
+        &self,
+        py: Python<'py>,
+        occurrence_key_id: &str,
+    ) -> PyResult<Option<Bound<'py, pyo3::types::PyDict>>> {
+        use base64::Engine as _;
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let inner = self.inner.clone();
+        let occurrence_key_id_owned = occurrence_key_id.to_string();
+        let kex = py.detach(|| {
+            run_async(&self.executor, async move {
+                inner
+                    .resolve_peer_kex_pubkeys(&occurrence_key_id_owned)
+                    .await
+            })
+            .map_err(|e| PyRuntimeError::new_err(format!("resolve_peer_kex_pubkeys: {e}")))
+        })?;
+        let Some(kex) = kex else {
+            let _ = b64; // suppress unused-binding lint in the None path
+            return Ok(None);
+        };
+        let dict = pyo3::types::PyDict::new(py);
+        dict.set_item("x25519_pub_base64", b64.encode(kex.x25519_pub))?;
+        if let Some(mlkem) = kex.mlkem768_pub {
+            dict.set_item("ml_kem_768_pub_base64", b64.encode(mlkem))?;
+        }
+        Ok(Some(dict))
     }
 
     // ─── CIRISEdge#22 Tier 2 (v0.9.0) — CommunicationBus replacement ──
@@ -3226,73 +3493,107 @@ fn init_edge_runtime(
     // a clean lease. (Auto-restart of the transport mid-process is out
     // of scope for v2.3.0 — Reticulum interfaces aren't swappable
     // live; the orchestrator owns process lifecycle.)
+    //
+    // v2.4.0 (CIRISEdge#103) — the heartbeat loop now `tokio::select!`s
+    // on a oneshot::Receiver so `PyEdge::close` can short-circuit it
+    // (rather than waiting up to 10s for the loop's next iteration).
+    // The matching Sender + lease + directory clone are stashed on
+    // PyEdge below so close() can also call
+    // `release_shared_instance_lease` to free the lease row
+    // immediately (rather than waiting for the 30s staleness window).
     #[cfg(feature = "transport-reticulum-local")]
-    if let Some(initial_lease) = acquired_lease {
-        let directory_for_heartbeat = Arc::clone(&federation_directory_for_edge);
-        let executor_for_heartbeat = Arc::clone(&executor);
-        let instance_name_outer = initial_lease.instance_name.clone();
-        let instance_name_inner = initial_lease.instance_name.clone();
-        let heartbeat_fut: BoxedFut = Box::pin(async move {
-            let mut lease = initial_lease;
-            let mut consecutive_backend_errors: u32 = 0;
-            loop {
-                tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                match directory_for_heartbeat
-                    .heartbeat_shared_instance(&lease)
-                    .await
-                {
-                    Ok(Some(renewed)) => {
-                        lease = renewed;
-                        consecutive_backend_errors = 0;
-                    }
-                    Ok(None) => {
-                        tracing::error!(
-                            instance_name = %instance_name_inner,
-                            "Reticulum shared-instance lease was stolen \
-                             (sibling promoted; this process is demoted to \
-                             a stale server). Restart this worker to re-elect."
-                        );
-                        return;
-                    }
-                    Err(e) => {
-                        consecutive_backend_errors += 1;
-                        tracing::warn!(
-                            instance_name = %instance_name_inner,
-                            error = %e,
-                            consecutive_errors = consecutive_backend_errors,
-                            "shared-instance heartbeat backend error"
-                        );
-                        if consecutive_backend_errors >= 6 {
-                            tracing::error!(
+    let shared_instance_cleanup: Option<SharedInstanceCleanup> =
+        if let Some(initial_lease) = acquired_lease {
+            let directory_for_heartbeat = Arc::clone(&federation_directory_for_edge);
+            let directory_for_cleanup = Arc::clone(&federation_directory_for_edge);
+            let executor_for_heartbeat = Arc::clone(&executor);
+            let instance_name_outer = initial_lease.instance_name.clone();
+            let instance_name_inner = initial_lease.instance_name.clone();
+            let lease_for_cleanup = initial_lease.clone();
+            let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
+            let heartbeat_fut: BoxedFut = Box::pin(async move {
+                let mut lease = initial_lease;
+                let mut consecutive_backend_errors: u32 = 0;
+                let mut shutdown_rx = shutdown_rx;
+                loop {
+                    tokio::select! {
+                        biased;
+                        // Shutdown branch (biased so it preempts the sleep).
+                        // Either explicit close() signal or close() dropped the
+                        // sender without sending — both terminate the loop.
+                        _ = &mut shutdown_rx => {
+                            tracing::info!(
                                 instance_name = %instance_name_inner,
-                                "shared-instance heartbeat: 6 consecutive backend \
-                                 errors — abandoning heartbeat task. Lease will \
-                                 expire after the staleness window."
+                                "shared-instance heartbeat: shutdown signal received; \
+                                 exiting loop"
                             );
                             return;
                         }
+                        () = tokio::time::sleep(std::time::Duration::from_secs(10)) => {}
+                    }
+                    match directory_for_heartbeat
+                        .heartbeat_shared_instance(&lease)
+                        .await
+                    {
+                        Ok(Some(renewed)) => {
+                            lease = renewed;
+                            consecutive_backend_errors = 0;
+                        }
+                        Ok(None) => {
+                            tracing::error!(
+                                instance_name = %instance_name_inner,
+                                "Reticulum shared-instance lease was stolen \
+                                 (sibling promoted; this process is demoted to \
+                                 a stale server). Restart this worker to re-elect."
+                            );
+                            return;
+                        }
+                        Err(e) => {
+                            consecutive_backend_errors += 1;
+                            tracing::warn!(
+                                instance_name = %instance_name_inner,
+                                error = %e,
+                                consecutive_errors = consecutive_backend_errors,
+                                "shared-instance heartbeat backend error"
+                            );
+                            if consecutive_backend_errors >= 6 {
+                                tracing::error!(
+                                    instance_name = %instance_name_inner,
+                                    "shared-instance heartbeat: 6 consecutive backend \
+                                     errors — abandoning heartbeat task. Lease will \
+                                     expire after the staleness window."
+                                );
+                                return;
+                            }
+                        }
                     }
                 }
+            });
+            let outer_box: Box<BoxedFut> = Box::new(heartbeat_fut);
+            let task_ptr: *mut ciris_persist::ffi::executor_capsule::TaskOpaque =
+                Box::into_raw(outer_box).cast();
+            // SAFETY: same contract as `run_async` — `executor.data` and
+            // `executor.vtable` come from the same `executor_capsule_v1`
+            // PyCapsule extracted at the top of init; `task_ptr` is a
+            // freshly-boxed `BoxedFut`. Fire-and-forget (no completion
+            // channel); the spawned future loops until self-termination
+            // (shutdown signal / lease stolen / repeated backend errors).
+            #[allow(unsafe_code)]
+            unsafe {
+                (executor_for_heartbeat.vtable.spawn)(executor_for_heartbeat.data, task_ptr);
             }
-        });
-        let outer_box: Box<BoxedFut> = Box::new(heartbeat_fut);
-        let task_ptr: *mut ciris_persist::ffi::executor_capsule::TaskOpaque =
-            Box::into_raw(outer_box).cast();
-        // SAFETY: same contract as `run_async` — `executor.data` and
-        // `executor.vtable` come from the same `executor_capsule_v1`
-        // PyCapsule extracted at the top of init; `task_ptr` is a
-        // freshly-boxed `BoxedFut`. Fire-and-forget (no completion
-        // channel); the spawned future loops until self-termination
-        // (lease stolen / repeated backend errors).
-        #[allow(unsafe_code)]
-        unsafe {
-            (executor_for_heartbeat.vtable.spawn)(executor_for_heartbeat.data, task_ptr);
-        }
-        tracing::info!(
-            instance_name = %instance_name_outer,
-            "Reticulum shared-instance heartbeat task spawned (10s cadence)"
-        );
-    }
+            tracing::info!(
+                instance_name = %instance_name_outer,
+                "Reticulum shared-instance heartbeat task spawned (10s cadence)"
+            );
+            Some(SharedInstanceCleanup {
+                shutdown_tx: Some(shutdown_tx),
+                lease: lease_for_cleanup,
+                directory: directory_for_cleanup,
+            })
+        } else {
+            None
+        };
 
     // ── Step 5.5 (v0.19.3 / CIRISEdge#49) — HTTPS transport build.
     //
@@ -3531,6 +3832,8 @@ fn init_edge_runtime(
         engine: Some(engine_handle),
         #[cfg(feature = "transport-http")]
         _dev_cert_tmpdir: https_dev_cert_tmpdir,
+        #[cfg(feature = "transport-reticulum-local")]
+        shared_instance_cleanup: std::sync::Mutex::new(shared_instance_cleanup),
     })
 }
 


### PR DESCRIPTION
## Summary

Three independent unblocked tracks bundled into one minor cut. Closes **CIRISEdge#95** (peer KEX pubkey accessor) and **CIRISEdge#103** (worker handoff latency); adds the **CIRISEdge#84** CI skew guard.

`Cargo.toml` bumped 2.3.1 → 2.4.0 (new public Python APIs warrant minor).

## Track 1 — CIRISEdge#95: peer KEX pubkey getter

Adds `Edge::resolve_peer_kex_pubkeys(occurrence_key_id)` (Rust) and the matching `PyEdge.resolve_peer_kex_pubkeys()` pymethod. Delegates to `FederationDirectory::resolve_encryption_keys` (persist v4.13.0+, returns `EncryptionPubkeys { x25519_base64, ml_kem_768_base64 }`), base64-decodes the two halves, returns `PeerKexPubkeys { x25519_pub: [u8;32], mlkem768_pub: Some(Vec<u8>) }`.

**Unblocks:** CIRISLensCore#34's `build_state_publication` — the KEX-wrap step in `canonical::ceg_egress` (Fed TM §3.3 Gap C HNDL closure).

Python shape mirrors `transport_identity_pubkeys()`:
```python
edge.resolve_peer_kex_pubkeys(peer_occurrence_key_id) == {
    "x25519_pub_base64":     "...",  # 32 bytes
    "ml_kem_768_pub_base64": "...",  # 1184 bytes
}
# OR None for unknown / expired / no encryption_pubkeys block.
```

## Track 2 — CIRISEdge#103: worker handoff latency (v2.3.0 follow-up)

v2.3.0 wired `try_acquire_shared_instance` + heartbeat but never called `release_shared_instance_lease`. On `kubectl rollout restart` the lease ages out via the 30s staleness window; sibling re-election takes that full window.

**Fix:** heartbeat task now `tokio::select!`s on a `oneshot::Receiver` so the loop preempts the 10s sleep on close signal. `PyEdge::close()` (idempotent, also wired as `__enter__`/`__exit__` and a `Drop` impl) signals the task and calls `release_shared_instance_lease`. Handoff drops from ~30s to ~hundreds of ms.

```python
# Explicit:
edge = init_edge_runtime(...)
try:
    ...
finally:
    edge.close()

# Or with context-manager:
with init_edge_runtime(...) as edge:
    ...  # close() runs on exit, even on exception

# Or implicit:
del edge  # Drop impl best-effort signals + releases
```

Errors from `release_shared_instance_lease` are **logged, not raised** — at process-shutdown time a caller is already exiting; the staleness window remains as the natural fallback. `Drop` is best-effort: same code path, no GIL needed.

## Track 3 — CIRISEdge#84: CI Cargo↔pyproject skew guard

`.github/scripts/check_cargo_pyproject_skew.py` parses Cargo.toml's `tag = "vX.Y.Z"` for `ciris-persist` and pyproject.toml's `>=X.Y.Z,<...` constraint, asserts Cargo's pin satisfies the PEP 440 spec via `packaging.specifiers`. Wired as `cargo-pyproject-skew-check` job in CI, gating `pyo3-wheel` via `needs:` — ~10s job, fails fast before any wheel build.

Would have caught the v1.7.0 → v2.0.1 cascade (`pip install ciris-edge ciris-persist==5.x` → ResolutionImpossible). Tested locally: passes on the v2.4.0 pin state; fails cleanly on a synthesized `>=4.15.0,<5` skew.

## Track 4 — CIRISEdge#77 confirmed already-shipped

v1.5.2 already ships `src/version.rs` with the `#[no_mangle] extern "C" fn ciris_edge_version()` C symbol + PyO3 `__version__`. Verified on the current cdylib: `strings libciris_edge.so | grep ^2.4.0$` matches and `nm -D` shows the symbol in `T`. Closed during this cycle, separately.

## Verification

- All 4 CI feature combos clean under `RUSTFLAGS=-D warnings`
- `cargo clippy --all-targets -D warnings` clean on pyo3-full
- `cargo test --lib` (pyo3-full): 255 / 255 pass
- `python3 .github/scripts/check_cargo_pyproject_skew.py` passes
- `cargo fmt --check` clean

## Test plan

- [ ] CI green (now includes the new `cargo-pyproject-skew-check` job)
- [ ] Tag → PyPI publish lands `ciris_edge-2.4.0` (4 wheels)
- [ ] Lens-core / agent picks up `Edge.close()` + `Edge.resolve_peer_kex_pubkeys()` Python surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)