### PR TITLE
release(v5.2.0): FountainSwarmRuntime — federation swarm orchestration runtime (closes #143)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "5.1.0"
+version = "5.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "5.0.1"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -908,6 +908,25 @@ pub struct Edge {
     /// no replication routing, every frame goes to `dispatch_inbound`.
     replication_registry:
         Arc<std::sync::OnceLock<Arc<crate::replication::registry::ReplicationRegistry>>>,
+    /// v5.2.0 (CIRISEdge#143) — opt-in fountain swarm orchestration
+    /// runtime. Set-once via `OnceLock`; the [`Edge::install_swarm_runtime`]
+    /// post-build setter holds the runtime for the lifetime of
+    /// `Edge`. When set, the operator's dispatch path may call
+    /// [`crate::swarm::FountainSwarmRuntime::register_observed_claim`]
+    /// on verified inbound holding-claim bodies. When `None`, no
+    /// swarm orchestration runs — the substrate primitives stay
+    /// reachable for tests but no live publisher / converger fires.
+    ///
+    /// `OnceLock<Arc<_>>` because the lifecycle is `install once
+    /// before run`; cheap atomic load from the inbound side.
+    swarm_runtime: Arc<std::sync::OnceLock<Arc<crate::swarm::FountainSwarmRuntime>>>,
+    /// v5.2.0 (CIRISEdge#143) — opt-in consent-decay scheduler
+    /// shutdown handle. Same lifecycle as [`Self::swarm_runtime`];
+    /// when set, [`Edge::shutdown_swarm_runtime`] also signals the
+    /// decay scheduler to stop. `None` keeps the v5.1.0 behavior
+    /// exactly (the operator drives the scheduler manually).
+    #[cfg(feature = "holonomic-consent-decay")]
+    consent_decay_shutdown: Arc<std::sync::OnceLock<tokio::sync::watch::Sender<()>>>,
     /// Optional pipeline run on outbound inline-text envelopes
     /// (SPEAK responses, LLM prompts, WBD bodies, DSAR text). When
     /// `Some`, `send_inline` / `send_durable_inline` invoke this
@@ -1567,6 +1586,55 @@ impl Edge {
         // we ignore it: the OnceLock semantics + the lifecycle
         // (install-before-run) make this a no-op race-free guarantee.
         let _ = self.replication_registry.set(runtime.registry());
+    }
+
+    /// v5.2.0 (CIRISEdge#143) — register a
+    /// [`crate::swarm::FountainSwarmRuntime`] with `Edge`. Set-once;
+    /// the runtime is held for the lifetime of `Edge`. After
+    /// installation:
+    ///
+    /// - [`Self::swarm_runtime_handle`] returns the registered
+    ///   runtime (None until install).
+    /// - The operator's inbound dispatch path may call
+    ///   [`crate::swarm::FountainSwarmRuntime::register_observed_claim`]
+    ///   on verified holding-claim bodies. (v5.2.0 does not yet
+    ///   add a wire-tier `MessageType::FountainHoldingClaim`
+    ///   discriminator — the integration point is exposed at the
+    ///   API surface so a follow-up cut can wire the dispatch
+    ///   routing without re-touching `Edge::run`.)
+    ///
+    /// Idempotent: a second call is silently ignored (first wins).
+    pub fn install_swarm_runtime(&self, runtime: Arc<crate::swarm::FountainSwarmRuntime>) {
+        let _ = self.swarm_runtime.set(runtime);
+    }
+
+    /// v5.2.0 — return the installed
+    /// [`crate::swarm::FountainSwarmRuntime`], if any. `None` when
+    /// [`Self::install_swarm_runtime`] has not been called yet.
+    pub fn swarm_runtime_handle(&self) -> Option<Arc<crate::swarm::FountainSwarmRuntime>> {
+        self.swarm_runtime.get().cloned()
+    }
+
+    /// v5.2.0 (CIRISEdge#143) — register a consent-decay scheduler
+    /// shutdown handle. The operator spawns
+    /// [`crate::holonomic::consent_decay::ConsentDecayScheduler::run`]
+    /// against a `tokio::sync::watch::channel(())` receiver and hands
+    /// the sender to this method; [`Self::shutdown_consent_decay`]
+    /// then flips the channel on `Edge` teardown.
+    ///
+    /// Gated on the `holonomic-consent-decay` feature.
+    #[cfg(feature = "holonomic-consent-decay")]
+    pub fn install_consent_decay_shutdown(&self, shutdown_tx: tokio::sync::watch::Sender<()>) {
+        let _ = self.consent_decay_shutdown.set(shutdown_tx);
+    }
+
+    /// v5.2.0 — flip the registered consent-decay shutdown channel.
+    /// Idempotent; no-op when nothing was registered.
+    #[cfg(feature = "holonomic-consent-decay")]
+    pub fn shutdown_consent_decay(&self) {
+        if let Some(tx) = self.consent_decay_shutdown.get() {
+            let _ = tx.send(());
+        }
     }
 
     /// Register a typed handler for message type `M`. Compile-time
@@ -4886,6 +4954,9 @@ impl EdgeBuilder {
             steward_directory: self.steward_directory,
             blob_chunk_source: self.blob_chunk_source,
             replication_registry: Arc::new(std::sync::OnceLock::new()),
+            swarm_runtime: Arc::new(std::sync::OnceLock::new()),
+            #[cfg(feature = "holonomic-consent-decay")]
+            consent_decay_shutdown: Arc::new(std::sync::OnceLock::new()),
             subscription_filter: self.subscription_filter,
             events,
             display_name: Arc::new(std::sync::RwLock::new(display_name)),

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1618,10 +1618,10 @@ impl PyReplicationHandle {
         })
     }
 
-    /// Hot-add a `(peer_key_id, kind)` after start. See
-    /// `ReplicationRuntime::register_peer` for the v1 limitation
-    /// (hot-adds default to Responder role; the scheduler's
-    /// Initiator set is fixed at start in v1).
+    /// Hot-add a `(peer_key_id, kind)` after start. Defaults to
+    /// Responder role — for the CEG-driven reconciler path that
+    /// needs the new peer to actively initiate rounds, use
+    /// [`Self::register_initiator_peer`] (CIRISEdge#173 / v5.1.0).
     fn register_peer(&self, py: Python<'_>, peer_key_id: &str, kind: &str) -> PyResult<()> {
         let kind = parse_envelope_kind(kind)?;
         let peer = peer_key_id.to_string();
@@ -1636,6 +1636,94 @@ impl PyReplicationHandle {
             });
         });
         Ok(())
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — hot-add an Initiator peer at runtime.
+    /// The scheduler spawns a task that fires anti-entropy rounds at
+    /// the configured cadence immediately. Idempotent.
+    ///
+    /// Raises `RuntimeError` if the runtime has been stopped.
+    fn register_initiator_peer(
+        &self,
+        py: Python<'_>,
+        peer_key_id: &str,
+        kind: &str,
+    ) -> PyResult<()> {
+        let kind = parse_envelope_kind(kind)?;
+        let peer = peer_key_id.to_string();
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .register_initiator_peer(peer, kind)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — hot-remove a `(peer_key_id, kind)`.
+    /// Stops the matching coordinator's scheduled rounds (if active)
+    /// AND deregisters from the inbound registry. Idempotent.
+    fn remove_peer(&self, py: Python<'_>, peer_key_id: &str, kind: &str) -> PyResult<()> {
+        let kind = parse_envelope_kind(kind)?;
+        let peer = peer_key_id.to_string();
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .remove_peer(peer, kind)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — diff-and-converge the live Initiator
+    /// set against `desired`. Adds and removes peers so that, after
+    /// the call returns, the runtime's Initiator coordinators exactly
+    /// match `desired`. The intended driver for CEG-reconcilers:
+    /// call on every consent-object delta.
+    ///
+    /// `desired` is a list of `(peer_key_id, kind)` tuples; kind is
+    /// one of the accepted [`crate::replication::protocol::EnvelopeKind`]
+    /// strings.
+    fn set_peers(&self, py: Python<'_>, desired: Vec<(String, String)>) -> PyResult<()> {
+        let mut peers = Vec::with_capacity(desired.len());
+        for (peer_key_id, kind_str) in desired {
+            let kind = parse_envelope_kind(&kind_str)?;
+            peers.push(crate::replication::runtime::ReplicationPeer { peer_key_id, kind });
+        }
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .set_peers(peers)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
     }
 
     /// Stop the replication runtime — signals the scheduler to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod outbound;
 pub mod reachability;
 pub mod replication;
 pub mod sas;
+pub mod swarm;
 pub mod transport;
 pub mod verify;
 pub mod version;

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -45,10 +45,11 @@
 //! wires it. A v1.7 follow-up may add an opt-in
 //! `Edge::install_replication_routing(runtime)` helper.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use ciris_persist::federation::FederationDirectory;
-use tokio::sync::watch;
+use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 
 use super::bridge::{BridgeConfig, CohortProvider, FederationDirectoryReplicationBridge};
@@ -56,7 +57,9 @@ use super::coordinator::ReplicationCoordinator;
 use super::directory::{DirectoryStateAdapter, MutableDirectoryStateAdapter, ReplicationDirectory};
 use super::protocol::EnvelopeKind;
 use super::registry::ReplicationRegistry;
-use super::scheduler::{ReplicationScheduler, SchedulerConfig};
+use super::scheduler::{
+    ReplicationScheduler, SchedulerCommandError, SchedulerConfig, SchedulerHandle,
+};
 use super::session::SessionRole;
 use super::summary::{StateApplier, StateProvider};
 use crate::transport::Transport;
@@ -92,6 +95,32 @@ pub struct ReplicationRuntime {
     cancel_tx: watch::Sender<bool>,
     scheduler_task: Option<JoinHandle<()>>,
     config: ReplicationRuntimeConfig,
+    /// Runtime control channel for the scheduler (CIRISEdge#173,
+    /// v5.1.0). Used by [`Self::register_initiator_peer`] /
+    /// [`Self::remove_peer`] / [`Self::set_peers`] to mutate the
+    /// scheduler's Initiator set without restart.
+    scheduler_handle: SchedulerHandle,
+    /// Current Initiator set, kept in sync with the scheduler's
+    /// live coordinator tasks. Drives [`Self::set_peers`]'s diff.
+    /// Pre-v5.1 entries (passed to `start`) populate this on init.
+    current_initiators: Arc<Mutex<HashSet<(String, EnvelopeKind)>>>,
+}
+
+/// Failure modes for the v5.1.0 runtime peer-mutation API
+/// (CIRISEdge#173).
+#[derive(Debug, thiserror::Error)]
+pub enum ReplicationRuntimeError {
+    /// The scheduler has stopped (e.g. [`ReplicationRuntime::shutdown`]
+    /// was called) — runtime control is no longer possible. Subsequent
+    /// calls will keep failing.
+    #[error("replication runtime has shut down; peer mutation is no longer accepted")]
+    SchedulerStopped,
+}
+
+impl From<SchedulerCommandError> for ReplicationRuntimeError {
+    fn from(_: SchedulerCommandError) -> Self {
+        Self::SchedulerStopped
+    }
 }
 
 impl ReplicationRuntime {
@@ -141,6 +170,7 @@ impl ReplicationRuntime {
         // session.rs's borrow story (the bridge is the same object
         // backing both).
         let mut scheduler = ReplicationScheduler::new(config.scheduler);
+        let scheduler_handle = scheduler.install_control_channel();
         let coords: Vec<Arc<ReplicationCoordinator>> = peers
             .iter()
             .map(|peer| {
@@ -161,8 +191,10 @@ impl ReplicationRuntime {
             })
             .collect();
 
+        let mut initial_initiator_set: HashSet<(String, EnvelopeKind)> = HashSet::new();
         for (peer, coord) in peers.iter().zip(coords.iter()) {
             scheduler.add_initiator(Arc::clone(coord));
+            initial_initiator_set.insert((peer.peer_key_id.clone(), peer.kind));
             // Register so the operator's listen loop can route
             // inbound replies (the Initiator side receives Summary
             // / Diff / Deliver back from the peer). Inline await
@@ -189,6 +221,8 @@ impl ReplicationRuntime {
             cancel_tx,
             scheduler_task: Some(scheduler_task),
             config,
+            scheduler_handle,
+            current_initiators: Arc::new(Mutex::new(initial_initiator_set)),
         }
     }
 
@@ -204,21 +238,139 @@ impl ReplicationRuntime {
     /// the scheduler with a dynamic-add API.
     pub async fn register_peer(&self, peer_key_id: impl Into<String>, kind: EnvelopeKind) {
         let peer_key_id = peer_key_id.into();
+        let coord = self.build_coordinator(&peer_key_id, kind, SessionRole::Responder);
+        self.registry.register(peer_key_id, kind, coord).await;
+    }
+
+    /// Hot-add a `(peer_key_id, kind)` **Initiator** coordinator —
+    /// CIRISEdge#173, v5.1.0.
+    ///
+    /// Builds a coordinator in [`SessionRole::Initiator`], registers
+    /// it with the registry (so inbound replies route correctly),
+    /// AND tells the scheduler's runtime control plane to spawn a
+    /// task that fires periodic anti-entropy rounds at the configured
+    /// cadence. Idempotent — re-adding an active `(peer, kind)` is a
+    /// no-op.
+    ///
+    /// Use this from CEG-driven reconcilers when `consent:replication`
+    /// objects materialize at runtime: the new peer begins active
+    /// pull immediately, no restart.
+    pub async fn register_initiator_peer(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let peer_key_id = peer_key_id.into();
+        let key = (peer_key_id.clone(), kind);
+
+        {
+            let mut active = self.current_initiators.lock().await;
+            if active.contains(&key) {
+                return Ok(());
+            }
+            active.insert(key);
+        }
+
+        let coord = self.build_coordinator(&peer_key_id, kind, SessionRole::Initiator);
+        // Register first so the inbound listen loop can route replies
+        // by the time the scheduler picks up the command.
+        self.registry
+            .register(peer_key_id, kind, Arc::clone(&coord))
+            .await;
+        self.scheduler_handle.add_initiator(coord).await?;
+        Ok(())
+    }
+
+    /// Hot-remove a `(peer_key_id, kind)` peer — CIRISEdge#173,
+    /// v5.1.0.
+    ///
+    /// Stops the matching Initiator coordinator's scheduled rounds
+    /// (if active) AND deregisters from the registry so inbound
+    /// routing for the peer ceases. Idempotent: removing a peer that
+    /// was never added is a no-op.
+    pub async fn remove_peer(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let peer_key_id = peer_key_id.into();
+        let key = (peer_key_id.clone(), kind);
+
+        let was_initiator = {
+            let mut active = self.current_initiators.lock().await;
+            active.remove(&key)
+        };
+        if was_initiator {
+            self.scheduler_handle
+                .remove_initiator(peer_key_id.clone(), kind)
+                .await?;
+        }
+        self.registry.deregister(&peer_key_id, kind).await;
+        Ok(())
+    }
+
+    /// Diff-and-converge the live Initiator set against `desired` —
+    /// CIRISEdge#173, v5.1.0.
+    ///
+    /// For each `(peer_key_id, kind)` in `desired` not currently
+    /// active, calls [`Self::register_initiator_peer`]. For each
+    /// currently-active pair NOT in `desired`, calls
+    /// [`Self::remove_peer`]. Net effect: after this call returns,
+    /// the runtime's Initiator coordinators exactly match `desired`.
+    ///
+    /// Atomic per individual add/remove only — partial progress is
+    /// possible if a mid-call command fails (the failed pair is
+    /// reflected by the returned error; pairs processed before the
+    /// failure stay applied). Intended driver for CEG-reconcilers:
+    /// call on every consent-object delta.
+    pub async fn set_peers(
+        &self,
+        desired: Vec<ReplicationPeer>,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let desired_set: HashSet<(String, EnvelopeKind)> = desired
+            .iter()
+            .map(|p| (p.peer_key_id.clone(), p.kind))
+            .collect();
+        let current_set: HashSet<(String, EnvelopeKind)> = {
+            let active = self.current_initiators.lock().await;
+            active.iter().cloned().collect()
+        };
+
+        // Adds first; the new peers begin active pull before the
+        // departing peers' rounds stop — minimizes the convergence
+        // window during a swap.
+        for (peer_key_id, kind) in desired_set.difference(&current_set) {
+            self.register_initiator_peer(peer_key_id.clone(), *kind)
+                .await?;
+        }
+        for (peer_key_id, kind) in current_set.difference(&desired_set) {
+            self.remove_peer(peer_key_id.clone(), *kind).await?;
+        }
+        Ok(())
+    }
+
+    /// Build a [`ReplicationCoordinator`] in the requested role with
+    /// the runtime's shared transport + bridge-backed provider/applier.
+    /// Internal helper for register_peer / register_initiator_peer.
+    fn build_coordinator(
+        &self,
+        peer_key_id: &str,
+        kind: EnvelopeKind,
+        role: SessionRole,
+    ) -> Arc<ReplicationCoordinator> {
         let bridge_dir: Arc<dyn ReplicationDirectory> = Arc::clone(&self.bridge) as _;
         let provider: Arc<dyn StateProvider> =
             Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
-        let applier: Arc<tokio::sync::Mutex<dyn StateApplier>> = Arc::new(tokio::sync::Mutex::new(
-            MutableDirectoryStateAdapter::new(bridge_dir),
-        ));
-        let coord = Arc::new(ReplicationCoordinator::new(
+        let applier: Arc<Mutex<dyn StateApplier>> =
+            Arc::new(Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)));
+        Arc::new(ReplicationCoordinator::new(
             Arc::clone(&self.transport),
-            peer_key_id.clone(),
+            peer_key_id.to_string(),
             kind,
-            SessionRole::Responder, // hot-add defaults to Responder; cf. doc above
+            role,
             provider,
             applier,
-        ));
-        self.registry.register(peer_key_id, kind, coord).await;
+        ))
     }
 
     /// Shared registry handle. The operator's `Transport::listen`
@@ -340,6 +492,125 @@ mod tests {
         rt.register_peer("agent-bob", EnvelopeKind::Attestation)
             .await;
         assert_eq!(rt.registry().len().await, 1);
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `register_initiator_peer` hot-adds an
+    /// Initiator coordinator (not just Responder) and bumps the
+    /// registry. Distinct from `register_peer` (Responder-only).
+    #[tokio::test]
+    async fn register_initiator_peer_hot_adds_initiator_role() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        rt.register_initiator_peer("agent-carol", EnvelopeKind::Key)
+            .await
+            .expect("hot-add succeeds while runtime is live");
+        assert_eq!(rt.registry().len().await, 1);
+        let coord = rt.registry().get("agent-carol", EnvelopeKind::Key).await;
+        assert!(coord.is_some());
+        assert_eq!(coord.unwrap().role(), SessionRole::Initiator);
+        // Idempotent: re-add is a no-op.
+        rt.register_initiator_peer("agent-carol", EnvelopeKind::Key)
+            .await
+            .expect("idempotent re-add");
+        assert_eq!(rt.registry().len().await, 1);
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `remove_peer` stops the matching
+    /// coordinator's scheduled rounds AND deregisters from the
+    /// registry. Idempotent.
+    #[tokio::test]
+    async fn remove_peer_drops_initiator_and_deregisters() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        rt.register_initiator_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .unwrap();
+        assert_eq!(rt.registry().len().await, 1);
+        rt.remove_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .expect("hot-remove succeeds while runtime is live");
+        assert!(rt.registry().is_empty().await);
+        // Idempotent: removing again is a no-op.
+        rt.remove_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .expect("idempotent re-remove");
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `set_peers` converges the live
+    /// Initiator set against the desired set. Verifies that adds
+    /// and removes both apply in one call, including starting from
+    /// a non-empty pre-existing set.
+    #[tokio::test]
+    async fn set_peers_diff_converges() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let initial = vec![
+            ReplicationPeer {
+                peer_key_id: "peer-keep".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+            ReplicationPeer {
+                peer_key_id: "peer-drop".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+        ];
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            initial,
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        assert_eq!(rt.registry().len().await, 2);
+
+        let desired = vec![
+            ReplicationPeer {
+                peer_key_id: "peer-keep".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+            ReplicationPeer {
+                peer_key_id: "peer-new".to_string(),
+                kind: EnvelopeKind::Attestation,
+            },
+        ];
+        rt.set_peers(desired).await.expect("converge succeeds");
+
+        assert_eq!(rt.registry().len().await, 2);
+        assert!(rt
+            .registry()
+            .get("peer-keep", EnvelopeKind::Key)
+            .await
+            .is_some());
+        assert!(rt
+            .registry()
+            .get("peer-new", EnvelopeKind::Attestation)
+            .await
+            .is_some());
+        assert!(rt
+            .registry()
+            .get("peer-drop", EnvelopeKind::Key)
+            .await
+            .is_none());
         rt.shutdown().await;
     }
 

--- a/src/replication/scheduler.rs
+++ b/src/replication/scheduler.rs
@@ -49,12 +49,14 @@
 //! round is a missed cadence, not a fault. The next round will pick
 //! up whatever state changed in the meantime.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 
 use super::coordinator::{CoordinatorError, DriveStep, ReplicationCoordinator, RoundReport};
+use super::protocol::EnvelopeKind;
 use super::session::SessionRole;
 
 /// Scheduler configuration shared across all coordinators it drives.
@@ -121,9 +123,102 @@ pub enum RoundEvent {
 /// Constructing the scheduler does NOT spawn any tasks; the caller
 /// chooses when to start the run loop via
 /// [`Self::run_until_cancelled`].
+///
+/// ## Runtime control plane (CIRISEdge#173, v5.1.0)
+///
+/// Call [`Self::install_control_channel`] before starting the run
+/// loop to obtain a [`SchedulerHandle`] that lets external code add
+/// or remove Initiator coordinators *while the loop is running* —
+/// no restart required. Without that call the scheduler keeps its
+/// pre-v5.1 fixed-set semantics.
 pub struct ReplicationScheduler {
     config: SchedulerConfig,
     coordinators: Vec<Arc<ReplicationCoordinator>>,
+    command_rx: Option<mpsc::Receiver<SchedulerCommand>>,
+}
+
+/// Runtime control command for an actively-running scheduler.
+///
+/// Emitted by [`SchedulerHandle`] and consumed inside
+/// [`ReplicationScheduler::run_with_events`].
+pub enum SchedulerCommand {
+    /// Spawn a new Initiator coordinator task. The coordinator's
+    /// role must be [`SessionRole::Initiator`] (debug-asserted).
+    AddInitiator(Arc<ReplicationCoordinator>),
+    /// Stop the running task for the matching `(peer_key_id, kind)`
+    /// coordinator, if present. No-op if the pair was never added.
+    RemoveInitiator {
+        peer_key_id: String,
+        kind: EnvelopeKind,
+    },
+}
+
+impl std::fmt::Debug for SchedulerCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AddInitiator(coord) => f
+                .debug_struct("AddInitiator")
+                .field("peer_key_id", &coord.peer_key_id())
+                .field("kind", &coord.kind())
+                .finish(),
+            Self::RemoveInitiator { peer_key_id, kind } => f
+                .debug_struct("RemoveInitiator")
+                .field("peer_key_id", peer_key_id)
+                .field("kind", kind)
+                .finish(),
+        }
+    }
+}
+
+/// External handle for mutating a running scheduler's Initiator set.
+///
+/// Acquired via [`ReplicationScheduler::install_control_channel`]
+/// BEFORE the run loop starts. Cheaply clonable. Sending on a closed
+/// channel (the scheduler has shut down) returns an error.
+#[derive(Clone, Debug)]
+pub struct SchedulerHandle {
+    command_tx: mpsc::Sender<SchedulerCommand>,
+}
+
+impl SchedulerHandle {
+    /// Add an Initiator coordinator to the running scheduler. The
+    /// scheduler spawns a new task on its next select iteration.
+    /// Idempotent vs. an already-active `(peer_key_id, kind)`:
+    /// duplicates are silently dropped inside the run loop.
+    pub async fn add_initiator(
+        &self,
+        coord: Arc<ReplicationCoordinator>,
+    ) -> Result<(), SchedulerCommandError> {
+        self.command_tx
+            .send(SchedulerCommand::AddInitiator(coord))
+            .await
+            .map_err(|_| SchedulerCommandError::SchedulerStopped)
+    }
+
+    /// Stop the running task for `(peer_key_id, kind)`. No-op if
+    /// that pair isn't currently active.
+    pub async fn remove_initiator(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), SchedulerCommandError> {
+        self.command_tx
+            .send(SchedulerCommand::RemoveInitiator {
+                peer_key_id: peer_key_id.into(),
+                kind,
+            })
+            .await
+            .map_err(|_| SchedulerCommandError::SchedulerStopped)
+    }
+}
+
+/// Failure reason for [`SchedulerHandle`] command sends.
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerCommandError {
+    /// The scheduler's run loop has exited, so its command receiver
+    /// dropped. Subsequent sends will keep failing.
+    #[error("scheduler has stopped; runtime control channel is closed")]
+    SchedulerStopped,
 }
 
 impl ReplicationScheduler {
@@ -131,7 +226,23 @@ impl ReplicationScheduler {
         Self {
             config,
             coordinators: Vec::new(),
+            command_rx: None,
         }
+    }
+
+    /// Install the runtime control channel (CIRISEdge#173). Returns
+    /// the sender side as a [`SchedulerHandle`]; the scheduler keeps
+    /// the receiver. Must be called before the run loop starts to
+    /// take effect; calling twice replaces the prior receiver, which
+    /// silently invalidates any earlier handle.
+    ///
+    /// Without this call the scheduler retains its pre-v5.1 fixed-set
+    /// semantics — only coordinators added before `run_until_cancelled`
+    /// via [`Self::add_initiator`] are driven.
+    pub fn install_control_channel(&mut self) -> SchedulerHandle {
+        let (command_tx, command_rx) = mpsc::channel(32);
+        self.command_rx = Some(command_rx);
+        SchedulerHandle { command_tx }
     }
 
     /// Register an Initiator-side coordinator with the scheduler.
@@ -185,37 +296,117 @@ impl ReplicationScheduler {
     /// events; the scheduler tolerates a closed sink (the round
     /// loops continue).
     pub async fn run_with_events(
-        self,
-        cancel: watch::Receiver<bool>,
-        event_sink: Option<tokio::sync::mpsc::Sender<(String, RoundEvent)>>,
+        mut self,
+        mut cancel: watch::Receiver<bool>,
+        event_sink: Option<mpsc::Sender<(String, RoundEvent)>>,
     ) {
+        // Per-coord cancel senders, keyed by (peer_key_id, kind).
+        // RemoveInitiator flips one entry; global cancel flips all.
+        let mut per_coord: HashMap<(String, EnvelopeKind), watch::Sender<bool>> = HashMap::new();
         let mut handles = Vec::with_capacity(self.coordinators.len());
-        for coord in self.coordinators {
-            let mut cancel_rx = cancel.clone();
-            let event_sink = event_sink.clone();
-            let cadence = self.config.cadence;
-            let round_timeout = self.config.round_timeout;
-            let h = tokio::spawn(async move {
-                run_one_coordinator_forever(
-                    coord,
-                    cadence,
-                    round_timeout,
-                    &mut cancel_rx,
-                    event_sink,
-                )
-                .await;
-            });
-            handles.push(h);
+
+        for coord in self.coordinators.drain(..) {
+            spawn_coord(
+                &mut per_coord,
+                &mut handles,
+                coord,
+                self.config.cadence,
+                self.config.round_timeout,
+                event_sink.clone(),
+            );
         }
+
+        let mut command_rx = self.command_rx.take();
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.changed() => {
+                    if *cancel.borrow() {
+                        for (_, tx) in per_coord.drain() {
+                            let _ = tx.send(true);
+                        }
+                        break;
+                    }
+                }
+                Some(cmd) = async {
+                    // SAFETY of unwrap: the `if` guard below is
+                    // evaluated before this branch is polled, so
+                    // command_rx is Some when we enter.
+                    command_rx.as_mut().unwrap().recv().await
+                }, if command_rx.is_some() => {
+                    match cmd {
+                        SchedulerCommand::AddInitiator(coord) => {
+                            let key = (coord.peer_key_id().to_string(), coord.kind());
+                            if per_coord.contains_key(&key) {
+                                tracing::debug!(
+                                    peer = %key.0,
+                                    kind = ?key.1,
+                                    "scheduler: AddInitiator ignored (already active)"
+                                );
+                                continue;
+                            }
+                            spawn_coord(
+                                &mut per_coord,
+                                &mut handles,
+                                coord,
+                                self.config.cadence,
+                                self.config.round_timeout,
+                                event_sink.clone(),
+                            );
+                        }
+                        SchedulerCommand::RemoveInitiator { peer_key_id, kind } => {
+                            if let Some(tx) = per_coord.remove(&(peer_key_id, kind)) {
+                                let _ = tx.send(true);
+                            }
+                        }
+                    }
+                }
+                else => {
+                    // command_rx is None AND cancel is not changing —
+                    // wait on cancel only.
+                    let _ = cancel.changed().await;
+                    if *cancel.borrow() {
+                        for (_, tx) in per_coord.drain() {
+                            let _ = tx.send(true);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         for h in handles {
             // join_all would be nicer but adds futures-util dep
-            // outside our current set. tokio::join! on a Vec needs
-            // boxing. Sequential .await is fine here — every task
-            // observes the same cancel signal so they all finish
-            // at about the same time anyway.
+            // outside our current set. Sequential .await is fine —
+            // tasks cancel concurrently in response to the same
+            // signal.
             let _ = h.await;
         }
     }
+}
+
+/// Spawn one coordinator task and record its per-coord cancel handle.
+fn spawn_coord(
+    per_coord: &mut HashMap<(String, EnvelopeKind), watch::Sender<bool>>,
+    handles: &mut Vec<tokio::task::JoinHandle<()>>,
+    coord: Arc<ReplicationCoordinator>,
+    cadence: Duration,
+    round_timeout: Duration,
+    event_sink: Option<mpsc::Sender<(String, RoundEvent)>>,
+) {
+    debug_assert_eq!(
+        coord.role(),
+        SessionRole::Initiator,
+        "scheduler spawns Initiator coordinators only"
+    );
+    let key = (coord.peer_key_id().to_string(), coord.kind());
+    let (cancel_tx, mut cancel_rx) = watch::channel(false);
+    per_coord.insert(key, cancel_tx);
+    let h = tokio::spawn(async move {
+        run_one_coordinator_forever(coord, cadence, round_timeout, &mut cancel_rx, event_sink)
+            .await;
+    });
+    handles.push(h);
 }
 
 async fn run_one_coordinator_forever(
@@ -657,6 +848,105 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), h)
             .await
             .expect("exit on cancel")
+            .expect("join");
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `SchedulerHandle::add_initiator` on
+    /// a running scheduler spawns a task that actively initiates
+    /// rounds. Proof-of-life via `RoundEvent` emission: a coord
+    /// targeting an unreachable peer produces `RoundEvent::Error`
+    /// rounds (transport Unreachable) which can only happen if the
+    /// task fired. Then `remove_initiator` stops the events.
+    #[tokio::test]
+    async fn control_channel_add_remove_drives_initiator_task() {
+        let mut sched = ReplicationScheduler::new(fast_config());
+        let control = sched.install_control_channel();
+        let (event_tx, mut event_rx) = mpsc::channel::<(String, RoundEvent)>(64);
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let sched_handle =
+            tokio::spawn(async move { sched.run_with_events(cancel_rx, Some(event_tx)).await });
+
+        // Build an Initiator coord pointing at a peer that doesn't
+        // exist in the in-memory inbox. Every send fails with
+        // TransportError::Unreachable → RoundEvent::Error per round.
+        let transport: Arc<dyn Transport> = Arc::new(InMemTransport {
+            peer_inbox: HashMap::new(),
+        });
+        let provider: Arc<dyn StateProvider> = Arc::new(StaticProvider {
+            state: {
+                let mut s = LocalState::new();
+                s.insert(EnvelopeKind::Key, h(7), 7);
+                s
+            },
+            envelopes: HashMap::new(),
+        });
+        let applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            known: HashMap::new(),
+            local_hashes: std::collections::HashSet::new(),
+        }));
+        let coord = Arc::new(ReplicationCoordinator::new(
+            transport,
+            "ghost-peer",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        ));
+
+        control
+            .add_initiator(Arc::clone(&coord))
+            .await
+            .expect("send AddInitiator");
+
+        // Wait for at least one event for ghost-peer to confirm the
+        // task spawned + the cadence tick fired.
+        let mut saw_add = false;
+        for _ in 0..50 {
+            if let Ok(Some((peer, _))) =
+                tokio::time::timeout(Duration::from_millis(60), event_rx.recv()).await
+            {
+                if peer == "ghost-peer" {
+                    saw_add = true;
+                    break;
+                }
+            }
+        }
+        assert!(saw_add, "AddInitiator did not produce any round events");
+
+        // Idempotent re-add: send the same coord again, no panic.
+        control
+            .add_initiator(Arc::clone(&coord))
+            .await
+            .expect("idempotent re-add");
+
+        // Remove and assert events for ghost-peer eventually stop.
+        control
+            .remove_initiator("ghost-peer", EnvelopeKind::Key)
+            .await
+            .expect("send RemoveInitiator");
+
+        // Drain a quiet window; an event landed before the remove
+        // took effect is fine, but the stream must go silent for at
+        // least one full cadence after remove.
+        let drain_start = tokio::time::Instant::now();
+        let mut last_event = drain_start;
+        while drain_start.elapsed() < Duration::from_millis(400) {
+            match tokio::time::timeout(Duration::from_millis(50), event_rx.recv()).await {
+                Ok(Some((peer, _))) if peer == "ghost-peer" => {
+                    last_event = tokio::time::Instant::now();
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            last_event.elapsed() >= Duration::from_millis(100),
+            "ghost-peer events did not cease after RemoveInitiator"
+        );
+
+        cancel_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), sched_handle)
+            .await
+            .expect("shutdown")
             .expect("join");
     }
 }

--- a/src/swarm/mod.rs
+++ b/src/swarm/mod.rs
@@ -1,0 +1,57 @@
+//! Federation-level fountain swarm orchestration runtime — v5.2.0.
+//!
+//! Closes the live-wiring gap identified in CIRISEdge#143. The
+//! holonomic substrate primitives ([`crate::holonomic::swarm_rarity`])
+//! are unit-tested in isolation; this module is what makes peers
+//! actually do the federation-coordinated work at runtime:
+//!
+//! - **Publisher**: periodically iterate the operator's held fountain
+//!   `content_id`s, build a
+//!   [`crate::holonomic::swarm_rarity::FountainHoldingClaim`] for
+//!   each, sign it via the local federation signer, and emit it to
+//!   the cohort over the canonical transport.
+//! - **Converger**: every `observe_cadence`, walk the in-memory
+//!   observed-claims map and:
+//!     * if observed_count exceeds `target_holders × (1 + grace_pct)`
+//!       and the local symbol is "common",
+//!       [`should_eject_above_target`] → call
+//!       [`FountainTierEvict::evict_fountain_content_to_tier`]
+//!       (the persist N5 path);
+//!     * if observed_count drops below `min_viable`, emit a repair
+//!       telemetry signal (a future cut wires the blob_swarm fetch
+//!       path off this);
+//!     * if consent is revoked, call
+//!       [`crate::holonomic::swarm_rarity::FountainEvictHardDelete::evict_fountain_content_hard_delete`].
+//!
+//! ## Persist surface gap (recorded for upstream)
+//!
+//! CIRISPersist v9.0.x does NOT expose:
+//!
+//! - `list_fountain_holdings()` — the operator's view of "which
+//!   `content_id`s am I currently holding?" against the federation
+//!   directory trait.
+//! - `evict_fountain_content_to_tier` / `evict_fountain_content_hard_delete`
+//!   on `Arc<dyn FederationDirectory>` (only on the concrete
+//!   `Engine`, gated behind backend cargo features).
+//!
+//! Until persist v9.x lands those surfaces on the public trait, the
+//! runtime is built against in-tree trait surfaces ([`FountainHoldingsSource`],
+//! [`FountainTierEvict`]) plus the existing
+//! [`crate::holonomic::swarm_rarity::FountainEvictHardDelete`]. The
+//! production deployment wires concrete impls of these traits over
+//! its persist `Engine` handle; the test surface implements them
+//! against in-memory state. **This is the documented scope-down per
+//! the v5.2.0 cut spec** (CIRISEdge#143).
+//!
+//! See [`runtime`] for the live runtime + scheduler.
+
+pub mod persist_fountain_evict;
+pub mod runtime;
+
+pub use persist_fountain_evict::{
+    FountainEvictError, FountainEvictHardDelete, FountainHoldingsSource, FountainTierEvict,
+    HeldFountainContent, NoopFountainHoldingsSource, PersistFountainEvictHardDelete,
+};
+pub use runtime::{
+    FountainSwarmRuntime, ObservedClaim, SwarmEvent, SwarmRuntimeConfig, SwarmRuntimeEventSink,
+};

--- a/src/swarm/persist_fountain_evict.rs
+++ b/src/swarm/persist_fountain_evict.rs
@@ -1,0 +1,249 @@
+//! Production-side trait surfaces + adapter for the v5.2.0 swarm
+//! orchestration runtime.
+//!
+//! Three trait surfaces participate here:
+//!
+//! - [`crate::holonomic::swarm_rarity::FountainEvictHardDelete`] —
+//!   the §8.1.11.3 N5 hard-delete primitive (already defined in the
+//!   substrate module; reused here unchanged).
+//! - [`FountainTierEvict`] — the tier-eviction sibling
+//!   ([`PersistEngine::evict_fountain_content_to_tier`] is the
+//!   persist-side concrete; until it appears on the public
+//!   `Arc<dyn FederationDirectory>` trait, the runtime threads an
+//!   `Arc<dyn FountainTierEvict>` for production wiring).
+//! - [`FountainHoldingsSource`] — the operator's "what content_ids
+//!   am I currently holding?" view. Persist v9.0.x does NOT yet
+//!   expose this on its public surface; the runtime threads an
+//!   `Arc<dyn FountainHoldingsSource>` so production can wire it
+//!   once persist lands the iteration API.
+//!
+//! ## Production adapter
+//!
+//! [`PersistFountainEvictHardDelete`] is a thin wrapper that holds
+//! an `Arc<dyn FountainEvictHardDelete>` (the production caller
+//! constructs this from its persist `Engine` handle). It exists so
+//! `Edge::run` / `init_edge_runtime` can pass *one* handle through
+//! the bootstrap and the runtime stays decoupled from the concrete
+//! engine type.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+pub use crate::holonomic::swarm_rarity::{FountainEvictError, FountainEvictHardDelete};
+
+/// A single fountain content unit the operator is currently holding.
+/// Returned by [`FountainHoldingsSource::list_held_fountain_content`]
+/// (the v5.2.0 publisher walks the returned vec to build claims).
+///
+/// Mirrors the shape persist's eventual `list_fountain_holdings` API
+/// is expected to return — content_id + corpus_kind + the symbol_ids
+/// the operator currently retains for that content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeldFountainContent {
+    /// The persist `fountain_contents.content_id`. Opaque substrate
+    /// identifier (typically the manifest sha256 hex).
+    pub content_id: String,
+    /// The persist `fountain_contents.corpus_kind` discriminator
+    /// (passed through opaquely to eviction calls).
+    pub corpus_kind: String,
+    /// The fountain `symbol_id`s the operator currently retains for
+    /// this content. The publisher signs a
+    /// [`crate::holonomic::swarm_rarity::FountainHoldingClaim`] over
+    /// this set.
+    pub symbol_ids: Vec<u32>,
+}
+
+/// Operator-side view of "what fountain content am I currently
+/// holding?". The v5.2.0 publisher consults this on every
+/// `publish_cadence` tick.
+///
+/// **Persist v9.0.x gap**: there is currently no public listing API
+/// on `Arc<dyn FederationDirectory>` that returns this view. Until
+/// persist v9.x lands one, production deployments implement this
+/// trait against their concrete persist `Engine` handle (or against
+/// whatever cohabitation surface their host exposes); the test
+/// surface ([`NoopFountainHoldingsSource`] + the in-tree
+/// `Vec`-backed test impls) drives the runtime in isolation.
+#[async_trait]
+pub trait FountainHoldingsSource: Send + Sync {
+    /// Enumerate the operator's currently-held fountain content units.
+    /// Order is implementation-defined; the runtime sorts internally
+    /// where determinism matters (the
+    /// [`crate::holonomic::swarm_rarity::FountainHoldingClaim`]
+    /// canonical bytes pre-sort `symbol_ids` ascending).
+    async fn list_held_fountain_content(
+        &self,
+    ) -> Result<Vec<HeldFountainContent>, FountainEvictError>;
+}
+
+/// A `FountainHoldingsSource` that returns an empty list. Used in
+/// `init_edge_runtime` when no concrete source has been wired —
+/// keeps the runtime spawnable on hosts that don't yet hold any
+/// fountain content (or whose persist handle doesn't yet expose the
+/// listing API). Tests and tier-1 deployments wire the real source.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopFountainHoldingsSource;
+
+#[async_trait]
+impl FountainHoldingsSource for NoopFountainHoldingsSource {
+    async fn list_held_fountain_content(
+        &self,
+    ) -> Result<Vec<HeldFountainContent>, FountainEvictError> {
+        Ok(Vec::new())
+    }
+}
+
+/// The tier-eviction sibling of
+/// [`FountainEvictHardDelete`]. Maps onto persist's
+/// `evict_fountain_content_to_tier(content_id, corpus_kind, tier)`
+/// concrete API. The `tier` parameter is the persist
+/// `FountainTier` discriminator as a stable string label
+/// (`"full" | "t2" | "t3" | "t4" | "t5"`) so the trait surface
+/// does NOT depend on which backend cfg-features are enabled.
+///
+/// **Persist v9.0.x gap**: like
+/// [`FountainEvictHardDelete`], not exposed on
+/// `Arc<dyn FederationDirectory>`. Production wires a concrete
+/// impl that calls into its `Engine` handle.
+#[async_trait]
+pub trait FountainTierEvict: Send + Sync {
+    /// Evict `content_id` (in the named corpus) down to the keep-
+    /// count for the named tier. The persist eviction surface
+    /// applies the change on its next maintenance pass — this call
+    /// does NOT block on the eviction itself. Returns `Ok(())` on
+    /// acceptance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FountainEvictError::HardDeleteFailed`] (the error
+    /// type is shared across the hard-delete + tier-evict surfaces
+    /// for v5.2.0 — a future cut may split it once persist's
+    /// public surface stabilizes).
+    async fn evict_fountain_content_to_tier(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+        tier: &str,
+    ) -> Result<(), FountainEvictError>;
+}
+
+/// Production-side adapter that satisfies [`FountainEvictHardDelete`]
+/// by delegating to an inner trait object. Constructor + the trait
+/// impl. Edge's bootstrap (`Edge::run` / `init_edge_runtime`)
+/// constructs one of these from the persist `Engine` handle the
+/// host exposes; the runtime holds the `Arc<dyn FountainEvictHardDelete>`
+/// and never sees the concrete engine type.
+///
+/// The `inner` trait object MUST be a concrete impl that calls into
+/// persist's `evict_fountain_content_hard_delete`; the v5.2.0 in-tree
+/// impl is a passthrough so production callers can substitute a real
+/// engine adapter without touching the runtime.
+pub struct PersistFountainEvictHardDelete {
+    inner: Arc<dyn FountainEvictHardDelete + Send + Sync>,
+}
+
+impl std::fmt::Debug for PersistFountainEvictHardDelete {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PersistFountainEvictHardDelete")
+            .finish_non_exhaustive()
+    }
+}
+
+impl PersistFountainEvictHardDelete {
+    /// Construct from any inner [`FountainEvictHardDelete`] impl.
+    /// The production caller passes its persist `Engine`-backed
+    /// adapter; the test surface passes the substrate module's
+    /// fake evictor.
+    #[must_use]
+    pub fn new(inner: Arc<dyn FountainEvictHardDelete + Send + Sync>) -> Self {
+        Self { inner }
+    }
+}
+
+impl FountainEvictHardDelete for PersistFountainEvictHardDelete {
+    fn evict_fountain_content_hard_delete(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+    ) -> Result<(), FountainEvictError> {
+        self.inner
+            .evict_fountain_content_hard_delete(content_id, corpus_kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// In-memory `FountainEvictHardDelete` that records the calls —
+    /// the substrate-tier `swarm_rarity` tests already exercise the
+    /// trait shape, this one is for the adapter passthrough check.
+    #[derive(Default)]
+    struct Recorder {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+    impl FountainEvictHardDelete for Recorder {
+        fn evict_fountain_content_hard_delete(
+            &self,
+            content_id: &str,
+            corpus_kind: &str,
+        ) -> Result<(), FountainEvictError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((content_id.to_string(), corpus_kind.to_string()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn adapter_delegates_to_inner() {
+        let rec: Arc<Recorder> = Arc::new(Recorder::default());
+        let adapter = PersistFountainEvictHardDelete::new(rec.clone());
+        adapter
+            .evict_fountain_content_hard_delete("c1", "fountain-corpus")
+            .expect("ok");
+        adapter
+            .evict_fountain_content_hard_delete("c2", "fountain-corpus")
+            .expect("ok");
+        let calls = rec.calls.lock().unwrap().clone();
+        assert_eq!(
+            calls,
+            vec![
+                ("c1".to_string(), "fountain-corpus".to_string()),
+                ("c2".to_string(), "fountain-corpus".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn adapter_surfaces_inner_failure() {
+        struct Failing;
+        impl FountainEvictHardDelete for Failing {
+            fn evict_fountain_content_hard_delete(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(), FountainEvictError> {
+                Err(FountainEvictError::HardDeleteFailed("inner-fail".into()))
+            }
+        }
+        let adapter = PersistFountainEvictHardDelete::new(Arc::new(Failing));
+        let err = adapter
+            .evict_fountain_content_hard_delete("c1", "f")
+            .expect_err("must surface");
+        assert!(matches!(err, FountainEvictError::HardDeleteFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn noop_holdings_source_returns_empty() {
+        let src = NoopFountainHoldingsSource;
+        assert!(src
+            .list_held_fountain_content()
+            .await
+            .expect("ok")
+            .is_empty());
+    }
+}

--- a/src/swarm/runtime.rs
+++ b/src/swarm/runtime.rs
@@ -1,0 +1,1019 @@
+//! `FountainSwarmRuntime` — the federation-level swarm orchestration
+//! runtime that closes the v5.1.0 → v5.2.0 wiring gap.
+//!
+//! Sibling to [`crate::replication::runtime::ReplicationRuntime`] in
+//! shape; the substrate piece it animates is the v3.10.0 swarm
+//! rarity / holding-claim primitive
+//! ([`crate::holonomic::swarm_rarity`]). The substrate types are pure,
+//! deterministic, byte-equal; this runtime is the live wiring that
+//! makes peers actually do:
+//!
+//! 1. **Publish**: every `publish_cadence`, walk the operator's held
+//!    fountain `content_id`s via
+//!    [`FountainHoldingsSource::list_held_fountain_content`], build
+//!    a [`FountainHoldingClaim`] per content, sign it via the
+//!    federation signer, ship it to the cohort over the transport.
+//! 2. **Observe**: peer claims arrive at
+//!    [`FountainSwarmRuntime::register_observed_claim`] (called from
+//!    edge's inbound dispatch path when a peer's holding-claim
+//!    envelope is verified) and accumulate in the in-memory
+//!    observed-holders map (TTL-pruned each tick).
+//! 3. **Converge**: every `observe_cadence`, for every content_id
+//!    with observed holders:
+//!    - `should_eject_above_target` for over-`H` content → call
+//!      [`FountainTierEvict::evict_fountain_content_to_tier`] with
+//!      the "t1" label;
+//!    - observed_count < `min_viable` → emit a
+//!      [`SwarmEvent::RepairNeeded`] telemetry record (downstream
+//!      cuts wire the blob_swarm fetch off this);
+//!    - `ConsentState::Revoked` → call
+//!      [`FountainEvictHardDelete::evict_fountain_content_hard_delete`].
+//!
+//! ## Why no per-peer mutation API
+//!
+//! [`ReplicationRuntime`] needed `register_initiator_peer` /
+//! `remove_peer` / `set_peers` because replication is per-peer:
+//! each peer in the cohort gets its own coordinator + scheduler
+//! task. Swarm orchestration is **federation-wide** — the publisher
+//! ships claims to the whole cohort and the converger reads the
+//! observed-claims map (not a per-peer queue), so there is no
+//! per-peer mutation surface to expose. Hot-changing the cohort
+//! membership is the replication runtime's job; the swarm runtime
+//! follows.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{watch, RwLock};
+use tokio::task::JoinHandle;
+
+use super::persist_fountain_evict::{
+    FountainEvictError, FountainEvictHardDelete, FountainHoldingsSource, FountainTierEvict,
+    HeldFountainContent,
+};
+use crate::holonomic::fountain_defaults::{recommended_policy, FountainPolicy};
+use crate::holonomic::swarm_rarity::{
+    compute_rarity_score, should_eject_above_target, ConsentState, EjectionVerdict,
+    FountainHoldingClaim, RarityScore,
+};
+use crate::transport::Transport;
+
+/// `target_holders` default — the recommended `H` from §R-policy
+/// (CEG 1.0 §R / [`crate::holonomic::fountain_defaults::DEFAULT_TARGET_HOLDERS`]).
+pub const DEFAULT_TARGET_HOLDERS: u32 = 30;
+
+/// `min_viable` default — the survival floor below which the
+/// converger emits `RepairNeeded`. Matches §R-policy's
+/// `min_viable_symbols` shape.
+pub const DEFAULT_MIN_VIABLE: u32 = 5;
+
+/// `eviction_grace_pct` default — the safety margin above
+/// `target_holders` before the converger calls eject. Matches the
+/// substrate's [`EJECT_ABOVE_TARGET_SAFETY_MARGIN_PCT`] (locked v1
+/// at 15%).
+///
+/// [`EJECT_ABOVE_TARGET_SAFETY_MARGIN_PCT`]: crate::holonomic::swarm_rarity::EJECT_ABOVE_TARGET_SAFETY_MARGIN_PCT
+pub const DEFAULT_EVICTION_GRACE_PCT: u8 = 15;
+
+/// Default observed-claim TTL — claims older than this are pruned
+/// on every converger tick. Bound by the substrate's expectation
+/// that claims are republished at `publish_cadence`; the TTL
+/// should comfortably exceed two publish intervals.
+pub const DEFAULT_OBSERVED_CLAIM_TTL: Duration = Duration::from_secs(600);
+
+/// A claim a peer published, as observed by this runtime. The runtime
+/// keeps one per `(content_id, peer_id)` — a later observation from
+/// the same peer for the same content replaces the prior entry.
+#[derive(Debug, Clone)]
+pub struct ObservedClaim {
+    /// The exact [`FountainHoldingClaim`] envelope-body, verified
+    /// upstream before reaching the runtime.
+    pub claim: FountainHoldingClaim,
+    /// Local wall-clock at which the claim was observed. Drives the
+    /// TTL prune on the converger tick.
+    pub observed_at: std::time::Instant,
+}
+
+/// Configuration for the swarm orchestration runtime. All fields are
+/// tunable per deployment; defaults match the v3.10.0 §R-policy.
+#[derive(Debug, Clone)]
+pub struct SwarmRuntimeConfig {
+    /// How often the publisher walks the operator's held content
+    /// and broadcasts a [`FountainHoldingClaim`] per content.
+    pub publish_cadence: Duration,
+    /// How often the converger walks the observed-claims map.
+    pub observe_cadence: Duration,
+    /// `H` — the §R-policy target holder count.
+    pub target_holders: u32,
+    /// Below this count the converger emits
+    /// [`SwarmEvent::RepairNeeded`].
+    pub min_viable: u32,
+    /// Safety margin above `target_holders` before the converger
+    /// calls eject. Defaults to 15% — wire-determinism-critical
+    /// (CEG 1.0 §R conformance vectors).
+    pub eviction_grace_pct: u8,
+    /// Claims older than this are pruned on every converger tick.
+    pub observed_claim_ttl: Duration,
+    /// `FountainPolicy` the substrate's
+    /// [`should_eject_above_target`] consults. Defaults to
+    /// [`recommended_policy()`].
+    pub policy: FountainPolicy,
+}
+
+impl Default for SwarmRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            publish_cadence: Duration::from_secs(60),
+            observe_cadence: Duration::from_secs(30),
+            target_holders: DEFAULT_TARGET_HOLDERS,
+            min_viable: DEFAULT_MIN_VIABLE,
+            eviction_grace_pct: DEFAULT_EVICTION_GRACE_PCT,
+            observed_claim_ttl: DEFAULT_OBSERVED_CLAIM_TTL,
+            policy: recommended_policy(),
+        }
+    }
+}
+
+/// Telemetry record emitted by the converger. The optional event sink
+/// passed at [`FountainSwarmRuntime::start`] receives one of these per
+/// per-content_id action the converger takes; downstream consumers
+/// (CIRISLens, the test e2e) read off it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SwarmEvent {
+    /// A claim was published to the cohort.
+    Published {
+        content_id: String,
+        cohort_size: usize,
+    },
+    /// Observed holders for `content_id` dropped below `min_viable`.
+    /// Downstream wires repair-fetch from current holders off this
+    /// signal.
+    RepairNeeded {
+        content_id: String,
+        observed_holders: u32,
+        min_viable: u32,
+    },
+    /// `should_eject_above_target` fired; the runtime called
+    /// [`FountainTierEvict::evict_fountain_content_to_tier`].
+    EjectedToTier {
+        content_id: String,
+        observed_holders: u32,
+        tier_label: String,
+    },
+    /// Consent was revoked for `content_id`; the runtime called
+    /// [`FountainEvictHardDelete::evict_fountain_content_hard_delete`].
+    HardDeleted { content_id: String },
+    /// Converger tick observed but took no eviction action for this
+    /// content_id (Keep verdict). Surfaced so tests can assert the
+    /// converger ran; production deployments may filter these out.
+    Keep {
+        content_id: String,
+        observed_holders: u32,
+    },
+}
+
+/// A sink for [`SwarmEvent`]s. The runtime emits via this callback;
+/// production deployments wire a `tokio::sync::mpsc::Sender` or
+/// equivalent (the runtime never blocks on the sink — the callback
+/// is invoked synchronously inside the converger task, so it MUST
+/// return quickly).
+pub type SwarmRuntimeEventSink = Arc<dyn Fn(SwarmEvent) + Send + Sync>;
+
+/// Live swarm-orchestration runtime — publisher + converger tasks +
+/// shutdown handle. Construct via [`Self::start`]; hold for the
+/// lifetime of the application; call [`Self::shutdown`] to stop the
+/// background tasks.
+pub struct FountainSwarmRuntime {
+    config: SwarmRuntimeConfig,
+    observed: Arc<RwLock<ObservedClaims>>,
+    cancel_tx: watch::Sender<bool>,
+    publisher_task: Option<JoinHandle<()>>,
+    converger_task: Option<JoinHandle<()>>,
+}
+
+/// Internal observed-claims map. Keyed by content_id → peer_id →
+/// observed claim. Sorted-map nesting keeps determinism over the
+/// observation set — the converger walks in stable order.
+///
+/// `pub` for the `observed_handle()` test surface — production
+/// callers should treat the inner shape as opaque.
+#[derive(Debug, Default)]
+pub struct ObservedClaims {
+    inner: BTreeMap<String, BTreeMap<String, ObservedClaim>>,
+}
+
+impl ObservedClaims {
+    fn upsert(&mut self, claim: FountainHoldingClaim) {
+        let entry = ObservedClaim {
+            observed_at: std::time::Instant::now(),
+            claim,
+        };
+        self.inner
+            .entry(entry.claim.content_id.clone())
+            .or_default()
+            .insert(entry.claim.peer_id.clone(), entry);
+    }
+
+    /// Drop entries older than `ttl`. Returns the count pruned.
+    fn prune_expired(&mut self, ttl: Duration) -> usize {
+        let now = std::time::Instant::now();
+        let mut dropped = 0usize;
+        self.inner.retain(|_, peers| {
+            peers.retain(|_, c| {
+                let keep = now.duration_since(c.observed_at) <= ttl;
+                if !keep {
+                    dropped += 1;
+                }
+                keep
+            });
+            !peers.is_empty()
+        });
+        dropped
+    }
+
+    fn distinct_holders(&self, content_id: &str) -> u32 {
+        self.inner
+            .get(content_id)
+            .map_or(0, |m| u32::try_from(m.len()).unwrap_or(u32::MAX))
+    }
+
+    fn all_claims_for(&self, content_id: &str) -> Vec<FountainHoldingClaim> {
+        self.inner
+            .get(content_id)
+            .map_or_else(Vec::new, |m| m.values().map(|c| c.claim.clone()).collect())
+    }
+
+    fn content_ids(&self) -> Vec<String> {
+        self.inner.keys().cloned().collect()
+    }
+}
+
+impl FountainSwarmRuntime {
+    /// Spawn the publisher + converger tasks against the given
+    /// substrate handles. The runtime holds clones of every Arc; the
+    /// caller can drop their originals after `start` returns.
+    ///
+    /// Cohort membership is read from `cohort` on every publish tick
+    /// — the same shape `ReplicationRuntime` uses for its bridge
+    /// callback. The publisher ships one envelope per `(content_id,
+    /// peer)` pair on every tick; v5.2.0 uses the transport's
+    /// fire-and-forget `send` path (a future cut may switch to
+    /// `send_durable` for at-least-once delivery once the substrate
+    /// requires it).
+    #[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
+    pub fn start(
+        config: SwarmRuntimeConfig,
+        holdings: Arc<dyn FountainHoldingsSource>,
+        tier_evict: Arc<dyn FountainTierEvict>,
+        hard_delete: Arc<dyn FountainEvictHardDelete + Send + Sync>,
+        transport: Arc<dyn Transport>,
+        cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+        local_peer_id: String,
+        sink: Option<SwarmRuntimeEventSink>,
+    ) -> Self {
+        let observed = Arc::new(RwLock::new(ObservedClaims::default()));
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+
+        let publisher_task = {
+            let holdings = Arc::clone(&holdings);
+            let transport = Arc::clone(&transport);
+            let cohort = Arc::clone(&cohort);
+            let cadence = config.publish_cadence;
+            let cancel_rx = cancel_rx.clone();
+            let sink = sink.clone();
+            let local_peer = local_peer_id.clone();
+            tokio::spawn(async move {
+                run_publisher(
+                    holdings, transport, cohort, local_peer, cadence, cancel_rx, sink,
+                )
+                .await;
+            })
+        };
+
+        let converger_task = {
+            let observed = Arc::clone(&observed);
+            let holdings = Arc::clone(&holdings);
+            let tier_evict = Arc::clone(&tier_evict);
+            let hard_delete = Arc::clone(&hard_delete);
+            let cfg = config.clone();
+            tokio::spawn(async move {
+                run_converger(
+                    observed,
+                    holdings,
+                    tier_evict,
+                    hard_delete,
+                    cfg,
+                    cancel_rx,
+                    sink,
+                )
+                .await;
+            })
+        };
+
+        Self {
+            config,
+            observed,
+            cancel_tx,
+            publisher_task: Some(publisher_task),
+            converger_task: Some(converger_task),
+        }
+    }
+
+    /// Called by the inbound dispatch path when a peer's
+    /// [`FountainHoldingClaim`] envelope is verified. Updates the
+    /// observed-claims map; the next converger tick consults the
+    /// fresh state.
+    ///
+    /// Idempotent on `(content_id, peer_id)` — a later observation
+    /// replaces the prior entry (the substrate's `observed_at_unix_ms`
+    /// field carries the producer's own staleness window; the
+    /// runtime's TTL prune is a local liveness signal).
+    pub async fn register_observed_claim(&self, claim: FountainHoldingClaim) {
+        self.observed.write().await.upsert(claim);
+    }
+
+    /// Shared observed-claims map for tests + telemetry. Cheap clone
+    /// (Arc bump).
+    #[doc(hidden)]
+    pub fn observed_handle(&self) -> Arc<RwLock<ObservedClaims>> {
+        Arc::clone(&self.observed)
+    }
+
+    /// The active runtime configuration.
+    pub fn config(&self) -> &SwarmRuntimeConfig {
+        &self.config
+    }
+
+    /// Signal both tasks to stop + await clean exit. Idempotent.
+    pub async fn shutdown(&mut self) {
+        let _ = self.cancel_tx.send(true);
+        if let Some(t) = self.publisher_task.take() {
+            let _ = t.await;
+        }
+        if let Some(t) = self.converger_task.take() {
+            let _ = t.await;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_publisher(
+    holdings: Arc<dyn FountainHoldingsSource>,
+    transport: Arc<dyn Transport>,
+    cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+    local_peer_id: String,
+    cadence: Duration,
+    mut cancel_rx: watch::Receiver<bool>,
+    sink: Option<SwarmRuntimeEventSink>,
+) {
+    let mut ticker = tokio::time::interval(cadence);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = cancel_rx.changed() => {
+                if *cancel_rx.borrow() {
+                    tracing::info!("swarm_runtime.publisher: shutdown");
+                    return;
+                }
+            }
+            _ = ticker.tick() => {
+                if let Err(e) = publish_tick(
+                    &holdings,
+                    &transport,
+                    cohort.as_ref(),
+                    &local_peer_id,
+                    sink.as_ref(),
+                )
+                .await
+                {
+                    tracing::warn!(error = %e, "swarm_runtime.publisher: tick failed");
+                }
+            }
+        }
+    }
+}
+
+async fn publish_tick(
+    holdings: &Arc<dyn FountainHoldingsSource>,
+    transport: &Arc<dyn Transport>,
+    cohort: &(dyn Fn() -> Vec<String> + Send + Sync),
+    local_peer_id: &str,
+    sink: Option<&SwarmRuntimeEventSink>,
+) -> Result<usize, FountainEvictError> {
+    let held = holdings.list_held_fountain_content().await?;
+    let peers = cohort();
+    let mut count = 0usize;
+    let observed_at_unix_ms = current_unix_ms();
+    for content in held {
+        let claim = FountainHoldingClaim::new(
+            local_peer_id.to_string(),
+            content.content_id.clone(),
+            content.symbol_ids.clone(),
+            observed_at_unix_ms,
+        );
+        // v5.2.0: ship the wire bytes as the substrate's
+        // canonical projection (a future cut will route this through
+        // the full envelope-signing path once a `MessageType::FountainHoldingClaim`
+        // wire discriminator lands; for now the canonical_bytes is
+        // the byte-form the federation cohort consumes).
+        let envelope_bytes = claim.canonical_bytes();
+        for peer in &peers {
+            // Skip self — the cohort callback typically already
+            // excludes the local peer, but defense in depth.
+            if peer == local_peer_id {
+                continue;
+            }
+            if let Err(e) = transport.send(peer, &envelope_bytes).await {
+                tracing::warn!(
+                    peer = %peer,
+                    content_id = %content.content_id,
+                    error = %e,
+                    "swarm_runtime.publisher: transport send failed",
+                );
+            }
+        }
+        if let Some(sink) = sink {
+            sink(SwarmEvent::Published {
+                content_id: content.content_id.clone(),
+                cohort_size: peers.len(),
+            });
+        }
+        count += 1;
+    }
+    Ok(count)
+}
+
+async fn run_converger(
+    observed: Arc<RwLock<ObservedClaims>>,
+    holdings: Arc<dyn FountainHoldingsSource>,
+    tier_evict: Arc<dyn FountainTierEvict>,
+    hard_delete: Arc<dyn FountainEvictHardDelete + Send + Sync>,
+    config: SwarmRuntimeConfig,
+    mut cancel_rx: watch::Receiver<bool>,
+    sink: Option<SwarmRuntimeEventSink>,
+) {
+    let mut ticker = tokio::time::interval(config.observe_cadence);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = cancel_rx.changed() => {
+                if *cancel_rx.borrow() {
+                    tracing::info!("swarm_runtime.converger: shutdown");
+                    return;
+                }
+            }
+            _ = ticker.tick() => {
+                converger_tick(
+                    &observed,
+                    &holdings,
+                    &tier_evict,
+                    &hard_delete,
+                    &config,
+                    sink.as_ref(),
+                )
+                .await;
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+async fn converger_tick(
+    observed: &Arc<RwLock<ObservedClaims>>,
+    holdings: &Arc<dyn FountainHoldingsSource>,
+    tier_evict: &Arc<dyn FountainTierEvict>,
+    hard_delete: &Arc<dyn FountainEvictHardDelete + Send + Sync>,
+    config: &SwarmRuntimeConfig,
+    sink: Option<&SwarmRuntimeEventSink>,
+) {
+    // Prune stale claims first so the rarity math sees a live view.
+    let dropped = observed
+        .write()
+        .await
+        .prune_expired(config.observed_claim_ttl);
+    if dropped > 0 {
+        tracing::debug!(dropped, "swarm_runtime.converger: pruned stale claims");
+    }
+
+    // Snapshot the operator's local holdings for the local-symbol
+    // rarity check. A missing holdings source returns an empty Vec,
+    // which means the converger treats every content as "not locally
+    // held" — no eviction action is taken on content the operator
+    // doesn't have a local symbol for.
+    let local_held = match holdings.list_held_fountain_content().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "swarm_runtime.converger: holdings list failed; skipping tick");
+            return;
+        }
+    };
+    let local_by_content: BTreeMap<String, HeldFountainContent> = local_held
+        .into_iter()
+        .map(|h| (h.content_id.clone(), h))
+        .collect();
+
+    let observed_snapshot = observed.read().await;
+    let content_ids = observed_snapshot.content_ids();
+    drop(observed_snapshot);
+
+    for content_id in content_ids {
+        let snapshot = observed.read().await;
+        let observed_count = snapshot.distinct_holders(&content_id);
+        let all_claims = snapshot.all_claims_for(&content_id);
+        drop(snapshot);
+
+        // Determine consent state. v5.2.0 defaults to Active —
+        // revocation routing rides the inbound dispatch path
+        // (when a `consent:state:revoked` envelope arrives, edge
+        // calls into `register_revocation` on the runtime; that
+        // wiring lands in v5.3.0 when the consent envelope shape
+        // is normative). For the v5.2.0 cut, the converger acts on
+        // the substrate-tier verdicts driven by `holders_observed`
+        // alone.
+        let consent = ConsentState::Active;
+
+        // Local-symbol rarity: compute over the merged claim set
+        // including the local peer's view if it holds a symbol for
+        // this content. The substrate's
+        // `should_eject_above_target` consults this to avoid
+        // evicting the last local copy of a rare symbol.
+        let local_symbol_rarity = if let Some(local) = local_by_content.get(&content_id) {
+            local.symbol_ids.first().map_or(RarityScore(0), |sym| {
+                compute_rarity_score(&content_id, *sym, &all_claims)
+            })
+        } else {
+            RarityScore(0)
+        };
+
+        let verdict =
+            should_eject_above_target(observed_count, &config.policy, consent, local_symbol_rarity);
+
+        match verdict {
+            EjectionVerdict::Keep => {
+                if observed_count > 0 && observed_count < config.min_viable {
+                    tracing::info!(
+                        content_id = %content_id,
+                        observed_holders = observed_count,
+                        min_viable = config.min_viable,
+                        "swarm_runtime.converger: repair needed",
+                    );
+                    if let Some(sink) = sink {
+                        sink(SwarmEvent::RepairNeeded {
+                            content_id: content_id.clone(),
+                            observed_holders: observed_count,
+                            min_viable: config.min_viable,
+                        });
+                    }
+                } else if let Some(sink) = sink {
+                    sink(SwarmEvent::Keep {
+                        content_id: content_id.clone(),
+                        observed_holders: observed_count,
+                    });
+                }
+            }
+            EjectionVerdict::EjectToTier => {
+                let corpus_kind = corpus_kind_for(&local_by_content, &content_id);
+                // v5.2.0 ejection target: persist's "t1" label
+                // (DiskPressure::Warn-equivalent — the gentlest
+                // step that actually frees symbol rows). Future
+                // cuts may consult the per-content_id pressure
+                // window to pick a coarser tier under load.
+                let tier_label = "t1".to_string();
+                if let Err(e) = tier_evict
+                    .evict_fountain_content_to_tier(&content_id, &corpus_kind, &tier_label)
+                    .await
+                {
+                    tracing::warn!(
+                        content_id = %content_id,
+                        error = %e,
+                        "swarm_runtime.converger: tier evict failed",
+                    );
+                } else if let Some(sink) = sink {
+                    sink(SwarmEvent::EjectedToTier {
+                        content_id: content_id.clone(),
+                        observed_holders: observed_count,
+                        tier_label,
+                    });
+                }
+            }
+            EjectionVerdict::EjectAggregatedTierOnly { tier: _ } => {
+                // §19.7.3 tier-only ejection — same dispatch as
+                // EjectToTier for v5.2.0 (the named pyramid stratum
+                // is consulted by the persist backend once it
+                // exposes the tier-granular evict; until then the
+                // runtime maps onto the coarse tier evict).
+                let corpus_kind = corpus_kind_for(&local_by_content, &content_id);
+                if let Err(e) = tier_evict
+                    .evict_fountain_content_to_tier(&content_id, &corpus_kind, "t1")
+                    .await
+                {
+                    tracing::warn!(
+                        content_id = %content_id,
+                        error = %e,
+                        "swarm_runtime.converger: aggregated-tier evict failed",
+                    );
+                }
+            }
+            EjectionVerdict::EjectHardDelete => {
+                let corpus_kind = corpus_kind_for(&local_by_content, &content_id);
+                if let Err(e) =
+                    hard_delete.evict_fountain_content_hard_delete(&content_id, &corpus_kind)
+                {
+                    tracing::warn!(
+                        content_id = %content_id,
+                        error = %e,
+                        "swarm_runtime.converger: hard delete failed",
+                    );
+                } else if let Some(sink) = sink {
+                    sink(SwarmEvent::HardDeleted {
+                        content_id: content_id.clone(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn corpus_kind_for(
+    local_by_content: &BTreeMap<String, HeldFountainContent>,
+    content_id: &str,
+) -> String {
+    local_by_content
+        .get(content_id)
+        .map_or_else(|| "fountain-corpus".to_string(), |h| h.corpus_kind.clone())
+}
+
+fn current_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::{InboundFrame, TransportError, TransportId, TransportSendOutcome};
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    // ─── Test fixtures ────────────────────────────────────────────
+
+    struct VecHoldings(Vec<HeldFountainContent>);
+    #[async_trait]
+    impl FountainHoldingsSource for VecHoldings {
+        async fn list_held_fountain_content(
+            &self,
+        ) -> Result<Vec<HeldFountainContent>, FountainEvictError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingTierEvict {
+        calls: Mutex<Vec<(String, String, String)>>,
+    }
+    #[async_trait]
+    impl FountainTierEvict for RecordingTierEvict {
+        async fn evict_fountain_content_to_tier(
+            &self,
+            content_id: &str,
+            corpus_kind: &str,
+            tier: &str,
+        ) -> Result<(), FountainEvictError> {
+            self.calls.lock().unwrap().push((
+                content_id.to_string(),
+                corpus_kind.to_string(),
+                tier.to_string(),
+            ));
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingHardDelete {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+    impl FountainEvictHardDelete for RecordingHardDelete {
+        fn evict_fountain_content_hard_delete(
+            &self,
+            content_id: &str,
+            corpus_kind: &str,
+        ) -> Result<(), FountainEvictError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((content_id.to_string(), corpus_kind.to_string()));
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingTransport {
+        sends: Mutex<Vec<(String, Vec<u8>)>>,
+    }
+    #[async_trait]
+    impl Transport for RecordingTransport {
+        fn id(&self) -> TransportId {
+            TransportId::HTTP
+        }
+        async fn send(
+            &self,
+            destination_key_id: &str,
+            envelope_bytes: &[u8],
+        ) -> Result<TransportSendOutcome, TransportError> {
+            self.sends
+                .lock()
+                .unwrap()
+                .push((destination_key_id.to_string(), envelope_bytes.to_vec()));
+            Ok(TransportSendOutcome::Delivered)
+        }
+        async fn listen(
+            &self,
+            _sink: tokio::sync::mpsc::Sender<InboundFrame>,
+        ) -> Result<(), TransportError> {
+            unimplemented!("test transports don't drive listen")
+        }
+    }
+
+    fn fast_config() -> SwarmRuntimeConfig {
+        SwarmRuntimeConfig {
+            publish_cadence: Duration::from_millis(20),
+            observe_cadence: Duration::from_millis(20),
+            ..SwarmRuntimeConfig::default()
+        }
+    }
+
+    // ─── Tests ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn empty_holdings_starts_and_shuts_down() {
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(super::super::NoopFountainHoldingsSource);
+        let tier: Arc<dyn FountainTierEvict> = Arc::new(RecordingTierEvict::default());
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let mut rt = FountainSwarmRuntime::start(
+            fast_config(),
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            None,
+        );
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        rt.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn publisher_ships_one_envelope_per_held_content_per_peer() {
+        let holdings: Arc<dyn FountainHoldingsSource> = Arc::new(VecHoldings(vec![
+            HeldFountainContent {
+                content_id: "c-x".into(),
+                corpus_kind: "fountain-corpus".into(),
+                symbol_ids: vec![1, 2, 3],
+            },
+            HeldFountainContent {
+                content_id: "c-y".into(),
+                corpus_kind: "fountain-corpus".into(),
+                symbol_ids: vec![10, 20],
+            },
+        ]));
+        let tier: Arc<dyn FountainTierEvict> = Arc::new(RecordingTierEvict::default());
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let recording_tx = Arc::new(RecordingTransport::default());
+        let tx: Arc<dyn Transport> = recording_tx.clone();
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
+            Arc::new(|| vec!["bob".to_string(), "carol".to_string()]);
+        let mut rt = FountainSwarmRuntime::start(
+            fast_config(),
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            None,
+        );
+        // Let the publisher fire at least once.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        rt.shutdown().await;
+        let sends = recording_tx.sends.lock().unwrap().clone();
+        // 2 content × 2 peers = 4 sends per tick; should be at least 4.
+        assert!(
+            sends.len() >= 4,
+            "expected >=4 publish sends, got {}",
+            sends.len()
+        );
+        // Every send must be addressed to a cohort peer (not self).
+        for (dest, _) in &sends {
+            assert!(
+                dest == "bob" || dest == "carol",
+                "self-addressed send: {dest}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn register_observed_claim_lands_in_map() {
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(super::super::NoopFountainHoldingsSource);
+        let tier: Arc<dyn FountainTierEvict> = Arc::new(RecordingTierEvict::default());
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let rt = FountainSwarmRuntime::start(
+            SwarmRuntimeConfig {
+                publish_cadence: Duration::from_secs(60),
+                observe_cadence: Duration::from_secs(60),
+                ..Default::default()
+            },
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            None,
+        );
+
+        rt.register_observed_claim(FountainHoldingClaim::new(
+            "bob",
+            "c-x",
+            vec![1, 2],
+            1_700_000_000,
+        ))
+        .await;
+        rt.register_observed_claim(FountainHoldingClaim::new(
+            "carol",
+            "c-x",
+            vec![1, 3],
+            1_700_000_000,
+        ))
+        .await;
+        let map = rt.observed_handle();
+        let g = map.read().await;
+        assert_eq!(g.distinct_holders("c-x"), 2);
+        assert_eq!(g.distinct_holders("c-y"), 0);
+        drop(g);
+        let mut rt = rt;
+        rt.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn converger_fires_eject_above_target_when_observed_holders_exceed_threshold() {
+        // 35 holders + local symbol "common" (rarity >= target/2=15)
+        // → EjectToTier per the substrate's threshold math.
+        let local_content_id = "c-popular";
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(VecHoldings(vec![HeldFountainContent {
+                content_id: local_content_id.into(),
+                corpus_kind: "fountain-corpus".into(),
+                symbol_ids: vec![1],
+            }]));
+        let tier_recorder = Arc::new(RecordingTierEvict::default());
+        let tier: Arc<dyn FountainTierEvict> = tier_recorder.clone();
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel::<SwarmEvent>();
+        let sink: SwarmRuntimeEventSink = Arc::new(move |ev| {
+            let _ = sink_tx.send(ev);
+        });
+        let rt = FountainSwarmRuntime::start(
+            fast_config(),
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            Some(sink),
+        );
+        // Publish 35 distinct peer claims for symbol_id=1 — every
+        // peer holds symbol 1, so the local symbol is "common"
+        // (rarity score = 35 > target/2=15) and observed_count=35
+        // is above target+grace=34, so the converger should eject.
+        for i in 0..35 {
+            rt.register_observed_claim(FountainHoldingClaim::new(
+                format!("peer-{i}"),
+                local_content_id,
+                vec![1],
+                1_700_000_000,
+            ))
+            .await;
+        }
+        // Wait a couple of converger ticks.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let mut rt = rt;
+        rt.shutdown().await;
+
+        let calls = tier_recorder.calls.lock().unwrap().clone();
+        assert!(
+            calls
+                .iter()
+                .any(|(cid, _, tier)| cid == local_content_id && tier == "t1"),
+            "expected EjectToTier(c-popular, t1), got {calls:?}"
+        );
+        // Sanity: a Published event fired (publisher saw c-popular).
+        let mut saw_eject = false;
+        while let Ok(ev) = sink_rx.try_recv() {
+            if matches!(
+                ev,
+                SwarmEvent::EjectedToTier { ref content_id, .. } if content_id == local_content_id
+            ) {
+                saw_eject = true;
+            }
+        }
+        assert!(saw_eject, "expected EjectedToTier event for c-popular");
+    }
+
+    #[tokio::test]
+    async fn converger_emits_repair_needed_when_below_min_viable() {
+        // 2 holders < min_viable=5 → RepairNeeded telemetry.
+        let content_id = "c-rare";
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(VecHoldings(vec![HeldFountainContent {
+                content_id: content_id.into(),
+                corpus_kind: "fountain-corpus".into(),
+                symbol_ids: vec![7],
+            }]));
+        let tier: Arc<dyn FountainTierEvict> = Arc::new(RecordingTierEvict::default());
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel::<SwarmEvent>();
+        let sink: SwarmRuntimeEventSink = Arc::new(move |ev| {
+            let _ = sink_tx.send(ev);
+        });
+        let rt = FountainSwarmRuntime::start(
+            fast_config(),
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            Some(sink),
+        );
+        for i in 0..2 {
+            rt.register_observed_claim(FountainHoldingClaim::new(
+                format!("peer-{i}"),
+                content_id,
+                vec![7],
+                1_700_000_000,
+            ))
+            .await;
+        }
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let mut rt = rt;
+        rt.shutdown().await;
+        let mut saw_repair = false;
+        while let Ok(ev) = sink_rx.try_recv() {
+            if let SwarmEvent::RepairNeeded {
+                content_id: cid,
+                observed_holders,
+                min_viable,
+            } = ev
+            {
+                if cid == content_id && observed_holders == 2 && min_viable == DEFAULT_MIN_VIABLE {
+                    saw_repair = true;
+                }
+            }
+        }
+        assert!(saw_repair, "expected RepairNeeded(c-rare, 2, 5)");
+    }
+
+    #[tokio::test]
+    async fn observed_claims_prune_when_ttl_elapsed() {
+        let mut claims = ObservedClaims::default();
+        let claim = FountainHoldingClaim::new("p", "c", vec![1], 1_700_000_000);
+        claims.upsert(claim);
+        assert_eq!(claims.distinct_holders("c"), 1);
+        // TTL=0 → every claim is "expired" instantly.
+        let dropped = claims.prune_expired(Duration::from_secs(0));
+        assert_eq!(dropped, 1);
+        assert_eq!(claims.distinct_holders("c"), 0);
+    }
+
+    #[tokio::test]
+    async fn observed_claims_dedupe_per_peer_content() {
+        let mut claims = ObservedClaims::default();
+        claims.upsert(FountainHoldingClaim::new("p", "c", vec![1], 1));
+        claims.upsert(FountainHoldingClaim::new("p", "c", vec![1, 2], 2));
+        // Same (peer, content) → upsert keeps the latest claim only.
+        assert_eq!(claims.distinct_holders("c"), 1);
+        let all = claims.all_claims_for("c");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].symbol_ids, vec![1, 2]);
+    }
+}

--- a/tests/fountain_hard_delete_path.rs
+++ b/tests/fountain_hard_delete_path.rs
@@ -1,0 +1,90 @@
+//! v5.2.0 (CIRISEdge#143) — production adapter exercises the
+//! [`FountainEvictHardDelete`] surface end-to-end.
+//!
+//! The substrate-tier `swarm_rarity` tests already prove the trait
+//! dispatches correctly; this integration test verifies the v5.2.0
+//! adapter shape — [`PersistFountainEvictHardDelete`] is a thin
+//! passthrough that the production caller wires over its persist
+//! `Engine` handle. Until persist v9.x exposes the eviction API on
+//! `Arc<dyn FederationDirectory>`, the test stops at the adapter
+//! boundary; the adapter is exercised against an in-tree recorder
+//! that stands in for the persist-side concrete.
+
+use std::sync::{Arc, Mutex};
+
+use ciris_edge::holonomic::swarm_rarity::{FountainEvictError, FountainEvictHardDelete};
+use ciris_edge::swarm::PersistFountainEvictHardDelete;
+
+#[derive(Default)]
+struct Recorder {
+    calls: Mutex<Vec<(String, String)>>,
+}
+impl FountainEvictHardDelete for Recorder {
+    fn evict_fountain_content_hard_delete(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+    ) -> Result<(), FountainEvictError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((content_id.to_string(), corpus_kind.to_string()));
+        Ok(())
+    }
+}
+
+#[test]
+fn production_adapter_calls_through_to_inner_evictor() {
+    let rec: Arc<Recorder> = Arc::new(Recorder::default());
+    let adapter = PersistFountainEvictHardDelete::new(rec.clone());
+
+    // Three distinct hard-delete invocations.
+    adapter
+        .evict_fountain_content_hard_delete("revoked-A", "fountain-corpus")
+        .expect("hard-delete succeeds");
+    adapter
+        .evict_fountain_content_hard_delete("revoked-B", "fountain-corpus")
+        .expect("hard-delete succeeds");
+    adapter
+        .evict_fountain_content_hard_delete("revoked-C", "different-corpus")
+        .expect("hard-delete succeeds");
+
+    let calls = rec.calls.lock().unwrap().clone();
+    assert_eq!(
+        calls,
+        vec![
+            ("revoked-A".to_string(), "fountain-corpus".to_string()),
+            ("revoked-B".to_string(), "fountain-corpus".to_string()),
+            ("revoked-C".to_string(), "different-corpus".to_string()),
+        ],
+        "production adapter must passthrough every call to the inner evictor",
+    );
+}
+
+#[test]
+fn production_adapter_surfaces_inner_failure() {
+    struct Failing;
+    impl FountainEvictHardDelete for Failing {
+        fn evict_fountain_content_hard_delete(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> Result<(), FountainEvictError> {
+            Err(FountainEvictError::HardDeleteFailed(
+                "persist-backend-down".into(),
+            ))
+        }
+    }
+    let adapter = PersistFountainEvictHardDelete::new(Arc::new(Failing));
+    let err = adapter
+        .evict_fountain_content_hard_delete("c1", "fountain-corpus")
+        .expect_err("must surface inner failure");
+    match err {
+        FountainEvictError::HardDeleteFailed(msg) => {
+            assert!(
+                msg.contains("persist-backend-down"),
+                "error message must propagate: {msg}"
+            );
+        }
+    }
+}

--- a/tests/swarm_runtime_e2e.rs
+++ b/tests/swarm_runtime_e2e.rs
@@ -1,0 +1,183 @@
+//! v5.2.0 (CIRISEdge#143) — end-to-end swarm-runtime smoke.
+//!
+//! Two peers (alice + bob); alice publishes a fountain holding claim
+//! and bob observes it via [`FountainSwarmRuntime::register_observed_claim`].
+//! Asserts:
+//!
+//! 1. Alice's publisher fires a `send` to the cohort.
+//! 2. Bob's converger ticks and observes the claim in the map.
+//! 3. The runtime shuts down cleanly.
+//!
+//! The wire shape between peers is currently
+//! `FountainHoldingClaim::canonical_bytes` — the substrate's domain-
+//! tagged bytes. A future cut adds a wire-tier
+//! `MessageType::FountainHoldingClaim` discriminator and re-uses
+//! `dispatch_inbound`'s verify path; for v5.2.0 the integration test
+//! drives `register_observed_claim` directly, simulating what the
+//! verify-path-aware dispatch hook will do.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use ciris_edge::holonomic::swarm_rarity::FountainHoldingClaim;
+use ciris_edge::swarm::{
+    FountainEvictHardDelete, FountainHoldingsSource, FountainSwarmRuntime, FountainTierEvict,
+    HeldFountainContent, NoopFountainHoldingsSource, SwarmRuntimeConfig,
+};
+use ciris_edge::transport::{
+    InboundFrame, Transport, TransportError, TransportId, TransportSendOutcome,
+};
+
+#[derive(Default)]
+struct RecordingTransport {
+    sends: std::sync::Mutex<Vec<(String, Vec<u8>)>>,
+}
+#[async_trait]
+impl Transport for RecordingTransport {
+    fn id(&self) -> TransportId {
+        TransportId::HTTP
+    }
+    async fn send(
+        &self,
+        destination_key_id: &str,
+        envelope_bytes: &[u8],
+    ) -> Result<TransportSendOutcome, TransportError> {
+        self.sends
+            .lock()
+            .unwrap()
+            .push((destination_key_id.to_string(), envelope_bytes.to_vec()));
+        Ok(TransportSendOutcome::Delivered)
+    }
+    async fn listen(
+        &self,
+        _sink: tokio::sync::mpsc::Sender<InboundFrame>,
+    ) -> Result<(), TransportError> {
+        unimplemented!("e2e doesn't drive listen")
+    }
+}
+
+struct VecHoldings(Vec<HeldFountainContent>);
+#[async_trait]
+impl FountainHoldingsSource for VecHoldings {
+    async fn list_held_fountain_content(
+        &self,
+    ) -> Result<Vec<HeldFountainContent>, ciris_edge::swarm::FountainEvictError> {
+        Ok(self.0.clone())
+    }
+}
+
+#[derive(Default)]
+struct NopTier;
+#[async_trait]
+impl FountainTierEvict for NopTier {
+    async fn evict_fountain_content_to_tier(
+        &self,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<(), ciris_edge::swarm::FountainEvictError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct NopHard;
+impl FountainEvictHardDelete for NopHard {
+    fn evict_fountain_content_hard_delete(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<(), ciris_edge::swarm::FountainEvictError> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn two_peer_publish_and_observe_roundtrip() {
+    // Alice — has held content. Publishes claims; bob is the cohort.
+    let alice_holdings: Arc<dyn FountainHoldingsSource> =
+        Arc::new(VecHoldings(vec![HeldFountainContent {
+            content_id: "shard-X".into(),
+            corpus_kind: "fountain-corpus".into(),
+            symbol_ids: vec![1, 2, 3],
+        }]));
+    let alice_tx = Arc::new(RecordingTransport::default());
+    let alice_tier: Arc<dyn FountainTierEvict> = Arc::new(NopTier);
+    let alice_hard: Arc<dyn FountainEvictHardDelete + Send + Sync> = Arc::new(NopHard);
+    let alice_cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
+        Arc::new(|| vec!["bob".to_string()]);
+    let mut alice = FountainSwarmRuntime::start(
+        SwarmRuntimeConfig {
+            publish_cadence: Duration::from_millis(20),
+            observe_cadence: Duration::from_millis(50),
+            ..Default::default()
+        },
+        alice_holdings,
+        alice_tier,
+        alice_hard,
+        alice_tx.clone() as Arc<dyn Transport>,
+        alice_cohort,
+        "alice".to_string(),
+        None,
+    );
+
+    // Bob — no held content; observes alice's claim. Cohort is
+    // empty (bob is the listener, not the publisher).
+    let bob_holdings: Arc<dyn FountainHoldingsSource> = Arc::new(NoopFountainHoldingsSource);
+    let bob_tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+    let bob_tier: Arc<dyn FountainTierEvict> = Arc::new(NopTier);
+    let bob_hard: Arc<dyn FountainEvictHardDelete + Send + Sync> = Arc::new(NopHard);
+    let bob_cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+    let mut bob = FountainSwarmRuntime::start(
+        SwarmRuntimeConfig {
+            publish_cadence: Duration::from_millis(20),
+            observe_cadence: Duration::from_millis(20),
+            ..Default::default()
+        },
+        bob_holdings,
+        bob_tier,
+        bob_hard,
+        bob_tx,
+        bob_cohort,
+        "bob".to_string(),
+        None,
+    );
+
+    // Let alice publish at least once.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let alice_sends = alice_tx.sends.lock().unwrap().clone();
+    assert!(
+        alice_sends.iter().any(|(dst, _)| dst == "bob"),
+        "alice's publisher must have shipped at least one envelope to bob; got {alice_sends:?}"
+    );
+
+    // Simulate the inbound dispatch path: bob's edge would call
+    // `register_observed_claim` on the verified body. We do that
+    // directly here (the wire-level MessageType wiring lands in a
+    // follow-up cut once the discriminator is approved).
+    bob.register_observed_claim(FountainHoldingClaim::new(
+        "alice",
+        "shard-X",
+        vec![1, 2, 3],
+        1_700_000_000,
+    ))
+    .await;
+
+    // Let bob's converger run.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let observed = bob.observed_handle();
+    let g = observed.read().await;
+    let inner = format!("{g:?}");
+    assert!(
+        inner.contains("shard-X"),
+        "bob's observed map must contain shard-X; got {inner}"
+    );
+    drop(g);
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}


### PR DESCRIPTION
## Summary

- Closes CIRISEdge#143 — the live wiring gap that left the v3.10.0 holonomic swarm primitives (FountainHoldingClaim, should_eject_above_target, FountainEvictHardDelete) reachable only from unit tests.
- Introduces new src/swarm/ module: FountainSwarmRuntime (publisher + converger tasks, in-memory observed-claims map), PersistFountainEvictHardDelete production adapter, FountainHoldingsSource / FountainTierEvict trait surfaces.
- Edge integration: install_swarm_runtime / swarm_runtime_handle (parallel to install_replication_routing); install_consent_decay_shutdown / shutdown_consent_decay close the v3.9.0 "decay scheduler built but not running" loop.

## Persist surface gap (recorded for upstream)

CIRISPersist v9.0.x does NOT yet expose on `Arc<dyn FederationDirectory>`:
- `list_fountain_holdings()` — operator-side "what content_ids do I hold?"
- `evict_fountain_content_to_tier` / `evict_fountain_content_hard_delete` on the public trait (Engine has them, cfg-gated)

v5.2.0 scopes around these by threading in-tree trait surfaces (FountainHoldingsSource, FountainTierEvict, FountainEvictHardDelete) — production wires concrete impls over the Engine handle. Bringing them onto FederationDirectory is upstream persist work; the runtime is forward-compatible with whatever shape persist eventually publishes.

## Wire-shape posture

No new `MessageType` discriminator in this cut. The substrate's `FountainHoldingClaim::canonical_bytes` is the v5.2.0 byte form between peers; a follow-up cut adds `MessageType::FountainHoldingClaim` + `dispatch_inbound` routing once the wire-determinism committee approves. v5.2.0 exposes `FountainSwarmRuntime::register_observed_claim` at the public API surface — same seam as `ReplicationRuntime::registry()`.

## Constraints honored

- Persist v9.0.2 pin held (no v9.2.0 bump; SCOPE_PRIVACY deliberately not bundled).
- Verify v6.2.0 pin held.
- MSRV 1.75 — no post-1.75 surface.
- Targeted `cargo test --lib <module>` only.
- `cargo fmt --all` pre-commit.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS="-D warnings" cargo clippy --no-default-features --features "transport-http transport-reticulum pyo3 holonomic-consent-decay" --lib --tests` clean
- [x] `cargo test --lib swarm` — 54 pass (12 new + 42 substrate)
- [x] `cargo test --lib replication::scheduler` — 6 pass (regression check)
- [x] `cargo test --lib holonomic` — 113 pass (regression check)
- [x] `cargo test --test swarm_runtime_e2e` — two-peer publish+observe smoke pass
- [x] `cargo test --test fountain_hard_delete_path` — production adapter passthrough pass

## v5.2.0 tag

Annotated `v5.2.0` → `48964ee35ed05bdaf945b8f35ddb93faa3430f86`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln