### PR TITLE
release(v5.1.0): ReplicationRuntime peer mutation API — closes #173

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "5.0.1"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1618,10 +1618,10 @@ impl PyReplicationHandle {
         })
     }
 
-    /// Hot-add a `(peer_key_id, kind)` after start. See
-    /// `ReplicationRuntime::register_peer` for the v1 limitation
-    /// (hot-adds default to Responder role; the scheduler's
-    /// Initiator set is fixed at start in v1).
+    /// Hot-add a `(peer_key_id, kind)` after start. Defaults to
+    /// Responder role — for the CEG-driven reconciler path that
+    /// needs the new peer to actively initiate rounds, use
+    /// [`Self::register_initiator_peer`] (CIRISEdge#173 / v5.1.0).
     fn register_peer(&self, py: Python<'_>, peer_key_id: &str, kind: &str) -> PyResult<()> {
         let kind = parse_envelope_kind(kind)?;
         let peer = peer_key_id.to_string();
@@ -1636,6 +1636,94 @@ impl PyReplicationHandle {
             });
         });
         Ok(())
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — hot-add an Initiator peer at runtime.
+    /// The scheduler spawns a task that fires anti-entropy rounds at
+    /// the configured cadence immediately. Idempotent.
+    ///
+    /// Raises `RuntimeError` if the runtime has been stopped.
+    fn register_initiator_peer(
+        &self,
+        py: Python<'_>,
+        peer_key_id: &str,
+        kind: &str,
+    ) -> PyResult<()> {
+        let kind = parse_envelope_kind(kind)?;
+        let peer = peer_key_id.to_string();
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .register_initiator_peer(peer, kind)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — hot-remove a `(peer_key_id, kind)`.
+    /// Stops the matching coordinator's scheduled rounds (if active)
+    /// AND deregisters from the inbound registry. Idempotent.
+    fn remove_peer(&self, py: Python<'_>, peer_key_id: &str, kind: &str) -> PyResult<()> {
+        let kind = parse_envelope_kind(kind)?;
+        let peer = peer_key_id.to_string();
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .remove_peer(peer, kind)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — diff-and-converge the live Initiator
+    /// set against `desired`. Adds and removes peers so that, after
+    /// the call returns, the runtime's Initiator coordinators exactly
+    /// match `desired`. The intended driver for CEG-reconcilers:
+    /// call on every consent-object delta.
+    ///
+    /// `desired` is a list of `(peer_key_id, kind)` tuples; kind is
+    /// one of the accepted [`crate::replication::protocol::EnvelopeKind`]
+    /// strings.
+    fn set_peers(&self, py: Python<'_>, desired: Vec<(String, String)>) -> PyResult<()> {
+        let mut peers = Vec::with_capacity(desired.len());
+        for (peer_key_id, kind_str) in desired {
+            let kind = parse_envelope_kind(&kind_str)?;
+            peers.push(crate::replication::runtime::ReplicationPeer { peer_key_id, kind });
+        }
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .set_peers(peers)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
     }
 
     /// Stop the replication runtime — signals the scheduler to

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -45,10 +45,11 @@
 //! wires it. A v1.7 follow-up may add an opt-in
 //! `Edge::install_replication_routing(runtime)` helper.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use ciris_persist::federation::FederationDirectory;
-use tokio::sync::watch;
+use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 
 use super::bridge::{BridgeConfig, CohortProvider, FederationDirectoryReplicationBridge};
@@ -56,7 +57,9 @@ use super::coordinator::ReplicationCoordinator;
 use super::directory::{DirectoryStateAdapter, MutableDirectoryStateAdapter, ReplicationDirectory};
 use super::protocol::EnvelopeKind;
 use super::registry::ReplicationRegistry;
-use super::scheduler::{ReplicationScheduler, SchedulerConfig};
+use super::scheduler::{
+    ReplicationScheduler, SchedulerCommandError, SchedulerConfig, SchedulerHandle,
+};
 use super::session::SessionRole;
 use super::summary::{StateApplier, StateProvider};
 use crate::transport::Transport;
@@ -92,6 +95,32 @@ pub struct ReplicationRuntime {
     cancel_tx: watch::Sender<bool>,
     scheduler_task: Option<JoinHandle<()>>,
     config: ReplicationRuntimeConfig,
+    /// Runtime control channel for the scheduler (CIRISEdge#173,
+    /// v5.1.0). Used by [`Self::register_initiator_peer`] /
+    /// [`Self::remove_peer`] / [`Self::set_peers`] to mutate the
+    /// scheduler's Initiator set without restart.
+    scheduler_handle: SchedulerHandle,
+    /// Current Initiator set, kept in sync with the scheduler's
+    /// live coordinator tasks. Drives [`Self::set_peers`]'s diff.
+    /// Pre-v5.1 entries (passed to `start`) populate this on init.
+    current_initiators: Arc<Mutex<HashSet<(String, EnvelopeKind)>>>,
+}
+
+/// Failure modes for the v5.1.0 runtime peer-mutation API
+/// (CIRISEdge#173).
+#[derive(Debug, thiserror::Error)]
+pub enum ReplicationRuntimeError {
+    /// The scheduler has stopped (e.g. [`ReplicationRuntime::shutdown`]
+    /// was called) — runtime control is no longer possible. Subsequent
+    /// calls will keep failing.
+    #[error("replication runtime has shut down; peer mutation is no longer accepted")]
+    SchedulerStopped,
+}
+
+impl From<SchedulerCommandError> for ReplicationRuntimeError {
+    fn from(_: SchedulerCommandError) -> Self {
+        Self::SchedulerStopped
+    }
 }
 
 impl ReplicationRuntime {
@@ -141,6 +170,7 @@ impl ReplicationRuntime {
         // session.rs's borrow story (the bridge is the same object
         // backing both).
         let mut scheduler = ReplicationScheduler::new(config.scheduler);
+        let scheduler_handle = scheduler.install_control_channel();
         let coords: Vec<Arc<ReplicationCoordinator>> = peers
             .iter()
             .map(|peer| {
@@ -161,8 +191,10 @@ impl ReplicationRuntime {
             })
             .collect();
 
+        let mut initial_initiator_set: HashSet<(String, EnvelopeKind)> = HashSet::new();
         for (peer, coord) in peers.iter().zip(coords.iter()) {
             scheduler.add_initiator(Arc::clone(coord));
+            initial_initiator_set.insert((peer.peer_key_id.clone(), peer.kind));
             // Register so the operator's listen loop can route
             // inbound replies (the Initiator side receives Summary
             // / Diff / Deliver back from the peer). Inline await
@@ -189,6 +221,8 @@ impl ReplicationRuntime {
             cancel_tx,
             scheduler_task: Some(scheduler_task),
             config,
+            scheduler_handle,
+            current_initiators: Arc::new(Mutex::new(initial_initiator_set)),
         }
     }
 
@@ -204,21 +238,139 @@ impl ReplicationRuntime {
     /// the scheduler with a dynamic-add API.
     pub async fn register_peer(&self, peer_key_id: impl Into<String>, kind: EnvelopeKind) {
         let peer_key_id = peer_key_id.into();
+        let coord = self.build_coordinator(&peer_key_id, kind, SessionRole::Responder);
+        self.registry.register(peer_key_id, kind, coord).await;
+    }
+
+    /// Hot-add a `(peer_key_id, kind)` **Initiator** coordinator —
+    /// CIRISEdge#173, v5.1.0.
+    ///
+    /// Builds a coordinator in [`SessionRole::Initiator`], registers
+    /// it with the registry (so inbound replies route correctly),
+    /// AND tells the scheduler's runtime control plane to spawn a
+    /// task that fires periodic anti-entropy rounds at the configured
+    /// cadence. Idempotent — re-adding an active `(peer, kind)` is a
+    /// no-op.
+    ///
+    /// Use this from CEG-driven reconcilers when `consent:replication`
+    /// objects materialize at runtime: the new peer begins active
+    /// pull immediately, no restart.
+    pub async fn register_initiator_peer(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let peer_key_id = peer_key_id.into();
+        let key = (peer_key_id.clone(), kind);
+
+        {
+            let mut active = self.current_initiators.lock().await;
+            if active.contains(&key) {
+                return Ok(());
+            }
+            active.insert(key);
+        }
+
+        let coord = self.build_coordinator(&peer_key_id, kind, SessionRole::Initiator);
+        // Register first so the inbound listen loop can route replies
+        // by the time the scheduler picks up the command.
+        self.registry
+            .register(peer_key_id, kind, Arc::clone(&coord))
+            .await;
+        self.scheduler_handle.add_initiator(coord).await?;
+        Ok(())
+    }
+
+    /// Hot-remove a `(peer_key_id, kind)` peer — CIRISEdge#173,
+    /// v5.1.0.
+    ///
+    /// Stops the matching Initiator coordinator's scheduled rounds
+    /// (if active) AND deregisters from the registry so inbound
+    /// routing for the peer ceases. Idempotent: removing a peer that
+    /// was never added is a no-op.
+    pub async fn remove_peer(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let peer_key_id = peer_key_id.into();
+        let key = (peer_key_id.clone(), kind);
+
+        let was_initiator = {
+            let mut active = self.current_initiators.lock().await;
+            active.remove(&key)
+        };
+        if was_initiator {
+            self.scheduler_handle
+                .remove_initiator(peer_key_id.clone(), kind)
+                .await?;
+        }
+        self.registry.deregister(&peer_key_id, kind).await;
+        Ok(())
+    }
+
+    /// Diff-and-converge the live Initiator set against `desired` —
+    /// CIRISEdge#173, v5.1.0.
+    ///
+    /// For each `(peer_key_id, kind)` in `desired` not currently
+    /// active, calls [`Self::register_initiator_peer`]. For each
+    /// currently-active pair NOT in `desired`, calls
+    /// [`Self::remove_peer`]. Net effect: after this call returns,
+    /// the runtime's Initiator coordinators exactly match `desired`.
+    ///
+    /// Atomic per individual add/remove only — partial progress is
+    /// possible if a mid-call command fails (the failed pair is
+    /// reflected by the returned error; pairs processed before the
+    /// failure stay applied). Intended driver for CEG-reconcilers:
+    /// call on every consent-object delta.
+    pub async fn set_peers(
+        &self,
+        desired: Vec<ReplicationPeer>,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let desired_set: HashSet<(String, EnvelopeKind)> = desired
+            .iter()
+            .map(|p| (p.peer_key_id.clone(), p.kind))
+            .collect();
+        let current_set: HashSet<(String, EnvelopeKind)> = {
+            let active = self.current_initiators.lock().await;
+            active.iter().cloned().collect()
+        };
+
+        // Adds first; the new peers begin active pull before the
+        // departing peers' rounds stop — minimizes the convergence
+        // window during a swap.
+        for (peer_key_id, kind) in desired_set.difference(&current_set) {
+            self.register_initiator_peer(peer_key_id.clone(), *kind)
+                .await?;
+        }
+        for (peer_key_id, kind) in current_set.difference(&desired_set) {
+            self.remove_peer(peer_key_id.clone(), *kind).await?;
+        }
+        Ok(())
+    }
+
+    /// Build a [`ReplicationCoordinator`] in the requested role with
+    /// the runtime's shared transport + bridge-backed provider/applier.
+    /// Internal helper for register_peer / register_initiator_peer.
+    fn build_coordinator(
+        &self,
+        peer_key_id: &str,
+        kind: EnvelopeKind,
+        role: SessionRole,
+    ) -> Arc<ReplicationCoordinator> {
         let bridge_dir: Arc<dyn ReplicationDirectory> = Arc::clone(&self.bridge) as _;
         let provider: Arc<dyn StateProvider> =
             Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
-        let applier: Arc<tokio::sync::Mutex<dyn StateApplier>> = Arc::new(tokio::sync::Mutex::new(
-            MutableDirectoryStateAdapter::new(bridge_dir),
-        ));
-        let coord = Arc::new(ReplicationCoordinator::new(
+        let applier: Arc<Mutex<dyn StateApplier>> =
+            Arc::new(Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)));
+        Arc::new(ReplicationCoordinator::new(
             Arc::clone(&self.transport),
-            peer_key_id.clone(),
+            peer_key_id.to_string(),
             kind,
-            SessionRole::Responder, // hot-add defaults to Responder; cf. doc above
+            role,
             provider,
             applier,
-        ));
-        self.registry.register(peer_key_id, kind, coord).await;
+        ))
     }
 
     /// Shared registry handle. The operator's `Transport::listen`
@@ -340,6 +492,125 @@ mod tests {
         rt.register_peer("agent-bob", EnvelopeKind::Attestation)
             .await;
         assert_eq!(rt.registry().len().await, 1);
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `register_initiator_peer` hot-adds an
+    /// Initiator coordinator (not just Responder) and bumps the
+    /// registry. Distinct from `register_peer` (Responder-only).
+    #[tokio::test]
+    async fn register_initiator_peer_hot_adds_initiator_role() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        rt.register_initiator_peer("agent-carol", EnvelopeKind::Key)
+            .await
+            .expect("hot-add succeeds while runtime is live");
+        assert_eq!(rt.registry().len().await, 1);
+        let coord = rt.registry().get("agent-carol", EnvelopeKind::Key).await;
+        assert!(coord.is_some());
+        assert_eq!(coord.unwrap().role(), SessionRole::Initiator);
+        // Idempotent: re-add is a no-op.
+        rt.register_initiator_peer("agent-carol", EnvelopeKind::Key)
+            .await
+            .expect("idempotent re-add");
+        assert_eq!(rt.registry().len().await, 1);
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `remove_peer` stops the matching
+    /// coordinator's scheduled rounds AND deregisters from the
+    /// registry. Idempotent.
+    #[tokio::test]
+    async fn remove_peer_drops_initiator_and_deregisters() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        rt.register_initiator_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .unwrap();
+        assert_eq!(rt.registry().len().await, 1);
+        rt.remove_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .expect("hot-remove succeeds while runtime is live");
+        assert!(rt.registry().is_empty().await);
+        // Idempotent: removing again is a no-op.
+        rt.remove_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .expect("idempotent re-remove");
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `set_peers` converges the live
+    /// Initiator set against the desired set. Verifies that adds
+    /// and removes both apply in one call, including starting from
+    /// a non-empty pre-existing set.
+    #[tokio::test]
+    async fn set_peers_diff_converges() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let initial = vec![
+            ReplicationPeer {
+                peer_key_id: "peer-keep".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+            ReplicationPeer {
+                peer_key_id: "peer-drop".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+        ];
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            initial,
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        assert_eq!(rt.registry().len().await, 2);
+
+        let desired = vec![
+            ReplicationPeer {
+                peer_key_id: "peer-keep".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+            ReplicationPeer {
+                peer_key_id: "peer-new".to_string(),
+                kind: EnvelopeKind::Attestation,
+            },
+        ];
+        rt.set_peers(desired).await.expect("converge succeeds");
+
+        assert_eq!(rt.registry().len().await, 2);
+        assert!(rt
+            .registry()
+            .get("peer-keep", EnvelopeKind::Key)
+            .await
+            .is_some());
+        assert!(rt
+            .registry()
+            .get("peer-new", EnvelopeKind::Attestation)
+            .await
+            .is_some());
+        assert!(rt
+            .registry()
+            .get("peer-drop", EnvelopeKind::Key)
+            .await
+            .is_none());
         rt.shutdown().await;
     }
 

--- a/src/replication/scheduler.rs
+++ b/src/replication/scheduler.rs
@@ -49,12 +49,14 @@
 //! round is a missed cadence, not a fault. The next round will pick
 //! up whatever state changed in the meantime.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 
 use super::coordinator::{CoordinatorError, DriveStep, ReplicationCoordinator, RoundReport};
+use super::protocol::EnvelopeKind;
 use super::session::SessionRole;
 
 /// Scheduler configuration shared across all coordinators it drives.
@@ -121,9 +123,102 @@ pub enum RoundEvent {
 /// Constructing the scheduler does NOT spawn any tasks; the caller
 /// chooses when to start the run loop via
 /// [`Self::run_until_cancelled`].
+///
+/// ## Runtime control plane (CIRISEdge#173, v5.1.0)
+///
+/// Call [`Self::install_control_channel`] before starting the run
+/// loop to obtain a [`SchedulerHandle`] that lets external code add
+/// or remove Initiator coordinators *while the loop is running* —
+/// no restart required. Without that call the scheduler keeps its
+/// pre-v5.1 fixed-set semantics.
 pub struct ReplicationScheduler {
     config: SchedulerConfig,
     coordinators: Vec<Arc<ReplicationCoordinator>>,
+    command_rx: Option<mpsc::Receiver<SchedulerCommand>>,
+}
+
+/// Runtime control command for an actively-running scheduler.
+///
+/// Emitted by [`SchedulerHandle`] and consumed inside
+/// [`ReplicationScheduler::run_with_events`].
+pub enum SchedulerCommand {
+    /// Spawn a new Initiator coordinator task. The coordinator's
+    /// role must be [`SessionRole::Initiator`] (debug-asserted).
+    AddInitiator(Arc<ReplicationCoordinator>),
+    /// Stop the running task for the matching `(peer_key_id, kind)`
+    /// coordinator, if present. No-op if the pair was never added.
+    RemoveInitiator {
+        peer_key_id: String,
+        kind: EnvelopeKind,
+    },
+}
+
+impl std::fmt::Debug for SchedulerCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AddInitiator(coord) => f
+                .debug_struct("AddInitiator")
+                .field("peer_key_id", &coord.peer_key_id())
+                .field("kind", &coord.kind())
+                .finish(),
+            Self::RemoveInitiator { peer_key_id, kind } => f
+                .debug_struct("RemoveInitiator")
+                .field("peer_key_id", peer_key_id)
+                .field("kind", kind)
+                .finish(),
+        }
+    }
+}
+
+/// External handle for mutating a running scheduler's Initiator set.
+///
+/// Acquired via [`ReplicationScheduler::install_control_channel`]
+/// BEFORE the run loop starts. Cheaply clonable. Sending on a closed
+/// channel (the scheduler has shut down) returns an error.
+#[derive(Clone, Debug)]
+pub struct SchedulerHandle {
+    command_tx: mpsc::Sender<SchedulerCommand>,
+}
+
+impl SchedulerHandle {
+    /// Add an Initiator coordinator to the running scheduler. The
+    /// scheduler spawns a new task on its next select iteration.
+    /// Idempotent vs. an already-active `(peer_key_id, kind)`:
+    /// duplicates are silently dropped inside the run loop.
+    pub async fn add_initiator(
+        &self,
+        coord: Arc<ReplicationCoordinator>,
+    ) -> Result<(), SchedulerCommandError> {
+        self.command_tx
+            .send(SchedulerCommand::AddInitiator(coord))
+            .await
+            .map_err(|_| SchedulerCommandError::SchedulerStopped)
+    }
+
+    /// Stop the running task for `(peer_key_id, kind)`. No-op if
+    /// that pair isn't currently active.
+    pub async fn remove_initiator(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), SchedulerCommandError> {
+        self.command_tx
+            .send(SchedulerCommand::RemoveInitiator {
+                peer_key_id: peer_key_id.into(),
+                kind,
+            })
+            .await
+            .map_err(|_| SchedulerCommandError::SchedulerStopped)
+    }
+}
+
+/// Failure reason for [`SchedulerHandle`] command sends.
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerCommandError {
+    /// The scheduler's run loop has exited, so its command receiver
+    /// dropped. Subsequent sends will keep failing.
+    #[error("scheduler has stopped; runtime control channel is closed")]
+    SchedulerStopped,
 }
 
 impl ReplicationScheduler {
@@ -131,7 +226,23 @@ impl ReplicationScheduler {
         Self {
             config,
             coordinators: Vec::new(),
+            command_rx: None,
         }
+    }
+
+    /// Install the runtime control channel (CIRISEdge#173). Returns
+    /// the sender side as a [`SchedulerHandle`]; the scheduler keeps
+    /// the receiver. Must be called before the run loop starts to
+    /// take effect; calling twice replaces the prior receiver, which
+    /// silently invalidates any earlier handle.
+    ///
+    /// Without this call the scheduler retains its pre-v5.1 fixed-set
+    /// semantics — only coordinators added before `run_until_cancelled`
+    /// via [`Self::add_initiator`] are driven.
+    pub fn install_control_channel(&mut self) -> SchedulerHandle {
+        let (command_tx, command_rx) = mpsc::channel(32);
+        self.command_rx = Some(command_rx);
+        SchedulerHandle { command_tx }
     }
 
     /// Register an Initiator-side coordinator with the scheduler.
@@ -185,37 +296,117 @@ impl ReplicationScheduler {
     /// events; the scheduler tolerates a closed sink (the round
     /// loops continue).
     pub async fn run_with_events(
-        self,
-        cancel: watch::Receiver<bool>,
-        event_sink: Option<tokio::sync::mpsc::Sender<(String, RoundEvent)>>,
+        mut self,
+        mut cancel: watch::Receiver<bool>,
+        event_sink: Option<mpsc::Sender<(String, RoundEvent)>>,
     ) {
+        // Per-coord cancel senders, keyed by (peer_key_id, kind).
+        // RemoveInitiator flips one entry; global cancel flips all.
+        let mut per_coord: HashMap<(String, EnvelopeKind), watch::Sender<bool>> = HashMap::new();
         let mut handles = Vec::with_capacity(self.coordinators.len());
-        for coord in self.coordinators {
-            let mut cancel_rx = cancel.clone();
-            let event_sink = event_sink.clone();
-            let cadence = self.config.cadence;
-            let round_timeout = self.config.round_timeout;
-            let h = tokio::spawn(async move {
-                run_one_coordinator_forever(
-                    coord,
-                    cadence,
-                    round_timeout,
-                    &mut cancel_rx,
-                    event_sink,
-                )
-                .await;
-            });
-            handles.push(h);
+
+        for coord in self.coordinators.drain(..) {
+            spawn_coord(
+                &mut per_coord,
+                &mut handles,
+                coord,
+                self.config.cadence,
+                self.config.round_timeout,
+                event_sink.clone(),
+            );
         }
+
+        let mut command_rx = self.command_rx.take();
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.changed() => {
+                    if *cancel.borrow() {
+                        for (_, tx) in per_coord.drain() {
+                            let _ = tx.send(true);
+                        }
+                        break;
+                    }
+                }
+                Some(cmd) = async {
+                    // SAFETY of unwrap: the `if` guard below is
+                    // evaluated before this branch is polled, so
+                    // command_rx is Some when we enter.
+                    command_rx.as_mut().unwrap().recv().await
+                }, if command_rx.is_some() => {
+                    match cmd {
+                        SchedulerCommand::AddInitiator(coord) => {
+                            let key = (coord.peer_key_id().to_string(), coord.kind());
+                            if per_coord.contains_key(&key) {
+                                tracing::debug!(
+                                    peer = %key.0,
+                                    kind = ?key.1,
+                                    "scheduler: AddInitiator ignored (already active)"
+                                );
+                                continue;
+                            }
+                            spawn_coord(
+                                &mut per_coord,
+                                &mut handles,
+                                coord,
+                                self.config.cadence,
+                                self.config.round_timeout,
+                                event_sink.clone(),
+                            );
+                        }
+                        SchedulerCommand::RemoveInitiator { peer_key_id, kind } => {
+                            if let Some(tx) = per_coord.remove(&(peer_key_id, kind)) {
+                                let _ = tx.send(true);
+                            }
+                        }
+                    }
+                }
+                else => {
+                    // command_rx is None AND cancel is not changing —
+                    // wait on cancel only.
+                    let _ = cancel.changed().await;
+                    if *cancel.borrow() {
+                        for (_, tx) in per_coord.drain() {
+                            let _ = tx.send(true);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         for h in handles {
             // join_all would be nicer but adds futures-util dep
-            // outside our current set. tokio::join! on a Vec needs
-            // boxing. Sequential .await is fine here — every task
-            // observes the same cancel signal so they all finish
-            // at about the same time anyway.
+            // outside our current set. Sequential .await is fine —
+            // tasks cancel concurrently in response to the same
+            // signal.
             let _ = h.await;
         }
     }
+}
+
+/// Spawn one coordinator task and record its per-coord cancel handle.
+fn spawn_coord(
+    per_coord: &mut HashMap<(String, EnvelopeKind), watch::Sender<bool>>,
+    handles: &mut Vec<tokio::task::JoinHandle<()>>,
+    coord: Arc<ReplicationCoordinator>,
+    cadence: Duration,
+    round_timeout: Duration,
+    event_sink: Option<mpsc::Sender<(String, RoundEvent)>>,
+) {
+    debug_assert_eq!(
+        coord.role(),
+        SessionRole::Initiator,
+        "scheduler spawns Initiator coordinators only"
+    );
+    let key = (coord.peer_key_id().to_string(), coord.kind());
+    let (cancel_tx, mut cancel_rx) = watch::channel(false);
+    per_coord.insert(key, cancel_tx);
+    let h = tokio::spawn(async move {
+        run_one_coordinator_forever(coord, cadence, round_timeout, &mut cancel_rx, event_sink)
+            .await;
+    });
+    handles.push(h);
 }
 
 async fn run_one_coordinator_forever(
@@ -657,6 +848,105 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), h)
             .await
             .expect("exit on cancel")
+            .expect("join");
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `SchedulerHandle::add_initiator` on
+    /// a running scheduler spawns a task that actively initiates
+    /// rounds. Proof-of-life via `RoundEvent` emission: a coord
+    /// targeting an unreachable peer produces `RoundEvent::Error`
+    /// rounds (transport Unreachable) which can only happen if the
+    /// task fired. Then `remove_initiator` stops the events.
+    #[tokio::test]
+    async fn control_channel_add_remove_drives_initiator_task() {
+        let mut sched = ReplicationScheduler::new(fast_config());
+        let control = sched.install_control_channel();
+        let (event_tx, mut event_rx) = mpsc::channel::<(String, RoundEvent)>(64);
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let sched_handle =
+            tokio::spawn(async move { sched.run_with_events(cancel_rx, Some(event_tx)).await });
+
+        // Build an Initiator coord pointing at a peer that doesn't
+        // exist in the in-memory inbox. Every send fails with
+        // TransportError::Unreachable → RoundEvent::Error per round.
+        let transport: Arc<dyn Transport> = Arc::new(InMemTransport {
+            peer_inbox: HashMap::new(),
+        });
+        let provider: Arc<dyn StateProvider> = Arc::new(StaticProvider {
+            state: {
+                let mut s = LocalState::new();
+                s.insert(EnvelopeKind::Key, h(7), 7);
+                s
+            },
+            envelopes: HashMap::new(),
+        });
+        let applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            known: HashMap::new(),
+            local_hashes: std::collections::HashSet::new(),
+        }));
+        let coord = Arc::new(ReplicationCoordinator::new(
+            transport,
+            "ghost-peer",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        ));
+
+        control
+            .add_initiator(Arc::clone(&coord))
+            .await
+            .expect("send AddInitiator");
+
+        // Wait for at least one event for ghost-peer to confirm the
+        // task spawned + the cadence tick fired.
+        let mut saw_add = false;
+        for _ in 0..50 {
+            if let Ok(Some((peer, _))) =
+                tokio::time::timeout(Duration::from_millis(60), event_rx.recv()).await
+            {
+                if peer == "ghost-peer" {
+                    saw_add = true;
+                    break;
+                }
+            }
+        }
+        assert!(saw_add, "AddInitiator did not produce any round events");
+
+        // Idempotent re-add: send the same coord again, no panic.
+        control
+            .add_initiator(Arc::clone(&coord))
+            .await
+            .expect("idempotent re-add");
+
+        // Remove and assert events for ghost-peer eventually stop.
+        control
+            .remove_initiator("ghost-peer", EnvelopeKind::Key)
+            .await
+            .expect("send RemoveInitiator");
+
+        // Drain a quiet window; an event landed before the remove
+        // took effect is fine, but the stream must go silent for at
+        // least one full cadence after remove.
+        let drain_start = tokio::time::Instant::now();
+        let mut last_event = drain_start;
+        while drain_start.elapsed() < Duration::from_millis(400) {
+            match tokio::time::timeout(Duration::from_millis(50), event_rx.recv()).await {
+                Ok(Some((peer, _))) if peer == "ghost-peer" => {
+                    last_event = tokio::time::Instant::now();
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            last_event.elapsed() >= Duration::from_millis(100),
+            "ghost-peer events did not cease after RemoveInitiator"
+        );
+
+        cancel_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), sched_handle)
+            .await
+            .expect("shutdown")
             .expect("join");
     }
 }


### PR DESCRIPTION
## Summary

Unblocks ciris-server's CEG-driven reconciler: peers can be added/removed at runtime to converge the live \`ReplicationRuntime\` against the corpus's \`consent:replication\` objects **without** restarting the process.

Three new methods on \`ReplicationRuntime\`, all mirrored in the \`PyReplicationHandle\` PyO3 surface:

- \`register_initiator_peer(peer_key_id, kind)\` — builds an Initiator coord, registers it, AND tells the scheduler to spawn its periodic-round task (the issue's point 2: \`register_peer\` builds a Responder and never reaches the scheduler — preserved for back-compat).
- \`remove_peer(peer_key_id, kind)\` — stops the matching coord's scheduled rounds AND deregisters from the inbound registry (the issue's point 3: only whole-runtime \`shutdown\` existed).
- \`set_peers(desired)\` — diff-and-converge against the current Initiator set; adds first then removes (minimizes swap window). The intended driver for CEG-reconcilers.

The issue's point 1 (\`OnceLock\` pin on \`Edge::install_replication_routing\`) resolves automatically — the same registry is mutated in place; no Edge change needed since the runtime never has to be rebuilt.

## Architecture

- \`SchedulerCommand { AddInitiator | RemoveInitiator }\` enum + \`SchedulerHandle\` (cloneable sender).
- \`ReplicationScheduler::install_control_channel(&mut self) -> SchedulerHandle\` — opt-in; without it the scheduler keeps pre-v5.1 fixed-set semantics.
- \`run_with_events\` refactored: an orchestrator \`tokio::select!\` loop holds per-coord \`watch::Sender<bool>\` cancels keyed by \`(peer_key_id, kind)\` and reacts to commands as they arrive. Global cancel still flips all per-coord watches at once.
- AddInitiator is idempotent vs. an already-active pair; RemoveInitiator is a no-op for a pair never added.

## Tests

- **runtime**: \`register_initiator_peer_hot_adds_initiator_role\`, \`remove_peer_drops_initiator_and_deregisters\`, \`set_peers_diff_converges\` (3 new + 4 pre-existing).
- **scheduler**: \`control_channel_add_remove_drives_initiator_task\` — proof-of-life via \`RoundEvent::Error\` against an unreachable peer confirms the spawned task actively initiates rounds; then \`RemoveInitiator\` silences the stream (1 new + 5 pre-existing).

## Verification

Under \`RUSTFLAGS=-D warnings\` + CI feature combo \`transport-http transport-reticulum pyo3 holonomic-consent-decay\`:

- \`cargo fmt --all\`: clean
- \`cargo check\` (default features): clean
- \`cargo clippy --lib --tests\`: clean
- \`cargo test --lib replication::scheduler\`: 6/6 green
- \`cargo test --lib replication::runtime\`: 7/7 green

## Family floor

Unchanged from v5.0.1: ciris-persist v9.0.3 + ciris-verify-family v6.2.0.

## Test plan

- [ ] CI matrix green (clippy/fmt/build/wheel/publish-pypi tag-gated)
- [ ] ciris-server can drop its boot-only-Initiator workaround and use \`set_peers(desired)\` from the reconciler

Closes #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln