### PR TITLE
release(v3.6.1): persist v7.1.0 (hardware-hybrid signer + aggregate fix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "3.6.0"
+version = "3.6.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.0.0", version = "7", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.1.0", version = "7", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -875,7 +875,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.0.0", version = "7", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.1.0", version = "7", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## Summary

- **persist v7.0.0 → v7.1.0** — additive only. Adds `Engine::with_hardware_signer_hybrid` (CIRISPersist#224 — TPM-sealed Ed25519 + ML-DSA-65 hybrid sigs without unsealing) and fixes `local_identity_aggregate` for hardware-signed Engines (#223 — content-KEM halves were null on classical-only hardware nodes).
- **Verify pin unchanged** at v5.6.0 — no co-bump needed.
- **No edge source change** — pure pin flip; edge doesn't directly invoke either new surface.
- **Skew floor stays `>=7.0.0,<8`** — v7.1.0 wheel hasn't published to PyPI yet (only v7.0.0 there); the v7.1.0 cdylib edge bundles is forward-compatible with cohabiting v7.0.0 wheels. Skew check: `Cargo v7.1.0 satisfies pyproject '>=7.0.0,<8'`.

## Local gate sweep

- ✓ 4 CI feature combos under `RUSTFLAGS=-D warnings`: `core` / `reticulum` / `packet-radio` / `all-transports`
- ✓ `cargo clippy --all-targets` clean for `pyo3` and `pyo3+ffi-uniffi` combos
- ✓ 38 test suites green (250 lib + 28 integration via `--all-targets`)
- ✓ Cargo↔pyproject skew check OK

## Test plan

- [ ] CI matrix green (core/reticulum/packet-radio/all-transports/pyo3-full)
- [ ] Both clippy combos green
- [ ] Cohabitation gate still informational (lens-core pin block per #114)
- [ ] Skew check + bench --no-run green

🤖 Generated with [Claude Code](https://claude.com/claude-code)