### PR TITLE
release(v3.7.0): realtime-A/V fan-out (#122) + PyO3 conformance surface (#123) + HNDL-strict KEX

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,69 @@
+# Pre-commit hooks for CIRISEdge.
+#
+# Install: pip install pre-commit && pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push
+#
+# Two stages by design:
+# - `commit` (default `pre-commit` stage): fast checks only.
+#   `cargo fmt --check`, generic whitespace/YAML/TOML hygiene. Runs on
+#   `git commit` (a few seconds).
+# - `pre-push`: the slow gates that catch what fmt can't.
+#   `cargo clippy` on the canonical feature set. Runs on `git push`
+#   (~30s warm, 90s cold).
+#
+# To bypass once: `git commit --no-verify` / `git push --no-verify`.
+# Only use for genuine emergencies — the local gates mirror CI's
+# `clippy + fmt` lane, so a hook failure means CI will fail too.
+
+# Excludes are deliberately broad:
+# - Cargo.lock / *.lock: tool-managed, never hand-edit
+# - target/: build cache
+# - bindings/: UniFFI-generated (Swift / Kotlin / Python FFI shims) —
+#   regenerated on every uniffi-bindgen run, manual edits get clobbered
+# - python/.*\.so + __pycache__: local maturin develop sideeffects
+# - .github/workflows/: GitHub Actions templating breaks plain YAML
+#   parsing
+exclude: |
+  (?x)^(
+    Cargo\.lock|
+    .*\.lock|
+    target/.*|
+    bindings/.*|
+    python/.*\.so|
+    python/.*/__pycache__/.*|
+    \.github/workflows/.*\.yml
+  )$
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=500']
+
+  # cargo fmt — runs at commit time. Fast (<1s for staged files).
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt --check
+        entry: cargo fmt --all -- --check
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-commit]
+
+  # cargo clippy — runs at push time. ~30s warm. Mirrors CI's
+  # `clippy + fmt` lane feature set so failures here = failures in CI.
+  - repo: local
+    hooks:
+      - id: cargo-clippy
+        name: cargo clippy (transport-http,transport-reticulum,pyo3) -D warnings
+        entry: cargo clippy --features "transport-http transport-reticulum pyo3" --all-targets -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false
+        stages: [pre-push]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "3.6.1"
+version = "3.7.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4505,7 +4505,9 @@ fn federation_session_respond(
     own_mlkem768_pub: Option<&[u8]>,
     handshake_msg_json: &[u8],
 ) -> PyResult<[u8; 32]> {
-    use crate::transport::federation_session::{FederationSession, OwnKexKeys, SessionHandshakeMsg};
+    use crate::transport::federation_session::{
+        FederationSession, OwnKexKeys, SessionHandshakeMsg,
+    };
     use ciris_crypto::hybrid_kex::{
         ClassicalHandshakeMsg, HybridHandshakeMsg, KEX_ALGORITHM_CLASSICAL_V1,
         KEX_ALGORITHM_HYBRID_V1,

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4298,6 +4298,284 @@ fn install_panic_logger() -> bool {
     crate::debug::install_panic_logger()
 }
 
+// ─── CIRISEdge#123 — cross-wheel conformance surface ─────────────────
+//
+// Thin PyO3 wrappers over existing Rust pub fns in `transport::realtime_av`
+// + `transport::federation_session` + the leviculum RNS destination-hash
+// (CEG §5.6.8.8.1.1) so the published Python wheel can drive these
+// surfaces under CIRISConformance — measuring the production cohabitation
+// cost (cross-wheel / FFI) of the realtime A/V mesh profile.
+//
+// No wire/API change to the Rust crate. All bytes in / bytes out — none
+// of the redacted-Debug newtypes (EpochDek / SessionKey / OwnKexKeys)
+// escape the Python boundary; callers thread the raw 32-byte slices.
+
+/// Coerce a Python `bytes`-like into a fixed-length array. Mirrors the
+/// idiom used for the federation-session KEX keys + epoch DEKs.
+fn fixed_bytes<const N: usize>(label: &str, b: &[u8]) -> PyResult<[u8; N]> {
+    if b.len() != N {
+        return Err(PyValueError::new_err(format!(
+            "{label}: expected {N} bytes, got {}",
+            b.len()
+        )));
+    }
+    let mut out = [0u8; N];
+    out.copy_from_slice(b);
+    Ok(out)
+}
+
+/// Seal a chunk under both the inner epoch DEK and the outer transit
+/// key (CEG §10.5.5 E1). Returns the on-wire bytes
+/// (`SealedAvChunk::to_bytes`) — caller threads them straight into the
+/// RNS Link outbound queue.
+#[pyfunction]
+#[pyo3(signature = (plaintext, transit_key, link_id, link_seq, epoch_dek, stream_id, epoch, chunk_seq))]
+#[allow(clippy::too_many_arguments)]
+fn seal_av_chunk(
+    plaintext: &[u8],
+    transit_key: &[u8],
+    link_id: &[u8],
+    link_seq: u64,
+    epoch_dek: &[u8],
+    stream_id: &[u8],
+    epoch: u64,
+    chunk_seq: u64,
+) -> PyResult<Vec<u8>> {
+    use crate::transport::realtime_av;
+    let transit = fixed_bytes::<32>("transit_key", transit_key)?;
+    let dek_bytes = fixed_bytes::<32>("epoch_dek", epoch_dek)?;
+    let stream = fixed_bytes::<32>("stream_id", stream_id)?;
+    let dek = realtime_av::EpochDek::from_bytes(dek_bytes);
+    let sealed = realtime_av::seal_av_chunk(
+        plaintext,
+        &transit,
+        link_id,
+        link_seq,
+        &dek,
+        realtime_av::StreamId(stream),
+        realtime_av::Epoch(epoch),
+        realtime_av::ChunkSeq(chunk_seq),
+    )
+    .map_err(|e| PyRuntimeError::new_err(format!("seal_av_chunk: {e}")))?;
+    Ok(sealed.to_bytes())
+}
+
+/// Open a sealed A/V chunk (inverse of [`seal_av_chunk`]). Input is the
+/// on-wire bytes; returns the chunk plaintext.
+#[pyfunction]
+#[pyo3(signature = (sealed_bytes, transit_key, link_id, link_seq, epoch_dek))]
+fn open_av_chunk(
+    sealed_bytes: &[u8],
+    transit_key: &[u8],
+    link_id: &[u8],
+    link_seq: u64,
+    epoch_dek: &[u8],
+) -> PyResult<Vec<u8>> {
+    use crate::transport::realtime_av;
+    let transit = fixed_bytes::<32>("transit_key", transit_key)?;
+    let dek_bytes = fixed_bytes::<32>("epoch_dek", epoch_dek)?;
+    let dek = realtime_av::EpochDek::from_bytes(dek_bytes);
+    let sealed = realtime_av::SealedAvChunk::from_bytes(sealed_bytes)
+        .map_err(|e| PyValueError::new_err(format!("open_av_chunk: parse: {e}")))?;
+    realtime_av::open_av_chunk(&sealed, &transit, link_id, link_seq, &dek)
+        .map_err(|e| PyRuntimeError::new_err(format!("open_av_chunk: aead: {e}")))
+}
+
+/// Inner-only seal — produces the inner AEAD ciphertext (E2E sealed
+/// under the epoch DEK). CIRISEdge#122 fan-out optimization: call once
+/// per chunk, then call [`seal_av_outer`] N times for the mesh.
+#[pyfunction]
+#[pyo3(signature = (plaintext, epoch_dek, stream_id, epoch, chunk_seq))]
+fn seal_av_inner(
+    plaintext: &[u8],
+    epoch_dek: &[u8],
+    stream_id: &[u8],
+    epoch: u64,
+    chunk_seq: u64,
+) -> PyResult<Vec<u8>> {
+    use crate::transport::realtime_av;
+    let dek_bytes = fixed_bytes::<32>("epoch_dek", epoch_dek)?;
+    let stream = fixed_bytes::<32>("stream_id", stream_id)?;
+    let dek = realtime_av::EpochDek::from_bytes(dek_bytes);
+    let inner = realtime_av::seal_av_inner(
+        plaintext,
+        &dek,
+        realtime_av::StreamId(stream),
+        realtime_av::Epoch(epoch),
+        realtime_av::ChunkSeq(chunk_seq),
+    )
+    .map_err(|e| PyRuntimeError::new_err(format!("seal_av_inner: {e}")))?;
+    Ok(inner.inner_ciphertext().to_vec())
+}
+
+/// Outer-only seal — given a pre-computed inner ciphertext (from
+/// [`seal_av_inner`]) and per-Link state, produces the on-wire bytes.
+/// CIRISEdge#122 fan-out optimization companion.
+///
+/// `stream_id` / `epoch` / `chunk_seq` are the chunk-header fields
+/// stamped into the wire shape (NOT inputs to the outer AEAD; the
+/// outer nonce derives only from `link_id` + `link_seq`).
+#[pyfunction]
+#[pyo3(signature = (inner_ciphertext, transit_key, link_id, link_seq, stream_id, epoch, chunk_seq))]
+#[allow(clippy::too_many_arguments)]
+fn seal_av_outer(
+    inner_ciphertext: &[u8],
+    transit_key: &[u8],
+    link_id: &[u8],
+    link_seq: u64,
+    stream_id: &[u8],
+    epoch: u64,
+    chunk_seq: u64,
+) -> PyResult<Vec<u8>> {
+    use crate::transport::realtime_av;
+    let transit = fixed_bytes::<32>("transit_key", transit_key)?;
+    let stream = fixed_bytes::<32>("stream_id", stream_id)?;
+    // Rebuild the inner sealed handle from its parts. The Rust struct's
+    // constructor is private; we go through the `seal_av_inner` ->
+    // `seal_av_outer` path conceptually by reconstructing equivalent
+    // bytes-equivalent state via a synthesized inner. Since the outer
+    // step only reads `inner_ciphertext` + the chunk header, we wrap
+    // them through the public ciphertext-bytes helper.
+    let inner = realtime_av::inner_sealed_from_parts(
+        realtime_av::StreamId(stream),
+        realtime_av::Epoch(epoch),
+        realtime_av::ChunkSeq(chunk_seq),
+        inner_ciphertext.to_vec(),
+    );
+    let sealed = realtime_av::seal_av_outer(&inner, &transit, link_id, link_seq)
+        .map_err(|e| PyRuntimeError::new_err(format!("seal_av_outer: {e}")))?;
+    Ok(sealed.to_bytes())
+}
+
+/// Hybrid X25519 + ML-KEM-768 KEX — initiator side (CIRISEdge#54).
+///
+/// `algorithm` is one of `"hybrid"`, `"hybrid-required"`, or `"classical"`.
+/// HNDL-strict callers (realtime A/V, key_grant DEK distribution) should
+/// pass `"hybrid-required"`: classical fallback is REJECTED rather than
+/// silently negotiated down.
+///
+/// Returns `(handshake_msg_json_bytes, session_key, negotiated_algorithm_wire_id)`.
+/// The handshake JSON round-trips through
+/// [`federation_session_respond`]; the session key is 32 bytes (the
+/// AES-256-GCM key for the transport layer).
+#[pyfunction]
+#[pyo3(signature = (peer_x25519_pub, peer_mlkem768_pub, algorithm))]
+fn federation_session_initiate(
+    peer_x25519_pub: &[u8],
+    peer_mlkem768_pub: Option<&[u8]>,
+    algorithm: &str,
+) -> PyResult<(Vec<u8>, [u8; 32], String)> {
+    use crate::transport::federation_session::{
+        FederationSession, KexAlgorithm, PeerKexPubkeys, SessionHandshakeMsg,
+    };
+    let x_pub = fixed_bytes::<32>("peer_x25519_pub", peer_x25519_pub)?;
+    let peer = PeerKexPubkeys {
+        x25519_pub: x_pub,
+        mlkem768_pub: peer_mlkem768_pub.map(<[u8]>::to_vec),
+    };
+    let requested = match algorithm {
+        "hybrid" => KexAlgorithm::Hybrid,
+        "hybrid-required" => KexAlgorithm::HybridRequired,
+        "classical" => KexAlgorithm::Classical,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "algorithm: expected 'hybrid' | 'hybrid-required' | 'classical', got {other:?}"
+            )));
+        }
+    };
+    let (msg, key) = FederationSession::initiate(&peer, requested)
+        .map_err(|e| PyRuntimeError::new_err(format!("initiate: {e}")))?;
+    let json = match &msg {
+        SessionHandshakeMsg::Hybrid(m) => serde_json::to_vec(m),
+        SessionHandshakeMsg::Classical(m) => serde_json::to_vec(m),
+    }
+    .map_err(|e| PyRuntimeError::new_err(format!("handshake encode: {e}")))?;
+    let mut key_out = [0u8; 32];
+    key_out.copy_from_slice(key.as_bytes());
+    Ok((json, key_out, msg.algorithm().to_string()))
+}
+
+/// Hybrid X25519 + ML-KEM-768 KEX — responder side. Recomputes the same
+/// 32-byte session key the initiator derived.
+#[pyfunction]
+#[pyo3(signature = (own_x25519_priv, own_mlkem768_priv, own_mlkem768_pub, handshake_msg_json))]
+fn federation_session_respond(
+    own_x25519_priv: &[u8],
+    own_mlkem768_priv: Option<&[u8]>,
+    own_mlkem768_pub: Option<&[u8]>,
+    handshake_msg_json: &[u8],
+) -> PyResult<[u8; 32]> {
+    use crate::transport::federation_session::{FederationSession, OwnKexKeys, SessionHandshakeMsg};
+    use ciris_crypto::hybrid_kex::{
+        ClassicalHandshakeMsg, HybridHandshakeMsg, KEX_ALGORITHM_CLASSICAL_V1,
+        KEX_ALGORITHM_HYBRID_V1,
+    };
+    let x_priv = fixed_bytes::<32>("own_x25519_priv", own_x25519_priv)?;
+    let own = OwnKexKeys {
+        x25519_priv: x_priv,
+        mlkem768_priv: own_mlkem768_priv.map(<[u8]>::to_vec),
+        mlkem768_pub: own_mlkem768_pub.map(<[u8]>::to_vec),
+    };
+    // Peek at the algorithm field — the JSON object always has an
+    // `algorithm` string at the top.
+    let raw: serde_json::Value = serde_json::from_slice(handshake_msg_json)
+        .map_err(|e| PyValueError::new_err(format!("handshake decode: {e}")))?;
+    let algo = raw
+        .get("algorithm")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| PyValueError::new_err("handshake missing `algorithm` field"))?;
+    let msg = match algo {
+        a if a == KEX_ALGORITHM_HYBRID_V1 => {
+            let m: HybridHandshakeMsg = serde_json::from_slice(handshake_msg_json)
+                .map_err(|e| PyValueError::new_err(format!("hybrid decode: {e}")))?;
+            SessionHandshakeMsg::Hybrid(m)
+        }
+        a if a == KEX_ALGORITHM_CLASSICAL_V1 => {
+            let m: ClassicalHandshakeMsg = serde_json::from_slice(handshake_msg_json)
+                .map_err(|e| PyValueError::new_err(format!("classical decode: {e}")))?;
+            SessionHandshakeMsg::Classical(m)
+        }
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "unknown algorithm: {other:?}"
+            )));
+        }
+    };
+    let key = FederationSession::respond(&own, &msg)
+        .map_err(|e| PyRuntimeError::new_err(format!("respond: {e}")))?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(key.as_bytes());
+    Ok(out)
+}
+
+/// CEG §5.6.8.8.1.1 — RC6-pinned two-stage RNS destination-hash recompute.
+/// Lets a conformance verifier independently derive an arbitrary peer's
+/// `destination_hash` from its advertised `(x25519_pub, ed25519_pub)`
+/// + the binding's app-name + aspect list.
+///
+/// Returns 16 bytes (the TRUNCATED_HASHLENGTH the spec pins). AV-42
+/// destination-authenticity recompute (CIRISVerify#28).
+#[cfg(feature = "transport-reticulum")]
+#[pyfunction]
+#[pyo3(signature = (app_name, aspects, x25519_pub, ed25519_pub))]
+fn rns_destination_hash(
+    app_name: &str,
+    aspects: &Bound<'_, PyAny>,
+    x25519_pub: &[u8],
+    ed25519_pub: &[u8],
+) -> PyResult<[u8; 16]> {
+    use reticulum_core::{Destination, Identity};
+    let x_pub = fixed_bytes::<32>("x25519_pub", x25519_pub)?;
+    let ed_pub = fixed_bytes::<32>("ed25519_pub", ed25519_pub)?;
+    let identity = Identity::from_public_keys(&x_pub, &ed_pub)
+        .map_err(|e| PyValueError::new_err(format!("identity: {e:?}")))?;
+    let aspects_vec: Vec<String> = aspects.extract()?;
+    let aspects_ref: Vec<&str> = aspects_vec.iter().map(String::as_str).collect();
+    let name_hash = Destination::compute_name_hash(app_name, &aspects_ref);
+    let dest_hash = Destination::compute_destination_hash(&name_hash, identity.hash());
+    Ok(*dest_hash.as_bytes())
+}
+
 #[pymodule]
 fn ciris_edge(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // v1.1.7 (CIRISEdge#58) — diagnostic harness, gated under the
@@ -4353,6 +4631,22 @@ fn ciris_edge(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // point in a future revision.
     #[cfg(feature = "transport-reticulum")]
     m.add_function(wrap_pyfunction!(init_edge_runtime, m)?)?;
+
+    // CIRISEdge#123 — cross-wheel conformance surface for
+    // realtime_av + federation_session + RNS dest-hash. Lets
+    // CIRISConformance / CIRISServer drive the substrate's HNDL-safe
+    // crypto paths from Python without reimplementing them. The
+    // realtime_av + federation_session wrappers are always available;
+    // the RNS dest-hash wrapper requires the leviculum reticulum-core
+    // dep that ships under `transport-reticulum`.
+    m.add_function(wrap_pyfunction!(seal_av_chunk, m)?)?;
+    m.add_function(wrap_pyfunction!(open_av_chunk, m)?)?;
+    m.add_function(wrap_pyfunction!(seal_av_inner, m)?)?;
+    m.add_function(wrap_pyfunction!(seal_av_outer, m)?)?;
+    m.add_function(wrap_pyfunction!(federation_session_initiate, m)?)?;
+    m.add_function(wrap_pyfunction!(federation_session_respond, m)?)?;
+    #[cfg(feature = "transport-reticulum")]
+    m.add_function(wrap_pyfunction!(rns_destination_hash, m)?)?;
 
     Ok(())
 }

--- a/src/transport/federation_session.rs
+++ b/src/transport/federation_session.rs
@@ -58,24 +58,36 @@ use zeroize::Zeroize;
 pub const ALGORITHM_HYBRID_V1: &str = KEX_ALGORITHM_HYBRID_V1;
 pub const ALGORITHM_CLASSICAL_V1: &str = KEX_ALGORITHM_CLASSICAL_V1;
 
-/// The two negotiated outcomes. ML-KEM-only is intentionally not
+/// The negotiated outcomes. ML-KEM-only is intentionally not
 /// representable — see module docs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KexAlgorithm {
     /// Hybrid X25519 + ML-KEM-768. Default whenever the peer advertises
-    /// both halves.
+    /// both halves; falls back to [`Self::Classical`] silently when the
+    /// peer is classical-only.
     Hybrid,
+    /// Hybrid X25519 + ML-KEM-768 with NO classical fallback. Caller
+    /// asserts the channel content is HNDL-sensitive (CEG §10.5.5;
+    /// realtime A/V; key_grant DEK distribution) — a peer that hasn't
+    /// advertised ML-KEM-768 is REJECTED with
+    /// [`SessionError::HybridRequiredButPeerLacksMlkem`] rather than
+    /// silently degraded.
+    HybridRequired,
     /// Classical X25519 only. Admitted when the peer hasn't published
-    /// an ML-KEM-768 pubkey.
+    /// an ML-KEM-768 pubkey AND the caller opted in to fallback via
+    /// [`Self::Hybrid`] (NOT [`Self::HybridRequired`]).
     Classical,
 }
 
 impl KexAlgorithm {
     /// Stable identifier — call sites stamp this into the transport
-    /// envelope per CIRISEdge#54 acceptance criterion 1.
+    /// envelope per CIRISEdge#54 acceptance criterion 1. `HybridRequired`
+    /// stamps the same wire ID as `Hybrid` (they negotiate to the same
+    /// wire output — `HybridRequired` differs only in refusing the
+    /// fallback path).
     pub fn wire_id(self) -> &'static str {
         match self {
-            Self::Hybrid => ALGORITHM_HYBRID_V1,
+            Self::Hybrid | Self::HybridRequired => ALGORITHM_HYBRID_V1,
             Self::Classical => ALGORITHM_CLASSICAL_V1,
         }
     }
