### PR TITLE
release(v3.0.0): family lockstep — pyo3 0.29 + persist v6.0.1 + verify v5.2.0 + leviculum upstream catch-up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "2.4.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.8.0", version = "5", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.0.1", version = "6", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.8.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.1.3", version = "5" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -435,8 +435,8 @@ tempfile       = { version = "3", optional = true }
 # currency with zero source-side changes on edge's side. `.recv().await`
 # unchanged. Future leviculum upstream releases land via the one-command
 # `scripts/ciris-sync-upstream.sh` rebase upstream-side now.
-reticulum-core = { git = "https://github.com/CIRISAI/leviculum", rev = "ded96eeb3b4dd7b8b6774c28c7fb30c51acf714d", version = "0.6", optional = true }
-reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", rev = "ded96eeb3b4dd7b8b6774c28c7fb30c51acf714d", version = "0.6", optional = true }
+reticulum-core = { git = "https://github.com/CIRISAI/leviculum", rev = "ffd261d73b77acde892be766064ff9dbc956812e", version = "0.6", optional = true }
+reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", rev = "ffd261d73b77acde892be766064ff9dbc956812e", version = "0.6", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in
@@ -454,14 +454,25 @@ qrcodegen = "1.8"
 # `__anext__` constructs a Python awaitable from a
 # `tokio::sync::broadcast::Receiver::recv()` future via this crate.
 # Gated under `pyo3` (only the AsyncIterator surface needs it).
-pyo3-async-runtimes = { version = "0.28", optional = true, features = ["tokio-runtime"] }
+pyo3-async-runtimes = { version = "0.29", optional = true, features = ["tokio-runtime"] }
 
 # v0.11.0 (CIRISEdge#35) — Stub generator dependency. Runtime-side
 # helpers used by `#[gen_stub_pyclass]` / `#[gen_stub_pymethods]` /
 # `#[gen_stub_pyfunction]`. The matching `pyo3-stub-gen-derive` proc-
 # macros are pulled transitively. We gate this under `pyo3` so a
 # non-pyo3 build doesn't pull the registry machinery.
-pyo3-stub-gen = { version = "0.22", optional = true, default-features = false }
+#
+# v3.0.0 (CIRISEdge#89) — pyo3-stub-gen 0.22.x does NOT compile against
+# pyo3 0.29 (PyCapsuleMethods::downcast removed; impl_exception_stub_type!
+# E0119 conflict on PyOSError/PyIOError). No 0.29-compatible upstream
+# release as of v3.0.0 (latest 0.22.3, 2026-05-16). Edge has zero active
+# `#[gen_stub_*]` attributes anywhere in `src/` (every match is in a doc
+# comment), so the surface this crate added — `define_stub_info_gatherer!`
+# + the `stub_gen` binary — is no-op'd while pyo3-stub-gen catches up.
+# Add an upstream-issue cross-ref here when one is filed. The existing
+# `python/ciris_edge/__init__.pyi` stays as the consumer-facing surface
+# and CI's stub-drift gate is satisfied as long as it doesn't regenerate.
+# pyo3-stub-gen = { version = "0.22", optional = true, default-features = false }
 
 # v0.13.0 (CIRISEdge#36 / #25 / #26 / #31 reads / #28 snapshot reads) —
 # UniFFI bindings generator. The spike's NO-GO carve-out keeps PyO3 for
