### PR TITLE
release(v3.3.0): persist v6.7.0 + verify v5.3.1 catch-up (closes #112)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.5.0", version = "6", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.7.0", version = "6", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.5.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.3.1", version = "5", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.3.1", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.2.0", version = "5" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.3.1", version = "5" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -875,7 +875,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.5.0", version = "6", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.7.0", version = "6", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=6.5.0,<7",
+    "ciris-persist>=6.7.0,<7",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

Pure pin-bump catch-up addressing the CIRISEdge#112 adoption ask. Persist v6.7.0 is the CEG-1.0-RC5 consent-surface keystone (#146 + #161 closed upstream end-to-end); edge takes it at the pin level only.

## Pin bumps (one cohesive cut)

| Crate | From | To |
|---|---|---|
| `ciris-persist` (Cargo + dev-deps + pyproject) | v6.5.0 / `>=6.5.0,<7` | **v6.7.0** / `>=6.7.0,<7` |
| `ciris-keyring` | v5.2.0 | **v5.3.1** |
| `ciris-crypto` | v5.2.0 | **v5.3.1** |
| `ciris-verify-core` | v5.2.0 | **v5.3.1** |

**The verify co-bump is load-bearing.** Persist v6.7.0 pins verify v5.3.1 across all six `[target.*]` tables (tpm / ios / android). If edge stayed on v5.2.0 the dep graph would resolve two `ciris_crypto` versions → type break.

## Zero delta on the substrate composition

- **No schema migration** — RC5 consent clauses ride existing tables; V078 shipped in v6.5.0 already.
- **No pyo3 change** — already on 0.29 since v3.0.0.
- **No edge code change** — every new persist/verify surface is opt-in; consent gates never reject previously-admitted rows; the moderation-withdraws bypass for `holds_bytes:sha256:*` targets stays intact.

## Family-state context (informational)

What v6.7.0 represents upstream:

- **CIRISPersist** complete-through-RC5: #146 (consent observability + `transport_destination` + `consent_record` + `canonical_binding`) + #161 (membership-change ceremonies + removal emission) + #183 (self-at-login keystone, edge consumed in v3.1/v3.2) + #209 (retention) + #210 (SharedInstanceLease, edge consumed in v2.3+) + #218 (retention PyO3 FFI).
- **CIRISVerify v5.3.1** — RC5-conformant; multi-role steward `identity_type` set-membership fix in `provenance.rs`.

Edge surface additions in this PR: **none** (pin-only).

## Surface edge MAY adopt in a future cut (non-blocking)

- `Engine::with_hardware_signer(Arc<dyn HardwareSigner>, dsn)` (persist v6.6.0) — from-scratch TPM/SE/StrongBox custody of the federation signing key. Complements the transport-identity hardware half already shipped in v3.1.0 (CIRISEdge#99 / CIRISVerify#68).
- Removal-emission `hard_case:family_membership_change` + `hard_case:community_membership_change` events with `change_kind:"removed"` (v6.7.0, #161 Ask 5). If edge's relay role gossips/consumes hard_case events, both add/remove directions are now wire.

Neither is required for the cohabitation bump.

## Verification

- `cargo test --lib`: **262 / 262 pass**
- `-D warnings` clean on all 4 CI feature combos
- `cargo clippy --all-targets -D warnings` clean
- `cargo fmt` clean
- `check_cargo_pyproject_skew.py` clean (Cargo v6.7.0 satisfies pyproject `>=6.7.0,<7`)

## Test plan

- [ ] CI green (cohab cells stay informational until lens-core co-bumps — known)
- [ ] Tag v3.3.0 → wheels publish to PyPI
- [ ] Downstream consumers (lens-core, agent, registry, NodeCore) co-bump to the family v6.7.0 / v5.3.1 / edge v3.3.0 floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)