@@ -205,6 +217,13 @@ pub enum SessionError {
     /// key pair to decapsulate.
     #[error("hybrid responder missing ML-KEM-768 private key")]
     HybridResponderMissingMlkem,
+    /// Caller requested [`KexAlgorithm::HybridRequired`] (HNDL-strict
+    /// mode) against a peer that hasn't advertised ML-KEM-768. Refused
+    /// rather than silently negotiated down to classical — `HybridRequired`
+    /// is the caller asserting the channel content must survive into the
+    /// post-quantum era, and a classical-only outcome would violate that.
+    #[error("HybridRequired mode rejects classical-fallback peer (HNDL discipline)")]
+    HybridRequiredButPeerLacksMlkem,
 }
 
 impl From<hybrid_kex::KexError> for SessionError {
@@ -244,12 +263,18 @@ impl FederationSession {
         if peer.x25519_pub == [0u8; 32] && peer.mlkem768_pub.is_some() {
             return Err(SessionError::MlKemOnlyRejected);
         }
-        // Negotiation: hybrid only when caller asked for hybrid AND peer
-        // advertised the ML-KEM half. Everything else collapses to classical.
-        let actual = if matches!(requested, KexAlgorithm::Hybrid) && peer.mlkem768_pub.is_some() {
-            KexAlgorithm::Hybrid
-        } else {
-            KexAlgorithm::Classical
+        // Negotiation:
+        // - HybridRequired + peer has ML-KEM → hybrid
+        // - HybridRequired + peer lacks ML-KEM → REJECT (HNDL discipline)
+        // - Hybrid + peer has ML-KEM → hybrid
+        // - Hybrid + peer lacks ML-KEM → classical fallback
+        // - Classical (requested) → classical
+        let actual = match (requested, peer.mlkem768_pub.is_some()) {
+            (KexAlgorithm::HybridRequired, false) => {
+                return Err(SessionError::HybridRequiredButPeerLacksMlkem);
+            }
+            (KexAlgorithm::HybridRequired | KexAlgorithm::Hybrid, true) => KexAlgorithm::Hybrid,
+            (KexAlgorithm::Hybrid, false) | (KexAlgorithm::Classical, _) => KexAlgorithm::Classical,
         };
         match actual {
             KexAlgorithm::Hybrid => {
@@ -261,6 +286,13 @@ impl FederationSession {
                 let (msg, k) = hybrid_kex::initiate_classical(&peer.x25519_pub)?;
                 Ok((SessionHandshakeMsg::Classical(msg), SessionKey(k)))
             }
+            // `actual` is the post-negotiation outcome — the negotiation
+            // arm above either returns Err for `HybridRequired` against
+            // a classical peer or collapses to `Hybrid` against a
+            // hybrid one, so `HybridRequired` never reaches here.
+            KexAlgorithm::HybridRequired => unreachable!(
+                "post-negotiation actual is Hybrid or Classical; HybridRequired never escapes"
+            ),
         }
     }
 
@@ -460,5 +492,59 @@ mod tests {
         let own = fresh_recipient();
         let s = format!("{own:?}");
         assert!(s.contains("<redacted>"), "private key leaked: {s}");
+    }
+
+    /// HNDL-strict mode succeeds against a hybrid peer — produces the
+    /// same hybrid session key as plain `Hybrid` mode would.
+    #[test]
+    fn hybrid_required_succeeds_against_hybrid_peer() {
+        let responder = fresh_recipient();
+        let peer_view = advertise(&responder);
+        let (msg, initiator_key) =
+            FederationSession::initiate(&peer_view, KexAlgorithm::HybridRequired)
+                .expect("initiate");
+        assert_eq!(msg.algorithm(), ALGORITHM_HYBRID_V1);
+        let responder_key = FederationSession::respond(&responder, &msg).expect("respond");
+        assert_eq!(initiator_key.as_bytes(), responder_key.as_bytes());
+    }
+
+    /// HNDL-strict mode refuses a classical-only peer instead of
+    /// silently degrading. This is the load-bearing assertion for
+    /// CEG §10.5.5 realtime A/V + key_grant DEK distribution: the
+    /// content's HNDL-secrecy is the caller's intent, and the substrate
+    /// honors it by refusal rather than fallback.
+    #[test]
+    fn hybrid_required_refuses_classical_only_peer() {
+        let responder = fresh_recipient();
+        let peer_view = advertise_classical_only(&responder);
+        let r = FederationSession::initiate(&peer_view, KexAlgorithm::HybridRequired);
+        assert!(
+            matches!(r, Err(SessionError::HybridRequiredButPeerLacksMlkem)),
+            "expected HybridRequiredButPeerLacksMlkem, got {r:?}"
+        );
+    }
+
+    /// HybridRequired still rejects the ML-KEM-only peer view shape
+    /// (defense-in-depth — the all-zero X25519 sentinel from upstream
+    /// deserializers should NOT trigger fallback semantics).
+    #[test]
+    fn hybrid_required_rejects_mlkem_only_peer_view() {
+        let responder = fresh_recipient();
+        let bad = PeerKexPubkeys {
+            x25519_pub: [0u8; 32],
+            mlkem768_pub: responder.mlkem768_pub.clone(),
+        };
+        let r = FederationSession::initiate(&bad, KexAlgorithm::HybridRequired);
+        assert!(matches!(r, Err(SessionError::MlKemOnlyRejected)));
+    }
+
+    /// HybridRequired stamps the hybrid wire ID — interop with existing
+    /// `Hybrid` responders is byte-identical, only the initiator
+    /// negotiation policy differs.
+    #[test]
+    fn hybrid_required_wire_id_matches_hybrid() {
+        assert_eq!(KexAlgorithm::HybridRequired.wire_id(), ALGORITHM_HYBRID_V1);
+        assert_eq!(KexAlgorithm::Hybrid.wire_id(), ALGORITHM_HYBRID_V1);
+        assert_eq!(KexAlgorithm::Classical.wire_id(), ALGORITHM_CLASSICAL_V1);
     }
 }

--- a/src/transport/realtime_av.rs
+++ b/src/transport/realtime_av.rs
@@ -49,9 +49,23 @@
 //! module owns a tightened ratio threshold ([`REALTIME_MIN_RATIO`])
 //! that callers can override.
 //!
+//! ## Fan-out optimization (inner-once / outer-N)
+//!
+//! Sending one frame to N mesh participants via [`seal_av_chunk`] N
+//! times re-does the **inner** AEAD work N times, but the inner seal
+//! is identical across the whole mesh (the inner nonce is
+//! `(stream_id, epoch, chunk_seq)` only — no per-Link input — and the
+//! epoch DEK is mesh-wide). [`seal_av_inner`] computes the inner half
+//! once; [`seal_av_outer`] applies the per-Link outer seal N times.
+//! Measured ~1.98× speedup at N=50, 16 KiB frames (CIRISEdge#122).
+//!
+//! Wire shape is byte-identical to N × [`seal_av_chunk`] — pure
+//! sender-side optimization, no codec implication.
+//!
 //! ## What this module IS
 //!
-//! - Chunk-seal / chunk-open primitives ([`seal_av_chunk`], [`open_av_chunk`]).
+//! - Single-chunk seal / open ([`seal_av_chunk`], [`open_av_chunk`]).
+//! - Fan-out seal split ([`seal_av_inner`] + [`seal_av_outer`], #122).
 //! - Wire shape definitions ([`SealedAvChunk`], [`StreamId`], [`Epoch`],
 //!   [`EpochDek`]).
 //! - The mesh-participant filter ([`RealtimeFanout::plan`]) over the
@@ -237,6 +251,122 @@ pub fn derive_outer_nonce(link_id: &[u8], link_seq: u64) -> [u8; 12] {
     out
 }
 
+/// The inner-sealed half of a chunk — E2E ciphertext shared across the
+/// whole mesh, *before* the per-Link outer seal is applied. Produced by
+/// [`seal_av_inner`] once per `(stream_id, epoch, chunk_seq)` and
+/// consumed N times by [`seal_av_outer`] (one per mesh participant).
+///
+/// Carries the chunk header (`stream_id` / `epoch` / `chunk_seq`) so
+/// the outer step can stamp it into the wire shape without re-threading
+/// those values through the call site.
+///
+/// CIRISEdge#122 fan-out optimization — see module docs § "Fan-out
+/// optimization (inner-once / outer-N)".
+#[derive(Debug, Clone)]
+pub struct InnerSealed {
+    stream_id: StreamId,
+    epoch: Epoch,
+    chunk_seq: ChunkSeq,
+    /// Inner AES-256-GCM ciphertext: `AEAD(epoch_dek, inner_nonce, plaintext)`.
+    inner_ciphertext: Vec<u8>,
+}
+
+impl InnerSealed {
+    /// Read access for the stream identity header — callers occasionally
+    /// route the inner-sealed ciphertext through application logic
+    /// (e.g. caching, repartitioning) before applying the per-Link outer
+    /// seal.
+    pub fn stream_id(&self) -> StreamId {
+        self.stream_id
+    }
+    pub fn epoch(&self) -> Epoch {
+        self.epoch
+    }
+    pub fn chunk_seq(&self) -> ChunkSeq {
+        self.chunk_seq
+    }
+    /// Borrow the inner ciphertext. Still sealed under the epoch DEK —
+    /// safe to ferry across the mesh.
+    pub fn inner_ciphertext(&self) -> &[u8] {
+        &self.inner_ciphertext
+    }
+}
+
+/// Seal the **inner** AEAD layer only — E2E sealed under the epoch DEK,
+/// independent of any Link. Produces an [`InnerSealed`] that can be
+/// fed to [`seal_av_outer`] once per mesh participant. CIRISEdge#122
+/// fan-out optimization: at room scale (N≈50) cuts sender CPU per
+/// chunk roughly in half because the inner AEAD work is amortized
+/// across the whole mesh instead of repeated per Link.
+///
+/// The inner nonce derivation is identical to [`seal_av_chunk`]'s
+/// inner step, so the on-wire bytes are byte-identical to N calls to
+/// `seal_av_chunk` with the same `(stream_id, epoch, chunk_seq)` and
+/// per-link `(transit_key, link_id, link_seq)` — fan-out optimization
+/// is a pure compute-side change, no wire-format implication.
+pub fn seal_av_inner(
+    plaintext: &[u8],
+    epoch_dek: &EpochDek,
+    stream_id: StreamId,
+    epoch: Epoch,
+    chunk_seq: ChunkSeq,
+) -> Result<InnerSealed, RealtimeAvError> {
+    let inner_nonce = derive_inner_nonce(stream_id, epoch, chunk_seq);
+    let inner_ciphertext = aes_gcm::encrypt(epoch_dek.as_bytes(), &inner_nonce, plaintext)
+        .map_err(RealtimeAvError::InnerAead)?;
+    Ok(InnerSealed {
+        stream_id,
+        epoch,
+        chunk_seq,
+        inner_ciphertext,
+    })
+}
+
+/// Reconstruct an [`InnerSealed`] from its parts. Internal-shape
+/// helper for cross-wheel PyO3 callers (CIRISEdge#123) — Python passes
+/// the inner ciphertext bytes + header fields back through the FFI
+/// boundary, and the outer-seal step rebuilds the handle here.
+///
+/// Rust callers should use [`seal_av_inner`] directly; this is the
+/// bytes-in escape hatch for the published Python wheel.
+#[doc(hidden)]
+pub fn inner_sealed_from_parts(
+    stream_id: StreamId,
+    epoch: Epoch,
+    chunk_seq: ChunkSeq,
+    inner_ciphertext: Vec<u8>,
+) -> InnerSealed {
+    InnerSealed {
+        stream_id,
+        epoch,
+        chunk_seq,
+        inner_ciphertext,
+    }
+}
+
+/// Seal the **outer** AEAD layer for one Link, given a pre-computed
+/// [`InnerSealed`]. The companion to [`seal_av_inner`].
+///
+/// Apply this once per mesh participant. The inner ciphertext is
+/// shared across the whole mesh; only the outer nonce + transit key
+/// differ per Link.
+pub fn seal_av_outer(
+    inner: &InnerSealed,
+    transit_key: &[u8; 32],
+    link_id: &[u8],
+    link_seq: u64,
+) -> Result<SealedAvChunk, RealtimeAvError> {
+    let outer_nonce = derive_outer_nonce(link_id, link_seq);
+    let outer_sealed = aes_gcm::encrypt(transit_key, &outer_nonce, &inner.inner_ciphertext)
+        .map_err(RealtimeAvError::OuterAead)?;
+    Ok(SealedAvChunk {
+        stream_id: inner.stream_id,
+        epoch: inner.epoch,
+        chunk_seq: inner.chunk_seq,
+        double_sealed_ciphertext: outer_sealed,
+    })
+}
+
 /// Seal a chunk for one mesh participant. Applies the two-layer
 /// crypto in inside-out order: inner DEK seal first (E2E), then outer
 /// transit-key seal (hop). Returns the on-wire bytes ready for the
@@ -247,6 +377,12 @@ pub fn derive_outer_nonce(link_id: &[u8], link_seq: u64) -> [u8; 12] {
 /// attacker holding ciphertext from Link X cannot replay it onto
 /// Link Y even if they have Link Y's transit key (different nonces
 /// → AEAD rejects on decrypt).
+///
+/// For mesh fan-out (one frame → N participants) prefer
+/// [`seal_av_inner`] + N × [`seal_av_outer`] — the inner AEAD work is
+/// identical across the mesh and amortizes (~2× sender CPU win at
+/// N=50, CIRISEdge#122). `seal_av_chunk` remains the right call for
+/// N=1 paths and the wire-shape compose primitive.
 #[allow(clippy::too_many_arguments)]
 pub fn seal_av_chunk(
     plaintext: &[u8],
@@ -258,18 +394,8 @@ pub fn seal_av_chunk(
     epoch: Epoch,
     chunk_seq: ChunkSeq,
 ) -> Result<SealedAvChunk, RealtimeAvError> {
-    let inner_nonce = derive_inner_nonce(stream_id, epoch, chunk_seq);
-    let inner_sealed = aes_gcm::encrypt(epoch_dek.as_bytes(), &inner_nonce, plaintext)
-        .map_err(RealtimeAvError::InnerAead)?;
-    let outer_nonce = derive_outer_nonce(link_id, link_seq);
-    let outer_sealed = aes_gcm::encrypt(transit_key, &outer_nonce, &inner_sealed)
-        .map_err(RealtimeAvError::OuterAead)?;
-    Ok(SealedAvChunk {
-        stream_id,
-        epoch,
-        chunk_seq,
-        double_sealed_ciphertext: outer_sealed,
-    })
+    let inner = seal_av_inner(plaintext, epoch_dek, stream_id, epoch, chunk_seq)?;
+    seal_av_outer(&inner, transit_key, link_id, link_seq)
 }
 
 /// Inverse of [`seal_av_chunk`]. Unwraps outer transit-key seal then
@@ -573,6 +699,84 @@ mod tests {
         let plan = RealtimeFanout::plan(&participants, &tracker, transport_id, REALTIME_MIN_RATIO);
         let ids: Vec<&str> = plan.iter().map(|p| p.peer_key_id.as_str()).collect();
         assert_eq!(ids, vec!["alice"], "only alice meets REALTIME_MIN_RATIO");
+    }
+
+    /// #122 fan-out split: composing `seal_av_inner` + `seal_av_outer`
+    /// produces byte-identical wire to `seal_av_chunk` for the same
+    /// inputs. Load-bearing — guarantees the optimization is a pure
+    /// compute-side change with zero wire-format implication.
+    #[test]
+    fn inner_outer_split_matches_single_chunk_wire() {
+        let plaintext = b"frame bytes";
+        let dek = dummy_dek();
+        let stream = dummy_stream();
+        let epoch = Epoch(7);
+        let cseq = ChunkSeq(99);
+        let transit = dummy_transit();
+        let link = b"link-A";
+        let lseq = 42u64;
+
+        let single = seal_av_chunk(plaintext, &transit, link, lseq, &dek, stream, epoch, cseq)
+            .expect("single");
+        let inner = seal_av_inner(plaintext, &dek, stream, epoch, cseq).expect("inner");
+        let split = seal_av_outer(&inner, &transit, link, lseq).expect("outer");
+
+        assert_eq!(single.stream_id, split.stream_id);
+        assert_eq!(single.epoch, split.epoch);
+        assert_eq!(single.chunk_seq, split.chunk_seq);
+        assert_eq!(
+            single.double_sealed_ciphertext, split.double_sealed_ciphertext,
+            "fan-out split changed the wire bytes"
+        );
+    }
+
+    /// #122 fan-out: ONE `seal_av_inner` + N `seal_av_outer` calls for
+    /// distinct Links each produce a sealed chunk that opens correctly
+    /// on its own Link — exactly mirroring N independent
+    /// `seal_av_chunk` calls.
+    #[test]
+    fn inner_once_outer_n_fanout_opens_per_link() {
+        let plaintext = b"mesh frame";
+        let dek = dummy_dek();
+        let stream = dummy_stream();
+        let epoch = Epoch(3);
+        let cseq = ChunkSeq(10);
+        let transit = dummy_transit();
+
+        let inner = seal_av_inner(plaintext, &dek, stream, epoch, cseq).expect("inner");
+        let links: Vec<(&[u8], u64)> = vec![
+            (b"link-A", 100),
+            (b"link-B", 200),
+            (b"link-C", 300),
+            (b"link-D", 400),
+        ];
+        for (link_id, link_seq) in links {
+            let sealed = seal_av_outer(&inner, &transit, link_id, link_seq).expect("outer");
+            // Each per-Link wire opens with the matching Link state.
+            let opened = open_av_chunk(&sealed, &transit, link_id, link_seq, &dek).expect("open");
+            assert_eq!(opened, plaintext);
+            // And refuses on a different Link's state — outer nonce
+            // is per-Link.
+            let r = open_av_chunk(&sealed, &transit, b"link-X", link_seq, &dek);
+            assert!(matches!(r, Err(RealtimeAvError::OuterAead(_))));
+        }
+    }
+
+    /// #122 — the InnerSealed accessor surface preserves the chunk
+    /// header so a caller can route the inner ciphertext through
+    /// app-level logic (cache, repartition) before applying the
+    /// per-Link outer seal.
+    #[test]
+    fn inner_sealed_header_accessors() {
+        let dek = dummy_dek();
+        let stream = StreamId([0xAB; 32]);
+        let epoch = Epoch(0xDEAD_BEEF);
+        let cseq = ChunkSeq(0xC0FFEE);
+        let inner = seal_av_inner(b"x", &dek, stream, epoch, cseq).expect("inner");
+        assert_eq!(inner.stream_id(), stream);
+        assert_eq!(inner.epoch(), epoch);
+        assert_eq!(inner.chunk_seq(), cseq);
+        assert!(!inner.inner_ciphertext().is_empty());
     }
 
     /// Threshold tunability — a stricter threshold (0.9) drops bob

--- a/src/transport/realtime_av.rs
+++ b/src/transport/realtime_av.rs
@@ -771,7 +771,7 @@ mod tests {
         let dek = dummy_dek();
         let stream = StreamId([0xAB; 32]);
         let epoch = Epoch(0xDEAD_BEEF);
-        let cseq = ChunkSeq(0xC0FFEE);
+        let cseq = ChunkSeq(0x00C0_FFEE);
         let inner = seal_av_inner(b"x", &dek, stream, epoch, cseq).expect("inner");
         assert_eq!(inner.stream_id(), stream);
         assert_eq!(inner.epoch(), epoch);


### PR DESCRIPTION
## Summary

Closes **CIRISEdge#122** (mesh fan-out optimization, ~2× sender CPU at N=50) and **CIRISEdge#123** (cross-wheel PyO3 surface for CIRISConformance). Adds `KexAlgorithm::HybridRequired` so the user's PQC discipline ("everything is PQC, no exceptions") becomes structurally enforced rather than documented.

### #122 — \`seal_av_inner\` / \`seal_av_outer\` (inner-once / outer-N)

The existing \`seal_av_chunk\` does both AEAD layers per call; for mesh fan-out the inner AEAD work is identical across the whole mesh (inner nonce derives only from \`(stream_id, epoch, chunk_seq)\`; epoch DEK is mesh-wide), so re-doing it per Link is wasted CPU.

New \`seal_av_inner\` returns an opaque \`InnerSealed\`; new \`seal_av_outer\` applies the per-Link outer AEAD. \`seal_av_chunk\` is reimplemented as \`inner ∘ outer\` so the wire is byte-identical to the old path — pure compute-side optimization, no codec implication. **~1.98× sender CPU win at N=50, 16 KiB frames** (per #122's measurements).

### #123 — Cross-wheel PyO3 conformance surface

CIRISConformance drives the published Python wheels in one process and measures the production cohabitation cost. Three substrate surfaces were Rust-only; the harness can now drive them from Python:

- \`seal_av_chunk\` / \`open_av_chunk\` (existing one-shot path)
- \`seal_av_inner\` / \`seal_av_outer\` (#122 fan-out split)
- \`federation_session_initiate\` / \`federation_session_respond\` (#54 hybrid KEX)
- \`rns_destination_hash\` (CEG 1.0-RC6 §5.6.8.8.1.1 two-stage construction via leviculum; AV-42 destination-authenticity recompute, CIRISVerify#28)

All wrappers are bytes-in/bytes-out — no redacted-Debug newtype (EpochDek/SessionKey/OwnKexKeys) escapes the Python boundary. Handshake wire form is JSON over the existing \`serde\`-enabled \`HybridHandshakeMsg\` / \`ClassicalHandshakeMsg\`.

### PQC / HNDL discipline — \`KexAlgorithm::HybridRequired\`

CEG §10.5.5 realtime A/V + key_grant DEK distribution carry HNDL-sensitive content. The existing \`KexAlgorithm::Hybrid\` silently falls back to classical when the peer hasn't advertised ML-KEM-768 — fine for low-stakes channels, **NOT** fine for content that must survive a CRQC.

New \`KexAlgorithm::HybridRequired\` rejects classical fallback with \`SessionError::HybridRequiredButPeerLacksMlkem\` instead of silently negotiating down. The variant stamps the same wire ID as \`Hybrid\` — byte-compatible with existing responders — and differs only in initiator-side negotiation policy. Exposed on the PyO3 surface as \`algorithm=\"hybrid-required\"\`.

**HNDL chain for realtime A/V (CEG §10.5.5):**
- INNER (epoch DEK): AES-256-GCM, distributed via key_grant's X25519+ML-KEM-768 hybrid PQC wrap. **HNDL-safe end-to-end regardless of session fallback.**
- OUTER (transit key): AES-256-GCM, derived from \`federation_session\`. Plain \`Hybrid\` admits classical fallback; \`HybridRequired\` does not. A/V content secrecy is HNDL-safe via the inner DEK even if outer falls back; using \`HybridRequired\` additionally protects replay/transit-binding.

## Test plan

- [ ] CI matrix green (core / reticulum / packet-radio / all-transports / pyo3-full \`--all-targets\`)
- [ ] Both clippy combos (\`pyo3\`, \`pyo3 ffi-uniffi\`) green
- [ ] Cohabitation gate green (lens-core retirement + CIRISServer takeover)
- [ ] Skew check + bench --no-run green
- [ ] PyO3 conformance surface importable from the wheel (CIRISConformance will pick up)

## Local gate sweep

- ✓ 4 build combos clean under \`RUSTFLAGS=-D warnings\`: core / reticulum / packet-radio / all-transports
- ✓ \`cargo clippy\` (lib) clean for pyo3 combo
- ✓ Targeted lib tests green: 14 \`transport::realtime_av\` + 12 \`transport::federation_session\` (added 3 + 4 net new)
- ✓ Cargo↔pyproject skew check OK
- (Local gate per \`feedback_targeted_local_tests\`: no \`--all-targets\` locally; CI runs the full matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)