@@ -660,7 +671,10 @@ transport-packet-radio = ["dep:crc32fast"]
 pyo3                  = [
     "dep:pyo3",
     "dep:pyo3-async-runtimes",
-    "dep:pyo3-stub-gen",
+    # v3.0.0 — `dep:pyo3-stub-gen` dropped pending the upstream 0.29
+    # release. See the commented-out `pyo3-stub-gen = ...` block above
+    # for the full rationale + the no-op shape this leaves in
+    # `src/ffi/pyo3.rs` and `src/bin/stub_gen.rs`.
     "ciris-persist/pyo3",
     "transport-reticulum",
     # v0.13.0 — wheel builds get the UniFFI surface by default. Per the
@@ -713,7 +727,7 @@ extension-module      = ["pyo3?/extension-module"]
 uniffi = { version = "=0.31.1", features = ["build"] }
 
 [dependencies.pyo3]
-version  = "0.28"
+version  = "0.29"
 # v0.7.0 (CIRISEdge#17) — `abi3-py310`, not `abi3-py311`. Chaquopy
 # bundles Python 3.10 (Android mobile cohabitation, CIRISPersist#96–99
 # precedent); abi3 is forward-compatible so a py310-tagged wheel runs
@@ -861,7 +875,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v5.8.0", version = "5", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.0.1", version = "6", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/deny.toml
+++ b/deny.toml
@@ -94,18 +94,11 @@ ignore = [
     "RUSTSEC-2025-0098",  # unic-* unmaintained
     "RUSTSEC-2025-0100",  # unic-* unmaintained
 
-    # v2.1.1 — pyo3 0.28 transitive-only advisories. Both fixed in
-    # pyo3 0.29.0; whole CIRIS substrate family must move in lockstep
-    # to avoid two-pyo3-versions in cohabitation graph. Tracking the
-    # lockstep upgrade in CIRISEdge#89 — these lift when that lands.
-    "RUSTSEC-2026-0176",  # pyo3 0.28 BoundList/Tuple nth/nth_back overflow
-                          # (edge does NOT call .nth()/.nth_back() on PyO3
-                          #  iterators — grep confirms; transitive-only)
-    "RUSTSEC-2026-0177",  # pyo3 0.28 PyCFunction::new_closure missing Sync
-                          # bound (data-race exposure on free-threaded Python
-                          #  variant; edge's pyfunctions are all `#[pyfunction]`
-                          #  attribute-macro generated, not new_closure-based;
-                          #  transitive-only)
+    # v3.0.0 (CIRISEdge#89) — the pyo3 0.28 → 0.29 family lockstep
+    # landed. RUSTSEC-2026-0176 + RUSTSEC-2026-0177 are GONE from the
+    # tree (pyo3 0.29 ships both fixes); the ignores that lived here
+    # since v2.1.1 are removed. If `cargo deny check advisories`
+    # surfaces either again, something regressed the substrate pin.
 ]
 
 [sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=5.8.0,<6",
+    "ciris-persist>=6.0.1,<7",
 ]
 dynamic = ["version"]
 

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2411,8 +2411,25 @@ where
     // same unsafe deref + cast at the call site. The safety surface
     // is unchanged from the .reference() era; the SAFETY comment on
     // the function-level docs still applies in full.
+    // v3.0.0 (CIRISEdge#89) — pyo3 0.29's `pointer_checked(name)`
+    // enforces a name match against the capsule's stored name when
+    // `name` is `Some`; `None` is only valid for unnamed capsules.
+    // Persist's capsules ALL have names (e.g.
+    // `c"ciris_persist::federation_directory"`), so we MUST pass the
+    // capsule's own name back through. Extracting via `cap.name()`
+    // returns the capsule-stored name as a `CapsuleName`; the
+    // `.as_cstr()` view feeds straight into `pointer_checked`.
+    // SAFETY (cap.name().as_cstr()): `CapsuleName::as_cstr` requires
+    // the capsule's name not to change between the `.name()` call and
+    // the `.pointer_checked()` call. We hold `cap` (the `Bound`) for
+    // both, no Python code runs between them, and the capsule's name
+    // is set once at construction in persist — no SetName drift.
+    let name = cap
+        .name()
+        .map_err(|e| PyTypeError::new_err(format!("engine.{method}(): capsule name: {e}")))?;
+    let name_cstr = name.as_ref().map(|n| unsafe { n.as_cstr() });
     let ptr = cap
-        .pointer_checked(None)
+        .pointer_checked(name_cstr)
         .map_err(|e| PyTypeError::new_err(format!("engine.{method}(): pointer_checked: {e}")))?;
     let inner: &T = unsafe { &*(ptr.as_ptr() as *const T) };
     Ok(map(inner))
@@ -2536,7 +2553,16 @@ fn extract_trust_scoring(
     // the capsule reference doesn't escape this function.
     // v3.0.0 (CIRISEdge#89) — pyo3 0.29 removes `.reference()`;
     // use `pointer_checked` + cast (same safety contract as before).
-    let ptr = cap.pointer_checked(None).map_err(|e| {
+    // pyo3 0.29's `pointer_checked(name)` enforces a name match; pass
+    // the capsule's own name through. See `extract_engine_capsule_arc`
+    // above for the matching pattern + SAFETY rationale.
+    let name = cap.name().map_err(|e| {
+        TrustScoringCapsuleError::Other(PyTypeError::new_err(format!(
+            "trust_scoring_capsule: capsule name: {e}"
+        )))
+    })?;
+    let name_cstr = name.as_ref().map(|n| unsafe { n.as_cstr() });
+    let ptr = cap.pointer_checked(name_cstr).map_err(|e| {
         TrustScoringCapsuleError::Other(PyTypeError::new_err(format!(
             "trust_scoring_capsule: pointer_checked: {e}"
         )))
@@ -2608,7 +2634,16 @@ fn extract_local_signer(
     // doesn't escape this function.
     // v3.0.0 (CIRISEdge#89) — pyo3 0.29 removes `.reference()`;
     // use `pointer_checked` + cast (same safety contract as before).
-    let ptr = cap.pointer_checked(None).map_err(|e| {
+    // pyo3 0.29's `pointer_checked(name)` enforces a name match; pass
+    // the capsule's own name through. See `extract_engine_capsule_arc`
+    // above for the matching pattern + SAFETY rationale.
+    let name = cap.name().map_err(|e| {
+        LocalSignerCapsuleError::Other(PyTypeError::new_err(format!(
+            "local_signer_capsule: capsule name: {e}"
+        )))
+    })?;
+    let name_cstr = name.as_ref().map(|n| unsafe { n.as_cstr() });
+    let ptr = cap.pointer_checked(name_cstr).map_err(|e| {
         LocalSignerCapsuleError::Other(PyTypeError::new_err(format!(
             "local_signer_capsule: pointer_checked: {e}"
         )))

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -197,7 +197,43 @@ use crate::verify::{HybridPolicy, RootingDirectory, VerifyDirectory};
 // via `inventory::submit!` and emit the merged `.pyi` to
 // `python/ciris_edge/__init__.pyi`. The macro expansion produces
 // `pub fn stub_info() -> pyo3_stub_gen::Result<pyo3_stub_gen::StubInfo>`.
-pyo3_stub_gen::define_stub_info_gatherer!(stub_info);
+//
+// v3.0.0 (CIRISEdge#89) — pyo3-stub-gen has no pyo3 0.29-compatible
+// release as of v3.0.0; the dep is dropped from Cargo.toml's `pyo3`
+// feature list. Edge has zero active `#[gen_stub_*]` attributes
+// anywhere in `src/` (every match is in a doc comment), so this
+// gatherer registered an empty set; the existing `__init__.pyi`
+// stays as the hand-maintained consumer-facing surface. A no-op
+// `stub_info()` keeps `src/bin/stub_gen.rs` compiling — restore the
+// macro invocation here when pyo3-stub-gen ships a 0.29 cut.
+//
+// pyo3_stub_gen::define_stub_info_gatherer!(stub_info);
+pub fn stub_info() -> Result<NoopStubInfo, Box<dyn std::error::Error>> {
+    Ok(NoopStubInfo)
+}
+
+/// v3.0.0 (CIRISEdge#89) — placeholder for the
+/// `pyo3_stub_gen::StubInfo` shape `stub_gen` calls `.generate()` on.
+/// While pyo3-stub-gen catches up to pyo3 0.29, this no-op preserves
+/// the `stub_gen` binary's compile shape: it does nothing on
+/// `generate()` and prints a notice. The existing
+/// `python/ciris_edge/__init__.pyi` is the source of truth for the
+/// Python type surface; CI's stub-drift gate is satisfied as long as
+/// it is not regenerated.
+pub struct NoopStubInfo;
+
+impl NoopStubInfo {
+    /// Stand-in for `pyo3_stub_gen::StubInfo::generate`. No-op; the
+    /// hand-maintained `__init__.pyi` is the source of truth until
+    /// pyo3-stub-gen ships 0.29 support.
+    pub fn generate(&self) -> Result<(), Box<dyn std::error::Error>> {
+        eprintln!(
+            "stub_gen: no-op (pyo3-stub-gen has no pyo3 0.29 release yet; \
+             see CIRISEdge#89 + Cargo.toml comment near pyo3-stub-gen)"
+        );
+        Ok(())
+    }
+}
 
 /// Wire-format schema versions edge supports. Strict allowlist (AV-7);
 /// out-of-set values reject at the verify pipeline. Mirrors persist's
@@ -2370,12 +2406,15 @@ where
     // produced by `reference::<T>()` is valid for the duration of the
     // map closure. The deprecation on `PyCapsule::reference` is
     // acknowledged: 0.28 ships `pointer_checked` as the
-    // non-deprecated alternative, but it still requires an unsafe
-    // deref + cast at the call site, so the safety surface is
-    // unchanged. We allow the deprecation here to keep the call site
-    // compact.
-    #[allow(deprecated)]
-    let inner: &T = unsafe { cap.reference::<T>() };
+    // non-deprecated alternative, and 0.29 REMOVES `reference()` —
+    // edge v3.0.0 (CIRISEdge#89) consumes `pointer_checked` with the
+    // same unsafe deref + cast at the call site. The safety surface
+    // is unchanged from the .reference() era; the SAFETY comment on
+    // the function-level docs still applies in full.
+    let ptr = cap
+        .pointer_checked(None)
+        .map_err(|e| PyTypeError::new_err(format!("engine.{method}(): pointer_checked: {e}")))?;
+    let inner: &T = unsafe { &*(ptr.as_ptr() as *const T) };
     Ok(map(inner))
 }
 
@@ -2495,9 +2534,15 @@ fn extract_trust_scoring(
     // that contract (v3.6.3 carries v3.5.1's surface forward via
     // v3.5.2 + v3.6.0). The cloned `Arc` is owned by the caller —
     // the capsule reference doesn't escape this function.
-    #[allow(deprecated)]
+    // v3.0.0 (CIRISEdge#89) — pyo3 0.29 removes `.reference()`;
+    // use `pointer_checked` + cast (same safety contract as before).
+    let ptr = cap.pointer_checked(None).map_err(|e| {
+        TrustScoringCapsuleError::Other(PyTypeError::new_err(format!(
+            "trust_scoring_capsule: pointer_checked: {e}"
+        )))
+    })?;
     let inner: &Arc<dyn ciris_persist::federation::TrustScoring> =
-        unsafe { cap.reference::<Arc<dyn ciris_persist::federation::TrustScoring>>() };
+        unsafe { &*(ptr.as_ptr() as *const Arc<dyn ciris_persist::federation::TrustScoring>) };
     Ok(Arc::clone(inner))
 }
 
@@ -2561,9 +2606,15 @@ fn extract_local_signer(
     // that contract (v3.2.0 carries v3.1.1's surface forward). The
     // cloned `Arc` is owned by the caller — the capsule reference
     // doesn't escape this function.
-    #[allow(deprecated)]
+    // v3.0.0 (CIRISEdge#89) — pyo3 0.29 removes `.reference()`;
+    // use `pointer_checked` + cast (same safety contract as before).
+    let ptr = cap.pointer_checked(None).map_err(|e| {
+        LocalSignerCapsuleError::Other(PyTypeError::new_err(format!(
+            "local_signer_capsule: pointer_checked: {e}"
+        )))
+    })?;
     let inner: &Arc<ciris_persist::signing::LocalSigner> =
-        unsafe { cap.reference::<Arc<ciris_persist::signing::LocalSigner>>() };
+        unsafe { &*(ptr.as_ptr() as *const Arc<ciris_persist::signing::LocalSigner>) };
     Ok(Arc::clone(inner))
 }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -904,7 +904,7 @@ impl FederationDirectoryReplicationBridge {
         let key_directory = (ops.key_directory)();
         let root_stewards = (ops.root_stewards)();
         self.directory
-            .put_organization(signed, &key_directory, &root_stewards)
+            .put_organization(signed, key_directory.as_slice(), root_stewards.as_slice())
             .await
             .is_ok()
     }
@@ -919,7 +919,7 @@ impl FederationDirectoryReplicationBridge {
         let key_directory = (ops.key_directory)();
         let root_stewards = (ops.root_stewards)();
         self.directory
-            .put_org_membership(signed, &key_directory, &root_stewards)
+            .put_org_membership(signed, key_directory.as_slice(), root_stewards.as_slice())
             .await
             .is_ok()
     }
@@ -933,7 +933,7 @@ impl FederationDirectoryReplicationBridge {
         };
         let steward_roster = (ops.steward_roster)();
         self.directory
-            .put_partner_record(signed, &steward_roster)
+            .put_partner_record(signed, steward_roster.as_slice())
             .await
             .is_ok()
     }

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -87,7 +87,7 @@ use tokio::sync::{mpsc, Mutex};
 use reticulum_core::link::LinkId;
 use reticulum_core::resource::ResourceStrategy;
 use reticulum_core::{Destination, DestinationHash, DestinationType, Direction, Identity};
-use reticulum_std::driver::{ReticulumNode, ReticulumNodeBuilder};
+use reticulum_std::driver::{EventReceiver, ReticulumNode, ReticulumNodeBuilder};
 use reticulum_std::NodeEvent;
 
 use super::attestation::{AnnounceAttestation, AttestationError, AttestationPayload};
@@ -862,7 +862,12 @@ pub struct ReticulumTransport {
     /// exactly once; a second `listen` call is a config error.
     /// Leviculum PR #9 switched this to an unbounded channel so node
     /// events are never dropped before a consumer attaches.
-    events: Mutex<Option<mpsc::UnboundedReceiver<NodeEvent>>>,
+    /// v3.0.0 — leviculum upstream introduced the two-bounded-plane
+    /// channel (lossless control + droppable data) at ffd261d; the
+    /// receiver type became `EventReceiver` with the same `.recv()` /
+    /// `.try_recv()` surface — call sites unchanged, field type
+    /// updated.
+    events: Mutex<Option<EventReceiver>>,
     /// `key_id → rooted peer`, populated by the authenticated
     /// cold-start path from received announces. Every entry has been
     /// rooted against the persist directory + had its attestation


### PR DESCRIPTION
## Summary

The CIRIS family-wide major cut. Closes the **RUSTSEC-2026-0176** + **RUSTSEC-2026-0177** advisories that had been `deny.toml`-ignored since v2.1.1. Persist v6.0.1 (CIRISPersist#216 catch-up) re-lands the pyo3 0.29 move with everything from the v5.x line forward-ported. Edge moves in lockstep; lens-core follows.

## Pin bumps

| Crate | From | To |
|---|---|---|
| ciris-persist (Cargo + dev-deps + pyproject) | v5.8.0 / `>=5.8.0,<6` | **v6.0.1** / `>=6.0.1,<7` |
| ciris-keyring | v5.1.3 | **v5.2.0** |
| ciris-crypto | v5.1.3 | **v5.2.0** |
| ciris-verify-core | v5.1.3 | **v5.2.0** |
| pyo3 | 0.28 | **0.29** |
| pyo3-async-runtimes | 0.28 | **0.29** |
| leviculum | `ded96ee` | **`ffd261d`** (upstream master catch-up + two-bounded-plane EventReceiver) |

## Code touch-ups

Surface matches the [pre-validated migration cookbook from CIRISEdge#89](https://github.com/CIRISAI/CIRISEdge/issues/89#issuecomment-4699303845) almost line-for-line — ~10 mechanical changes total.

### pyo3 0.29 Bound-API: `PyCapsule::reference()` removed

Three call sites in `src/ffi/pyo3.rs` rewritten to use `pointer_checked` + unsafe cast. Same SAFETY contract as the `.reference()` era; no behavioral change.

- `extract_engine_capsule_arc` (generic helper) — line ~2414
- trust_scoring capsule extraction — line ~2536
- local_signer capsule extraction — line ~2602

### Persist v6.0.1 trait-shape: `&Vec` → `as_slice()`

`src/replication/bridge.rs` lines 907, 922, 936 — `put_organization`, `put_org_membership`, `put_partner_record` now expect `&[ThresholdMember]` / `&[String]`.

### Leviculum upstream: two-bounded-plane `EventReceiver`

`src/transport/reticulum.rs`: the `events` field type went from `Mutex<Option<mpsc::UnboundedReceiver<NodeEvent>>>` to `Mutex<Option<EventReceiver>>`. New type's `.recv()` / `.try_recv()` surface matches the old `UnboundedReceiver` exactly — call sites unchanged.

### pyo3-stub-gen — temporarily dropped (upstream lag)

pyo3-stub-gen 0.22.x doesn't compile against pyo3 0.29 (`PyCapsuleMethods::downcast` removed; `impl_exception_stub_type!` E0119 conflict). No upstream 0.29 release as of v3.0.0. Edge has **zero active `#[gen_stub_*]` attributes** anywhere in `src/`, so the surface lost is only the `.pyi` regenerator — the existing `python/ciris_edge/__init__.pyi` stays as the source of truth.

Cargo.toml `dep:pyo3-stub-gen` dropped from the `pyo3` feature; `src/ffi/pyo3.rs` `define_stub_info_gatherer!` macro call replaced with a no-op `stub_info()` + `NoopStubInfo::generate()` so `src/bin/stub_gen.rs` still compiles + runs cleanly (prints a notice). CI stub-drift gate satisfied as long as `__init__.pyi` is preserved. Restore the macro invocation when pyo3-stub-gen ships 0.29 support — TODO: file upstream at Jij-Inc/pyo3-stub-gen.

### deny.toml: RUSTSEC ignores lifted

Both `RUSTSEC-2026-0176` + `RUSTSEC-2026-0177` ignores removed. `cargo deny check advisories` reports `advisories ok` — pyo3 0.29 ships both fixes; the advisories are gone from the tree.

## Verification

- `-D warnings` clean on all 4 CI feature combos (core / reticulum / packet-radio / all-transports)
- `cargo clippy --all-targets -D warnings` clean on pyo3-full
- `cargo test --lib` (pyo3-full): **255 / 255 pass**
- `cargo deny check advisories`: ok
- `cargo fmt --check` clean
- `check_cargo_pyproject_skew.py` clean (persist v6.0.1 satisfies `>=6.0.1,<7`)

## What v3.0.0 unblocks downstream

- **Lens-core** can pin `ciris-edge>=3.0.0,<4` + `ciris-persist>=6.0.1,<7` and complete its own pyo3 0.29 lockstep.
- **CIRISEdge#99** (hardware-back RNS transport identity + migration) is now actionable — persist v6.0.1 includes verify v5.2.0 which ships `TransportIdentityKeystore` (CIRISVerify#68). Separate cut.
- **RUSTSEC family-wide cleanup** complete on the substrate side.

## Test plan

- [ ] CI green
- [ ] Tag → PyPI publishes `ciris_edge-3.0.0` (4 wheels)
- [ ] Lens-core picks up the new pin chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)