### PR TITLE
Co-bump persist v6.5.0 -> v6.6.0 (with_hardware_signer family floor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.5.0", version = "6", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.6.0", version = "6", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -875,7 +875,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.5.0", version = "6", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.6.0", version = "6", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
Version-only co-bump (dep + dev-dep) to persist **v6.6.0** (additive — adds `Engine::with_hardware_signer`, CIRISPersist#220/#221). Lets a host (CIRISServer) resolve the whole graph to one persist rev on the 6.6 floor. Suggest tagging **v3.3.0** so consumers (lens-core, CIRISServer) can repin from this branch to a tag. lens-core's matching co-bump rides CIRISLensCore#55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)