### PR TITLE
release(v6.0.0): scope-native privacy substrate — CC 1.13.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "5.2.0"
+version = "6.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.0.3", version = "9", features = ["sqlite"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.2.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.0.3
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.2.0", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.2.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.2.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.2.0", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1028,7 +1028,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.0.3", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.2.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "5.1.0"
+version = "5.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "5.0.1"
+version = "5.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/MISSION.md
+++ b/MISSION.md
@@ -929,6 +929,7 @@ witness equivocation exception for founder-quorum keys.
 | CC 1.7 | 1+4 envelope surface frozen — wire framing carries every claim; no out-of-band channels |
 | CC 1.13.5 | Operational-language gate — refusals describe mechanism, not preferences |
 | CC 1.13.4 | Substrate-stores-never-adjudicates — `should_eject_above_target`, `recursive_trust_bootstrap` are mechanical; agency lives above |
+| CC 1.13.3.4 (v6.0.0) | Anonymity-by-default at every scope below federation — `scope_privacy` re-exports verify v6.3.0's §2.2/§2.4/§3.4 derivations; `CohortScope::default_for_audience` flip; `mls::welcome_wrap` HPKE-Base + ML-DSA-65 §3.3 wrap; `DirectoryCache` §3.3 cached directory; `mls::scope_state` cold-state opacity via persist v9.2.0 `XChaChaKvStore`; archive_mode honest-holder forward-secrecy. CC 1.13.3.1 GPA-unobservability residual at federation scope routes to ANONYMOUS_TIER.md (opt-in tier, distinct construction) |
 | CC 3.2 / 3.4.7.1 | Owner-binding precondition for non-infra community membership — `SignedClaim::user_owner` / `delegates_to` / `identity_occurrence` fields |
 | CC 4.4.3.2.1 / .2 | Community DEK cascade + rotation-on-removal — consumed via persist v9.0.0 G5 |
 | CC 4.4.3.4.3 / 1.13.5 | Infra-vs-agency split — pure fabric nodes perform §19.7 forever-memory without reasoning; brain enrichment optional |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.0.3,<10",
+    "ciris-persist>=9.2.0,<10",
 ]
 dynamic = ["version"]
 

--- a/src/cohort_scope.rs
+++ b/src/cohort_scope.rs
@@ -50,6 +50,14 @@
 
 use serde::{Deserialize, Serialize};
 
+// v6.0.0 (CIRISEdge#175) — FSD §2.1 implementation note: edge
+// resolves through persist's `crypto_tier()` rather than enumerating
+// the 7-value lattice so future `affiliations` semantic changes flow
+// without wire-format churn.
+pub use ciris_persist::federation::types::cohort_scope::{
+    crypto_tier as persist_crypto_tier, CryptoTier,
+};
+
 /// Wire-form cohort-scope discriminator for the federation's locality
 /// dividend (CIRISEdge#48-A; FSD `FEDERATION_SCALING_MODEL.md`).
 ///
@@ -146,6 +154,64 @@ impl CohortScope {
             // Cohort scope: recipient must be in the same named cohort.
             (Self::Cohort { cohort_id: a }, Self::Cohort { cohort_id: b }) => a == b,
             (Self::Cohort { .. }, _) => false,
+        }
+    }
+
+    /// v6.0.0 (CIRISEdge#175, FSD §2.1) — resolve the at-rest crypto
+    /// tier this scope corresponds to via persist v9.2.0's
+    /// [`persist_crypto_tier`] (CC 4.4.3.2.1 lattice). Edge does NOT
+    /// duplicate persist's closed-set match; this method is the
+    /// single bridge so future `affiliations` semantic changes flow
+    /// without wire-format churn.
+    ///
+    /// The mapping edge's enum → persist's 7-value string lattice:
+    ///
+    /// - [`Self::Public`] → `"federation"` (Commons-tier plaintext)
+    /// - [`Self::SelfOnly`] → `"self"` (InvisibleEncrypted)
+    /// - [`Self::Family`] → `"family"` (InvisibleEncrypted)
+    /// - [`Self::Cohort`] → `"community"` with `cohort_subkind = None`
+    ///   (CommunityDek tier)
+    ///
+    /// The `cohort_subkind: "infrastructure"` opt-out (which
+    /// promotes community/affiliations to Commons-tier plaintext)
+    /// is a downstream-of-edge concern owned by persist's admission
+    /// path; edge's wire-format invariant continues to treat
+    /// `Cohort{..}` as CommunityDek at this resolution layer.
+    #[must_use]
+    pub fn crypto_tier(&self) -> CryptoTier {
+        match self {
+            Self::Public => persist_crypto_tier("federation", None),
+            Self::SelfOnly => persist_crypto_tier("self", None),
+            Self::Family => persist_crypto_tier("family", None),
+            Self::Cohort { .. } => persist_crypto_tier("community", None),
+        }
+    }
+
+    /// v6.0.0 (CIRISEdge#175, FSD §3.2) — the §3.2 default
+    /// cohort_scope flip: `cohort_scope` defaults to the smallest
+    /// scope consistent with the publisher's stated audience
+    /// context. **Federation scope is opt-in.**
+    ///
+    /// The §3.2 rule:
+    /// - if a `community_id` is active → `Cohort { community_id }`
+    /// - else if a family context is active → `Family`
+    /// - else → `SelfOnly`
+    ///
+    /// Federation publication is NEVER the default; callers must
+    /// pass `CohortScope::Public` explicitly to opt up to federation.
+    #[must_use]
+    pub fn default_for_audience(
+        active_community_id: Option<&str>,
+        in_family_context: bool,
+    ) -> Self {
+        if let Some(cid) = active_community_id {
+            Self::Cohort {
+                cohort_id: cid.to_string(),
+            }
+        } else if in_family_context {
+            Self::Family
+        } else {
+            Self::SelfOnly
         }
     }
 }
@@ -305,5 +371,72 @@ mod tests {
         assert_eq!(CohortScopeEnforcement::Strict.as_str(), "strict");
         assert_eq!(CohortScopeEnforcement::WarnOnly.as_str(), "warn_only");
         assert_eq!(CohortScopeEnforcement::Off.as_str(), "off");
+    }
+
+    // ─── v6.0.0 (CIRISEdge#175) — FSD §2.1 / §3.2 surface ───────────
+
+    #[test]
+    fn crypto_tier_resolves_through_persist() {
+        // FSD §2.1 implementation note — edge's enum maps onto
+        // persist's CC 4.4.3.2.1 lattice through `crypto_tier()`.
+        assert_eq!(
+            CohortScope::SelfOnly.crypto_tier(),
+            CryptoTier::InvisibleEncrypted
+        );
+        assert_eq!(
+            CohortScope::Family.crypto_tier(),
+            CryptoTier::InvisibleEncrypted
+        );
+        assert_eq!(
+            CohortScope::Cohort {
+                cohort_id: "alpha".into()
+            }
+            .crypto_tier(),
+            CryptoTier::CommunityDek
+        );
+        assert_eq!(CohortScope::Public.crypto_tier(), CryptoTier::Plaintext);
+    }
+
+    #[test]
+    fn default_for_audience_prefers_smallest_scope() {
+        // §3.2 — community when group context is active
+        assert_eq!(
+            CohortScope::default_for_audience(Some("alpha"), false),
+            CohortScope::Cohort {
+                cohort_id: "alpha".into()
+            }
+        );
+        // §3.2 — family when in family
+        assert_eq!(
+            CohortScope::default_for_audience(None, true),
+            CohortScope::Family
+        );
+        // §3.2 — self when no group context
+        assert_eq!(
+            CohortScope::default_for_audience(None, false),
+            CohortScope::SelfOnly
+        );
+        // Community wins over family when both signals fire
+        assert_eq!(
+            CohortScope::default_for_audience(Some("beta"), true),
+            CohortScope::Cohort {
+                cohort_id: "beta".into()
+            }
+        );
+    }
+
+    #[test]
+    fn default_never_returns_public() {
+        // §3.2 — federation is opt-in. The default flip MUST NEVER
+        // return Public — that's the entire CC 1.13.3.4 protection.
+        for (cid, fam) in [
+            (Some("c"), true),
+            (Some("c"), false),
+            (None, true),
+            (None, false),
+        ] {
+            let s = CohortScope::default_for_audience(cid, fam);
+            assert_ne!(s, CohortScope::Public, "default MUST never be Public");
+        }
     }
 }

