### PR TITLE
release(v3.7.1): persist v7.2.0 + verify v5.7.0 (RC7 hybrid hard cut)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "3.7.0"
+version = "3.7.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.1.0", version = "7", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.2.0", version = "7", features = ["sqlite"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.1.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.6.0", version = "5", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.6.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.7.0", version = "5", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.7.0", version = "5", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.6.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.6.0", version = "5" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v5.7.0", version = "5" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -875,7 +875,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.1.0", version = "7", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v7.2.0", version = "7", features = ["sqlite", "cirisnode", "classify", "scrub"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## Summary

CEG 1.0-RC7 (CIRISRegistry 9535b2a) pinned the hybrid-required posture at every federation-tier gate. The substrate co-bumped:

- **persist v7.1.0 → v7.2.0** — trace-tier hybrid hard cut (CIRISPersist#225). V083 migration adds \`signature_ml_dsa_65\` + \`pubkey_ml_dsa_65\` + \`pqc_key_id\` on \`trace_events\` (full pg + sqlite parity, no TimescaleDB). \`VerifyMode::Full\` rejects classical-only per-trace sigs at admission; a CRQC-era attacker who breaks Ed25519 cannot forge backdated traces under any historical key. Per-trace testimony is now post-quantum.
- **verify-family v5.6.0 → v5.7.0** — \`HybridPolicy::RequireHybrid\` is the new default at three federation-tier gates (CIRISVerify#75): \`threshold::verify_threshold_signatures\`, \`provenance::verify_provenance_chain\`, license gate. A stripped PQC half no longer counts. Partnership envelope shape (#76) + infra/agency scope split (#77) align with RC7 §8.1.12.7.1 / §5.6.8.10 / §1.3.

**Edge impact: pure pin flip, no source change.** Edge re-exports \`HybridPolicy\` from \`persist::prelude\` (\`src/verify.rs:48\`), and that re-export tracks persist's default flip transitively — no edge signature touches the policy default. The seven-member partnership envelope + scope-split verifier are producer/consumer at agent/server tier; edge is byte-transport.

**Alignment with v3.7.0:** edge's \`KexAlgorithm::HybridRequired\` for transit KEX + verify-family's \`HybridPolicy::RequireHybrid\` for federation-tier verification = the whole stack is now consistently HNDL-strict at the federation boundary, with explicit \`AllowClassicalPending\` / \`Hybrid\` fallback for local-tier paths only.

## Local gate sweep

- ✓ 4 CI feature combos under \`RUSTFLAGS=-D warnings\`: core / reticulum / packet-radio / all-transports
- ✓ Targeted lib tests green: 14 \`transport::realtime_av\` + 12 \`transport::federation_session\` + 4 \`verify\`
- ✓ Cargo↔pyproject skew check OK
- ✓ Pre-commit hooks fired clean (fmt + hygiene); pre-push clippy gate skipped (Cargo.toml-only diff)

## Test plan

- [ ] CI matrix green (core / reticulum / packet-radio / all-transports / pyo3-full \`--all-targets\`)
- [ ] Both clippy combos (\`pyo3\`, \`pyo3 ffi-uniffi\`) green
- [ ] Cohabitation gate green
- [ ] Skew check + bench --no-run green

🤖 Generated with [Claude Code](https://claude.com/claude-code)