### PR TITLE
release(v3.6.0): persist v7.0.0 + verify v5.6.0 (CEWP-ready substrate opt-in)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "3.5.1"
+version = "3.6.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.8.1", version = "6", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.0.0", version = "7", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.8.1
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.4.0", version = "5", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.4.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.6.0", version = "5", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.6.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.4.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.4.0", version = "5" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.6.0", version = "5" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -875,7 +875,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v6.8.1", version = "6", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.0.0", version = "7", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=6.8.1,<7",
+    "ciris-persist>=7.0.0,<8",
 ]
 dynamic = ["version"]
 

--- a/src/transport/attestation.rs
+++ b/src/transport/attestation.rs
@@ -277,7 +277,7 @@ mod tests {
     /// A legitimately signed attestation verifies; a tamper does not.
     #[test]
     fn signed_attestation_round_trips_and_rejects_tamper() {
-        let signer = ciris_crypto::Ed25519Signer::random();
+        let signer = ciris_crypto::Ed25519Signer::random().unwrap();
         let fed_pubkey: [u8; 32] = signer.public_key().unwrap().try_into().unwrap();
         let transport_pubkey = [0x5au8; 32];
 


### PR DESCRIPTION
## Summary

- **persist v6.8.1 → v7.0.0** — opt-in onto the CEWP-ready substrate. Persist v7 is the device-agnostic cut (no TimescaleDB anywhere, strict pg/sqlite parity); the `>=7,<8` pin is the deliberate downstream coordination firewall for edge/server/lens-core/node-core. Edge's `Backend` usage doesn't intersect the v7 breaking removals (the vestigial Phase-2/3 default methods edge never overrode or called) — the opt-in is a pure pin flip.
- **verify-family v5.4.0 → v5.6.0** lockstep co-bump (keyring/crypto/verify-core), matching persist v7.0.0's verify pin. Keeps a single `ciris_crypto` symbol across the cohabitation graph. v5.6.0 lands #72 (license-sig fail-closed), #73 (real TPM2 seal/unseal), #74 (RNG fail-secure latch extended to keygen), and #28 (shared §5.6.8.8.1.1 `compute_destination_hash` producer↔consumer).
- **One call-site touch** — verify #74's keygen latch flips `Ed25519Signer::random()` to `Result<_, RngHealthCheckFailed>`. The one usage (`signed_attestation_round_trips_and_rejects_tamper`) gains `.unwrap()` — test fixture; panic-on-RNG-fault is the fail-secure semantics.
- **CEG 1.0-RC6 conformance — verified ✓**. RC6's only delta over RC4 is a normative correctness pin on the §5.6.8.8.1.1 two-stage RNS destination-hash: `name_hash = SHA256(app_name ∥ dot-joined-aspects)[:10]`, `destination_hash = SHA256(name_hash ∥ identity_hash)[:16]` — NOT the flat single-concat the ≤RC5 wording implied. Edge's `Destination::compute_destination_hash` (via leviculum `reticulum-core@ffd261d`) implements this exactly; invoked at `src/transport/reticulum.rs:2203-2204` (own dest) and `:2541-2543` (peer attribution from v3.5.1 source_key_id wiring). AV-42 destination-authenticity recompute is now spec-recoverable.
- **No 1+4 wire change, no new edge surface, no new replication kind.** RC6 explicitly: "no new replication kind, no Edge wire."

## Local gate sweep

- ✓ 5 CI feature combos clean under `RUSTFLAGS=-D warnings`: `core` / `reticulum` / `packet-radio` / `all-transports` / `pyo3-full --all-targets`
- ✓ `cargo clippy --all-targets` clean for `pyo3` and `pyo3+ffi-uniffi` combos
- ✓ 250 lib tests + 38 integration suites green (`--all-targets`)
- ✓ `cargo bench --no-run` clean
- ✓ Cargo↔pyproject skew check: `ciris-persist Cargo v7.0.0 satisfies pyproject '>=7.0.0,<8'`

## Test plan

- [ ] CI: all `ci.yml` matrix combos green (core / reticulum / packet-radio / all-transports / pyo3-full)
- [ ] CI: both clippy combos (`pyo3`, `pyo3 ffi-uniffi`) green
- [ ] CI: cohabitation gate informational (still gated on lens-core co-bump per #114)
- [ ] CI: skew check green
- [ ] CI: bench `--no-run` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)