--- a/src/directory_cache.rs
+++ b/src/directory_cache.rs
@@ -1,0 +1,284 @@
+//! §3.3 federation directory cache (CIRISEdge#175, v6.0.0).
+//!
+//! CEWP `SCOPE_PRIVACY.md` §3.3 — every participating L1 peer
+//! maintains a complete local copy of the federation directory's
+//! X-Wing + ML-DSA-65 public keys, refreshed via the substrate's
+//! existing `federation_keys` anti-entropy stream. **No per-
+//! invitation directory query is emitted.** Phone-class peers query
+//! through their L1-relay parent over a relay-blinded path (the
+//! existing Reticulum transport-node mode).
+//!
+//! The cache exposes the federation-public X-Wing keys (already
+//! public per FSD §9.5) without exposing the per-invitation
+//! `querier → invitee` edges that would otherwise be subpoenable
+//! under §5's "subpoena federation directory" defense.
+//!
+//! # v6.0.0 surface
+//!
+//! - [`DirectoryCache`] — in-memory `HashMap<FederationKeyId,
+//!   FederationDirectoryEntry>` with `RwLock`-backed concurrent
+//!   reads. The anti-entropy subscription wiring (the producer side
+//!   that fills the cache from the substrate's `federation_keys`
+//!   stream) is deferred to v6.1.0 — v6.0.0 ships the cache with a
+//!   public [`DirectoryCache::insert`] / [`DirectoryCache::remove`]
+//!   API for the v6.1.0 wiring agent to drive against.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+use crate::mls::welcome_wrap::FederationDirectoryEntry;
+
+/// §3.3 directory key identifier. Caller-scoped (a key_id,
+/// fingerprint, or federation_id — edge does not interpret); the
+/// only required property is that it round-trips byte-equal on the
+/// substrate-wide `federation_keys` anti-entropy stream.
+pub type FederationKeyId = String;
+
+/// Reachability hint stored on the directory entry. Used by the
+/// emission layer to choose a route (direct vs. relay-blinded
+/// through an L1 parent) without re-querying the directory at send
+/// time.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum Reachability {
+    /// Peer is directly reachable on at least one transport
+    /// interface the local peer participates on.
+    Direct,
+    /// Peer is reachable only through an L1 relay parent (FSD §3.3
+    /// phone-class-via-relay path).
+    Relay,
+    /// Unknown reachability — treat as relay for safety.
+    #[default]
+    Unknown,
+}
+
+/// §3.3 directory identity type. Caller-tagged (`steward`, `agent`,
+/// `phone`, `infra`, etc.) — edge does not interpret. Drives the
+/// emission layer's relay-blinding policy at the application tier.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct IdentityType(pub String);
+
+impl IdentityType {
+    /// `phone` — phone-class peers query through their L1-relay
+    /// parent over a relay-blinded path (§3.3).
+    pub fn phone() -> Self {
+        Self("phone".into())
+    }
+    /// `steward` — federation steward / governance tier.
+    pub fn steward() -> Self {
+        Self("steward".into())
+    }
+    /// `agent` — full-tier participating peer.
+    pub fn agent() -> Self {
+        Self("agent".into())
+    }
+}
+
+/// In-memory federation directory entry. Mirrors the four-field
+/// shape FSD §3.3 enumerates: X-Wing public key, ML-DSA-65 public
+/// key, identity_type, reachability.
+#[derive(Debug, Clone)]
+pub struct DirectoryRecord {
+    /// Federation identifier (the cache key).
+    pub federation_id: FederationKeyId,
+    /// ML-DSA-65 public key bytes (the
+    /// `EncodedVerifyingKey<MlDsa65>` form).
+    pub ml_dsa_pk: Vec<u8>,
+    /// X-Wing public key (X25519 + ML-KEM-768 halves). Optional
+    /// because some directory entries — e.g. read-only governance
+    /// keys — may carry only ML-DSA-65.
+    pub x_wing_pk: Option<XWingPublic>,
+    /// Caller-tagged identity type.
+    pub identity_type: IdentityType,
+    /// Reachability hint.
+    pub reachability: Reachability,
+}
+
+/// Plain-data X-Wing public key. Mirrors
+/// [`ciris_crypto::hpke::XWingRecipientPublic`] but as
+/// `Serialize`/`Deserialize` so directory entries can ride the
+/// anti-entropy stream.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct XWingPublic {
+    /// X25519 public key (32 bytes).
+    pub x25519_pub: [u8; 32],
+    /// ML-KEM-768 public key bytes.
+    pub mlkem768_pub: Vec<u8>,
+}
+
+impl From<XWingPublic> for ciris_crypto::hpke::XWingRecipientPublic {
+    fn from(p: XWingPublic) -> Self {
+        Self {
+            x25519_pub: p.x25519_pub,
+            mlkem768_pub: p.mlkem768_pub,
+        }
+    }
+}
+
+impl From<&XWingPublic> for ciris_crypto::hpke::XWingRecipientPublic {
+    fn from(p: &XWingPublic) -> Self {
+        Self {
+            x25519_pub: p.x25519_pub,
+            mlkem768_pub: p.mlkem768_pub.clone(),
+        }
+    }
+}
+
+/// §3.3 federation directory cache.
+///
+/// Clone-cheap: holds an `Arc<RwLock<HashMap>>` so multiple Edge
+/// surfaces (Welcome wrap, emission layer, scope echo) share one
+/// view without per-handle copies.
+#[derive(Clone, Default)]
+pub struct DirectoryCache {
+    inner: Arc<RwLock<HashMap<FederationKeyId, DirectoryRecord>>>,
+}
+
+impl DirectoryCache {
+    /// Construct an empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert / update a directory record. Used by the anti-entropy
+    /// driver (v6.1.0 — see module docs).
+    pub fn insert(&self, record: DirectoryRecord) {
+        let mut g = self.inner.write();
+        g.insert(record.federation_id.clone(), record);
+    }
+
+    /// Remove a directory record by `federation_id`. Used when the
+    /// anti-entropy stream observes a key revocation.
+    pub fn remove(&self, federation_id: &str) -> Option<DirectoryRecord> {
+        let mut g = self.inner.write();
+        g.remove(federation_id)
+    }
+
+    /// Lookup a directory record by `federation_id`.
+    #[must_use]
+    pub fn get(&self, federation_id: &str) -> Option<DirectoryRecord> {
+        let g = self.inner.read();
+        g.get(federation_id).cloned()
+    }
+
+    /// Total number of cached entries.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.read().len()
+    }
+
+    /// `true` iff the cache is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().is_empty()
+    }
+
+    /// `true` iff `federation_id` is present in the cache.
+    #[must_use]
+    pub fn contains(&self, federation_id: &str) -> bool {
+        self.inner.read().contains_key(federation_id)
+    }
+
+    /// Build a closure usable as the `directory_lookup` argument to
+    /// [`crate::mls::welcome_wrap::unwrap_welcome`]. The closure
+    /// resolves `pk_id → FederationDirectoryEntry` against THIS
+    /// cache.
+    pub fn welcome_wrap_lookup(&self) -> impl FnMut(&str) -> Option<FederationDirectoryEntry> + '_ {
+        move |pk_id: &str| {
+            let g = self.inner.read();
+            g.get(pk_id).map(|r| FederationDirectoryEntry {
+                pk_id: r.federation_id.clone(),
+                ml_dsa_pk: r.ml_dsa_pk.clone(),
+                x_wing_pk: r.x_wing_pk.as_ref().map(Into::into),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rec(id: &str, pk_byte: u8) -> DirectoryRecord {
+        DirectoryRecord {
+            federation_id: id.into(),
+            ml_dsa_pk: vec![pk_byte; 1952],
+            x_wing_pk: Some(XWingPublic {
+                x25519_pub: [pk_byte; 32],
+                mlkem768_pub: vec![pk_byte; 1184],
+            }),
+            identity_type: IdentityType::agent(),
+            reachability: Reachability::Direct,
+        }
+    }
+
+    #[test]
+    fn insert_get_roundtrip() {
+        let cache = DirectoryCache::new();
+        assert!(cache.is_empty());
+        cache.insert(rec("alice", 0xaa));
+        assert_eq!(cache.len(), 1);
+        assert!(cache.contains("alice"));
+        let got = cache.get("alice").unwrap();
+        assert_eq!(got.federation_id, "alice");
+        assert_eq!(got.ml_dsa_pk[0], 0xaa);
+        assert_eq!(got.identity_type, IdentityType::agent());
+    }
+
+    #[test]
+    fn lookup_missing_returns_none() {
+        let cache = DirectoryCache::new();
+        cache.insert(rec("alice", 0xaa));
+        assert!(cache.get("bob").is_none());
+    }
+
+    #[test]
+    fn remove_pulls_entry() {
+        let cache = DirectoryCache::new();
+        cache.insert(rec("alice", 0xaa));
+        let removed = cache.remove("alice").unwrap();
+        assert_eq!(removed.federation_id, "alice");
+        assert!(cache.get("alice").is_none());
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn welcome_wrap_lookup_resolves_via_cache() {
+        let cache = DirectoryCache::new();
+        cache.insert(rec("alice", 0xaa));
+        let mut lookup = cache.welcome_wrap_lookup();
+        let entry = lookup("alice").unwrap();
+        assert_eq!(entry.pk_id, "alice");
+        assert_eq!(entry.ml_dsa_pk[0], 0xaa);
+        assert!(lookup("bob").is_none());
+    }
+
+    #[test]
+    fn insert_overwrites_existing() {
+        let cache = DirectoryCache::new();
+        cache.insert(rec("alice", 0xaa));
+        cache.insert(rec("alice", 0xbb));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get("alice").unwrap().ml_dsa_pk[0], 0xbb);
+    }
+
+    #[test]
+    fn reachability_default_is_unknown() {
+        assert_eq!(Reachability::default(), Reachability::Unknown);
+    }
+
+    #[test]
+    fn xwing_public_into_recipient_roundtrip() {
+        let p = XWingPublic {
+            x25519_pub: [0x42; 32],
+            mlkem768_pub: vec![0x11; 1184],
+        };
+        let recipient: ciris_crypto::hpke::XWingRecipientPublic = (&p).into();
+        assert_eq!(recipient.x25519_pub, p.x25519_pub);
+        assert_eq!(recipient.mlkem768_pub, p.mlkem768_pub);
+    }
+}

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -908,6 +908,25 @@ pub struct Edge {
     /// no replication routing, every frame goes to `dispatch_inbound`.
     replication_registry:
         Arc<std::sync::OnceLock<Arc<crate::replication::registry::ReplicationRegistry>>>,
+    /// v5.2.0 (CIRISEdge#143) — opt-in fountain swarm orchestration
+    /// runtime. Set-once via `OnceLock`; the [`Edge::install_swarm_runtime`]
+    /// post-build setter holds the runtime for the lifetime of
+    /// `Edge`. When set, the operator's dispatch path may call
+    /// [`crate::swarm::FountainSwarmRuntime::register_observed_claim`]
+    /// on verified inbound holding-claim bodies. When `None`, no
+    /// swarm orchestration runs — the substrate primitives stay
+    /// reachable for tests but no live publisher / converger fires.
+    ///
+    /// `OnceLock<Arc<_>>` because the lifecycle is `install once
+    /// before run`; cheap atomic load from the inbound side.
+    swarm_runtime: Arc<std::sync::OnceLock<Arc<crate::swarm::FountainSwarmRuntime>>>,
+    /// v5.2.0 (CIRISEdge#143) — opt-in consent-decay scheduler
+    /// shutdown handle. Same lifecycle as [`Self::swarm_runtime`];
+    /// when set, [`Edge::shutdown_swarm_runtime`] also signals the
+    /// decay scheduler to stop. `None` keeps the v5.1.0 behavior
+    /// exactly (the operator drives the scheduler manually).
+    #[cfg(feature = "holonomic-consent-decay")]
+    consent_decay_shutdown: Arc<std::sync::OnceLock<tokio::sync::watch::Sender<()>>>,
     /// Optional pipeline run on outbound inline-text envelopes
     /// (SPEAK responses, LLM prompts, WBD bodies, DSAR text). When
     /// `Some`, `send_inline` / `send_durable_inline` invoke this
@@ -1567,6 +1586,55 @@ impl Edge {
         // we ignore it: the OnceLock semantics + the lifecycle
         // (install-before-run) make this a no-op race-free guarantee.
         let _ = self.replication_registry.set(runtime.registry());
+    }
+
+    /// v5.2.0 (CIRISEdge#143) — register a
+    /// [`crate::swarm::FountainSwarmRuntime`] with `Edge`. Set-once;
+    /// the runtime is held for the lifetime of `Edge`. After
+    /// installation:
+    ///
+    /// - [`Self::swarm_runtime_handle`] returns the registered
+    ///   runtime (None until install).
+    /// - The operator's inbound dispatch path may call
+    ///   [`crate::swarm::FountainSwarmRuntime::register_observed_claim`]
+    ///   on verified holding-claim bodies. (v5.2.0 does not yet
+    ///   add a wire-tier `MessageType::FountainHoldingClaim`
+    ///   discriminator — the integration point is exposed at the
+    ///   API surface so a follow-up cut can wire the dispatch
+    ///   routing without re-touching `Edge::run`.)
+    ///
+    /// Idempotent: a second call is silently ignored (first wins).
+    pub fn install_swarm_runtime(&self, runtime: Arc<crate::swarm::FountainSwarmRuntime>) {
+        let _ = self.swarm_runtime.set(runtime);
+    }
+
+    /// v5.2.0 — return the installed
+    /// [`crate::swarm::FountainSwarmRuntime`], if any. `None` when
+    /// [`Self::install_swarm_runtime`] has not been called yet.
+    pub fn swarm_runtime_handle(&self) -> Option<Arc<crate::swarm::FountainSwarmRuntime>> {
+        self.swarm_runtime.get().cloned()
+    }
+
+    /// v5.2.0 (CIRISEdge#143) — register a consent-decay scheduler
+    /// shutdown handle. The operator spawns
+    /// [`crate::holonomic::consent_decay::ConsentDecayScheduler::run`]
+    /// against a `tokio::sync::watch::channel(())` receiver and hands
+    /// the sender to this method; [`Self::shutdown_consent_decay`]
+    /// then flips the channel on `Edge` teardown.
+    ///
+    /// Gated on the `holonomic-consent-decay` feature.
+    #[cfg(feature = "holonomic-consent-decay")]
+    pub fn install_consent_decay_shutdown(&self, shutdown_tx: tokio::sync::watch::Sender<()>) {
+        let _ = self.consent_decay_shutdown.set(shutdown_tx);
+    }
+
+    /// v5.2.0 — flip the registered consent-decay shutdown channel.
+    /// Idempotent; no-op when nothing was registered.
+    #[cfg(feature = "holonomic-consent-decay")]
+    pub fn shutdown_consent_decay(&self) {
+        if let Some(tx) = self.consent_decay_shutdown.get() {
+            let _ = tx.send(());
+        }
     }
 
     /// Register a typed handler for message type `M`. Compile-time
@@ -4886,6 +4954,9 @@ impl EdgeBuilder {
             steward_directory: self.steward_directory,
             blob_chunk_source: self.blob_chunk_source,
             replication_registry: Arc::new(std::sync::OnceLock::new()),
+            swarm_runtime: Arc::new(std::sync::OnceLock::new()),
+            #[cfg(feature = "holonomic-consent-decay")]
+            consent_decay_shutdown: Arc::new(std::sync::OnceLock::new()),
             subscription_filter: self.subscription_filter,
             events,
             display_name: Arc::new(std::sync::RwLock::new(display_name)),

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1618,10 +1618,10 @@ impl PyReplicationHandle {
         })
     }
 
-    /// Hot-add a `(peer_key_id, kind)` after start. See
-    /// `ReplicationRuntime::register_peer` for the v1 limitation
-    /// (hot-adds default to Responder role; the scheduler's
-    /// Initiator set is fixed at start in v1).
+    /// Hot-add a `(peer_key_id, kind)` after start. Defaults to
+    /// Responder role — for the CEG-driven reconciler path that
+    /// needs the new peer to actively initiate rounds, use
+    /// [`Self::register_initiator_peer`] (CIRISEdge#173 / v5.1.0).
     fn register_peer(&self, py: Python<'_>, peer_key_id: &str, kind: &str) -> PyResult<()> {
         let kind = parse_envelope_kind(kind)?;
         let peer = peer_key_id.to_string();
@@ -1636,6 +1636,94 @@ impl PyReplicationHandle {
             });
         });
         Ok(())
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — hot-add an Initiator peer at runtime.
+    /// The scheduler spawns a task that fires anti-entropy rounds at
+    /// the configured cadence immediately. Idempotent.
+    ///
+    /// Raises `RuntimeError` if the runtime has been stopped.
+    fn register_initiator_peer(
+        &self,
+        py: Python<'_>,
+        peer_key_id: &str,
+        kind: &str,
+    ) -> PyResult<()> {
+        let kind = parse_envelope_kind(kind)?;
+        let peer = peer_key_id.to_string();
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .register_initiator_peer(peer, kind)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — hot-remove a `(peer_key_id, kind)`.
+    /// Stops the matching coordinator's scheduled rounds (if active)
+    /// AND deregisters from the inbound registry. Idempotent.
+    fn remove_peer(&self, py: Python<'_>, peer_key_id: &str, kind: &str) -> PyResult<()> {
+        let kind = parse_envelope_kind(kind)?;
+        let peer = peer_key_id.to_string();
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .remove_peer(peer, kind)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — diff-and-converge the live Initiator
+    /// set against `desired`. Adds and removes peers so that, after
+    /// the call returns, the runtime's Initiator coordinators exactly
+    /// match `desired`. The intended driver for CEG-reconcilers:
+    /// call on every consent-object delta.
+    ///
+    /// `desired` is a list of `(peer_key_id, kind)` tuples; kind is
+    /// one of the accepted [`crate::replication::protocol::EnvelopeKind`]
+    /// strings.
+    fn set_peers(&self, py: Python<'_>, desired: Vec<(String, String)>) -> PyResult<()> {
+        let mut peers = Vec::with_capacity(desired.len());
+        for (peer_key_id, kind_str) in desired {
+            let kind = parse_envelope_kind(&kind_str)?;
+            peers.push(crate::replication::runtime::ReplicationPeer { peer_key_id, kind });
+        }
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .set_peers(peers)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
     }
 
     /// Stop the replication runtime — signals the scheduler to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ pub mod outbound;
 pub mod reachability;
 pub mod replication;
 pub mod sas;
+pub mod swarm;
 pub mod transport;
 pub mod verify;
 pub mod version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ pub mod cohort_scope;
 #[cfg(feature = "debug-tools")]
 pub mod debug;
 pub mod detector;
+// v6.0.0 (CIRISEdge#175, FSD §3.3) — cached federation directory.
+pub mod directory_cache;
 mod edge;
 pub mod events;
 pub mod ffi;
@@ -68,12 +70,18 @@ pub mod identity;
 pub mod key_boundary;
 pub mod manifest;
 pub mod messages;
+// v6.0.0 (CIRISEdge#175, FSD §3.3 / §3.5 / §6) — substrate-tier MLS
+// state for scope-native privacy. Distinct from
+// `transport::realtime_av_mls` (per-stream AV MLS).
+pub mod mls;
 pub mod multimedia;
 pub mod observability;
 pub mod outbound;
 pub mod reachability;
 pub mod replication;
 pub mod sas;
+// v6.0.0 (CIRISEdge#175) — CC 1.13.3.4 substrate.
+pub mod scope_privacy;
 pub mod swarm;
 pub mod transport;
 pub mod verify;
@@ -83,10 +91,14 @@ pub use blob_swarm::{
     BlobChunkSource, BlobChunkVerifier, ChunkManifestLite, ChunkSourceRefusal, ChunkVerifyError,
     PeerState, SwarmConfig, SwarmError, SwarmScheduler,
 };
-pub use cohort_scope::{CohortScope, CohortScopeEnforcement};
+pub use cohort_scope::{CohortScope, CohortScopeEnforcement, CryptoTier};
+// v6.0.0 (CIRISEdge#175) — scope-native privacy surface re-exports.
 pub use detector::{
     ConsentRole, DetectionVerdict, EdgeDetectionAdmission, ProbePatternConfig,
     ProbePatternObserver, ProbePatternState,
+};
+pub use directory_cache::{
+    DirectoryCache, DirectoryRecord, FederationKeyId, IdentityType, Reachability, XWingPublic,
 };
 pub use edge::{
     reseed_canonical_bootstrap_peers, run_blackhole_pruner, AgentMode, CanonicalBootstrapPeer,
@@ -121,6 +133,11 @@ pub use messages::{
     DELIVERY_REFUSAL_ATTESTATION_DOMAIN, FEDERATION_ANNOUNCEMENT_ACCORD_SIG_DOMAIN,
     GOAL_DECLARATION_DOMAIN, GOAL_RETIREMENT_DOMAIN,
 };
+pub use mls::{
+    unwrap_welcome, wrap_welcome, ArchiveMode, ArchiveModeError, FederationDirectoryEntry,
+    ScopeStateProvider, ScopeStateProviderError, WelcomeWrapError, WrappedWelcome,
+    DEFAULT_ROTATE_FORWARD_WINDOW_DAYS,
+};
 pub use multimedia::{
     cdn_edge_prefetch_stub, is_fast_path_legal_basis, ContributionDispatchProbe,
     ContributionSubjectKind, ExternalRefWithAcl, FastPathLegalBasis,
@@ -133,6 +150,10 @@ pub use outbound::{
     StewardKey,
 };
 pub use reachability::{AttemptOutcome, PeerMediumReachability, ReachabilityTracker};
+pub use scope_privacy::{
+    derive_record_id, derive_symbol_key, k_record_id, k_symbol, witness_cover_leaf, RecordType,
+    HPKE_SUITE_ID, LABEL_RECORD_ID, LABEL_SYMBOL,
+};
 pub use transport::{InboundFrame, Transport, TransportError, TransportId, TransportSendOutcome};
 pub use verify::{
     AccordHolderKey, HybridPolicy, ProvenanceChain, ProvenanceLink, RootingDirectory,

--- a/src/mls/archive_mode.rs
+++ b/src/mls/archive_mode.rs
@@ -1,0 +1,191 @@
+//! §3.5 per-community archive policy (CIRISEdge#175, v6.0.0).
+//!
+//! CEWP `SCOPE_PRIVACY.md` §3.5 — MLS epoch advance bounds the
+//! lifetime of `K_record_id` / `K_symbol`. Each community configures
+//! one of:
+//!
+//! - [`ArchiveMode::RotateForward`] (default, 30-day window): honest
+//!   holders delete past-epoch keys after the window. Forward-secrecy
+//!   is **honest-holder discipline, not cryptographic** — a holder
+//!   under coercion or running modified software can retain keys
+//!   (FSD §7.8 — warm-state seizure / dishonest holder).
+//! - [`ArchiveMode::Retain`]: holders retain past-epoch keys
+//!   indefinitely for archive readability; an adversary compromising
+//!   a member at epoch N+k recovers everything back to their join
+//!   epoch.
+//!
+//! Stored alongside the MLS group state in the
+//! [`super::scope_state::ScopeStateProvider`]'s KV under the
+//! `"archive_mode"` namespace.
+
+use serde::{Deserialize, Serialize};
+
+/// FSD §3.5 default rotate-forward window (days).
+pub const DEFAULT_ROTATE_FORWARD_WINDOW_DAYS: u32 = 30;
+
+/// Reserved KV namespace under which the per-community archive_mode
+/// value is stored in the [`super::scope_state::ScopeStateProvider`].
+pub const ARCHIVE_MODE_NAMESPACE: &str = "archive_mode";
+
+/// FSD §3.5 per-community archive policy.
+///
+/// **Honest-holder discipline.** [`ArchiveMode::RotateForward`] is
+/// the default and provides forward-secrecy *only against an honest
+/// holder under uncoerced operation*. A holder under coercion, a
+/// holder running modified software, or a warm-state seizure of the
+/// holder's RAM (FSD §7.8) all defeat forward-secrecy structurally;
+/// the policy is not cryptographic. Communities that need
+/// archive-readable history opt to [`ArchiveMode::Retain`] knowing
+/// that an adversary compromising any member at epoch N+k recovers
+/// everything back to that member's join epoch.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum ArchiveMode {
+    /// Honest holders delete past-epoch `K_record_id` / `K_symbol`
+    /// keys after `window_days`. The default; the FSD §3.5 policy.
+    RotateForward {
+        /// Retention window (days) after which past-epoch keys are
+        /// deleted. Default [`DEFAULT_ROTATE_FORWARD_WINDOW_DAYS`].
+        window_days: u32,
+    },
+    /// Holders retain past-epoch keys indefinitely for archive
+    /// readability. Trades forward-secrecy for archive-readable
+    /// history.
+    Retain,
+}
+
+impl ArchiveMode {
+    /// The FSD §3.5 default: `RotateForward { window_days = 30 }`.
+    #[must_use]
+    pub const fn default_rotate_forward() -> Self {
+        Self::RotateForward {
+            window_days: DEFAULT_ROTATE_FORWARD_WINDOW_DAYS,
+        }
+    }
+
+    /// Stable string-token for telemetry / structured logging.
+    #[must_use]
+    pub const fn kind_token(&self) -> &'static str {
+        match self {
+            Self::RotateForward { .. } => "rotate_forward",
+            Self::Retain => "retain",
+        }
+    }
+
+    /// `true` iff this mode provides honest-holder forward-secrecy
+    /// (rotate-forward only).
+    #[must_use]
+    pub const fn is_forward_secret(&self) -> bool {
+        matches!(self, Self::RotateForward { .. })
+    }
+}
+
+impl Default for ArchiveMode {
+    fn default() -> Self {
+        Self::default_rotate_forward()
+    }
+}
+
+/// Errors from the archive_mode persistence surface.
+#[derive(Debug, thiserror::Error)]
+pub enum ArchiveModeError {
+    /// The `window_days` value is out of acceptable bounds. FSD §3.5
+    /// has no explicit ceiling, but values >= 10 years (3650 days)
+    /// are rejected as almost certainly operator error — a community
+    /// asking for 10-year forward-secret rotation effectively wants
+    /// `Retain` and should opt in explicitly.
+    #[error("rotate_forward window_days {0} out of bounds (1..=3650)")]
+    WindowDaysOutOfBounds(u32),
+    /// Underlying KV store error (passed through from persist's
+    /// `EncryptedKVStore`).
+    #[error("archive_mode kv error: {0}")]
+    Kv(String),
+    /// Codec error decoding a stored archive_mode value.
+    #[error("archive_mode decode error: {0}")]
+    Decode(String),
+}
+
+impl ArchiveMode {
+    /// Validate the mode for storage. `RotateForward { window_days = 0 }`
+    /// or `window_days > 3650` (10y) is rejected — see [`ArchiveModeError`].
+    pub fn validate(&self) -> Result<(), ArchiveModeError> {
+        match self {
+            Self::RotateForward { window_days } => {
+                if *window_days == 0 || *window_days > 3650 {
+                    return Err(ArchiveModeError::WindowDaysOutOfBounds(*window_days));
+                }
+                Ok(())
+            }
+            Self::Retain => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_rotate_forward_30_days() {
+        assert_eq!(
+            ArchiveMode::default(),
+            ArchiveMode::RotateForward { window_days: 30 }
+        );
+    }
+
+    #[test]
+    fn kind_token_stable() {
+        assert_eq!(ArchiveMode::default().kind_token(), "rotate_forward");
+        assert_eq!(ArchiveMode::Retain.kind_token(), "retain");
+    }
+
+    #[test]
+    fn forward_secret_only_rotate_forward() {
+        assert!(ArchiveMode::default().is_forward_secret());
+        assert!(!ArchiveMode::Retain.is_forward_secret());
+    }
+
+    #[test]
+    fn validate_accepts_sane_windows() {
+        assert!(ArchiveMode::RotateForward { window_days: 1 }
+            .validate()
+            .is_ok());
+        assert!(ArchiveMode::RotateForward { window_days: 30 }
+            .validate()
+            .is_ok());
+        assert!(ArchiveMode::RotateForward { window_days: 3650 }
+            .validate()
+            .is_ok());
+        assert!(ArchiveMode::Retain.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_out_of_bounds_window() {
+        assert!(matches!(
+            ArchiveMode::RotateForward { window_days: 0 }.validate(),
+            Err(ArchiveModeError::WindowDaysOutOfBounds(0))
+        ));
+        assert!(matches!(
+            ArchiveMode::RotateForward { window_days: 3651 }.validate(),
+            Err(ArchiveModeError::WindowDaysOutOfBounds(3651))
+        ));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let m = ArchiveMode::RotateForward { window_days: 30 };
+        let s = serde_json::to_string(&m).unwrap();
+        let back: ArchiveMode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, m);
+
+        let r = ArchiveMode::Retain;
+        let s = serde_json::to_string(&r).unwrap();
+        let back: ArchiveMode = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, r);
+    }
+
+    #[test]
+    fn namespace_pinned() {
+        assert_eq!(ARCHIVE_MODE_NAMESPACE, "archive_mode");
+    }
+}

--- a/src/mls/mod.rs
+++ b/src/mls/mod.rs
@@ -1,0 +1,37 @@
+//! Substrate-tier MLS state for scope-native privacy (CIRISEdge#175,
+//! v6.0.0).
+//!
+//! Distinct from `transport::realtime_av_mls` — the per-AV-stream
+//! MLS exporter-bound media key state used by the realtime AV
+//! dispatcher. This module owns the **persistent, substrate-tier**
+//! MLS group state per `(community_id, group_epoch)` referenced by
+//! CEWP `SCOPE_PRIVACY.md` §3.3 (Welcome wrap), §3.5 (archive_mode),
+//! and §2.2 (group exporter_secret → record_id / symbol subkeys via
+//! verify v6.3.0's `ciris_crypto::scope_privacy`).
+//!
+//! # Layering
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────────────────────┐
+//! │ scope_privacy.rs (verify v6.3.0 re-exports)                 │
+//! │     k_record_id  │  k_symbol  │  derive_record_id  │ …      │
+//! └───────────────────────────┬─────────────────────────────────┘
+//!                             │
+//! ┌───────────────────────────┴─────────────────────────────────┐
+//! │ mls/                                                        │
+//! │  ├── archive_mode      — §3.5 per-community config          │
+//! │  ├── welcome_wrap      — §3.3 HPKE-Base + ML-DSA-65 Welcome │
+//! │  ├── scope_state       — substrate-tier StorageProvider     │
+//! │  │                      (openmls 0.8) over EncryptedKVStore │
+//! └─────────────────────────────────────────────────────────────┘
+//! ```
+
+pub mod archive_mode;
+pub mod scope_state;
+pub mod welcome_wrap;
+
+pub use archive_mode::{ArchiveMode, ArchiveModeError, DEFAULT_ROTATE_FORWARD_WINDOW_DAYS};
+pub use scope_state::{ScopeStateProvider, ScopeStateProviderError};
+pub use welcome_wrap::{
+    unwrap_welcome, wrap_welcome, FederationDirectoryEntry, WelcomeWrapError, WrappedWelcome,
+};

--- a/src/mls/scope_state.rs
+++ b/src/mls/scope_state.rs
@@ -1,0 +1,309 @@
+//! Substrate-tier MLS state provider (CIRISEdge#175, v6.0.0).
+//!
+//! Backed by [`ciris_persist::encrypted_kv::XChaChaKvStore`] — the
+//! persist v9.2.0 app-layer XChaCha20-Poly1305-sealed KV store. The
+//! at-rest database file is **opaque** to anyone who reads it
+//! without the boot passphrase (CEWP `SCOPE_PRIVACY.md` §6 / §7.8
+//! cold-state opacity property).
+//!
+//! # What this is in v6.0.0
+//!
+//! The persistent KV surface CIRISEdge layers substrate-tier MLS
+//! group state on. Per FSD §6.1 the openmls 0.8
+//! [`openmls_traits::storage::StorageProvider`] implementation is
+//! the eventual landing point; v6.0.0 ships the
+//! [`ScopeStateProvider`] scaffold that owns the KV handle, the
+//! namespace conventions (one per `(community_id, group_epoch)`),
+//! and the [`crate::mls::archive_mode::ArchiveMode`] get/put surface.
+//!
+//! The full `StorageProvider` trait surface (~60 methods spanning
+//! group state, ratchet trees, secrets, proposals, key packages,
+//! own-leaf bookkeeping) is **DEFERRED to v6.1.0** so this cut
+//! doesn't carry a half-implemented MLS storage layer. The deferred
+//! work lives at [`StorageProvider impl`](https://github.com/CIRISAI/CIRISEdge/issues/175)
+//! — the v6.0.0 cut intentionally hands edge an opaque KV with the
+//! right namespace conventions, and v6.1.0 will implement the trait
+//! over THIS exact scaffold.
+//!
+//! # Namespace conventions
+//!
+//! Per-community state is namespaced as
+//! `"mls/{community_id}/{kind}"` so a single
+//! `XChaChaKvStore` houses every community the operator participates
+//! in without cross-namespace AEAD bleed (persist's namespace
+//! isolation is cryptographic: `K_value(ns)` is HKDF-bound to the
+//! namespace bytes — see persist v9.2.0 `encrypted_kv` module docs).
+//!
+//! Kinds defined in v6.0.0:
+//! - [`KIND_ARCHIVE_MODE`] — the §3.5 per-community archive policy
+//!   (stored under [`super::archive_mode::ARCHIVE_MODE_NAMESPACE`]
+//!   sub-key).
+//! - [`KIND_GROUP_STATE`] — opaque MLS group serialization
+//!   (v6.1.0 fills in via `StorageProvider`).
+
+use std::sync::Arc;
+
+use ciris_persist::encrypted_kv::{EncryptedKVStore, KVError, XChaChaKvStore};
+
+use super::archive_mode::{ArchiveMode, ArchiveModeError, ARCHIVE_MODE_NAMESPACE};
+
+/// MLS group-state kind. The opaque MLS serialization
+/// (`MlsGroup::save` output, or the v6.1.0 `StorageProvider`-
+/// produced serialization).
+pub const KIND_GROUP_STATE: &str = "group_state";
+
+/// Archive-mode kind — see [`ARCHIVE_MODE_NAMESPACE`].
+pub const KIND_ARCHIVE_MODE: &str = ARCHIVE_MODE_NAMESPACE;
+
+/// Build the per-community namespace for a kind under
+/// `mls/{community_id}/{kind}`.
+#[must_use]
+fn namespace_for(community_id: &str, kind: &str) -> String {
+    format!("mls/{community_id}/{kind}")
+}
+
+/// Substrate-tier MLS state provider — the KV-backed surface the
+/// v6.1.0 openmls 0.8 [`StorageProvider`] will implement over.
+///
+/// # Cloning
+///
+/// `ScopeStateProvider` holds an [`Arc<XChaChaKvStore>`]. Cheap to
+/// clone; clones share the same on-disk database and boot
+/// passphrase.
+///
+/// # v6.0.0 surface
+///
+/// - [`Self::archive_mode_get`] / [`Self::archive_mode_put`] — §3.5
+///   per-community archive policy.
+/// - [`Self::group_state_get`] / [`Self::group_state_put`] —
+///   opaque MLS group serialization slot. Will be the entry point
+///   for v6.1.0's `StorageProvider::write_group_state` /
+///   `read_group_state`.
+#[derive(Clone)]
+pub struct ScopeStateProvider {
+    kv: Arc<XChaChaKvStore>,
+}
+
+/// Errors from the substrate-tier MLS state provider.
+#[derive(Debug, thiserror::Error)]
+pub enum ScopeStateProviderError {
+    /// Underlying [`XChaChaKvStore`] error.
+    #[error("kv error: {0}")]
+    Kv(KVError),
+    /// Archive-mode codec / validation error.
+    #[error(transparent)]
+    ArchiveMode(#[from] ArchiveModeError),
+    /// CBOR / JSON codec error.
+    #[error("codec error: {0}")]
+    Codec(String),
+}
+
+impl From<KVError> for ScopeStateProviderError {
+    fn from(e: KVError) -> Self {
+        Self::Kv(e)
+    }
+}
+
+impl ScopeStateProvider {
+    /// Wrap an existing [`XChaChaKvStore`] handle. The store MUST
+    /// already be opened with the operator's boot passphrase (or a
+    /// hardware-released equivalent — see persist v9.2.0
+    /// `encrypted_kv` "Hardware-key custodian boundary").
+    #[must_use]
+    pub fn new(kv: Arc<XChaChaKvStore>) -> Self {
+        Self { kv }
+    }
+
+    /// Read the per-community [`ArchiveMode`], or `None` if no
+    /// archive_mode has been configured for this community.
+    ///
+    /// # Errors
+    ///
+    /// - KV read fault → [`ScopeStateProviderError::Kv`]
+    /// - Corrupt JSON value → [`ScopeStateProviderError::Codec`]
+    pub async fn archive_mode_get(
+        &self,
+        community_id: &str,
+    ) -> Result<Option<ArchiveMode>, ScopeStateProviderError> {
+        let ns = namespace_for(community_id, KIND_ARCHIVE_MODE);
+        let raw = self.kv.get(&ns, b"v1").await?;
+        match raw {
+            None => Ok(None),
+            Some(bytes) => {
+                let parsed: ArchiveMode = serde_json::from_slice(&bytes)
+                    .map_err(|e| ScopeStateProviderError::Codec(e.to_string()))?;
+                Ok(Some(parsed))
+            }
+        }
+    }
+
+    /// Write the per-community [`ArchiveMode`]. The mode is
+    /// validated ([`ArchiveMode::validate`]) before storage.
+    ///
+    /// # Errors
+    ///
+    /// - Validation fault → [`ScopeStateProviderError::ArchiveMode`]
+    /// - KV write fault → [`ScopeStateProviderError::Kv`]
+    pub async fn archive_mode_put(
+        &self,
+        community_id: &str,
+        mode: ArchiveMode,
+    ) -> Result<(), ScopeStateProviderError> {
+        mode.validate()?;
+        let ns = namespace_for(community_id, KIND_ARCHIVE_MODE);
+        let bytes =
+            serde_json::to_vec(&mode).map_err(|e| ScopeStateProviderError::Codec(e.to_string()))?;
+        self.kv.put(&ns, b"v1", &bytes).await?;
+        Ok(())
+    }
+
+    /// Read the opaque MLS group-state serialization, or `None` if
+    /// no group state has been persisted for `(community_id, epoch)`.
+    ///
+    /// v6.0.0 ships an opaque `Vec<u8>` slot; v6.1.0's
+    /// `StorageProvider` will own the codec.
+    ///
+    /// # Errors
+    ///
+    /// - KV read fault → [`ScopeStateProviderError::Kv`]
+    pub async fn group_state_get(
+        &self,
+        community_id: &str,
+        epoch: u64,
+    ) -> Result<Option<Vec<u8>>, ScopeStateProviderError> {
+        let ns = namespace_for(community_id, KIND_GROUP_STATE);
+        let key = epoch.to_be_bytes();
+        let raw = self.kv.get(&ns, &key).await?;
+        Ok(raw)
+    }
+
+    /// Write the opaque MLS group-state serialization for
+    /// `(community_id, epoch)`. Overwrites any prior value at the
+    /// same coordinates (re-persisting the same epoch after a no-op
+    /// commit is allowed).
+    ///
+    /// # Errors
+    ///
+    /// - KV write fault → [`ScopeStateProviderError::Kv`]
+    pub async fn group_state_put(
+        &self,
+        community_id: &str,
+        epoch: u64,
+        bytes: &[u8],
+    ) -> Result<(), ScopeStateProviderError> {
+        let ns = namespace_for(community_id, KIND_GROUP_STATE);
+        let key = epoch.to_be_bytes();
+        self.kv.put(&ns, &key, bytes).await?;
+        Ok(())
+    }
+
+    /// Delete the opaque MLS group-state serialization for
+    /// `(community_id, epoch)`. Used by §3.5 `rotate-forward`'s
+    /// past-epoch-key prune sweep (honest-holder discipline; FSD
+    /// §3.5 / §7.8).
+    ///
+    /// # Errors
+    ///
+    /// - KV delete fault → [`ScopeStateProviderError::Kv`]
+    pub async fn group_state_delete(
+        &self,
+        community_id: &str,
+        epoch: u64,
+    ) -> Result<(), ScopeStateProviderError> {
+        let ns = namespace_for(community_id, KIND_GROUP_STATE);
+        let key = epoch.to_be_bytes();
+        self.kv.delete(&ns, &key).await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn open_provider() -> ScopeStateProvider {
+        let kv = XChaChaKvStore::open_in_memory(b"test-passphrase").unwrap();
+        ScopeStateProvider::new(Arc::new(kv))
+    }
+
+    #[tokio::test]
+    async fn archive_mode_roundtrip() {
+        let provider = open_provider();
+        assert_eq!(
+            provider.archive_mode_get("community-1").await.unwrap(),
+            None
+        );
+
+        let mode = ArchiveMode::RotateForward { window_days: 7 };
+        provider
+            .archive_mode_put("community-1", mode)
+            .await
+            .unwrap();
+        let back = provider.archive_mode_get("community-1").await.unwrap();
+        assert_eq!(back, Some(mode));
+    }
+
+    #[tokio::test]
+    async fn archive_mode_per_community_isolation() {
+        let provider = open_provider();
+        provider
+            .archive_mode_put("community-A", ArchiveMode::default())
+            .await
+            .unwrap();
+        provider
+            .archive_mode_put("community-B", ArchiveMode::Retain)
+            .await
+            .unwrap();
+        assert_eq!(
+            provider.archive_mode_get("community-A").await.unwrap(),
+            Some(ArchiveMode::default())
+        );
+        assert_eq!(
+            provider.archive_mode_get("community-B").await.unwrap(),
+            Some(ArchiveMode::Retain)
+        );
+    }
+
+    #[tokio::test]
+    async fn archive_mode_rejects_invalid_window() {
+        let provider = open_provider();
+        let bad = ArchiveMode::RotateForward { window_days: 0 };
+        assert!(matches!(
+            provider.archive_mode_put("community-c", bad).await,
+            Err(ScopeStateProviderError::ArchiveMode(
+                ArchiveModeError::WindowDaysOutOfBounds(0)
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn group_state_roundtrip() {
+        let provider = open_provider();
+        assert_eq!(provider.group_state_get("c1", 0).await.unwrap(), None);
+
+        let payload = b"opaque mls group serialization".to_vec();
+        provider.group_state_put("c1", 0, &payload).await.unwrap();
+        assert_eq!(
+            provider.group_state_get("c1", 0).await.unwrap(),
+            Some(payload.clone())
+        );
+
+        // Distinct epoch is independent.
+        assert_eq!(provider.group_state_get("c1", 1).await.unwrap(), None);
+
+        // Delete the epoch — gone.
+        provider.group_state_delete("c1", 0).await.unwrap();
+        assert_eq!(provider.group_state_get("c1", 0).await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn group_state_overwrites_per_epoch() {
+        let provider = open_provider();
+        provider.group_state_put("c1", 5, b"v1").await.unwrap();
+        provider.group_state_put("c1", 5, b"v2").await.unwrap();
+        assert_eq!(
+            provider.group_state_get("c1", 5).await.unwrap(),
+            Some(b"v2".to_vec())
+        );
+    }
+}

--- a/src/mls/welcome_wrap.rs
+++ b/src/mls/welcome_wrap.rs
@@ -1,0 +1,331 @@
+//! §3.3 HPKE-Base + ML-DSA-65 Welcome wrap (CIRISEdge#175, v6.0.0).
+//!
+//! CEWP `SCOPE_PRIVACY.md` §3.3 — MLS Welcome messages are wrapped by
+//! HPKE `mode_base` (RFC 9180 §5.1.1) under the invitee's static
+//! X-Wing public key. X-Wing has no AuthEncap
+//! (draft-connolly-cfrg-xwing-kem; confirmed in draft-ietf-hpke-pq
+//! §7.2), so HPKE `mode_auth` is structurally unavailable; sender
+//! authentication is provided **out-of-band** by an ML-DSA-65
+//! signature from the inviter over the canonical encapsulation
+//! bytes ([`ciris_crypto::hpke::encap_signing_bytes`]).
+//!
+//! The verifier MUST check the signature BEFORE attempting HPKE
+//! `open_base`. Skipping the signature check forfeits sender
+//! authentication — FSD §4 "Forwarder-side membership opacity" no
+//! longer holds.
+//!
+//! # HPKE parameters (pinned cross-impl)
+//!
+//! - `HPKE_SUITE_ID = b"HPKE-xwing-hkdf-sha256-aes256gcm-v1"`
+//!   ([`crate::scope_privacy::HPKE_SUITE_ID`])
+//! - KDF: HKDF-SHA256
+//! - AEAD: AES-256-GCM
+//! - KEM: X-Wing (X25519 + ML-KEM-768)
+//! - Sender auth: ML-DSA-65 over
+//!   `x25519_ephemeral_pub(32) || u32_be(len) || mlkem768_ciphertext`
+//!
+//! AES-256-GCM here is **distinct** from the §2.4 / §3.1
+//! XChaCha20-Poly1305 used for symbol AEAD and envelope framing —
+//! HPKE binds AEAD = AES-256-GCM at the HPKE layer.
+
+use ciris_crypto::hpke::{self, HpkeSealed, XWingRecipientPublic, XWingRecipientSecret};
+use ciris_crypto::{CryptoError, MlDsa65Signer, MlDsa65Verifier, PqcSigner, PqcVerifier};
+
+/// HPKE `info` string used in every wrap/unwrap pair. The string
+/// binds the key schedule to "ciris-edge MLS Welcome wrap, v1".
+/// Cross-impl pinned; producer + verifier MUST use identical bytes.
+pub const WELCOME_WRAP_INFO: &[u8] = b"ciris-edge/scope-privacy/welcome-wrap/v1";
+
+/// Wrapped MLS Welcome — the wire payload of a §3.3 wrap.
+///
+/// Edge ships the four-tuple `(hpke_sealed, inviter_signature,
+/// inviter_pk_id, inviter_pk_bytes)`. The recipient resolves the
+/// inviter's ML-DSA-65 public key from a directory keyed by
+/// `inviter_pk_id` (and falls back to the inline `inviter_pk_bytes`
+/// when the directory has not seen the key yet, with the directory's
+/// trust gate then applied at admission time).
+#[derive(Debug, Clone)]
+pub struct WrappedWelcome {
+    /// HPKE seal of the inner MLS Welcome bytes under the invitee's
+    /// static X-Wing public key.
+    pub hpke_sealed: HpkeSealed,
+    /// ML-DSA-65 signature by the inviter over
+    /// [`hpke::encap_signing_bytes`].
+    pub inviter_signature: Vec<u8>,
+    /// Identifier of the inviter's ML-DSA-65 public key (caller-
+    /// scoped: a fingerprint, key_id, or federation_id — edge does
+    /// not interpret).
+    pub inviter_pk_id: String,
+    /// Inviter's ML-DSA-65 public key bytes (the
+    /// `EncodedVerifyingKey<MlDsa65>` form, as returned by
+    /// [`PqcSigner::public_key`]).
+    pub inviter_pk_bytes: Vec<u8>,
+}
+
+/// Errors from the §3.3 Welcome wrap surface.
+#[derive(Debug, thiserror::Error)]
+pub enum WelcomeWrapError {
+    /// HPKE seal/open or ML-DSA-65 sign/verify failed.
+    #[error("crypto error: {0}")]
+    Crypto(#[from] CryptoError),
+    /// The inviter signature failed to verify against the
+    /// `encap_signing_bytes`. **This is a precondition violation**
+    /// — see the module docs.
+    #[error("inviter signature verify failed")]
+    SignatureRejected,
+    /// The directory has no inviter ML-DSA-65 public key registered
+    /// for `inviter_pk_id` and the unwrap is configured to require
+    /// directory-resolved keys.
+    #[error("inviter pk_id {0:?} not in directory")]
+    InviterUnknown(String),
+}
+
+/// §3.3 Welcome wrap. Inputs:
+///
+/// - `inviter_signer` — the inviter's `MlDsa65Signer` (CIRISVerify
+///   v6.3.0 `ciris_crypto::ml_dsa::MlDsa65Signer`).
+/// - `inviter_pk_id` — caller-scoped identifier the recipient uses
+///   to look up the inviter's public key in the federation directory
+///   (§3.3 cached directory).
+/// - `invitee_pk` — the invitee's static X-Wing public key.
+/// - `welcome_bytes` — the inner MLS Welcome message bytes
+///   (serialized openmls `Welcome`).
+/// - `aad` — application AAD bound at the AEAD layer. Pass an empty
+///   slice for the FSD §3.3 default; some callers may bind a group
+///   identifier here.
+///
+/// Returns a [`WrappedWelcome`] ready to ship over the substrate.
+///
+/// # Errors
+///
+/// - HPKE seal failure → [`WelcomeWrapError::Crypto`]
+/// - ML-DSA-65 sign or public-key extraction failure →
+///   [`WelcomeWrapError::Crypto`]
+pub fn wrap_welcome(
+    inviter_signer: &MlDsa65Signer,
+    inviter_pk_id: &str,
+    invitee_pk: &XWingRecipientPublic,
+    welcome_bytes: &[u8],
+    aad: &[u8],
+) -> Result<WrappedWelcome, WelcomeWrapError> {
+    // HPKE seal_base — bind WELCOME_WRAP_INFO at the key schedule and
+    // the caller's aad at the AEAD seal.
+    let hpke_sealed = hpke::seal_base(invitee_pk, WELCOME_WRAP_INFO, aad, welcome_bytes)?;
+
+    // Sign the canonical encapsulation bytes with ML-DSA-65 — the
+    // §3.3 sender-authentication contract.
+    let signing_bytes = hpke::encap_signing_bytes(&hpke_sealed.encapsulation);
+    let inviter_signature = inviter_signer.sign(&signing_bytes)?;
+    let inviter_pk_bytes = inviter_signer.public_key()?;
+
+    Ok(WrappedWelcome {
+        hpke_sealed,
+        inviter_signature,
+        inviter_pk_id: inviter_pk_id.to_string(),
+        inviter_pk_bytes,
+    })
+}
+
+/// §3.3 directory entry for an inviter's ML-DSA-65 public key. The
+/// caller (typically [`crate::directory_cache::DirectoryCache`])
+/// supplies a closure that resolves `pk_id → bytes`; this struct is
+/// the minimal hand-off shape.
+///
+/// `verify_inline_match` controls fallback policy when the directory
+/// returns `None` for `pk_id`:
+/// - `true` (default for v6.0.0) — fall back to the inline
+///   `inviter_pk_bytes` carried on the wrap.
+/// - `false` — refuse the unwrap with
+///   [`WelcomeWrapError::InviterUnknown`].
+#[derive(Debug, Clone)]
+pub struct FederationDirectoryEntry {
+    /// Inviter's federation identifier (key_id, fingerprint, or
+    /// federation_id — edge does not interpret).
+    pub pk_id: String,
+    /// Inviter's ML-DSA-65 public key bytes (the
+    /// `EncodedVerifyingKey<MlDsa65>` form).
+    pub ml_dsa_pk: Vec<u8>,
+    /// Inviter's X-Wing public key (for outgoing wraps — unused
+    /// during inbound verification but included for parity with the
+    /// substrate-tier directory).
+    pub x_wing_pk: Option<XWingRecipientPublic>,
+}
+
+/// §3.3 Welcome unwrap. Verifies the inviter signature on
+/// [`hpke::encap_signing_bytes`] FIRST, then runs HPKE `open_base`.
+///
+/// `directory_lookup` resolves the inviter's ML-DSA-65 public key
+/// from `inviter_pk_id`; when it returns `None`, the function falls
+/// back to the inline `wrapped.inviter_pk_bytes` (v6.0.0 behaviour —
+/// the cached-directory + TOFU posture; a directory-required mode
+/// flips at the caller's discretion).
+///
+/// # Errors
+///
+/// - Signature verify fail → [`WelcomeWrapError::SignatureRejected`]
+/// - HPKE open fail → [`WelcomeWrapError::Crypto`]
+pub fn unwrap_welcome<F>(
+    invitee_sk: &XWingRecipientSecret,
+    wrapped: &WrappedWelcome,
+    aad: &[u8],
+    mut directory_lookup: F,
+) -> Result<Vec<u8>, WelcomeWrapError>
+where
+    F: FnMut(&str) -> Option<FederationDirectoryEntry>,
+{
+    // Resolve the inviter's public key. Directory wins; inline is
+    // the v6.0.0 TOFU fallback.
+    let inviter_pk_bytes: Vec<u8> = match directory_lookup(&wrapped.inviter_pk_id) {
+        Some(entry) => entry.ml_dsa_pk,
+        None => wrapped.inviter_pk_bytes.clone(),
+    };
+
+    // §3.3 PRECONDITION — verify the signature before open_base.
+    let verifier = MlDsa65Verifier::new();
+    let signing_bytes = hpke::encap_signing_bytes(&wrapped.hpke_sealed.encapsulation);
+    let ok = verifier.verify(
+        &inviter_pk_bytes,
+        &signing_bytes,
+        &wrapped.inviter_signature,
+    )?;
+    if !ok {
+        return Err(WelcomeWrapError::SignatureRejected);
+    }
+
+    // HPKE open_base — recovers the inner MLS Welcome bytes.
+    let inner = hpke::open_base(invitee_sk, &wrapped.hpke_sealed, WELCOME_WRAP_INFO, aad)?;
+    Ok(inner)
+}
+
+#[cfg(test)]
+#[allow(clippy::similar_names)]
+mod tests {
+    use super::*;
+    use ciris_crypto::{ml_kem, x25519};
+
+    fn fresh_invitee() -> (XWingRecipientPublic, XWingRecipientSecret) {
+        let (x_sk, x_pk) = x25519::generate_ephemeral_keypair().unwrap();
+        let (mlkem_sk, mlkem_pk) = ml_kem::generate_keypair().unwrap();
+        let pk = XWingRecipientPublic {
+            x25519_pub: x_pk,
+            mlkem768_pub: mlkem_pk.clone(),
+        };
+        let sk = XWingRecipientSecret {
+            x25519_priv: x_sk,
+            mlkem768_priv: mlkem_sk,
+            mlkem768_pub: mlkem_pk,
+        };
+        (pk, sk)
+    }
+
+    #[test]
+    fn wrap_then_unwrap_recovers_welcome_bytes() {
+        let inviter = MlDsa65Signer::new().unwrap();
+        let (invitee_pk, invitee_sk) = fresh_invitee();
+        let welcome = b"openmls Welcome bytes (pretend)";
+        let wrapped =
+            wrap_welcome(&inviter, "inviter-key-1", &invitee_pk, welcome, b"group-42").unwrap();
+
+        // Directory has no entry — falls through to inline pk.
+        let opened = unwrap_welcome(&invitee_sk, &wrapped, b"group-42", |_| None).unwrap();
+        assert_eq!(opened, welcome);
+    }
+
+    #[test]
+    fn unwrap_uses_directory_when_present() {
+        let inviter = MlDsa65Signer::new().unwrap();
+        let (invitee_pk, invitee_sk) = fresh_invitee();
+        let welcome = b"directory-resolved welcome";
+        let wrapped = wrap_welcome(&inviter, "inviter-A", &invitee_pk, welcome, b"").unwrap();
+
+        let entry = FederationDirectoryEntry {
+            pk_id: "inviter-A".into(),
+            ml_dsa_pk: inviter.public_key().unwrap(),
+            x_wing_pk: None,
+        };
+        let opened = unwrap_welcome(&invitee_sk, &wrapped, b"", |id| {
+            if id == "inviter-A" {
+                Some(entry.clone())
+            } else {
+                None
+            }
+        })
+        .unwrap();
+        assert_eq!(opened, welcome);
+    }
+
+    #[test]
+    fn tampered_signature_is_rejected() {
+        let inviter = MlDsa65Signer::new().unwrap();
+        let (invitee_pk, invitee_sk) = fresh_invitee();
+        let welcome = b"signed welcome";
+        let mut wrapped = wrap_welcome(&inviter, "inv-x", &invitee_pk, welcome, b"").unwrap();
+        // Flip a byte of the signature.
+        wrapped.inviter_signature[0] ^= 0x01;
+        let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| None).unwrap_err();
+        assert!(matches!(err, WelcomeWrapError::SignatureRejected));
+    }
+
+    #[test]
+    fn wrong_inviter_pk_is_rejected() {
+        let inviter = MlDsa65Signer::new().unwrap();
+        let bystander = MlDsa65Signer::new().unwrap();
+        let (invitee_pk, invitee_sk) = fresh_invitee();
+        let welcome = b"hostile substitution attempt";
+        let wrapped = wrap_welcome(&inviter, "inv-real", &invitee_pk, welcome, b"").unwrap();
+
+        // Directory returns the WRONG inviter's pk → signature fails.
+        let bad_entry = FederationDirectoryEntry {
+            pk_id: "inv-real".into(),
+            ml_dsa_pk: bystander.public_key().unwrap(),
+            x_wing_pk: None,
+        };
+        let err =
+            unwrap_welcome(&invitee_sk, &wrapped, b"", |_| Some(bad_entry.clone())).unwrap_err();
+        assert!(matches!(err, WelcomeWrapError::SignatureRejected));
+    }
+
+    #[test]
+    fn tampered_encap_diverges_aead_open() {
+        let inviter = MlDsa65Signer::new().unwrap();
+        let (invitee_pk, invitee_sk) = fresh_invitee();
+        let welcome = b"safe welcome";
+        let mut wrapped = wrap_welcome(&inviter, "inv-y", &invitee_pk, welcome, b"").unwrap();
+
+        // Flip a byte of the encapsulated ML-KEM ct AND re-sign with
+        // the (legitimate) inviter — the signature now covers the
+        // tampered encapsulation, so it verifies. HPKE open then
+        // diverges. The §3.3 acceptance is that the unwrap fails
+        // SOMEWHERE — here it fails at HPKE.
+        wrapped.hpke_sealed.encapsulation.mlkem768_ciphertext[0] ^= 0x01;
+        wrapped.inviter_signature = inviter
+            .sign(&hpke::encap_signing_bytes(
+                &wrapped.hpke_sealed.encapsulation,
+            ))
+            .unwrap();
+        let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| None).unwrap_err();
+        assert!(matches!(err, WelcomeWrapError::Crypto(_)));
+    }
+
+    #[test]
+    fn aad_mismatch_fails_open() {
+        let inviter = MlDsa65Signer::new().unwrap();
+        let (invitee_pk, invitee_sk) = fresh_invitee();
+        let welcome = b"aad-bound welcome";
+        let wrapped = wrap_welcome(&inviter, "inv-z", &invitee_pk, welcome, b"aad-1").unwrap();
+
+        // Verify-side uses a different aad → AEAD open fails. The
+        // signature is fine (it covers encap bytes, not aad), so the
+        // failure surfaces as a CryptoError from open_base.
+        let err = unwrap_welcome(&invitee_sk, &wrapped, b"aad-2", |_| None).unwrap_err();
+        assert!(matches!(err, WelcomeWrapError::Crypto(_)));
+    }
+
+    #[test]
+    fn welcome_wrap_info_pinned() {
+        assert_eq!(
+            WELCOME_WRAP_INFO,
+            b"ciris-edge/scope-privacy/welcome-wrap/v1"
+        );
+    }
+}

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -45,10 +45,11 @@
 //! wires it. A v1.7 follow-up may add an opt-in
 //! `Edge::install_replication_routing(runtime)` helper.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use ciris_persist::federation::FederationDirectory;
-use tokio::sync::watch;
+use tokio::sync::{watch, Mutex};
 use tokio::task::JoinHandle;
 
 use super::bridge::{BridgeConfig, CohortProvider, FederationDirectoryReplicationBridge};
@@ -56,7 +57,9 @@ use super::coordinator::ReplicationCoordinator;
 use super::directory::{DirectoryStateAdapter, MutableDirectoryStateAdapter, ReplicationDirectory};
 use super::protocol::EnvelopeKind;
 use super::registry::ReplicationRegistry;
-use super::scheduler::{ReplicationScheduler, SchedulerConfig};
+use super::scheduler::{
+    ReplicationScheduler, SchedulerCommandError, SchedulerConfig, SchedulerHandle,
+};
 use super::session::SessionRole;
 use super::summary::{StateApplier, StateProvider};
 use crate::transport::Transport;
@@ -92,6 +95,32 @@ pub struct ReplicationRuntime {
     cancel_tx: watch::Sender<bool>,
     scheduler_task: Option<JoinHandle<()>>,
     config: ReplicationRuntimeConfig,
+    /// Runtime control channel for the scheduler (CIRISEdge#173,
+    /// v5.1.0). Used by [`Self::register_initiator_peer`] /
+    /// [`Self::remove_peer`] / [`Self::set_peers`] to mutate the
+    /// scheduler's Initiator set without restart.
+    scheduler_handle: SchedulerHandle,
+    /// Current Initiator set, kept in sync with the scheduler's
+    /// live coordinator tasks. Drives [`Self::set_peers`]'s diff.
+    /// Pre-v5.1 entries (passed to `start`) populate this on init.
+    current_initiators: Arc<Mutex<HashSet<(String, EnvelopeKind)>>>,
+}
+
+/// Failure modes for the v5.1.0 runtime peer-mutation API
+/// (CIRISEdge#173).
+#[derive(Debug, thiserror::Error)]
+pub enum ReplicationRuntimeError {
+    /// The scheduler has stopped (e.g. [`ReplicationRuntime::shutdown`]
+    /// was called) — runtime control is no longer possible. Subsequent
+    /// calls will keep failing.
+    #[error("replication runtime has shut down; peer mutation is no longer accepted")]
+    SchedulerStopped,
+}
+
+impl From<SchedulerCommandError> for ReplicationRuntimeError {
+    fn from(_: SchedulerCommandError) -> Self {
+        Self::SchedulerStopped
+    }
 }
 
 impl ReplicationRuntime {
@@ -141,6 +170,7 @@ impl ReplicationRuntime {
         // session.rs's borrow story (the bridge is the same object
         // backing both).
         let mut scheduler = ReplicationScheduler::new(config.scheduler);
+        let scheduler_handle = scheduler.install_control_channel();
         let coords: Vec<Arc<ReplicationCoordinator>> = peers
             .iter()
             .map(|peer| {
@@ -161,8 +191,10 @@ impl ReplicationRuntime {
             })
             .collect();
 
+        let mut initial_initiator_set: HashSet<(String, EnvelopeKind)> = HashSet::new();
         for (peer, coord) in peers.iter().zip(coords.iter()) {
             scheduler.add_initiator(Arc::clone(coord));
+            initial_initiator_set.insert((peer.peer_key_id.clone(), peer.kind));
             // Register so the operator's listen loop can route
             // inbound replies (the Initiator side receives Summary
             // / Diff / Deliver back from the peer). Inline await
@@ -189,6 +221,8 @@ impl ReplicationRuntime {
             cancel_tx,
             scheduler_task: Some(scheduler_task),
             config,
+            scheduler_handle,
+            current_initiators: Arc::new(Mutex::new(initial_initiator_set)),
         }
     }
 
@@ -204,21 +238,139 @@ impl ReplicationRuntime {
     /// the scheduler with a dynamic-add API.
     pub async fn register_peer(&self, peer_key_id: impl Into<String>, kind: EnvelopeKind) {
         let peer_key_id = peer_key_id.into();
+        let coord = self.build_coordinator(&peer_key_id, kind, SessionRole::Responder);
+        self.registry.register(peer_key_id, kind, coord).await;
+    }
+
+    /// Hot-add a `(peer_key_id, kind)` **Initiator** coordinator —
+    /// CIRISEdge#173, v5.1.0.
+    ///
+    /// Builds a coordinator in [`SessionRole::Initiator`], registers
+    /// it with the registry (so inbound replies route correctly),
+    /// AND tells the scheduler's runtime control plane to spawn a
+    /// task that fires periodic anti-entropy rounds at the configured
+    /// cadence. Idempotent — re-adding an active `(peer, kind)` is a
+    /// no-op.
+    ///
+    /// Use this from CEG-driven reconcilers when `consent:replication`
+    /// objects materialize at runtime: the new peer begins active
+    /// pull immediately, no restart.
+    pub async fn register_initiator_peer(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let peer_key_id = peer_key_id.into();
+        let key = (peer_key_id.clone(), kind);
+
+        {
+            let mut active = self.current_initiators.lock().await;
+            if active.contains(&key) {
+                return Ok(());
+            }
+            active.insert(key);
+        }
+
+        let coord = self.build_coordinator(&peer_key_id, kind, SessionRole::Initiator);
+        // Register first so the inbound listen loop can route replies
+        // by the time the scheduler picks up the command.
+        self.registry
+            .register(peer_key_id, kind, Arc::clone(&coord))
+            .await;
+        self.scheduler_handle.add_initiator(coord).await?;
+        Ok(())
+    }
+
+    /// Hot-remove a `(peer_key_id, kind)` peer — CIRISEdge#173,
+    /// v5.1.0.
+    ///
+    /// Stops the matching Initiator coordinator's scheduled rounds
+    /// (if active) AND deregisters from the registry so inbound
+    /// routing for the peer ceases. Idempotent: removing a peer that
+    /// was never added is a no-op.
+    pub async fn remove_peer(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let peer_key_id = peer_key_id.into();
+        let key = (peer_key_id.clone(), kind);
+
+        let was_initiator = {
+            let mut active = self.current_initiators.lock().await;
+            active.remove(&key)
+        };
+        if was_initiator {
+            self.scheduler_handle
+                .remove_initiator(peer_key_id.clone(), kind)
+                .await?;
+        }
+        self.registry.deregister(&peer_key_id, kind).await;
+        Ok(())
+    }
+
+    /// Diff-and-converge the live Initiator set against `desired` —
+    /// CIRISEdge#173, v5.1.0.
+    ///
+    /// For each `(peer_key_id, kind)` in `desired` not currently
+    /// active, calls [`Self::register_initiator_peer`]. For each
+    /// currently-active pair NOT in `desired`, calls
+    /// [`Self::remove_peer`]. Net effect: after this call returns,
+    /// the runtime's Initiator coordinators exactly match `desired`.
+    ///
+    /// Atomic per individual add/remove only — partial progress is
+    /// possible if a mid-call command fails (the failed pair is
+    /// reflected by the returned error; pairs processed before the
+    /// failure stay applied). Intended driver for CEG-reconcilers:
+    /// call on every consent-object delta.
+    pub async fn set_peers(
+        &self,
+        desired: Vec<ReplicationPeer>,
+    ) -> Result<(), ReplicationRuntimeError> {
+        let desired_set: HashSet<(String, EnvelopeKind)> = desired
+            .iter()
+            .map(|p| (p.peer_key_id.clone(), p.kind))
+            .collect();
+        let current_set: HashSet<(String, EnvelopeKind)> = {
+            let active = self.current_initiators.lock().await;
+            active.iter().cloned().collect()
+        };
+
+        // Adds first; the new peers begin active pull before the
+        // departing peers' rounds stop — minimizes the convergence
+        // window during a swap.
+        for (peer_key_id, kind) in desired_set.difference(&current_set) {
+            self.register_initiator_peer(peer_key_id.clone(), *kind)
+                .await?;
+        }
+        for (peer_key_id, kind) in current_set.difference(&desired_set) {
+            self.remove_peer(peer_key_id.clone(), *kind).await?;
+        }
+        Ok(())
+    }
+
+    /// Build a [`ReplicationCoordinator`] in the requested role with
+    /// the runtime's shared transport + bridge-backed provider/applier.
+    /// Internal helper for register_peer / register_initiator_peer.
+    fn build_coordinator(
+        &self,
+        peer_key_id: &str,
+        kind: EnvelopeKind,
+        role: SessionRole,
+    ) -> Arc<ReplicationCoordinator> {
         let bridge_dir: Arc<dyn ReplicationDirectory> = Arc::clone(&self.bridge) as _;
         let provider: Arc<dyn StateProvider> =
             Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
-        let applier: Arc<tokio::sync::Mutex<dyn StateApplier>> = Arc::new(tokio::sync::Mutex::new(
-            MutableDirectoryStateAdapter::new(bridge_dir),
-        ));
-        let coord = Arc::new(ReplicationCoordinator::new(
+        let applier: Arc<Mutex<dyn StateApplier>> =
+            Arc::new(Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)));
+        Arc::new(ReplicationCoordinator::new(
             Arc::clone(&self.transport),
-            peer_key_id.clone(),
+            peer_key_id.to_string(),
             kind,
-            SessionRole::Responder, // hot-add defaults to Responder; cf. doc above
+            role,
             provider,
             applier,
-        ));
-        self.registry.register(peer_key_id, kind, coord).await;
+        ))
     }
 
     /// Shared registry handle. The operator's `Transport::listen`
@@ -340,6 +492,125 @@ mod tests {
         rt.register_peer("agent-bob", EnvelopeKind::Attestation)
             .await;
         assert_eq!(rt.registry().len().await, 1);
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `register_initiator_peer` hot-adds an
+    /// Initiator coordinator (not just Responder) and bumps the
+    /// registry. Distinct from `register_peer` (Responder-only).
+    #[tokio::test]
+    async fn register_initiator_peer_hot_adds_initiator_role() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        rt.register_initiator_peer("agent-carol", EnvelopeKind::Key)
+            .await
+            .expect("hot-add succeeds while runtime is live");
+        assert_eq!(rt.registry().len().await, 1);
+        let coord = rt.registry().get("agent-carol", EnvelopeKind::Key).await;
+        assert!(coord.is_some());
+        assert_eq!(coord.unwrap().role(), SessionRole::Initiator);
+        // Idempotent: re-add is a no-op.
+        rt.register_initiator_peer("agent-carol", EnvelopeKind::Key)
+            .await
+            .expect("idempotent re-add");
+        assert_eq!(rt.registry().len().await, 1);
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `remove_peer` stops the matching
+    /// coordinator's scheduled rounds AND deregisters from the
+    /// registry. Idempotent.
+    #[tokio::test]
+    async fn remove_peer_drops_initiator_and_deregisters() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            Vec::new(),
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        rt.register_initiator_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .unwrap();
+        assert_eq!(rt.registry().len().await, 1);
+        rt.remove_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .expect("hot-remove succeeds while runtime is live");
+        assert!(rt.registry().is_empty().await);
+        // Idempotent: removing again is a no-op.
+        rt.remove_peer("agent-dave", EnvelopeKind::Attestation)
+            .await
+            .expect("idempotent re-remove");
+        rt.shutdown().await;
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `set_peers` converges the live
+    /// Initiator set against the desired set. Verifies that adds
+    /// and removes both apply in one call, including starting from
+    /// a non-empty pre-existing set.
+    #[tokio::test]
+    async fn set_peers_diff_converges() {
+        let backend = Arc::new(MemoryBackend::new());
+        let directory: Arc<dyn FederationDirectory> = backend;
+        let transport: Arc<dyn Transport> = Arc::new(NoopTransport);
+        let initial = vec![
+            ReplicationPeer {
+                peer_key_id: "peer-keep".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+            ReplicationPeer {
+                peer_key_id: "peer-drop".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+        ];
+        let mut rt = ReplicationRuntime::start(
+            directory,
+            transport,
+            initial,
+            ReplicationRuntimeConfig::default(),
+        )
+        .await;
+        assert_eq!(rt.registry().len().await, 2);
+
+        let desired = vec![
+            ReplicationPeer {
+                peer_key_id: "peer-keep".to_string(),
+                kind: EnvelopeKind::Key,
+            },
+            ReplicationPeer {
+                peer_key_id: "peer-new".to_string(),
+                kind: EnvelopeKind::Attestation,
+            },
+        ];
+        rt.set_peers(desired).await.expect("converge succeeds");
+
+        assert_eq!(rt.registry().len().await, 2);
+        assert!(rt
+            .registry()
+            .get("peer-keep", EnvelopeKind::Key)
+            .await
+            .is_some());
+        assert!(rt
+            .registry()
+            .get("peer-new", EnvelopeKind::Attestation)
+            .await
+            .is_some());
+        assert!(rt
+            .registry()
+            .get("peer-drop", EnvelopeKind::Key)
+            .await
+            .is_none());
         rt.shutdown().await;
     }
 

--- a/src/replication/scheduler.rs
+++ b/src/replication/scheduler.rs
@@ -49,12 +49,14 @@
 //! round is a missed cadence, not a fault. The next round will pick
 //! up whatever state changed in the meantime.
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 
 use super::coordinator::{CoordinatorError, DriveStep, ReplicationCoordinator, RoundReport};
+use super::protocol::EnvelopeKind;
 use super::session::SessionRole;
 
 /// Scheduler configuration shared across all coordinators it drives.
@@ -121,9 +123,102 @@ pub enum RoundEvent {
 /// Constructing the scheduler does NOT spawn any tasks; the caller
 /// chooses when to start the run loop via
 /// [`Self::run_until_cancelled`].
+///
+/// ## Runtime control plane (CIRISEdge#173, v5.1.0)
+///
+/// Call [`Self::install_control_channel`] before starting the run
+/// loop to obtain a [`SchedulerHandle`] that lets external code add
+/// or remove Initiator coordinators *while the loop is running* —
+/// no restart required. Without that call the scheduler keeps its
+/// pre-v5.1 fixed-set semantics.
 pub struct ReplicationScheduler {
     config: SchedulerConfig,
     coordinators: Vec<Arc<ReplicationCoordinator>>,
+    command_rx: Option<mpsc::Receiver<SchedulerCommand>>,
+}
+
+/// Runtime control command for an actively-running scheduler.
+///
+/// Emitted by [`SchedulerHandle`] and consumed inside
+/// [`ReplicationScheduler::run_with_events`].
+pub enum SchedulerCommand {
+    /// Spawn a new Initiator coordinator task. The coordinator's
+    /// role must be [`SessionRole::Initiator`] (debug-asserted).
+    AddInitiator(Arc<ReplicationCoordinator>),
+    /// Stop the running task for the matching `(peer_key_id, kind)`
+    /// coordinator, if present. No-op if the pair was never added.
+    RemoveInitiator {
+        peer_key_id: String,
+        kind: EnvelopeKind,
+    },
+}
+
+impl std::fmt::Debug for SchedulerCommand {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AddInitiator(coord) => f
+                .debug_struct("AddInitiator")
+                .field("peer_key_id", &coord.peer_key_id())
+                .field("kind", &coord.kind())
+                .finish(),
+            Self::RemoveInitiator { peer_key_id, kind } => f
+                .debug_struct("RemoveInitiator")
+                .field("peer_key_id", peer_key_id)
+                .field("kind", kind)
+                .finish(),
+        }
+    }
+}
+
+/// External handle for mutating a running scheduler's Initiator set.
+///
+/// Acquired via [`ReplicationScheduler::install_control_channel`]
+/// BEFORE the run loop starts. Cheaply clonable. Sending on a closed
+/// channel (the scheduler has shut down) returns an error.
+#[derive(Clone, Debug)]
+pub struct SchedulerHandle {
+    command_tx: mpsc::Sender<SchedulerCommand>,
+}
+
+impl SchedulerHandle {
+    /// Add an Initiator coordinator to the running scheduler. The
+    /// scheduler spawns a new task on its next select iteration.
+    /// Idempotent vs. an already-active `(peer_key_id, kind)`:
+    /// duplicates are silently dropped inside the run loop.
+    pub async fn add_initiator(
+        &self,
+        coord: Arc<ReplicationCoordinator>,
+    ) -> Result<(), SchedulerCommandError> {
+        self.command_tx
+            .send(SchedulerCommand::AddInitiator(coord))
+            .await
+            .map_err(|_| SchedulerCommandError::SchedulerStopped)
+    }
+
+    /// Stop the running task for `(peer_key_id, kind)`. No-op if
+    /// that pair isn't currently active.
+    pub async fn remove_initiator(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), SchedulerCommandError> {
+        self.command_tx
+            .send(SchedulerCommand::RemoveInitiator {
+                peer_key_id: peer_key_id.into(),
+                kind,
+            })
+            .await
+            .map_err(|_| SchedulerCommandError::SchedulerStopped)
+    }
+}
+
+/// Failure reason for [`SchedulerHandle`] command sends.
+#[derive(Debug, thiserror::Error)]
+pub enum SchedulerCommandError {
+    /// The scheduler's run loop has exited, so its command receiver
+    /// dropped. Subsequent sends will keep failing.
+    #[error("scheduler has stopped; runtime control channel is closed")]
+    SchedulerStopped,
 }
 
 impl ReplicationScheduler {
@@ -131,7 +226,23 @@ impl ReplicationScheduler {
         Self {
             config,
             coordinators: Vec::new(),
+            command_rx: None,
         }
+    }
+
+    /// Install the runtime control channel (CIRISEdge#173). Returns
+    /// the sender side as a [`SchedulerHandle`]; the scheduler keeps
+    /// the receiver. Must be called before the run loop starts to
+    /// take effect; calling twice replaces the prior receiver, which
+    /// silently invalidates any earlier handle.
+    ///
+    /// Without this call the scheduler retains its pre-v5.1 fixed-set
+    /// semantics — only coordinators added before `run_until_cancelled`
+    /// via [`Self::add_initiator`] are driven.
+    pub fn install_control_channel(&mut self) -> SchedulerHandle {
+        let (command_tx, command_rx) = mpsc::channel(32);
+        self.command_rx = Some(command_rx);
+        SchedulerHandle { command_tx }
     }
 
     /// Register an Initiator-side coordinator with the scheduler.
@@ -185,37 +296,117 @@ impl ReplicationScheduler {
     /// events; the scheduler tolerates a closed sink (the round
     /// loops continue).
     pub async fn run_with_events(
-        self,
-        cancel: watch::Receiver<bool>,
-        event_sink: Option<tokio::sync::mpsc::Sender<(String, RoundEvent)>>,
+        mut self,
+        mut cancel: watch::Receiver<bool>,
+        event_sink: Option<mpsc::Sender<(String, RoundEvent)>>,
     ) {
+        // Per-coord cancel senders, keyed by (peer_key_id, kind).
+        // RemoveInitiator flips one entry; global cancel flips all.
+        let mut per_coord: HashMap<(String, EnvelopeKind), watch::Sender<bool>> = HashMap::new();
         let mut handles = Vec::with_capacity(self.coordinators.len());
-        for coord in self.coordinators {
-            let mut cancel_rx = cancel.clone();
-            let event_sink = event_sink.clone();
-            let cadence = self.config.cadence;
-            let round_timeout = self.config.round_timeout;
-            let h = tokio::spawn(async move {
-                run_one_coordinator_forever(
-                    coord,
-                    cadence,
-                    round_timeout,
-                    &mut cancel_rx,
-                    event_sink,
-                )
-                .await;
-            });
-            handles.push(h);
+
+        for coord in self.coordinators.drain(..) {
+            spawn_coord(
+                &mut per_coord,
+                &mut handles,
+                coord,
+                self.config.cadence,
+                self.config.round_timeout,
+                event_sink.clone(),
+            );
         }
+
+        let mut command_rx = self.command_rx.take();
+        loop {
+            tokio::select! {
+                biased;
+                _ = cancel.changed() => {
+                    if *cancel.borrow() {
+                        for (_, tx) in per_coord.drain() {
+                            let _ = tx.send(true);
+                        }
+                        break;
+                    }
+                }
+                Some(cmd) = async {
+                    // SAFETY of unwrap: the `if` guard below is
+                    // evaluated before this branch is polled, so
+                    // command_rx is Some when we enter.
+                    command_rx.as_mut().unwrap().recv().await
+                }, if command_rx.is_some() => {
+                    match cmd {
+                        SchedulerCommand::AddInitiator(coord) => {
+                            let key = (coord.peer_key_id().to_string(), coord.kind());
+                            if per_coord.contains_key(&key) {
+                                tracing::debug!(
+                                    peer = %key.0,
+                                    kind = ?key.1,
+                                    "scheduler: AddInitiator ignored (already active)"
+                                );
+                                continue;
+                            }
+                            spawn_coord(
+                                &mut per_coord,
+                                &mut handles,
+                                coord,
+                                self.config.cadence,
+                                self.config.round_timeout,
+                                event_sink.clone(),
+                            );
+                        }
+                        SchedulerCommand::RemoveInitiator { peer_key_id, kind } => {
+                            if let Some(tx) = per_coord.remove(&(peer_key_id, kind)) {
+                                let _ = tx.send(true);
+                            }
+                        }
+                    }
+                }
+                else => {
+                    // command_rx is None AND cancel is not changing —
+                    // wait on cancel only.
+                    let _ = cancel.changed().await;
+                    if *cancel.borrow() {
+                        for (_, tx) in per_coord.drain() {
+                            let _ = tx.send(true);
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+
         for h in handles {
             // join_all would be nicer but adds futures-util dep
-            // outside our current set. tokio::join! on a Vec needs
-            // boxing. Sequential .await is fine here — every task
-            // observes the same cancel signal so they all finish
-            // at about the same time anyway.
+            // outside our current set. Sequential .await is fine —
+            // tasks cancel concurrently in response to the same
+            // signal.
             let _ = h.await;
         }
     }
+}
+
+/// Spawn one coordinator task and record its per-coord cancel handle.
+fn spawn_coord(
+    per_coord: &mut HashMap<(String, EnvelopeKind), watch::Sender<bool>>,
+    handles: &mut Vec<tokio::task::JoinHandle<()>>,
+    coord: Arc<ReplicationCoordinator>,
+    cadence: Duration,
+    round_timeout: Duration,
+    event_sink: Option<mpsc::Sender<(String, RoundEvent)>>,
+) {
+    debug_assert_eq!(
+        coord.role(),
+        SessionRole::Initiator,
+        "scheduler spawns Initiator coordinators only"
+    );
+    let key = (coord.peer_key_id().to_string(), coord.kind());
+    let (cancel_tx, mut cancel_rx) = watch::channel(false);
+    per_coord.insert(key, cancel_tx);
+    let h = tokio::spawn(async move {
+        run_one_coordinator_forever(coord, cadence, round_timeout, &mut cancel_rx, event_sink)
+            .await;
+    });
+    handles.push(h);
 }
 
 async fn run_one_coordinator_forever(
@@ -657,6 +848,105 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(2), h)
             .await
             .expect("exit on cancel")
+            .expect("join");
+    }
+
+    /// CIRISEdge#173 / v5.1.0 — `SchedulerHandle::add_initiator` on
+    /// a running scheduler spawns a task that actively initiates
+    /// rounds. Proof-of-life via `RoundEvent` emission: a coord
+    /// targeting an unreachable peer produces `RoundEvent::Error`
+    /// rounds (transport Unreachable) which can only happen if the
+    /// task fired. Then `remove_initiator` stops the events.
+    #[tokio::test]
+    async fn control_channel_add_remove_drives_initiator_task() {
+        let mut sched = ReplicationScheduler::new(fast_config());
+        let control = sched.install_control_channel();
+        let (event_tx, mut event_rx) = mpsc::channel::<(String, RoundEvent)>(64);
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+        let sched_handle =
+            tokio::spawn(async move { sched.run_with_events(cancel_rx, Some(event_tx)).await });
+
+        // Build an Initiator coord pointing at a peer that doesn't
+        // exist in the in-memory inbox. Every send fails with
+        // TransportError::Unreachable → RoundEvent::Error per round.
+        let transport: Arc<dyn Transport> = Arc::new(InMemTransport {
+            peer_inbox: HashMap::new(),
+        });
+        let provider: Arc<dyn StateProvider> = Arc::new(StaticProvider {
+            state: {
+                let mut s = LocalState::new();
+                s.insert(EnvelopeKind::Key, h(7), 7);
+                s
+            },
+            envelopes: HashMap::new(),
+        });
+        let applier: Arc<Mutex<dyn StateApplier>> = Arc::new(Mutex::new(RecordingApplier {
+            known: HashMap::new(),
+            local_hashes: std::collections::HashSet::new(),
+        }));
+        let coord = Arc::new(ReplicationCoordinator::new(
+            transport,
+            "ghost-peer",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        ));
+
+        control
+            .add_initiator(Arc::clone(&coord))
+            .await
+            .expect("send AddInitiator");
+
+        // Wait for at least one event for ghost-peer to confirm the
+        // task spawned + the cadence tick fired.
+        let mut saw_add = false;
+        for _ in 0..50 {
+            if let Ok(Some((peer, _))) =
+                tokio::time::timeout(Duration::from_millis(60), event_rx.recv()).await
+            {
+                if peer == "ghost-peer" {
+                    saw_add = true;
+                    break;
+                }
+            }
+        }
+        assert!(saw_add, "AddInitiator did not produce any round events");
+
+        // Idempotent re-add: send the same coord again, no panic.
+        control
+            .add_initiator(Arc::clone(&coord))
+            .await
+            .expect("idempotent re-add");
+
+        // Remove and assert events for ghost-peer eventually stop.
+        control
+            .remove_initiator("ghost-peer", EnvelopeKind::Key)
+            .await
+            .expect("send RemoveInitiator");
+
+        // Drain a quiet window; an event landed before the remove
+        // took effect is fine, but the stream must go silent for at
+        // least one full cadence after remove.
+        let drain_start = tokio::time::Instant::now();
+        let mut last_event = drain_start;
+        while drain_start.elapsed() < Duration::from_millis(400) {
+            match tokio::time::timeout(Duration::from_millis(50), event_rx.recv()).await {
+                Ok(Some((peer, _))) if peer == "ghost-peer" => {
+                    last_event = tokio::time::Instant::now();
+                }
+                _ => {}
+            }
+        }
+        assert!(
+            last_event.elapsed() >= Duration::from_millis(100),
+            "ghost-peer events did not cease after RemoveInitiator"
+        );
+
+        cancel_tx.send(true).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), sched_handle)
+            .await
+            .expect("shutdown")
             .expect("join");
     }
 }

--- a/src/scope_privacy.rs
+++ b/src/scope_privacy.rs
@@ -1,0 +1,165 @@
+//! Scope-native privacy substrate (CIRISEdge#175, v6.0.0).
+//!
+//! The CEWP `SCOPE_PRIVACY.md` substrate — realization of CIRIS
+//! Constitution **CC 1.13.3.4** "anonymity-by-default at every scope
+//! below federation". This module is the edge-side façade over
+//! CIRISVerify v6.3.0's `ciris_crypto::scope_privacy` cross-impl
+//! authority surface:
+//!
+//! - §2.2 — `k_record_id` / `k_symbol` group subkeys via bare
+//!   `HKDF-SHA256-Expand` on the MLS group's raw `exporter_secret`.
+//! - §2.4 — `derive_record_id` (HMAC-SHA3 over RFC 8949 deterministic
+//!   CBOR `{v, epc, iid, typ}`) + `derive_symbol_key` (HKDF-SHA3 with
+//!   `record_id` salt).
+//! - §3.4 — `witness_cover_leaf` (HMAC-SHA3 cover leaf for the
+//!   federation witness chain).
+//!
+//! Verify is the **first conformant impl** per FSD §9; edge MUST
+//! reproduce the byte-for-byte vectors. The
+//! [`tests::conformance_vectors`] module re-asserts verify's pinned
+//! KAT vectors against THIS crate's call path so that any cross-impl
+//! drift fires in edge's own CI.
+//!
+//! # What edge owns vs. what verify owns
+//!
+//! Verify owns:
+//! - the derivation primitives (`hpke`, `xchacha`, `kdf`, `hmac`)
+//! - the §2.2 / §2.4 / §3.4 helpers (this module re-exports them)
+//! - the `HPKE_SUITE_ID` byte string
+//! - the `RecordType` integer encoding
+//!
+//! Edge owns:
+//! - the §3.2 default-cohort_scope flip (`Edge::resolve_default_scope`)
+//! - the §3.3 Welcome wrap composition (`mls::welcome_wrap`)
+//! - the §3.3 directory cache (`directory_cache`)
+//! - the §3.5 per-community `archive_mode` config (`mls::archive_mode`)
+//! - the openmls cold-state `StorageProvider` (`mls::scope_state`)
+//! - the §3.1 Poisson emission discipline (DEFERRED → v6.1.0)
+//! - the §3.4 per-community witness chain split (DEFERRED → v6.1.0)
+//! - the §3.3 Leviculum announce-suppression patch (DEFERRED → v6.1.0)
+
+// ─── §2.2 / §2.4 / §3.4 re-exports (verify v6.3.0 authority) ────────
+
+pub use ciris_crypto::scope_privacy::{
+    derive_record_id, derive_symbol_key, k_record_id, k_symbol, witness_cover_leaf, RecordType,
+    LABEL_RECORD_ID, LABEL_SYMBOL,
+};
+
+// ─── §3.3 HPKE_SUITE_ID re-export (verify v6.3.0 pinned bytes) ──────
+
+pub use ciris_crypto::hpke::HPKE_SUITE_ID;
+
+#[cfg(test)]
+mod tests {
+    //! Cross-impl conformance vectors — edge reproduces verify's pinned
+    //! §9 acceptance vectors via THIS crate's re-export call path. If
+    //! verify and edge ever diverge on bytes, this module's KATs fire.
+
+    use super::*;
+
+    fn hex(bytes: &[u8]) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            write!(s, "{b:02x}").unwrap();
+        }
+        s
+    }
+
+    /// §2.2 subkey KAT — exporter = [0x42; 32].
+    #[test]
+    fn subkey_kat_matches_verify_v6_3_0() {
+        let exporter = [0x42u8; 32];
+        assert_eq!(
+            hex(&k_record_id(&exporter)),
+            "49209926b0439f10d73d63317758b9ec19492429368c6aa67e33232da586af99",
+            "k_record_id subkey (cross-impl)"
+        );
+        assert_eq!(
+            hex(&k_symbol(&exporter)),
+            "3c973c828a218053dc909c51337ae256164437353bde347ee4bac6874888450f",
+            "k_symbol subkey (cross-impl)"
+        );
+    }
+
+    /// §2.4 record_id KAT vector 1 — CommunityRecord (typ=3), epoch=7.
+    #[test]
+    fn record_id_vector_1_small() {
+        let k = [0x11u8; 32];
+        let rid = derive_record_id(&k, b"record-0001", RecordType::CommunityRecord, 7);
+        assert_eq!(
+            hex(&rid),
+            "5428ddb514a8f8692cc4f254f3550ea75790f5069673e42afb6ef318517a0b21",
+            "record_id (cross-impl)"
+        );
+    }
+
+    /// §2.4 record_id KAT vector 2 — FederationRecord (typ=4), u16 epoch.
+    #[test]
+    fn record_id_vector_2_u16_epoch() {
+        let k = [0x11u8; 32];
+        let rid = derive_record_id(&k, b"record-0002", RecordType::FederationRecord, 300);
+        assert_eq!(
+            hex(&rid),
+            "04eebeee4d5b83f2fdd0012a205781e6c05fe9a587377e6161b347629a189ff2",
+            "record_id (cross-impl)"
+        );
+    }
+
+    /// §2.4 record_id KAT vector 3 — SelfRecord (typ=1), u32 epoch.
+    #[test]
+    fn record_id_vector_3_u32_epoch() {
+        let k = [0x11u8; 32];
+        let rid = derive_record_id(&k, b"x", RecordType::SelfRecord, 16_909_060);
+        assert_eq!(
+            hex(&rid),
+            "79bee8b3f1e815a1df03ca9d83427dc5ab474e184f34e3876d3ef3c36559d6a3",
+            "record_id (cross-impl)"
+        );
+    }
+
+    /// `RecordType` integer encoding (§2.4 pinned table).
+    #[test]
+    fn record_type_integer_encoding_pinned() {
+        assert_eq!(RecordType::SelfRecord.as_cbor_uint(), 1);
+        assert_eq!(RecordType::FamilyRecord.as_cbor_uint(), 2);
+        assert_eq!(RecordType::CommunityRecord.as_cbor_uint(), 3);
+        assert_eq!(RecordType::FederationRecord.as_cbor_uint(), 4);
+    }
+
+    /// §3.4 witness cover-leaf — exercise the 12-byte preimage layout.
+    #[test]
+    fn witness_cover_leaf_deterministic_and_sensitive() {
+        let key = [0x55u8; 32];
+        let base = witness_cover_leaf(&key, 7, 99);
+        assert_eq!(base, witness_cover_leaf(&key, 7, 99));
+        assert_ne!(base, witness_cover_leaf(&key, 8, 99));
+        assert_ne!(base, witness_cover_leaf(&key, 7, 100));
+    }
+
+    /// `HPKE_SUITE_ID` pinned bytes — cross-impl invariant.
+    #[test]
+    fn hpke_suite_id_pinned() {
+        assert_eq!(HPKE_SUITE_ID, b"HPKE-xwing-hkdf-sha256-aes256gcm-v1");
+    }
+
+    /// §2.2 labels pinned.
+    #[test]
+    fn labels_pinned() {
+        assert_eq!(LABEL_RECORD_ID, "ciris-edge/scope-privacy/record-id/v1");
+        assert_eq!(LABEL_SYMBOL, "ciris-edge/scope-privacy/symbol/v1");
+    }
+
+    /// §2.4 symbol_key — deterministic + sensitivity.
+    #[test]
+    fn symbol_key_deterministic_and_sensitive() {
+        let ks = [0x22u8; 32];
+        let rid = [0x33u8; 32];
+        let base = derive_symbol_key(&ks, &rid, 0);
+        assert_eq!(base, derive_symbol_key(&ks, &rid, 0));
+        assert_ne!(base, derive_symbol_key(&ks, &rid, 1));
+        let mut rid2 = rid;
+        rid2[0] ^= 0x01;
+        assert_ne!(base, derive_symbol_key(&ks, &rid2, 0));
+    }
+}

--- a/src/swarm/mod.rs
+++ b/src/swarm/mod.rs
@@ -1,0 +1,57 @@
+//! Federation-level fountain swarm orchestration runtime — v5.2.0.
+//!
+//! Closes the live-wiring gap identified in CIRISEdge#143. The
+//! holonomic substrate primitives ([`crate::holonomic::swarm_rarity`])
+//! are unit-tested in isolation; this module is what makes peers
+//! actually do the federation-coordinated work at runtime:
+//!
+//! - **Publisher**: periodically iterate the operator's held fountain
+//!   `content_id`s, build a
+//!   [`crate::holonomic::swarm_rarity::FountainHoldingClaim`] for
+//!   each, sign it via the local federation signer, and emit it to
+//!   the cohort over the canonical transport.
+//! - **Converger**: every `observe_cadence`, walk the in-memory
+//!   observed-claims map and:
+//!     * if observed_count exceeds `target_holders × (1 + grace_pct)`
+//!       and the local symbol is "common",
+//!       [`should_eject_above_target`] → call
+//!       [`FountainTierEvict::evict_fountain_content_to_tier`]
+//!       (the persist N5 path);
+//!     * if observed_count drops below `min_viable`, emit a repair
+//!       telemetry signal (a future cut wires the blob_swarm fetch
+//!       path off this);
+//!     * if consent is revoked, call
+//!       [`crate::holonomic::swarm_rarity::FountainEvictHardDelete::evict_fountain_content_hard_delete`].
+//!
+//! ## Persist surface gap (recorded for upstream)
+//!
+//! CIRISPersist v9.0.x does NOT expose:
+//!
+//! - `list_fountain_holdings()` — the operator's view of "which
+//!   `content_id`s am I currently holding?" against the federation
+//!   directory trait.
+//! - `evict_fountain_content_to_tier` / `evict_fountain_content_hard_delete`
+//!   on `Arc<dyn FederationDirectory>` (only on the concrete
+//!   `Engine`, gated behind backend cargo features).
+//!
+//! Until persist v9.x lands those surfaces on the public trait, the
+//! runtime is built against in-tree trait surfaces ([`FountainHoldingsSource`],
+//! [`FountainTierEvict`]) plus the existing
+//! [`crate::holonomic::swarm_rarity::FountainEvictHardDelete`]. The
+//! production deployment wires concrete impls of these traits over
+//! its persist `Engine` handle; the test surface implements them
+//! against in-memory state. **This is the documented scope-down per
+//! the v5.2.0 cut spec** (CIRISEdge#143).
+//!
+//! See [`runtime`] for the live runtime + scheduler.
+
+pub mod persist_fountain_evict;
+pub mod runtime;
+
+pub use persist_fountain_evict::{
+    FountainEvictError, FountainEvictHardDelete, FountainHoldingsSource, FountainTierEvict,
+    HeldFountainContent, NoopFountainHoldingsSource, PersistFountainEvictHardDelete,
+};
+pub use runtime::{
+    FountainSwarmRuntime, ObservedClaim, SwarmEvent, SwarmRuntimeConfig, SwarmRuntimeEventSink,
+};

--- a/src/swarm/persist_fountain_evict.rs
+++ b/src/swarm/persist_fountain_evict.rs
@@ -1,0 +1,249 @@
+//! Production-side trait surfaces + adapter for the v5.2.0 swarm
+//! orchestration runtime.
+//!
+//! Three trait surfaces participate here:
+//!
+//! - [`crate::holonomic::swarm_rarity::FountainEvictHardDelete`] —
+//!   the §8.1.11.3 N5 hard-delete primitive (already defined in the
+//!   substrate module; reused here unchanged).
+//! - [`FountainTierEvict`] — the tier-eviction sibling
+//!   ([`PersistEngine::evict_fountain_content_to_tier`] is the
+//!   persist-side concrete; until it appears on the public
+//!   `Arc<dyn FederationDirectory>` trait, the runtime threads an
+//!   `Arc<dyn FountainTierEvict>` for production wiring).
+//! - [`FountainHoldingsSource`] — the operator's "what content_ids
+//!   am I currently holding?" view. Persist v9.0.x does NOT yet
+//!   expose this on its public surface; the runtime threads an
+//!   `Arc<dyn FountainHoldingsSource>` so production can wire it
+//!   once persist lands the iteration API.
+//!
+//! ## Production adapter
+//!
+//! [`PersistFountainEvictHardDelete`] is a thin wrapper that holds
+//! an `Arc<dyn FountainEvictHardDelete>` (the production caller
+//! constructs this from its persist `Engine` handle). It exists so
+//! `Edge::run` / `init_edge_runtime` can pass *one* handle through
+//! the bootstrap and the runtime stays decoupled from the concrete
+//! engine type.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+pub use crate::holonomic::swarm_rarity::{FountainEvictError, FountainEvictHardDelete};
+
+/// A single fountain content unit the operator is currently holding.
+/// Returned by [`FountainHoldingsSource::list_held_fountain_content`]
+/// (the v5.2.0 publisher walks the returned vec to build claims).
+///
+/// Mirrors the shape persist's eventual `list_fountain_holdings` API
+/// is expected to return — content_id + corpus_kind + the symbol_ids
+/// the operator currently retains for that content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HeldFountainContent {
+    /// The persist `fountain_contents.content_id`. Opaque substrate
+    /// identifier (typically the manifest sha256 hex).
+    pub content_id: String,
+    /// The persist `fountain_contents.corpus_kind` discriminator
+    /// (passed through opaquely to eviction calls).
+    pub corpus_kind: String,
+    /// The fountain `symbol_id`s the operator currently retains for
+    /// this content. The publisher signs a
+    /// [`crate::holonomic::swarm_rarity::FountainHoldingClaim`] over
+    /// this set.
+    pub symbol_ids: Vec<u32>,
+}
+
+/// Operator-side view of "what fountain content am I currently
+/// holding?". The v5.2.0 publisher consults this on every
+/// `publish_cadence` tick.
+///
+/// **Persist v9.0.x gap**: there is currently no public listing API
+/// on `Arc<dyn FederationDirectory>` that returns this view. Until
+/// persist v9.x lands one, production deployments implement this
+/// trait against their concrete persist `Engine` handle (or against
+/// whatever cohabitation surface their host exposes); the test
+/// surface ([`NoopFountainHoldingsSource`] + the in-tree
+/// `Vec`-backed test impls) drives the runtime in isolation.
+#[async_trait]
+pub trait FountainHoldingsSource: Send + Sync {
+    /// Enumerate the operator's currently-held fountain content units.
+    /// Order is implementation-defined; the runtime sorts internally
+    /// where determinism matters (the
+    /// [`crate::holonomic::swarm_rarity::FountainHoldingClaim`]
+    /// canonical bytes pre-sort `symbol_ids` ascending).
+    async fn list_held_fountain_content(
+        &self,
+    ) -> Result<Vec<HeldFountainContent>, FountainEvictError>;
+}
+
+/// A `FountainHoldingsSource` that returns an empty list. Used in
+/// `init_edge_runtime` when no concrete source has been wired —
+/// keeps the runtime spawnable on hosts that don't yet hold any
+/// fountain content (or whose persist handle doesn't yet expose the
+/// listing API). Tests and tier-1 deployments wire the real source.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopFountainHoldingsSource;
+
+#[async_trait]
+impl FountainHoldingsSource for NoopFountainHoldingsSource {
+    async fn list_held_fountain_content(
+        &self,
+    ) -> Result<Vec<HeldFountainContent>, FountainEvictError> {
+        Ok(Vec::new())
+    }
+}
+
+/// The tier-eviction sibling of
+/// [`FountainEvictHardDelete`]. Maps onto persist's
+/// `evict_fountain_content_to_tier(content_id, corpus_kind, tier)`
+/// concrete API. The `tier` parameter is the persist
+/// `FountainTier` discriminator as a stable string label
+/// (`"full" | "t2" | "t3" | "t4" | "t5"`) so the trait surface
+/// does NOT depend on which backend cfg-features are enabled.
+///
+/// **Persist v9.0.x gap**: like
+/// [`FountainEvictHardDelete`], not exposed on
+/// `Arc<dyn FederationDirectory>`. Production wires a concrete
+/// impl that calls into its `Engine` handle.
+#[async_trait]
+pub trait FountainTierEvict: Send + Sync {
+    /// Evict `content_id` (in the named corpus) down to the keep-
+    /// count for the named tier. The persist eviction surface
+    /// applies the change on its next maintenance pass — this call
+    /// does NOT block on the eviction itself. Returns `Ok(())` on
+    /// acceptance.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FountainEvictError::HardDeleteFailed`] (the error
+    /// type is shared across the hard-delete + tier-evict surfaces
+    /// for v5.2.0 — a future cut may split it once persist's
+    /// public surface stabilizes).
+    async fn evict_fountain_content_to_tier(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+        tier: &str,
+    ) -> Result<(), FountainEvictError>;
+}
+
+/// Production-side adapter that satisfies [`FountainEvictHardDelete`]
+/// by delegating to an inner trait object. Constructor + the trait
+/// impl. Edge's bootstrap (`Edge::run` / `init_edge_runtime`)
+/// constructs one of these from the persist `Engine` handle the
+/// host exposes; the runtime holds the `Arc<dyn FountainEvictHardDelete>`
+/// and never sees the concrete engine type.
+///
+/// The `inner` trait object MUST be a concrete impl that calls into
+/// persist's `evict_fountain_content_hard_delete`; the v5.2.0 in-tree
+/// impl is a passthrough so production callers can substitute a real
+/// engine adapter without touching the runtime.
+pub struct PersistFountainEvictHardDelete {
+    inner: Arc<dyn FountainEvictHardDelete + Send + Sync>,
+}
+
+impl std::fmt::Debug for PersistFountainEvictHardDelete {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PersistFountainEvictHardDelete")
+            .finish_non_exhaustive()
+    }
+}
+
+impl PersistFountainEvictHardDelete {
+    /// Construct from any inner [`FountainEvictHardDelete`] impl.
+    /// The production caller passes its persist `Engine`-backed
+    /// adapter; the test surface passes the substrate module's
+    /// fake evictor.
+    #[must_use]
+    pub fn new(inner: Arc<dyn FountainEvictHardDelete + Send + Sync>) -> Self {
+        Self { inner }
+    }
+}
+
+impl FountainEvictHardDelete for PersistFountainEvictHardDelete {
+    fn evict_fountain_content_hard_delete(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+    ) -> Result<(), FountainEvictError> {
+        self.inner
+            .evict_fountain_content_hard_delete(content_id, corpus_kind)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// In-memory `FountainEvictHardDelete` that records the calls —
+    /// the substrate-tier `swarm_rarity` tests already exercise the
+    /// trait shape, this one is for the adapter passthrough check.
+    #[derive(Default)]
+    struct Recorder {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+    impl FountainEvictHardDelete for Recorder {
+        fn evict_fountain_content_hard_delete(
+            &self,
+            content_id: &str,
+            corpus_kind: &str,
+        ) -> Result<(), FountainEvictError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((content_id.to_string(), corpus_kind.to_string()));
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn adapter_delegates_to_inner() {
+        let rec: Arc<Recorder> = Arc::new(Recorder::default());
+        let adapter = PersistFountainEvictHardDelete::new(rec.clone());
+        adapter
+            .evict_fountain_content_hard_delete("c1", "fountain-corpus")
+            .expect("ok");
+        adapter
+            .evict_fountain_content_hard_delete("c2", "fountain-corpus")
+            .expect("ok");
+        let calls = rec.calls.lock().unwrap().clone();
+        assert_eq!(
+            calls,
+            vec![
+                ("c1".to_string(), "fountain-corpus".to_string()),
+                ("c2".to_string(), "fountain-corpus".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn adapter_surfaces_inner_failure() {
+        struct Failing;
+        impl FountainEvictHardDelete for Failing {
+            fn evict_fountain_content_hard_delete(
+                &self,
+                _: &str,
+                _: &str,
+            ) -> Result<(), FountainEvictError> {
+                Err(FountainEvictError::HardDeleteFailed("inner-fail".into()))
+            }
+        }
+        let adapter = PersistFountainEvictHardDelete::new(Arc::new(Failing));
+        let err = adapter
+            .evict_fountain_content_hard_delete("c1", "f")
+            .expect_err("must surface");
+        assert!(matches!(err, FountainEvictError::HardDeleteFailed(_)));
+    }
+
+    #[tokio::test]
+    async fn noop_holdings_source_returns_empty() {
+        let src = NoopFountainHoldingsSource;
+        assert!(src
+            .list_held_fountain_content()
+            .await
+            .expect("ok")
+            .is_empty());
+    }
+}

--- a/src/swarm/runtime.rs
+++ b/src/swarm/runtime.rs
@@ -1,0 +1,1019 @@
+//! `FountainSwarmRuntime` — the federation-level swarm orchestration
+//! runtime that closes the v5.1.0 → v5.2.0 wiring gap.
+//!
+//! Sibling to [`crate::replication::runtime::ReplicationRuntime`] in
+//! shape; the substrate piece it animates is the v3.10.0 swarm
+//! rarity / holding-claim primitive
+//! ([`crate::holonomic::swarm_rarity`]). The substrate types are pure,
+//! deterministic, byte-equal; this runtime is the live wiring that
+//! makes peers actually do:
+//!
+//! 1. **Publish**: every `publish_cadence`, walk the operator's held
+//!    fountain `content_id`s via
+//!    [`FountainHoldingsSource::list_held_fountain_content`], build
+//!    a [`FountainHoldingClaim`] per content, sign it via the
+//!    federation signer, ship it to the cohort over the transport.
+//! 2. **Observe**: peer claims arrive at
+//!    [`FountainSwarmRuntime::register_observed_claim`] (called from
+//!    edge's inbound dispatch path when a peer's holding-claim
+//!    envelope is verified) and accumulate in the in-memory
+//!    observed-holders map (TTL-pruned each tick).
+//! 3. **Converge**: every `observe_cadence`, for every content_id
+//!    with observed holders:
+//!    - `should_eject_above_target` for over-`H` content → call
+//!      [`FountainTierEvict::evict_fountain_content_to_tier`] with
+//!      the "t1" label;
+//!    - observed_count < `min_viable` → emit a
+//!      [`SwarmEvent::RepairNeeded`] telemetry record (downstream
+//!      cuts wire the blob_swarm fetch off this);
+//!    - `ConsentState::Revoked` → call
+//!      [`FountainEvictHardDelete::evict_fountain_content_hard_delete`].
+//!
+//! ## Why no per-peer mutation API
+//!
+//! [`ReplicationRuntime`] needed `register_initiator_peer` /
+//! `remove_peer` / `set_peers` because replication is per-peer:
+//! each peer in the cohort gets its own coordinator + scheduler
+//! task. Swarm orchestration is **federation-wide** — the publisher
+//! ships claims to the whole cohort and the converger reads the
+//! observed-claims map (not a per-peer queue), so there is no
+//! per-peer mutation surface to expose. Hot-changing the cohort
+//! membership is the replication runtime's job; the swarm runtime
+//! follows.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{watch, RwLock};
+use tokio::task::JoinHandle;
+
+use super::persist_fountain_evict::{
+    FountainEvictError, FountainEvictHardDelete, FountainHoldingsSource, FountainTierEvict,
+    HeldFountainContent,
+};
+use crate::holonomic::fountain_defaults::{recommended_policy, FountainPolicy};
+use crate::holonomic::swarm_rarity::{
+    compute_rarity_score, should_eject_above_target, ConsentState, EjectionVerdict,
+    FountainHoldingClaim, RarityScore,
+};
+use crate::transport::Transport;
+
+/// `target_holders` default — the recommended `H` from §R-policy
+/// (CEG 1.0 §R / [`crate::holonomic::fountain_defaults::DEFAULT_TARGET_HOLDERS`]).
+pub const DEFAULT_TARGET_HOLDERS: u32 = 30;
+
+/// `min_viable` default — the survival floor below which the
+/// converger emits `RepairNeeded`. Matches §R-policy's
+/// `min_viable_symbols` shape.
+pub const DEFAULT_MIN_VIABLE: u32 = 5;
+
+/// `eviction_grace_pct` default — the safety margin above
+/// `target_holders` before the converger calls eject. Matches the
+/// substrate's [`EJECT_ABOVE_TARGET_SAFETY_MARGIN_PCT`] (locked v1
+/// at 15%).
+///
+/// [`EJECT_ABOVE_TARGET_SAFETY_MARGIN_PCT`]: crate::holonomic::swarm_rarity::EJECT_ABOVE_TARGET_SAFETY_MARGIN_PCT
+pub const DEFAULT_EVICTION_GRACE_PCT: u8 = 15;
+
+/// Default observed-claim TTL — claims older than this are pruned
+/// on every converger tick. Bound by the substrate's expectation
+/// that claims are republished at `publish_cadence`; the TTL
+/// should comfortably exceed two publish intervals.
+pub const DEFAULT_OBSERVED_CLAIM_TTL: Duration = Duration::from_secs(600);
+
+/// A claim a peer published, as observed by this runtime. The runtime
+/// keeps one per `(content_id, peer_id)` — a later observation from
+/// the same peer for the same content replaces the prior entry.
+#[derive(Debug, Clone)]
+pub struct ObservedClaim {
+    /// The exact [`FountainHoldingClaim`] envelope-body, verified
+    /// upstream before reaching the runtime.
+    pub claim: FountainHoldingClaim,
+    /// Local wall-clock at which the claim was observed. Drives the
+    /// TTL prune on the converger tick.
+    pub observed_at: std::time::Instant,
+}
+
+/// Configuration for the swarm orchestration runtime. All fields are
+/// tunable per deployment; defaults match the v3.10.0 §R-policy.
+#[derive(Debug, Clone)]
+pub struct SwarmRuntimeConfig {
+    /// How often the publisher walks the operator's held content
+    /// and broadcasts a [`FountainHoldingClaim`] per content.
+    pub publish_cadence: Duration,
+    /// How often the converger walks the observed-claims map.
+    pub observe_cadence: Duration,
+    /// `H` — the §R-policy target holder count.
+    pub target_holders: u32,
+    /// Below this count the converger emits
+    /// [`SwarmEvent::RepairNeeded`].
+    pub min_viable: u32,
+    /// Safety margin above `target_holders` before the converger
+    /// calls eject. Defaults to 15% — wire-determinism-critical
+    /// (CEG 1.0 §R conformance vectors).
+    pub eviction_grace_pct: u8,
+    /// Claims older than this are pruned on every converger tick.
+    pub observed_claim_ttl: Duration,
+    /// `FountainPolicy` the substrate's
+    /// [`should_eject_above_target`] consults. Defaults to
+    /// [`recommended_policy()`].
+    pub policy: FountainPolicy,
+}
+
+impl Default for SwarmRuntimeConfig {
+    fn default() -> Self {
+        Self {
+            publish_cadence: Duration::from_secs(60),
+            observe_cadence: Duration::from_secs(30),
+            target_holders: DEFAULT_TARGET_HOLDERS,
+            min_viable: DEFAULT_MIN_VIABLE,
+            eviction_grace_pct: DEFAULT_EVICTION_GRACE_PCT,
+            observed_claim_ttl: DEFAULT_OBSERVED_CLAIM_TTL,
+            policy: recommended_policy(),
+        }
+    }
+}
+
+/// Telemetry record emitted by the converger. The optional event sink
+/// passed at [`FountainSwarmRuntime::start`] receives one of these per
+/// per-content_id action the converger takes; downstream consumers
+/// (CIRISLens, the test e2e) read off it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SwarmEvent {
+    /// A claim was published to the cohort.
+    Published {
+        content_id: String,
+        cohort_size: usize,
+    },
+    /// Observed holders for `content_id` dropped below `min_viable`.
+    /// Downstream wires repair-fetch from current holders off this
+    /// signal.
+    RepairNeeded {
+        content_id: String,
+        observed_holders: u32,
+        min_viable: u32,
+    },
+    /// `should_eject_above_target` fired; the runtime called
+    /// [`FountainTierEvict::evict_fountain_content_to_tier`].
+    EjectedToTier {
+        content_id: String,
+        observed_holders: u32,
+        tier_label: String,
+    },
+    /// Consent was revoked for `content_id`; the runtime called
+    /// [`FountainEvictHardDelete::evict_fountain_content_hard_delete`].
+    HardDeleted { content_id: String },
+    /// Converger tick observed but took no eviction action for this
+    /// content_id (Keep verdict). Surfaced so tests can assert the
+    /// converger ran; production deployments may filter these out.
+    Keep {
+        content_id: String,
+        observed_holders: u32,
+    },
+}
+
+/// A sink for [`SwarmEvent`]s. The runtime emits via this callback;
+/// production deployments wire a `tokio::sync::mpsc::Sender` or
+/// equivalent (the runtime never blocks on the sink — the callback
+/// is invoked synchronously inside the converger task, so it MUST
+/// return quickly).
+pub type SwarmRuntimeEventSink = Arc<dyn Fn(SwarmEvent) + Send + Sync>;
+
+/// Live swarm-orchestration runtime — publisher + converger tasks +
+/// shutdown handle. Construct via [`Self::start`]; hold for the
+/// lifetime of the application; call [`Self::shutdown`] to stop the
+/// background tasks.
+pub struct FountainSwarmRuntime {
+    config: SwarmRuntimeConfig,
+    observed: Arc<RwLock<ObservedClaims>>,
+    cancel_tx: watch::Sender<bool>,
+    publisher_task: Option<JoinHandle<()>>,
+    converger_task: Option<JoinHandle<()>>,
+}
+
+/// Internal observed-claims map. Keyed by content_id → peer_id →
+/// observed claim. Sorted-map nesting keeps determinism over the
+/// observation set — the converger walks in stable order.
+///
+/// `pub` for the `observed_handle()` test surface — production
+/// callers should treat the inner shape as opaque.
+#[derive(Debug, Default)]
+pub struct ObservedClaims {
+    inner: BTreeMap<String, BTreeMap<String, ObservedClaim>>,
+}
+
+impl ObservedClaims {
+    fn upsert(&mut self, claim: FountainHoldingClaim) {
+        let entry = ObservedClaim {
+            observed_at: std::time::Instant::now(),
+            claim,
+        };
+        self.inner
+            .entry(entry.claim.content_id.clone())
+            .or_default()
+            .insert(entry.claim.peer_id.clone(), entry);
+    }
+
+    /// Drop entries older than `ttl`. Returns the count pruned.
+    fn prune_expired(&mut self, ttl: Duration) -> usize {
+        let now = std::time::Instant::now();
+        let mut dropped = 0usize;
+        self.inner.retain(|_, peers| {
+            peers.retain(|_, c| {
+                let keep = now.duration_since(c.observed_at) <= ttl;
+                if !keep {
+                    dropped += 1;
+                }
+                keep
+            });
+            !peers.is_empty()
+        });
+        dropped
+    }
+
+    fn distinct_holders(&self, content_id: &str) -> u32 {
+        self.inner
+            .get(content_id)
+            .map_or(0, |m| u32::try_from(m.len()).unwrap_or(u32::MAX))
+    }
+
+    fn all_claims_for(&self, content_id: &str) -> Vec<FountainHoldingClaim> {
+        self.inner
+            .get(content_id)
+            .map_or_else(Vec::new, |m| m.values().map(|c| c.claim.clone()).collect())
+    }
+
+    fn content_ids(&self) -> Vec<String> {
+        self.inner.keys().cloned().collect()
+    }
+}
+
+impl FountainSwarmRuntime {
+    /// Spawn the publisher + converger tasks against the given
+    /// substrate handles. The runtime holds clones of every Arc; the
+    /// caller can drop their originals after `start` returns.
+    ///
+    /// Cohort membership is read from `cohort` on every publish tick
+    /// — the same shape `ReplicationRuntime` uses for its bridge
+    /// callback. The publisher ships one envelope per `(content_id,
+    /// peer)` pair on every tick; v5.2.0 uses the transport's
+    /// fire-and-forget `send` path (a future cut may switch to
+    /// `send_durable` for at-least-once delivery once the substrate
+    /// requires it).
+    #[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
+    pub fn start(
+        config: SwarmRuntimeConfig,
+        holdings: Arc<dyn FountainHoldingsSource>,
+        tier_evict: Arc<dyn FountainTierEvict>,
+        hard_delete: Arc<dyn FountainEvictHardDelete + Send + Sync>,
+        transport: Arc<dyn Transport>,
+        cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+        local_peer_id: String,
+        sink: Option<SwarmRuntimeEventSink>,
+    ) -> Self {
+        let observed = Arc::new(RwLock::new(ObservedClaims::default()));
+        let (cancel_tx, cancel_rx) = watch::channel(false);
+
+        let publisher_task = {
+            let holdings = Arc::clone(&holdings);
+            let transport = Arc::clone(&transport);
+            let cohort = Arc::clone(&cohort);
+            let cadence = config.publish_cadence;
+            let cancel_rx = cancel_rx.clone();
+            let sink = sink.clone();
+            let local_peer = local_peer_id.clone();
+            tokio::spawn(async move {
+                run_publisher(
+                    holdings, transport, cohort, local_peer, cadence, cancel_rx, sink,
+                )
+                .await;
+            })
+        };
+
+        let converger_task = {
+            let observed = Arc::clone(&observed);
+            let holdings = Arc::clone(&holdings);
+            let tier_evict = Arc::clone(&tier_evict);
+            let hard_delete = Arc::clone(&hard_delete);
+            let cfg = config.clone();
+            tokio::spawn(async move {
+                run_converger(
+                    observed,
+                    holdings,
+                    tier_evict,
+                    hard_delete,
+                    cfg,
+                    cancel_rx,
+                    sink,
+                )
+                .await;
+            })
+        };
+
+        Self {
+            config,
+            observed,
+            cancel_tx,
+            publisher_task: Some(publisher_task),
+            converger_task: Some(converger_task),
+        }
+    }
+
+    /// Called by the inbound dispatch path when a peer's
+    /// [`FountainHoldingClaim`] envelope is verified. Updates the
+    /// observed-claims map; the next converger tick consults the
+    /// fresh state.
+    ///
+    /// Idempotent on `(content_id, peer_id)` — a later observation
+    /// replaces the prior entry (the substrate's `observed_at_unix_ms`
+    /// field carries the producer's own staleness window; the
+    /// runtime's TTL prune is a local liveness signal).
+    pub async fn register_observed_claim(&self, claim: FountainHoldingClaim) {
+        self.observed.write().await.upsert(claim);
+    }
+
+    /// Shared observed-claims map for tests + telemetry. Cheap clone
+    /// (Arc bump).
+    #[doc(hidden)]
+    pub fn observed_handle(&self) -> Arc<RwLock<ObservedClaims>> {
+        Arc::clone(&self.observed)
+    }
+
+    /// The active runtime configuration.
+    pub fn config(&self) -> &SwarmRuntimeConfig {
+        &self.config
+    }
+
+    /// Signal both tasks to stop + await clean exit. Idempotent.
+    pub async fn shutdown(&mut self) {
+        let _ = self.cancel_tx.send(true);
+        if let Some(t) = self.publisher_task.take() {
+            let _ = t.await;
+        }
+        if let Some(t) = self.converger_task.take() {
+            let _ = t.await;
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_publisher(
+    holdings: Arc<dyn FountainHoldingsSource>,
+    transport: Arc<dyn Transport>,
+    cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+    local_peer_id: String,
+    cadence: Duration,
+    mut cancel_rx: watch::Receiver<bool>,
+    sink: Option<SwarmRuntimeEventSink>,
+) {
+    let mut ticker = tokio::time::interval(cadence);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = cancel_rx.changed() => {
+                if *cancel_rx.borrow() {
+                    tracing::info!("swarm_runtime.publisher: shutdown");
+                    return;
+                }
+            }
+            _ = ticker.tick() => {
+                if let Err(e) = publish_tick(
+                    &holdings,
+                    &transport,
+                    cohort.as_ref(),
+                    &local_peer_id,
+                    sink.as_ref(),
+                )
+                .await
+                {
+                    tracing::warn!(error = %e, "swarm_runtime.publisher: tick failed");
+                }
+            }
+        }
+    }
+}
+
+async fn publish_tick(
+    holdings: &Arc<dyn FountainHoldingsSource>,
+    transport: &Arc<dyn Transport>,
+    cohort: &(dyn Fn() -> Vec<String> + Send + Sync),
+    local_peer_id: &str,
+    sink: Option<&SwarmRuntimeEventSink>,
+) -> Result<usize, FountainEvictError> {
+    let held = holdings.list_held_fountain_content().await?;
+    let peers = cohort();
+    let mut count = 0usize;
+    let observed_at_unix_ms = current_unix_ms();
+    for content in held {
+        let claim = FountainHoldingClaim::new(
+            local_peer_id.to_string(),
+            content.content_id.clone(),
+            content.symbol_ids.clone(),
+            observed_at_unix_ms,
+        );
+        // v5.2.0: ship the wire bytes as the substrate's
+        // canonical projection (a future cut will route this through
+        // the full envelope-signing path once a `MessageType::FountainHoldingClaim`
+        // wire discriminator lands; for now the canonical_bytes is
+        // the byte-form the federation cohort consumes).
+        let envelope_bytes = claim.canonical_bytes();
+        for peer in &peers {
+            // Skip self — the cohort callback typically already
+            // excludes the local peer, but defense in depth.
+            if peer == local_peer_id {
+                continue;
+            }
+            if let Err(e) = transport.send(peer, &envelope_bytes).await {
+                tracing::warn!(
+                    peer = %peer,
+                    content_id = %content.content_id,
+                    error = %e,
+                    "swarm_runtime.publisher: transport send failed",
+                );
+            }
+        }
+        if let Some(sink) = sink {
+            sink(SwarmEvent::Published {
+                content_id: content.content_id.clone(),
+                cohort_size: peers.len(),
+            });
+        }
+        count += 1;
+    }
+    Ok(count)
+}
+
+async fn run_converger(
+    observed: Arc<RwLock<ObservedClaims>>,
+    holdings: Arc<dyn FountainHoldingsSource>,
+    tier_evict: Arc<dyn FountainTierEvict>,
+    hard_delete: Arc<dyn FountainEvictHardDelete + Send + Sync>,
+    config: SwarmRuntimeConfig,
+    mut cancel_rx: watch::Receiver<bool>,
+    sink: Option<SwarmRuntimeEventSink>,
+) {
+    let mut ticker = tokio::time::interval(config.observe_cadence);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            _ = cancel_rx.changed() => {
+                if *cancel_rx.borrow() {
+                    tracing::info!("swarm_runtime.converger: shutdown");
+                    return;
+                }
+            }
+            _ = ticker.tick() => {
+                converger_tick(
+                    &observed,
+                    &holdings,
+                    &tier_evict,
+                    &hard_delete,
+                    &config,
+                    sink.as_ref(),
+                )
+                .await;
+            }
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+async fn converger_tick(
+    observed: &Arc<RwLock<ObservedClaims>>,
+    holdings: &Arc<dyn FountainHoldingsSource>,
+    tier_evict: &Arc<dyn FountainTierEvict>,
+    hard_delete: &Arc<dyn FountainEvictHardDelete + Send + Sync>,
+    config: &SwarmRuntimeConfig,
+    sink: Option<&SwarmRuntimeEventSink>,
+) {
+    // Prune stale claims first so the rarity math sees a live view.
+    let dropped = observed
+        .write()
+        .await
+        .prune_expired(config.observed_claim_ttl);
+    if dropped > 0 {
+        tracing::debug!(dropped, "swarm_runtime.converger: pruned stale claims");
+    }
+
+    // Snapshot the operator's local holdings for the local-symbol
+    // rarity check. A missing holdings source returns an empty Vec,
+    // which means the converger treats every content as "not locally
+    // held" — no eviction action is taken on content the operator
+    // doesn't have a local symbol for.
+    let local_held = match holdings.list_held_fountain_content().await {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::warn!(error = %e, "swarm_runtime.converger: holdings list failed; skipping tick");
+            return;
+        }
+    };
+    let local_by_content: BTreeMap<String, HeldFountainContent> = local_held
+        .into_iter()
+        .map(|h| (h.content_id.clone(), h))
+        .collect();
+
+    let observed_snapshot = observed.read().await;
+    let content_ids = observed_snapshot.content_ids();
+    drop(observed_snapshot);
+
+    for content_id in content_ids {
+        let snapshot = observed.read().await;
+        let observed_count = snapshot.distinct_holders(&content_id);
+        let all_claims = snapshot.all_claims_for(&content_id);
+        drop(snapshot);
+
+        // Determine consent state. v5.2.0 defaults to Active —
+        // revocation routing rides the inbound dispatch path
+        // (when a `consent:state:revoked` envelope arrives, edge
+        // calls into `register_revocation` on the runtime; that
+        // wiring lands in v5.3.0 when the consent envelope shape
+        // is normative). For the v5.2.0 cut, the converger acts on
+        // the substrate-tier verdicts driven by `holders_observed`
+        // alone.
+        let consent = ConsentState::Active;
+
+        // Local-symbol rarity: compute over the merged claim set
+        // including the local peer's view if it holds a symbol for
+        // this content. The substrate's
+        // `should_eject_above_target` consults this to avoid
+        // evicting the last local copy of a rare symbol.
+        let local_symbol_rarity = if let Some(local) = local_by_content.get(&content_id) {
+            local.symbol_ids.first().map_or(RarityScore(0), |sym| {
+                compute_rarity_score(&content_id, *sym, &all_claims)
+            })
+        } else {
+            RarityScore(0)
+        };
+
+        let verdict =
+            should_eject_above_target(observed_count, &config.policy, consent, local_symbol_rarity);
+
+        match verdict {
+            EjectionVerdict::Keep => {
+                if observed_count > 0 && observed_count < config.min_viable {
+                    tracing::info!(
+                        content_id = %content_id,
+                        observed_holders = observed_count,
+                        min_viable = config.min_viable,
+                        "swarm_runtime.converger: repair needed",
+                    );
+                    if let Some(sink) = sink {
+                        sink(SwarmEvent::RepairNeeded {
+                            content_id: content_id.clone(),
+                            observed_holders: observed_count,
+                            min_viable: config.min_viable,
+                        });
+                    }
+                } else if let Some(sink) = sink {
+                    sink(SwarmEvent::Keep {
+                        content_id: content_id.clone(),
+                        observed_holders: observed_count,
+                    });
+                }
+            }
+            EjectionVerdict::EjectToTier => {
+                let corpus_kind = corpus_kind_for(&local_by_content, &content_id);
+                // v5.2.0 ejection target: persist's "t1" label
+                // (DiskPressure::Warn-equivalent — the gentlest
+                // step that actually frees symbol rows). Future
+                // cuts may consult the per-content_id pressure
+                // window to pick a coarser tier under load.
+                let tier_label = "t1".to_string();
+                if let Err(e) = tier_evict
+                    .evict_fountain_content_to_tier(&content_id, &corpus_kind, &tier_label)
+                    .await
+                {
+                    tracing::warn!(
+                        content_id = %content_id,
+                        error = %e,
+                        "swarm_runtime.converger: tier evict failed",
+                    );
+                } else if let Some(sink) = sink {
+                    sink(SwarmEvent::EjectedToTier {
+                        content_id: content_id.clone(),
+                        observed_holders: observed_count,
+                        tier_label,
+                    });
+                }
+            }
+            EjectionVerdict::EjectAggregatedTierOnly { tier: _ } => {
+                // §19.7.3 tier-only ejection — same dispatch as
+                // EjectToTier for v5.2.0 (the named pyramid stratum
+                // is consulted by the persist backend once it
+                // exposes the tier-granular evict; until then the
+                // runtime maps onto the coarse tier evict).
+                let corpus_kind = corpus_kind_for(&local_by_content, &content_id);
+                if let Err(e) = tier_evict
+                    .evict_fountain_content_to_tier(&content_id, &corpus_kind, "t1")
+                    .await
+                {
+                    tracing::warn!(
+                        content_id = %content_id,
+                        error = %e,
+                        "swarm_runtime.converger: aggregated-tier evict failed",
+                    );
+                }
+            }
+            EjectionVerdict::EjectHardDelete => {
+                let corpus_kind = corpus_kind_for(&local_by_content, &content_id);
+                if let Err(e) =
+                    hard_delete.evict_fountain_content_hard_delete(&content_id, &corpus_kind)
+                {
+                    tracing::warn!(
+                        content_id = %content_id,
+                        error = %e,
+                        "swarm_runtime.converger: hard delete failed",
+                    );
+                } else if let Some(sink) = sink {
+                    sink(SwarmEvent::HardDeleted {
+                        content_id: content_id.clone(),
+                    });
+                }
+            }
+        }
+    }
+}
+
+fn corpus_kind_for(
+    local_by_content: &BTreeMap<String, HeldFountainContent>,
+    content_id: &str,
+) -> String {
+    local_by_content
+        .get(content_id)
+        .map_or_else(|| "fountain-corpus".to_string(), |h| h.corpus_kind.clone())
+}
+
+fn current_unix_ms() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| i64::try_from(d.as_millis()).unwrap_or(i64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transport::{InboundFrame, TransportError, TransportId, TransportSendOutcome};
+    use async_trait::async_trait;
+    use std::sync::Mutex;
+
+    // ─── Test fixtures ────────────────────────────────────────────
+
+    struct VecHoldings(Vec<HeldFountainContent>);
+    #[async_trait]
+    impl FountainHoldingsSource for VecHoldings {
+        async fn list_held_fountain_content(
+            &self,
+        ) -> Result<Vec<HeldFountainContent>, FountainEvictError> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingTierEvict {
+        calls: Mutex<Vec<(String, String, String)>>,
+    }
+    #[async_trait]
+    impl FountainTierEvict for RecordingTierEvict {
+        async fn evict_fountain_content_to_tier(
+            &self,
+            content_id: &str,
+            corpus_kind: &str,
+            tier: &str,
+        ) -> Result<(), FountainEvictError> {
+            self.calls.lock().unwrap().push((
+                content_id.to_string(),
+                corpus_kind.to_string(),
+                tier.to_string(),
+            ));
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingHardDelete {
+        calls: Mutex<Vec<(String, String)>>,
+    }
+    impl FountainEvictHardDelete for RecordingHardDelete {
+        fn evict_fountain_content_hard_delete(
+            &self,
+            content_id: &str,
+            corpus_kind: &str,
+        ) -> Result<(), FountainEvictError> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((content_id.to_string(), corpus_kind.to_string()));
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct RecordingTransport {
+        sends: Mutex<Vec<(String, Vec<u8>)>>,
+    }
+    #[async_trait]
+    impl Transport for RecordingTransport {
+        fn id(&self) -> TransportId {
+            TransportId::HTTP
+        }
+        async fn send(
+            &self,
+            destination_key_id: &str,
+            envelope_bytes: &[u8],
+        ) -> Result<TransportSendOutcome, TransportError> {
+            self.sends
+                .lock()
+                .unwrap()
+                .push((destination_key_id.to_string(), envelope_bytes.to_vec()));
+            Ok(TransportSendOutcome::Delivered)
+        }
+        async fn listen(
+            &self,
+            _sink: tokio::sync::mpsc::Sender<InboundFrame>,
+        ) -> Result<(), TransportError> {
+            unimplemented!("test transports don't drive listen")
+        }
+    }
+
+    fn fast_config() -> SwarmRuntimeConfig {
+        SwarmRuntimeConfig {
+            publish_cadence: Duration::from_millis(20),
+            observe_cadence: Duration::from_millis(20),
+            ..SwarmRuntimeConfig::default()
+        }
+    }
+
+    // ─── Tests ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn empty_holdings_starts_and_shuts_down() {
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(super::super::NoopFountainHoldingsSource);
+        let tier: Arc<dyn FountainTierEvict> = Arc::new(RecordingTierEvict::default());
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let mut rt = FountainSwarmRuntime::start(
+            fast_config(),
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            None,
+        );
+        tokio::time::sleep(Duration::from_millis(60)).await;
+        rt.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn publisher_ships_one_envelope_per_held_content_per_peer() {
+        let holdings: Arc<dyn FountainHoldingsSource> = Arc::new(VecHoldings(vec![
+            HeldFountainContent {
+                content_id: "c-x".into(),
+                corpus_kind: "fountain-corpus".into(),
+                symbol_ids: vec![1, 2, 3],
+            },
+            HeldFountainContent {
+                content_id: "c-y".into(),
+                corpus_kind: "fountain-corpus".into(),
+                symbol_ids: vec![10, 20],
+            },
+        ]));
+        let tier: Arc<dyn FountainTierEvict> = Arc::new(RecordingTierEvict::default());
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let recording_tx = Arc::new(RecordingTransport::default());
+        let tx: Arc<dyn Transport> = recording_tx.clone();
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
+            Arc::new(|| vec!["bob".to_string(), "carol".to_string()]);
+        let mut rt = FountainSwarmRuntime::start(
+            fast_config(),
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            None,
+        );
+        // Let the publisher fire at least once.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        rt.shutdown().await;
+        let sends = recording_tx.sends.lock().unwrap().clone();
+        // 2 content × 2 peers = 4 sends per tick; should be at least 4.
+        assert!(
+            sends.len() >= 4,
+            "expected >=4 publish sends, got {}",
+            sends.len()
+        );
+        // Every send must be addressed to a cohort peer (not self).
+        for (dest, _) in &sends {
+            assert!(
+                dest == "bob" || dest == "carol",
+                "self-addressed send: {dest}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn register_observed_claim_lands_in_map() {
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(super::super::NoopFountainHoldingsSource);
+        let tier: Arc<dyn FountainTierEvict> = Arc::new(RecordingTierEvict::default());
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let rt = FountainSwarmRuntime::start(
+            SwarmRuntimeConfig {
+                publish_cadence: Duration::from_secs(60),
+                observe_cadence: Duration::from_secs(60),
+                ..Default::default()
+            },
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            None,
+        );
+
+        rt.register_observed_claim(FountainHoldingClaim::new(
+            "bob",
+            "c-x",
+            vec![1, 2],
+            1_700_000_000,
+        ))
+        .await;
+        rt.register_observed_claim(FountainHoldingClaim::new(
+            "carol",
+            "c-x",
+            vec![1, 3],
+            1_700_000_000,
+        ))
+        .await;
+        let map = rt.observed_handle();
+        let g = map.read().await;
+        assert_eq!(g.distinct_holders("c-x"), 2);
+        assert_eq!(g.distinct_holders("c-y"), 0);
+        drop(g);
+        let mut rt = rt;
+        rt.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn converger_fires_eject_above_target_when_observed_holders_exceed_threshold() {
+        // 35 holders + local symbol "common" (rarity >= target/2=15)
+        // → EjectToTier per the substrate's threshold math.
+        let local_content_id = "c-popular";
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(VecHoldings(vec![HeldFountainContent {
+                content_id: local_content_id.into(),
+                corpus_kind: "fountain-corpus".into(),
+                symbol_ids: vec![1],
+            }]));
+        let tier_recorder = Arc::new(RecordingTierEvict::default());
+        let tier: Arc<dyn FountainTierEvict> = tier_recorder.clone();
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel::<SwarmEvent>();
+        let sink: SwarmRuntimeEventSink = Arc::new(move |ev| {
+            let _ = sink_tx.send(ev);
+        });
+        let rt = FountainSwarmRuntime::start(
+            fast_config(),
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            Some(sink),
+        );
+        // Publish 35 distinct peer claims for symbol_id=1 — every
+        // peer holds symbol 1, so the local symbol is "common"
+        // (rarity score = 35 > target/2=15) and observed_count=35
+        // is above target+grace=34, so the converger should eject.
+        for i in 0..35 {
+            rt.register_observed_claim(FountainHoldingClaim::new(
+                format!("peer-{i}"),
+                local_content_id,
+                vec![1],
+                1_700_000_000,
+            ))
+            .await;
+        }
+        // Wait a couple of converger ticks.
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let mut rt = rt;
+        rt.shutdown().await;
+
+        let calls = tier_recorder.calls.lock().unwrap().clone();
+        assert!(
+            calls
+                .iter()
+                .any(|(cid, _, tier)| cid == local_content_id && tier == "t1"),
+            "expected EjectToTier(c-popular, t1), got {calls:?}"
+        );
+        // Sanity: a Published event fired (publisher saw c-popular).
+        let mut saw_eject = false;
+        while let Ok(ev) = sink_rx.try_recv() {
+            if matches!(
+                ev,
+                SwarmEvent::EjectedToTier { ref content_id, .. } if content_id == local_content_id
+            ) {
+                saw_eject = true;
+            }
+        }
+        assert!(saw_eject, "expected EjectedToTier event for c-popular");
+    }
+
+    #[tokio::test]
+    async fn converger_emits_repair_needed_when_below_min_viable() {
+        // 2 holders < min_viable=5 → RepairNeeded telemetry.
+        let content_id = "c-rare";
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(VecHoldings(vec![HeldFountainContent {
+                content_id: content_id.into(),
+                corpus_kind: "fountain-corpus".into(),
+                symbol_ids: vec![7],
+            }]));
+        let tier: Arc<dyn FountainTierEvict> = Arc::new(RecordingTierEvict::default());
+        let hard: Arc<dyn FountainEvictHardDelete + Send + Sync> =
+            Arc::new(RecordingHardDelete::default());
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let (sink_tx, mut sink_rx) = tokio::sync::mpsc::unbounded_channel::<SwarmEvent>();
+        let sink: SwarmRuntimeEventSink = Arc::new(move |ev| {
+            let _ = sink_tx.send(ev);
+        });
+        let rt = FountainSwarmRuntime::start(
+            fast_config(),
+            holdings,
+            tier,
+            hard,
+            tx,
+            cohort,
+            "alice".to_string(),
+            Some(sink),
+        );
+        for i in 0..2 {
+            rt.register_observed_claim(FountainHoldingClaim::new(
+                format!("peer-{i}"),
+                content_id,
+                vec![7],
+                1_700_000_000,
+            ))
+            .await;
+        }
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let mut rt = rt;
+        rt.shutdown().await;
+        let mut saw_repair = false;
+        while let Ok(ev) = sink_rx.try_recv() {
+            if let SwarmEvent::RepairNeeded {
+                content_id: cid,
+                observed_holders,
+                min_viable,
+            } = ev
+            {
+                if cid == content_id && observed_holders == 2 && min_viable == DEFAULT_MIN_VIABLE {
+                    saw_repair = true;
+                }
+            }
+        }
+        assert!(saw_repair, "expected RepairNeeded(c-rare, 2, 5)");
+    }
+
+    #[tokio::test]
+    async fn observed_claims_prune_when_ttl_elapsed() {
+        let mut claims = ObservedClaims::default();
+        let claim = FountainHoldingClaim::new("p", "c", vec![1], 1_700_000_000);
+        claims.upsert(claim);
+        assert_eq!(claims.distinct_holders("c"), 1);
+        // TTL=0 → every claim is "expired" instantly.
+        let dropped = claims.prune_expired(Duration::from_secs(0));
+        assert_eq!(dropped, 1);
+        assert_eq!(claims.distinct_holders("c"), 0);
+    }
+
+    #[tokio::test]
+    async fn observed_claims_dedupe_per_peer_content() {
+        let mut claims = ObservedClaims::default();
+        claims.upsert(FountainHoldingClaim::new("p", "c", vec![1], 1));
+        claims.upsert(FountainHoldingClaim::new("p", "c", vec![1, 2], 2));
+        // Same (peer, content) → upsert keeps the latest claim only.
+        assert_eq!(claims.distinct_holders("c"), 1);
+        let all = claims.all_claims_for("c");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].symbol_ids, vec![1, 2]);
+    }
+}

--- a/tests/directory_cache_e2e.rs
+++ b/tests/directory_cache_e2e.rs
@@ -1,0 +1,102 @@
+//! v6.0.0 (CIRISEdge#175, FSD §3.3) — directory cache end-to-end.
+//!
+//! Simulates the `federation_keys` anti-entropy stream populating
+//! the cache. Per FSD §3.3, no per-invitation directory query is
+//! emitted; the cache is the only lookup surface. Subpoena of the
+//! directory yields the federation-public X-Wing keys (already
+//! public per §9.5) but no `querier → invitee` edges.
+
+#![allow(clippy::similar_names)]
+
+use ciris_crypto::hpke::XWingRecipientPublic;
+use ciris_crypto::{ml_kem, x25519, MlDsa65Signer, PqcSigner};
+use ciris_edge::{
+    unwrap_welcome, wrap_welcome, DirectoryCache, DirectoryRecord, IdentityType, Reachability,
+    XWingPublic,
+};
+
+#[test]
+fn anti_entropy_populated_cache_resolves_by_federation_id() {
+    let cache = DirectoryCache::new();
+    assert!(cache.is_empty());
+
+    // Simulate two anti-entropy events.
+    cache.insert(DirectoryRecord {
+        federation_id: "alice@fed.example".into(),
+        ml_dsa_pk: vec![0x11u8; 1952],
+        x_wing_pk: Some(XWingPublic {
+            x25519_pub: [0x11; 32],
+            mlkem768_pub: vec![0x11; 1184],
+        }),
+        identity_type: IdentityType::agent(),
+        reachability: Reachability::Direct,
+    });
+    cache.insert(DirectoryRecord {
+        federation_id: "bob@fed.example".into(),
+        ml_dsa_pk: vec![0x22u8; 1952],
+        x_wing_pk: Some(XWingPublic {
+            x25519_pub: [0x22; 32],
+            mlkem768_pub: vec![0x22; 1184],
+        }),
+        identity_type: IdentityType::phone(),
+        reachability: Reachability::Relay,
+    });
+
+    assert_eq!(cache.len(), 2);
+    let alice = cache.get("alice@fed.example").unwrap();
+    assert_eq!(alice.identity_type, IdentityType::agent());
+    assert_eq!(alice.reachability, Reachability::Direct);
+    let bob = cache.get("bob@fed.example").unwrap();
+    assert_eq!(bob.identity_type, IdentityType::phone());
+    assert_eq!(bob.reachability, Reachability::Relay);
+}
+
+#[test]
+fn cache_drives_welcome_wrap_unwrap_directory_lookup() {
+    let cache = DirectoryCache::new();
+
+    let inviter = MlDsa65Signer::new().unwrap();
+    let inviter_pk_bytes = inviter.public_key().unwrap();
+    cache.insert(DirectoryRecord {
+        federation_id: "inviter-X".into(),
+        ml_dsa_pk: inviter_pk_bytes.clone(),
+        x_wing_pk: None,
+        identity_type: IdentityType::steward(),
+        reachability: Reachability::Direct,
+    });
+
+    // Build an invitee X-Wing keypair (also added to cache).
+    let (x_sk, x_pk) = x25519::generate_ephemeral_keypair().unwrap();
+    let (mlkem_sk, mlkem_pk) = ml_kem::generate_keypair().unwrap();
+    let invitee_pk = XWingRecipientPublic {
+        x25519_pub: x_pk,
+        mlkem768_pub: mlkem_pk.clone(),
+    };
+    let invitee_sk = ciris_crypto::hpke::XWingRecipientSecret {
+        x25519_priv: x_sk,
+        mlkem768_priv: mlkem_sk,
+        mlkem768_pub: mlkem_pk,
+    };
+
+    let welcome = b"directory-driven Welcome unwrap";
+    let wrapped = wrap_welcome(&inviter, "inviter-X", &invitee_pk, welcome, b"").unwrap();
+
+    let opened = unwrap_welcome(&invitee_sk, &wrapped, b"", cache.welcome_wrap_lookup()).unwrap();
+    assert_eq!(opened, welcome);
+}
+
+#[test]
+fn revocation_via_remove_drops_directory_record() {
+    let cache = DirectoryCache::new();
+    cache.insert(DirectoryRecord {
+        federation_id: "ephemeral".into(),
+        ml_dsa_pk: vec![0; 1952],
+        x_wing_pk: None,
+        identity_type: IdentityType::agent(),
+        reachability: Reachability::Direct,
+    });
+    assert!(cache.contains("ephemeral"));
+    let removed = cache.remove("ephemeral").unwrap();
+    assert_eq!(removed.federation_id, "ephemeral");
+    assert!(!cache.contains("ephemeral"));
+}

--- a/tests/fountain_hard_delete_path.rs
+++ b/tests/fountain_hard_delete_path.rs
@@ -1,0 +1,90 @@
+//! v5.2.0 (CIRISEdge#143) — production adapter exercises the
+//! [`FountainEvictHardDelete`] surface end-to-end.
+//!
+//! The substrate-tier `swarm_rarity` tests already prove the trait
+//! dispatches correctly; this integration test verifies the v5.2.0
+//! adapter shape — [`PersistFountainEvictHardDelete`] is a thin
+//! passthrough that the production caller wires over its persist
+//! `Engine` handle. Until persist v9.x exposes the eviction API on
+//! `Arc<dyn FederationDirectory>`, the test stops at the adapter
+//! boundary; the adapter is exercised against an in-tree recorder
+//! that stands in for the persist-side concrete.
+
+use std::sync::{Arc, Mutex};
+
+use ciris_edge::holonomic::swarm_rarity::{FountainEvictError, FountainEvictHardDelete};
+use ciris_edge::swarm::PersistFountainEvictHardDelete;
+
+#[derive(Default)]
+struct Recorder {
+    calls: Mutex<Vec<(String, String)>>,
+}
+impl FountainEvictHardDelete for Recorder {
+    fn evict_fountain_content_hard_delete(
+        &self,
+        content_id: &str,
+        corpus_kind: &str,
+    ) -> Result<(), FountainEvictError> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((content_id.to_string(), corpus_kind.to_string()));
+        Ok(())
+    }
+}
+
+#[test]
+fn production_adapter_calls_through_to_inner_evictor() {
+    let rec: Arc<Recorder> = Arc::new(Recorder::default());
+    let adapter = PersistFountainEvictHardDelete::new(rec.clone());
+
+    // Three distinct hard-delete invocations.
+    adapter
+        .evict_fountain_content_hard_delete("revoked-A", "fountain-corpus")
+        .expect("hard-delete succeeds");
+    adapter
+        .evict_fountain_content_hard_delete("revoked-B", "fountain-corpus")
+        .expect("hard-delete succeeds");
+    adapter
+        .evict_fountain_content_hard_delete("revoked-C", "different-corpus")
+        .expect("hard-delete succeeds");
+
+    let calls = rec.calls.lock().unwrap().clone();
+    assert_eq!(
+        calls,
+        vec![
+            ("revoked-A".to_string(), "fountain-corpus".to_string()),
+            ("revoked-B".to_string(), "fountain-corpus".to_string()),
+            ("revoked-C".to_string(), "different-corpus".to_string()),
+        ],
+        "production adapter must passthrough every call to the inner evictor",
+    );
+}
+
+#[test]
+fn production_adapter_surfaces_inner_failure() {
+    struct Failing;
+    impl FountainEvictHardDelete for Failing {
+        fn evict_fountain_content_hard_delete(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> Result<(), FountainEvictError> {
+            Err(FountainEvictError::HardDeleteFailed(
+                "persist-backend-down".into(),
+            ))
+        }
+    }
+    let adapter = PersistFountainEvictHardDelete::new(Arc::new(Failing));
+    let err = adapter
+        .evict_fountain_content_hard_delete("c1", "fountain-corpus")
+        .expect_err("must surface inner failure");
+    match err {
+        FountainEvictError::HardDeleteFailed(msg) => {
+            assert!(
+                msg.contains("persist-backend-down"),
+                "error message must propagate: {msg}"
+            );
+        }
+    }
+}

--- a/tests/scope_echo_default_flip.rs
+++ b/tests/scope_echo_default_flip.rs
@@ -1,0 +1,95 @@
+//! v6.0.0 (CIRISEdge#175, FSD §3.2) — default cohort_scope flip +
+//! scope echo.
+//!
+//! The §3.2 rule: `cohort_scope` defaults to the smallest scope
+//! consistent with the publisher's audience context. Federation
+//! scope is **opt-in**. The default flip MUST NEVER return Public.
+//!
+//! This test exercises [`CohortScope::default_for_audience`] across
+//! the four (community_context, family_context) input combinations;
+//! the CC 1.13.3.4 invariant is that no input combination yields
+//! Public.
+
+use ciris_edge::{CohortScope, CryptoTier};
+
+#[test]
+fn default_with_community_context_yields_cohort_scope() {
+    let s = CohortScope::default_for_audience(Some("alpha"), false);
+    assert_eq!(
+        s,
+        CohortScope::Cohort {
+            cohort_id: "alpha".into()
+        }
+    );
+    assert_eq!(s.crypto_tier(), CryptoTier::CommunityDek);
+}
+
+#[test]
+fn default_with_family_context_yields_family() {
+    let s = CohortScope::default_for_audience(None, true);
+    assert_eq!(s, CohortScope::Family);
+    assert_eq!(s.crypto_tier(), CryptoTier::InvisibleEncrypted);
+}
+
+#[test]
+fn default_without_context_yields_self() {
+    let s = CohortScope::default_for_audience(None, false);
+    assert_eq!(s, CohortScope::SelfOnly);
+    assert_eq!(s.crypto_tier(), CryptoTier::InvisibleEncrypted);
+}
+
+#[test]
+fn default_community_wins_over_family() {
+    let s = CohortScope::default_for_audience(Some("beta"), true);
+    assert_eq!(
+        s,
+        CohortScope::Cohort {
+            cohort_id: "beta".into()
+        }
+    );
+}
+
+#[test]
+fn explicit_public_is_federation_opt_in() {
+    // §3.2 — operators opt up to federation explicitly; the wire
+    // representation is the existing `Public` variant.
+    let s = CohortScope::Public;
+    assert_eq!(s.crypto_tier(), CryptoTier::Plaintext);
+    assert!(!s.is_restricted());
+}
+
+#[test]
+fn default_never_returns_public_under_any_input() {
+    // CC 1.13.3.4 invariant — anonymity-by-default at every scope
+    // below federation. The default flip MUST NEVER return Public.
+    for (cid, fam) in [
+        (Some("c"), true),
+        (Some("c"), false),
+        (None, true),
+        (None, false),
+    ] {
+        let s = CohortScope::default_for_audience(cid, fam);
+        assert_ne!(
+            s,
+            CohortScope::Public,
+            "input ({cid:?}, {fam}) must not default to Public"
+        );
+    }
+}
+
+#[test]
+fn scope_echo_returns_chosen_scope() {
+    // §3.2 scope echo — every publication carries the chosen scope
+    // back to the operator API. v6.0.0 ships the resolver; PyO3
+    // surface is the v6.1.0 wiring (the resolver itself is the
+    // wire-format invariant).
+    let s = CohortScope::default_for_audience(Some("comm-1"), false);
+    let echo = s.kind_token();
+    assert_eq!(echo, "cohort");
+
+    let s = CohortScope::default_for_audience(None, true);
+    assert_eq!(s.kind_token(), "family");
+
+    let s = CohortScope::default_for_audience(None, false);
+    assert_eq!(s.kind_token(), "self");
+}

--- a/tests/scope_privacy_e2e.rs
+++ b/tests/scope_privacy_e2e.rs
@@ -1,0 +1,124 @@
+//! v6.0.0 (CIRISEdge#175, FSD §2.4) — scope-privacy end-to-end.
+//!
+//! Two-peer setup: alice and bob share an MLS group exporter_secret;
+//! charlie is outside the group. Alice "publishes" a record at
+//! community scope (derives record_id + symbol_key); bob reproduces
+//! the same `record_id`/`symbol_key` from the same exporter_secret;
+//! charlie's distinct exporter_secret produces non-matching bytes.
+//!
+//! Scope: validates that v6.3.0's `ciris_crypto::scope_privacy`
+//! derivations work end-to-end from edge's re-export path AND that
+//! cross-impl conformance vectors reproduce.
+
+use ciris_edge::{derive_record_id, derive_symbol_key, k_record_id, k_symbol, RecordType};
+
+/// Alice and bob share `exporter_secret`; they derive the same
+/// `record_id` and `symbol_key`. Charlie's distinct exporter_secret
+/// produces different bytes — community-scope confidentiality.
+#[test]
+fn community_member_sees_matching_record_id_outsider_does_not() {
+    // Alice + bob: shared MLS group exporter_secret.
+    let group_exporter = [0x42u8; 32];
+    let community_epoch = 7;
+    let internal_id = b"record-0001";
+
+    let alice_k_rec = k_record_id(&group_exporter);
+    let bob_k_rec = k_record_id(&group_exporter);
+    assert_eq!(
+        alice_k_rec, bob_k_rec,
+        "shared exporter_secret yields identical K_record_id"
+    );
+
+    let alice_rid = derive_record_id(
+        &alice_k_rec,
+        internal_id,
+        RecordType::CommunityRecord,
+        community_epoch,
+    );
+    let bob_rid = derive_record_id(
+        &bob_k_rec,
+        internal_id,
+        RecordType::CommunityRecord,
+        community_epoch,
+    );
+    assert_eq!(
+        alice_rid, bob_rid,
+        "community members produce identical record_id from shared state"
+    );
+
+    // Charlie: outside the group, distinct exporter_secret.
+    let charlie_exporter = [0xCCu8; 32];
+    let charlie_k_rec = k_record_id(&charlie_exporter);
+    let charlie_rid = derive_record_id(
+        &charlie_k_rec,
+        internal_id,
+        RecordType::CommunityRecord,
+        community_epoch,
+    );
+    assert_ne!(
+        alice_rid, charlie_rid,
+        "outsider with distinct exporter_secret produces distinct record_id"
+    );
+}
+
+/// §2.4 symbol_key — community members derive identical symbol keys
+/// for each (record_id, symbol_index) pair; outsiders cannot.
+#[test]
+fn community_members_share_symbol_keys_outsider_does_not() {
+    let group_exporter = [0x42u8; 32];
+    let alice_k_sym = k_symbol(&group_exporter);
+    let bob_k_sym = k_symbol(&group_exporter);
+    assert_eq!(alice_k_sym, bob_k_sym);
+
+    let alice_k_rec = k_record_id(&group_exporter);
+    let rid = derive_record_id(&alice_k_rec, b"record-001", RecordType::CommunityRecord, 1);
+
+    // 20 symbol fragments (the default RaptorQ N=20 from FSD §2.4).
+    for idx in 0..20u16 {
+        let alice_sym = derive_symbol_key(&alice_k_sym, &rid, idx);
+        let bob_sym = derive_symbol_key(&bob_k_sym, &rid, idx);
+        assert_eq!(alice_sym, bob_sym, "symbol {idx} matches across members");
+    }
+
+    // Outsider charlie — distinct exporter, can't reproduce.
+    let charlie_exporter = [0xCCu8; 32];
+    let charlie_k_sym = k_symbol(&charlie_exporter);
+    let charlie_sym = derive_symbol_key(&charlie_k_sym, &rid, 0);
+    let alice_sym = derive_symbol_key(&alice_k_sym, &rid, 0);
+    assert_ne!(charlie_sym, alice_sym);
+}
+
+/// §2.4 — distinct record_types under the same key produce distinct
+/// `record_id`s, even with identical internal_id + epoch.
+#[test]
+fn record_type_disambiguates_record_id() {
+    let k = k_record_id(&[0x99u8; 32]);
+    let rid_self = derive_record_id(&k, b"x", RecordType::SelfRecord, 1);
+    let rid_fam = derive_record_id(&k, b"x", RecordType::FamilyRecord, 1);
+    let rid_com = derive_record_id(&k, b"x", RecordType::CommunityRecord, 1);
+    let rid_fed = derive_record_id(&k, b"x", RecordType::FederationRecord, 1);
+    assert_ne!(rid_self, rid_fam);
+    assert_ne!(rid_fam, rid_com);
+    assert_ne!(rid_com, rid_fed);
+    assert_ne!(rid_self, rid_fed);
+}
+
+/// §2.2 domain separation — k_record_id and k_symbol must NEVER
+/// match for the same exporter_secret. If they did, a holder
+/// observing one would compromise the other.
+#[test]
+fn record_id_and_symbol_subkeys_are_distinct() {
+    let exporter = [0x42u8; 32];
+    assert_ne!(k_record_id(&exporter), k_symbol(&exporter));
+}
+
+/// §2.4 — epoch advance produces non-matching record_id even with
+/// the same internal_id + record_type. The MLS epoch-advance is the
+/// rotation hook FSD §3.5 leans on.
+#[test]
+fn epoch_advance_rotates_record_id() {
+    let k = k_record_id(&[0x11u8; 32]);
+    let rid_e0 = derive_record_id(&k, b"x", RecordType::CommunityRecord, 0);
+    let rid_e1 = derive_record_id(&k, b"x", RecordType::CommunityRecord, 1);
+    assert_ne!(rid_e0, rid_e1);
+}

--- a/tests/swarm_runtime_e2e.rs
+++ b/tests/swarm_runtime_e2e.rs
@@ -1,0 +1,183 @@
+//! v5.2.0 (CIRISEdge#143) — end-to-end swarm-runtime smoke.
+//!
+//! Two peers (alice + bob); alice publishes a fountain holding claim
+//! and bob observes it via [`FountainSwarmRuntime::register_observed_claim`].
+//! Asserts:
+//!
+//! 1. Alice's publisher fires a `send` to the cohort.
+//! 2. Bob's converger ticks and observes the claim in the map.
+//! 3. The runtime shuts down cleanly.
+//!
+//! The wire shape between peers is currently
+//! `FountainHoldingClaim::canonical_bytes` — the substrate's domain-
+//! tagged bytes. A future cut adds a wire-tier
+//! `MessageType::FountainHoldingClaim` discriminator and re-uses
+//! `dispatch_inbound`'s verify path; for v5.2.0 the integration test
+//! drives `register_observed_claim` directly, simulating what the
+//! verify-path-aware dispatch hook will do.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+
+use ciris_edge::holonomic::swarm_rarity::FountainHoldingClaim;
+use ciris_edge::swarm::{
+    FountainEvictHardDelete, FountainHoldingsSource, FountainSwarmRuntime, FountainTierEvict,
+    HeldFountainContent, NoopFountainHoldingsSource, SwarmRuntimeConfig,
+};
+use ciris_edge::transport::{
+    InboundFrame, Transport, TransportError, TransportId, TransportSendOutcome,
+};
+
+#[derive(Default)]
+struct RecordingTransport {
+    sends: std::sync::Mutex<Vec<(String, Vec<u8>)>>,
+}
+#[async_trait]
+impl Transport for RecordingTransport {
+    fn id(&self) -> TransportId {
+        TransportId::HTTP
+    }
+    async fn send(
+        &self,
+        destination_key_id: &str,
+        envelope_bytes: &[u8],
+    ) -> Result<TransportSendOutcome, TransportError> {
+        self.sends
+            .lock()
+            .unwrap()
+            .push((destination_key_id.to_string(), envelope_bytes.to_vec()));
+        Ok(TransportSendOutcome::Delivered)
+    }
+    async fn listen(
+        &self,
+        _sink: tokio::sync::mpsc::Sender<InboundFrame>,
+    ) -> Result<(), TransportError> {
+        unimplemented!("e2e doesn't drive listen")
+    }
+}
+
+struct VecHoldings(Vec<HeldFountainContent>);
+#[async_trait]
+impl FountainHoldingsSource for VecHoldings {
+    async fn list_held_fountain_content(
+        &self,
+    ) -> Result<Vec<HeldFountainContent>, ciris_edge::swarm::FountainEvictError> {
+        Ok(self.0.clone())
+    }
+}
+
+#[derive(Default)]
+struct NopTier;
+#[async_trait]
+impl FountainTierEvict for NopTier {
+    async fn evict_fountain_content_to_tier(
+        &self,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<(), ciris_edge::swarm::FountainEvictError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct NopHard;
+impl FountainEvictHardDelete for NopHard {
+    fn evict_fountain_content_hard_delete(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<(), ciris_edge::swarm::FountainEvictError> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn two_peer_publish_and_observe_roundtrip() {
+    // Alice — has held content. Publishes claims; bob is the cohort.
+    let alice_holdings: Arc<dyn FountainHoldingsSource> =
+        Arc::new(VecHoldings(vec![HeldFountainContent {
+            content_id: "shard-X".into(),
+            corpus_kind: "fountain-corpus".into(),
+            symbol_ids: vec![1, 2, 3],
+        }]));
+    let alice_tx = Arc::new(RecordingTransport::default());
+    let alice_tier: Arc<dyn FountainTierEvict> = Arc::new(NopTier);
+    let alice_hard: Arc<dyn FountainEvictHardDelete + Send + Sync> = Arc::new(NopHard);
+    let alice_cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> =
+        Arc::new(|| vec!["bob".to_string()]);
+    let mut alice = FountainSwarmRuntime::start(
+        SwarmRuntimeConfig {
+            publish_cadence: Duration::from_millis(20),
+            observe_cadence: Duration::from_millis(50),
+            ..Default::default()
+        },
+        alice_holdings,
+        alice_tier,
+        alice_hard,
+        alice_tx.clone() as Arc<dyn Transport>,
+        alice_cohort,
+        "alice".to_string(),
+        None,
+    );
+
+    // Bob — no held content; observes alice's claim. Cohort is
+    // empty (bob is the listener, not the publisher).
+    let bob_holdings: Arc<dyn FountainHoldingsSource> = Arc::new(NoopFountainHoldingsSource);
+    let bob_tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+    let bob_tier: Arc<dyn FountainTierEvict> = Arc::new(NopTier);
+    let bob_hard: Arc<dyn FountainEvictHardDelete + Send + Sync> = Arc::new(NopHard);
+    let bob_cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+    let mut bob = FountainSwarmRuntime::start(
+        SwarmRuntimeConfig {
+            publish_cadence: Duration::from_millis(20),
+            observe_cadence: Duration::from_millis(20),
+            ..Default::default()
+        },
+        bob_holdings,
+        bob_tier,
+        bob_hard,
+        bob_tx,
+        bob_cohort,
+        "bob".to_string(),
+        None,
+    );
+
+    // Let alice publish at least once.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let alice_sends = alice_tx.sends.lock().unwrap().clone();
+    assert!(
+        alice_sends.iter().any(|(dst, _)| dst == "bob"),
+        "alice's publisher must have shipped at least one envelope to bob; got {alice_sends:?}"
+    );
+
+    // Simulate the inbound dispatch path: bob's edge would call
+    // `register_observed_claim` on the verified body. We do that
+    // directly here (the wire-level MessageType wiring lands in a
+    // follow-up cut once the discriminator is approved).
+    bob.register_observed_claim(FountainHoldingClaim::new(
+        "alice",
+        "shard-X",
+        vec![1, 2, 3],
+        1_700_000_000,
+    ))
+    .await;
+
+    // Let bob's converger run.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let observed = bob.observed_handle();
+    let g = observed.read().await;
+    let inner = format!("{g:?}");
+    assert!(
+        inner.contains("shard-X"),
+        "bob's observed map must contain shard-X; got {inner}"
+    );
+    drop(g);
+
+    alice.shutdown().await;
+    bob.shutdown().await;
+}

--- a/tests/welcome_wrap_e2e.rs
+++ b/tests/welcome_wrap_e2e.rs
@@ -1,0 +1,124 @@
+//! v6.0.0 (CIRISEdge#175, FSD §3.3) — Welcome wrap end-to-end.
+//!
+//! Inviter wraps an MLS Welcome to the invitee via HPKE-Base over
+//! the invitee's static X-Wing public key + ML-DSA-65 sender
+//! authentication signature over `encap_signing_bytes`. The
+//! invitee verifies the signature BEFORE HPKE open_base; tampered
+//! signatures are structurally rejected.
+
+#![allow(clippy::similar_names)]
+
+use ciris_crypto::hpke::{XWingRecipientPublic, XWingRecipientSecret};
+use ciris_crypto::{ml_kem, x25519, MlDsa65Signer, PqcSigner};
+use ciris_edge::{unwrap_welcome, wrap_welcome, FederationDirectoryEntry, WelcomeWrapError};
+
+fn fresh_invitee() -> (XWingRecipientPublic, XWingRecipientSecret) {
+    let (x_sk, x_pk) = x25519::generate_ephemeral_keypair().unwrap();
+    let (mlkem_sk, mlkem_pk) = ml_kem::generate_keypair().unwrap();
+    let pk = XWingRecipientPublic {
+        x25519_pub: x_pk,
+        mlkem768_pub: mlkem_pk.clone(),
+    };
+    let sk = XWingRecipientSecret {
+        x25519_priv: x_sk,
+        mlkem768_priv: mlkem_sk,
+        mlkem768_pub: mlkem_pk,
+    };
+    (pk, sk)
+}
+
+#[test]
+fn wrap_and_unwrap_round_trip() {
+    let inviter = MlDsa65Signer::new().unwrap();
+    let (invitee_pk, invitee_sk) = fresh_invitee();
+    let welcome = b"MLS Welcome bytes (test stub)";
+
+    let wrapped = wrap_welcome(
+        &inviter,
+        "inviter-fingerprint-A",
+        &invitee_pk,
+        welcome,
+        b"group-id-42",
+    )
+    .unwrap();
+
+    // Directory lookup returns None — falls back to inline pk.
+    let opened = unwrap_welcome(&invitee_sk, &wrapped, b"group-id-42", |_| None).unwrap();
+    assert_eq!(opened, welcome);
+}
+
+#[test]
+fn signature_verification_is_precondition_to_open() {
+    // FSD §3.3 acceptance — implementations MUST verify the inviter
+    // signature on `encap_signing_bytes` before opening HPKE.
+    let inviter = MlDsa65Signer::new().unwrap();
+    let (invitee_pk, invitee_sk) = fresh_invitee();
+    let welcome = b"sender-authed Welcome";
+    let mut wrapped = wrap_welcome(&inviter, "inv-1", &invitee_pk, welcome, b"").unwrap();
+
+    // Flip a byte of the inviter signature.
+    wrapped.inviter_signature[0] ^= 0x01;
+
+    let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| None).unwrap_err();
+    assert!(
+        matches!(err, WelcomeWrapError::SignatureRejected),
+        "tampered inviter signature MUST be rejected"
+    );
+}
+
+#[test]
+fn directory_resolved_pk_takes_precedence_over_inline() {
+    let inviter = MlDsa65Signer::new().unwrap();
+    let (invitee_pk, invitee_sk) = fresh_invitee();
+    let welcome = b"directory-bound Welcome";
+    let wrapped = wrap_welcome(&inviter, "inviter-id-real", &invitee_pk, welcome, b"").unwrap();
+
+    let entry = FederationDirectoryEntry {
+        pk_id: "inviter-id-real".into(),
+        ml_dsa_pk: inviter.public_key().unwrap(),
+        x_wing_pk: None,
+    };
+    let opened = unwrap_welcome(&invitee_sk, &wrapped, b"", |id| {
+        if id == "inviter-id-real" {
+            Some(entry.clone())
+        } else {
+            None
+        }
+    })
+    .unwrap();
+    assert_eq!(opened, welcome);
+}
+
+#[test]
+fn directory_substitution_attack_is_rejected() {
+    // If a directory hands back the WRONG inviter pk, the signature
+    // fails — the directory cannot trick the invitee into accepting
+    // a substituted Welcome.
+    let inviter = MlDsa65Signer::new().unwrap();
+    let attacker = MlDsa65Signer::new().unwrap();
+    let (invitee_pk, invitee_sk) = fresh_invitee();
+    let welcome = b"substitution-attack target";
+    let wrapped = wrap_welcome(&inviter, "inv-real", &invitee_pk, welcome, b"").unwrap();
+
+    let bad_entry = FederationDirectoryEntry {
+        pk_id: "inv-real".into(),
+        ml_dsa_pk: attacker.public_key().unwrap(),
+        x_wing_pk: None,
+    };
+    let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| Some(bad_entry.clone())).unwrap_err();
+    assert!(matches!(err, WelcomeWrapError::SignatureRejected));
+}
+
+#[test]
+fn aad_mismatch_fails_open_after_signature_verifies() {
+    // The signature only covers encap bytes (FSD §3.3), so an aad
+    // mismatch passes signature but fails HPKE open — surfaces as
+    // CryptoError.
+    let inviter = MlDsa65Signer::new().unwrap();
+    let (invitee_pk, invitee_sk) = fresh_invitee();
+    let welcome = b"aad-bound Welcome";
+    let wrapped = wrap_welcome(&inviter, "inv-aad", &invitee_pk, welcome, b"aad-A").unwrap();
+
+    let err = unwrap_welcome(&invitee_sk, &wrapped, b"aad-B", |_| None).unwrap_err();
+    assert!(matches!(err, WelcomeWrapError::Crypto(_)));
+}


### PR DESCRIPTION
## Summary

Lands CIRISEdge#175 — the substrate-tier realization of CEWP `SCOPE_PRIVACY.md`. Per CIRIS Constitution **CC 1.13.3.4**, anonymity-to-outsiders is the default at every scope below federation; this PR provides the construction.

- Pin bumps in lockstep: ciris-crypto v6.2.0 → v6.3.0, ciris-keyring v6.2.0 → v6.3.0, ciris-verify-core v6.2.0 → v6.3.0, ciris-persist v9.0.3 → v9.2.0.
- New surfaces: `scope_privacy` (verify v6.3.0 re-exports + cross-impl conformance vectors); `cohort_scope::{crypto_tier, default_for_audience}` (FSD §2.1 / §3.2); `mls::welcome_wrap` (FSD §3.3 HPKE-Base + ML-DSA-65); `mls::scope_state` (substrate-tier KV scaffold over persist v9.2.0 `XChaChaKvStore`); `mls::archive_mode` (FSD §3.5); `directory_cache` (FSD §3.3 cached federation directory).
- MISSION.md §13 cross-reference grows the CC 1.13.3.4 row.

## What this closes vs. what splits to v6.1.0

**Closed in v6.0.0** (CIRISEdge#175 acceptance checkboxes):
- [x] §2.2/§2.4/§3.4 derivation surface + cross-impl conformance vectors
- [x] CohortScope reconciliation via persist `crypto_tier()`
- [x] §3.2 default cohort_scope flip — `default_for_audience` API
- [x] §3.3 HPKE-Base + ML-DSA-65 Welcome wrap + signature precondition
- [x] §3.3 federation directory cache (in-memory)
- [x] §3.5 per-community archive_mode config
- [x] openmls cold-state KV scaffold over `XChaChaKvStore` (cold-state opacity)
- [x] Tests: scope_privacy_e2e (5), welcome_wrap_e2e (5), directory_cache_e2e (3), scope_echo_default_flip (7), 70+ new lib tests including verify v6.3.0 conformance vectors

**Split to v6.1.0** (filed against CIRISEdge#175):
- [ ] §3.1 Poisson emission discipline with synthetic cover envelopes
- [ ] §3.3 Leviculum announce-suppression patch
- [ ] §3.4 per-community witness chain split (current `WholenessWitness` is a federation-wide singleton)
- [ ] openmls 0.8 `StorageProvider` trait impl over `ScopeStateProvider` (60-method surface)
- [ ] `federation_keys` anti-entropy driver wiring into `DirectoryCache`
- [ ] PyO3 `Edge::resolve_default_scope` + `PublishOutcome` scope-echo wiring

## Ratified cross-impl decisions

- `HPKE_SUITE_ID = b\"HPKE-xwing-hkdf-sha256-aes256gcm-v1\"`
- RecordType ints: `reserved=0, SelfRecord=1, FamilyRecord=2, CommunityRecord=3, FederationRecord=4`
- CBOR canonical key order (encoded-length first then lexicographic) yields `v, epc, iid, typ` for `record_id_input`
- §2.2 K_record_id / K_symbol use **bare HKDF-SHA256-Expand** (NOT RFC 9420 ExpandWithLabel)

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS=\"-D warnings\" cargo clippy --no-default-features --features \"transport-http transport-reticulum pyo3 holonomic-consent-decay\" --lib --tests` clean
- [x] Feature-matrix clippy sweep across 4 combos clean
- [x] `cargo test --lib` — 586 pass / 0 fail / 5 ignored
- [x] `cargo test --test scope_privacy_e2e` — 5 / 5
- [x] `cargo test --test welcome_wrap_e2e` — 5 / 5
- [x] `cargo test --test directory_cache_e2e` — 3 / 3
- [x] `cargo test --test scope_echo_default_flip` — 7 / 7
- [x] MSRV 1.75 preserved
- [ ] CI green
- [ ] Cross-cdylib pyEdge / pyPersist install-graph sanity (post-merge)

Tag: `v6.0.0` at `b60451c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln