### PR TITLE
release(v6.2.4): adopt CIRISPersist v9.10.0 + verify-family v6.11.0 lockstep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.3"
+version = "6.2.4"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.10.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.11.0", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.11.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.11.0", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.10.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.2.0", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.2.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.2.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.2"
+version = "6.2.3"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.1"
+version = "6.2.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.0"
+version = "6.2.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.2.0,<10",
+    "ciris-persist>=9.4.0,<10",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.4.1,<10",
+    "ciris-persist>=9.9.0,<10",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.4.0,<10",
+    "ciris-persist>=9.4.1,<10",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.9.0,<10",
+    "ciris-persist>=9.10.0,<10",
 ]
 dynamic = ["version"]
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -415,268 +415,231 @@ impl FederationDirectoryReplicationBridge {
         refs
     }
 
-    async fn list_attestations(&self) -> Vec<EnvelopeRef> {
+    // ─── v6.2.0 (#179, CIRISPersist#249 Cut D) — generic cohort fan-out ──
+    //
+    // The 9 per-kind blocks below collapsed into a single
+    // [`Self::fan_out_for_member`] combinator + 9 call sites. The
+    // structural pattern is uniform across kinds (cohort iterate → per-key
+    // `list_*_for` → `persist_row_hash` decode → HashSet dedupe → wrap in
+    // `Signed*` → cache + emit `EnvelopeRef`); only the per-row
+    // projections (timestamp accessor, hash accessor) and the wrapper
+    // differ. Persist v9.3.0 keeps the `list_*_for_member` surface
+    // uniform across kinds, so one parameterized combinator replaces the
+    // hand-unrolled cases without changing wire-format behavior.
+    //
+    // `Row`-generic by inference: the closures fix the row type per call
+    // site without requiring dyn-compatibility on the directory trait.
+    // Async via boxed future on the per-key fetch (the directory trait is
+    // already `async_trait`-boxed).
+    async fn fan_out_for_member<Row, Signed, FetchFut, F, W, H>(
+        &self,
+        kind: EnvelopeKind,
+        mut fetch: F,
+        wrap: W,
+        timestamp: impl Fn(&Row) -> chrono::DateTime<chrono::Utc>,
+        hash: H,
+    ) -> Vec<EnvelopeRef>
+    where
+        F: FnMut(String) -> FetchFut,
+        FetchFut: std::future::Future<Output = Vec<Row>>,
+        W: Fn(&Row) -> Signed,
+        Signed: serde::Serialize,
+        H: Fn(&Row) -> &str,
+    {
         let mut refs = Vec::new();
         let mut seen: HashSet<[u8; 32]> = HashSet::new();
         for key_id in (self.cohort)() {
-            // Union: attestations ABOUT this key + attestations FROM
-            // this key. The dedupe by hash collapses cross-references.
-            let about = self
-                .directory
-                .list_attestations_for(&key_id)
-                .await
-                .unwrap_or_default();
-            let from = self
-                .directory
-                .list_attestations_by(&key_id)
-                .await
-                .unwrap_or_default();
-            for row in about.into_iter().chain(from) {
-                if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                    if !seen.insert(hash) {
-                        continue;
-                    }
-                    let bytes = serde_json::to_vec(&SignedAttestation {
-                        attestation: row.clone(),
-                    })
-                    .unwrap_or_default();
-                    self.cache_insert(EnvelopeKind::Attestation, hash, bytes)
-                        .await;
-                    refs.push(EnvelopeRef {
-                        envelope_hash: hash,
-                        seq: Self::ms_seq(row.asserted_at),
-                    });
+            let rows = fetch(key_id).await;
+            for row in rows {
+                let Some(envelope_hash) = Self::decode_hash(hash(&row)) else {
+                    continue;
+                };
+                if !seen.insert(envelope_hash) {
+                    continue;
                 }
+                let signed = wrap(&row);
+                let bytes = serde_json::to_vec(&signed).unwrap_or_default();
+                self.cache_insert(kind, envelope_hash, bytes).await;
+                refs.push(EnvelopeRef {
+                    envelope_hash,
+                    seq: Self::ms_seq(timestamp(&row)),
+                });
             }
         }
         refs
+    }
+
+    async fn list_attestations(&self) -> Vec<EnvelopeRef> {
+        // Union: attestations ABOUT this key + attestations FROM this key.
+        // The dedupe by hash collapses cross-references. This is the only
+        // kind whose per-key list is the chain of two `list_*` reads;
+        // every other kind hits one `list_*_for` surface.
+        self.fan_out_for_member(
+            EnvelopeKind::Attestation,
+            |key_id| async move {
+                let about = self
+                    .directory
+                    .list_attestations_for(&key_id)
+                    .await
+                    .unwrap_or_default();
+                let from = self
+                    .directory
+                    .list_attestations_by(&key_id)
+                    .await
+                    .unwrap_or_default();
+                about.into_iter().chain(from).collect()
+            },
+            |row| SignedAttestation {
+                attestation: row.clone(),
+            },
+            |row| row.asserted_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_revocations(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.revocations_for(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedRevocation {
-                            revocation: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::Revocation, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.revoked_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::Revocation,
+            |key_id| async move {
+                self.directory
+                    .revocations_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedRevocation {
+                revocation: row.clone(),
+            },
+            |row| row.revoked_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_identity_occurrences(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.list_identity_occurrences_for(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedIdentityOccurrence {
-                            identity_occurrence: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::IdentityOccurrence, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.asserted_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::IdentityOccurrence,
+            |key_id| async move {
+                self.directory
+                    .list_identity_occurrences_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedIdentityOccurrence {
+                identity_occurrence: row.clone(),
+            },
+            |row| row.asserted_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_families(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.list_families_for_member(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedFamily {
-                            family: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::Family, hash, bytes).await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.founded_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::Family,
+            |key_id| async move {
+                self.directory
+                    .list_families_for_member(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedFamily {
+                family: row.clone(),
+            },
+            |row| row.founded_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_communities(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.list_communities_for_member(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedCommunity {
-                            community: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::Community, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.founded_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::Community,
+            |key_id| async move {
+                self.directory
+                    .list_communities_for_member(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedCommunity {
+                community: row.clone(),
+            },
+            |row| row.founded_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_identity_occurrence_revocations(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self
-                .directory
-                .list_identity_occurrence_revocations_for(&key_id)
-                .await
-            {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedIdentityOccurrenceRevocation {
-                            identity_occurrence_revocation: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::IdentityOccurrenceRevocation, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.revoked_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::IdentityOccurrenceRevocation,
+            |key_id| async move {
+                self.directory
+                    .list_identity_occurrence_revocations_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedIdentityOccurrenceRevocation {
+                identity_occurrence_revocation: row.clone(),
+            },
+            |row| row.revoked_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_family_membership_revocations(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self
-                .directory
-                .list_family_membership_revocations_for(&key_id)
-                .await
-            {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedFamilyMembershipRevocation {
-                            family_membership_revocation: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::FamilyMembershipRevocation, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.removed_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::FamilyMembershipRevocation,
+            |key_id| async move {
+                self.directory
+                    .list_family_membership_revocations_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedFamilyMembershipRevocation {
+                family_membership_revocation: row.clone(),
+            },
+            |row| row.removed_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_community_membership_revocations(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self
-                .directory
-                .list_community_membership_revocations_for(&key_id)
-                .await
-            {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedCommunityMembershipRevocation {
-                            community_membership_revocation: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::CommunityMembershipRevocation, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.removed_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::CommunityMembershipRevocation,
+            |key_id| async move {
+                self.directory
+                    .list_community_membership_revocations_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedCommunityMembershipRevocation {
+                community_membership_revocation: row.clone(),
+            },
+            |row| row.removed_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_location_proofs(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.list_location_proofs_for(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedLocationProof {
-                            location_proof: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::LocationProof, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.asserted_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::LocationProof,
+            |key_id| async move {
+                self.directory
+                    .list_location_proofs_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedLocationProof {
+                location_proof: row.clone(),
+            },
+            |row| row.asserted_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     // ── v2 operational-data list_* ─────────────────────────────────

--- a/tests/active_roster_e2e.rs
+++ b/tests/active_roster_e2e.rs
@@ -1,0 +1,111 @@
+//! v6.2.0 (#179) — persist v9.3.0 `active_*` roster reads are reachable
+//! from edge via the `FederationDirectory` trait object.
+//!
+//! ## Why this test exists
+//!
+//! Persist v9.3.0 introduced four server-side memberships-MINUS-
+//! revocations folds:
+//!
+//! - `active_community_members(community) -> Vec<CommunityMember>`
+//! - `active_family_members(family) -> Vec<FamilyMember>`
+//! - `list_communities_for_member_active(member) -> Vec<Community>`
+//! - `list_families_for_member_active(member) -> Vec<Family>`
+//!
+//! Before v9.3.0, any consumer that wanted the LIVE roster had to ship
+//! both memberships + revocations as separate reads and fold them
+//! client-side. v9.3.0 closes that gap: the fold is exactly one read.
+//!
+//! ## What edge does with them today
+//!
+//! `grep -rn 'list_community_members\|list_family_members\|memberships_for'
+//! src/` finds zero edge-side sites that hand-roll the
+//! membership+revocation fold. The edge bridge (`src/replication/bridge.rs`)
+//! ships BOTH streams independently on the wire — that is the
+//! anti-entropy invariant and MUST stay independent. So the v6.2.0 cut's
+//! contribution for ask #2 is: prove the new active reads are reachable
+//! through edge's `Arc<dyn FederationDirectory>` so any FUTURE edge
+//! feature that needs a live roster uses the one-read fold rather than
+//! hand-rolling.
+//!
+//! ## What this test asserts
+//!
+//! 1. The four `active_*` reads are reachable through the trait object
+//!    edge holds (`Arc<dyn FederationDirectory>`), i.e. they're on the
+//!    trait surface, not on a backend-specific type.
+//! 2. On an empty backend, the inverse reads
+//!    (`list_*_for_member_active`) return an empty `Vec`, NOT an error
+//!    — the consumer can treat "no live memberships" as a valid empty
+//!    result.
+//! 3. On an empty backend, the forward reads (`active_*_members`)
+//!    return `Err(InvalidArgument)` for an unknown group_key_id —
+//!    confirming the trait contract documented in persist v9.3.0's
+//!    `FederationDirectory` ("Error::InvalidArgument if the family is
+//!    unknown"). This is the trait-shape edge must adapt to.
+//!
+//! ## What this test does NOT assert
+//!
+//! The functional revocation-subtraction semantics of `active_*_members`
+//! are covered by persist's own test suite (see
+//! `src/store/memory.rs::active_community_members_subtracts_effective_revocation`
+//! / `active_family_members_future_revocation_keeps_member` in persist
+//! v9.3.0). Asserting them from edge would require synthesizing real
+//! hybrid PQC signatures (the same blocker the existing
+//! `federation_present_attestation_appears_in_list_envelope_refs`
+//! `#[ignore]` annotation calls out). The trait-surface reachability
+//! this test asserts is what edge's adoption needs.
+
+use std::sync::Arc;
+
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::store::MemoryBackend;
+
+// ─── Assertion 1 — reachable through `dyn FederationDirectory` ──────
+
+/// The four v9.3.0 reads compile against the trait object edge actually
+/// holds: `Arc<dyn FederationDirectory>`. If persist regressed any of
+/// them off the trait into an inherent method, this test would fail to
+/// compile.
+#[tokio::test]
+async fn v9_3_0_active_reads_callable_through_dyn_trait() {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+
+    // 1 + 2 — the two `list_*_for_member_active` inverse reads return
+    // Ok(empty) for a member with no rosters. This is the consumer-side
+    // shape edge will adopt: "what live groups is this member in?".
+    let families = dir
+        .list_families_for_member_active("nonexistent-member")
+        .await
+        .expect("list_families_for_member_active reachable through dyn FederationDirectory");
+    assert!(families.is_empty(), "empty backend: no families");
+
+    let communities = dir
+        .list_communities_for_member_active("nonexistent-member")
+        .await
+        .expect("list_communities_for_member_active reachable through dyn FederationDirectory");
+    assert!(communities.is_empty(), "empty backend: no communities");
+}
+
+// ─── Assertion 2 — InvalidArgument on unknown group ─────────────────
+
+/// The forward reads (`active_*_members`) name a specific group and
+/// must error if that group doesn't exist. This is the trait-contract
+/// edge must adapt to when consuming the fold (it's NOT silent-empty
+/// like the inverse).
+#[tokio::test]
+async fn active_members_invalid_argument_on_unknown_group() {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+
+    let community_err = dir.active_community_members("no-such-community").await;
+    assert!(
+        community_err.is_err(),
+        "active_community_members on unknown community → Err(InvalidArgument)"
+    );
+
+    let family_err = dir.active_family_members("no-such-family").await;
+    assert!(
+        family_err.is_err(),
+        "active_family_members on unknown family → Err(InvalidArgument)"
+    );
+}

--- a/tests/bridge_combinator_e2e.rs
+++ b/tests/bridge_combinator_e2e.rs
@@ -1,0 +1,233 @@
+//! v6.2.0 (#179, CIRISPersist#249 Cut D) — `fan_out_for_member`
+//! combinator equivalence + dispatch-completeness invariants.
+//!
+//! The bridge's 9 per-kind cohort fan-outs collapsed into a single
+//! parameterized combinator (`fan_out_for_member`). This integration
+//! test fences the refactor by asserting:
+//!
+//! 1. **Dispatch completeness** — `list_envelope_refs(kind)` returns a
+//!    well-formed `Vec<EnvelopeRef>` (possibly empty) for every
+//!    `EnvelopeKind` variant. No panics, no `unimplemented!()`. This is
+//!    the structural invariant the per-kind unrolling provided
+//!    implicitly via the `match` arms.
+//!
+//! 2. **Empty-backend → empty refs across ALL kinds** — the combinator
+//!    handles the no-rows case identically to the v6.1.0 hand-unrolled
+//!    code. (The v6.1.0 implementation used per-block
+//!    `if let Ok(rows) = ...` which silently absorbed errors; the
+//!    combinator uses `unwrap_or_default()` for the same semantics.)
+//!
+//! 3. **Cohort-iteration shape preserved** — repeated cohort entries
+//!    yielding the same `key_id` deduplicate per the
+//!    `seen: HashSet<[u8; 32]>` dedupe; this invariant matters for the
+//!    9 base kinds + the 3 `*_since` operational kinds (which also
+//!    dedupe by hash, just from a different source).
+//!
+//! 4. **Key-kind round-trip continues to work** — the seeded-key
+//!    round-trip exercises `list_keys` (still hand-written; not part of
+//!    the combinator collapse since it's a point-read shape, not a
+//!    fan-out shape). This serves as the canary that the broader
+//!    refactor didn't perturb the shared cache + dispatch surface.
+//!
+//! ## What's NOT asserted here (intentional)
+//!
+//! - The persist-side `put_attestation` admission gate requires real
+//!   hybrid PQC signatures (per the existing
+//!   `federation_present_attestation_appears_in_list_envelope_refs`
+//!   `#[ignore]` annotation). This test does not synthesize those; the
+//!   existing per-kind unit tests inside `src/replication/bridge.rs`
+//!   already cover the seed-and-list round trip for keys, and the
+//!   structural shape this file asserts is what the combinator
+//!   refactor needs to preserve.
+//!
+//! - Wire-format byte stability across the refactor is covered by
+//!   `tests/replication_wire_proptest.rs` (which proptests the
+//!   serialization/deserialization round-trip of every `EnvelopeKind`
+//!   variant) — the combinator does not touch wire-frame serialization;
+//!   it only changes the host-side enumeration shape.
+
+use std::sync::Arc;
+
+use ciris_persist::federation::types::{algorithm, identity_type, KeyRecord, SignedKeyRecord};
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::store::MemoryBackend;
+
+use ciris_edge::replication::bridge::{CohortProvider, FederationDirectoryReplicationBridge};
+use ciris_edge::replication::{EnvelopeKind, ReplicationDirectory};
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+fn fresh_bridge(cohort: Vec<String>) -> (Arc<MemoryBackend>, FederationDirectoryReplicationBridge) {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+    let cohort_cb: CohortProvider = Arc::new(move || cohort.clone());
+    let bridge = FederationDirectoryReplicationBridge::new(dir, cohort_cb);
+    (backend, bridge)
+}
+
+fn fixture_key_record(key_id: &str, identity_type_: &str) -> KeyRecord {
+    let now = chrono::Utc::now();
+    KeyRecord {
+        key_id: key_id.to_string(),
+        pubkey_ed25519_base64: "0".repeat(44),
+        pubkey_ml_dsa_65_base64: None,
+        algorithm: algorithm::HYBRID.to_string(),
+        identity_type: identity_type_.to_string(),
+        identity_ref: format!("{identity_type_}-ref-{key_id}"),
+        valid_from: now,
+        valid_until: None,
+        registration_envelope: serde_json::json!({
+            "key_id": key_id,
+            "identity_type": identity_type_,
+        }),
+        original_content_hash: "0".repeat(64),
+        scrub_signature_classical: "x".repeat(88),
+        scrub_signature_pqc: None,
+        scrub_key_id: key_id.to_string(),
+        scrub_timestamp: now,
+        pqc_completed_at: None,
+        persist_row_hash: String::new(),
+        roles: Vec::new(),
+        attestation_evidence: None,
+    }
+}
+
+/// Every `EnvelopeKind` variant — both the 9 base kinds the v6.2.0
+/// combinator collapses AND the 3 operational `*_since` kinds (which
+/// also went through the same structural review per #179).
+fn all_envelope_kinds() -> &'static [EnvelopeKind] {
+    &[
+        EnvelopeKind::Key,
+        EnvelopeKind::Attestation,
+        EnvelopeKind::Revocation,
+        EnvelopeKind::IdentityOccurrence,
+        EnvelopeKind::Family,
+        EnvelopeKind::Community,
+        EnvelopeKind::IdentityOccurrenceRevocation,
+        EnvelopeKind::FamilyMembershipRevocation,
+        EnvelopeKind::CommunityMembershipRevocation,
+        EnvelopeKind::LocationProof,
+        EnvelopeKind::Organization,
+        EnvelopeKind::OrgMembership,
+        EnvelopeKind::PartnerRecord,
+    ]
+}
+
+// ─── Invariant 1 — dispatch completeness ────────────────────────────
+
+/// Every `EnvelopeKind` resolves to a well-formed (possibly empty) ref
+/// list. This is the load-bearing invariant the combinator must
+/// preserve: each per-kind site of the v6.1.0 9× unrolling becomes ONE
+/// call site through the combinator, and missing one would surface as a
+/// `match`-arm gap in `list_envelope_refs`.
+#[tokio::test]
+async fn every_envelope_kind_dispatches_through_combinator() {
+    let (_backend, bridge) = fresh_bridge(vec!["agent-alpha".to_string()]);
+    for kind in all_envelope_kinds() {
+        let refs = bridge.list_envelope_refs(*kind).await;
+        // No panic; empty is fine — backend is empty.
+        assert!(
+            refs.is_empty(),
+            "kind={kind:?} empty-backend MUST yield empty refs, got {refs:?}"
+        );
+    }
+}
+
+// ─── Invariant 2 — empty backend, every kind ────────────────────────
+
+/// Empty cohort + empty backend: every kind yields empty. Sanity that
+/// the combinator's early `cohort.is_empty()` shortcut + the directory
+/// trait's empty-list response don't perturb each other.
+#[tokio::test]
+async fn empty_cohort_yields_empty_refs_across_all_kinds() {
+    let (_backend, bridge) = fresh_bridge(Vec::new());
+    for kind in all_envelope_kinds() {
+        let refs = bridge.list_envelope_refs(*kind).await;
+        assert!(refs.is_empty(), "kind={kind:?} expected empty");
+    }
+}
+
+// ─── Invariant 3 — cohort dedupe via the combinator's HashSet ────────
+
+/// The combinator's `seen: HashSet<[u8; 32]>` dedupe fires when the
+/// cohort callback yields the same `key_id` more than once. Seed one
+/// Key, list with a cohort that names that key 3 times — exactly one
+/// ref surfaces.
+#[tokio::test]
+async fn cohort_duplicates_dedupe_to_single_ref() {
+    let key_id = "agent-bravo";
+    let (backend, bridge) = fresh_bridge(vec![
+        key_id.to_string(),
+        key_id.to_string(),
+        key_id.to_string(),
+    ]);
+    backend
+        .put_public_key(SignedKeyRecord {
+            record: fixture_key_record(key_id, identity_type::AGENT),
+        })
+        .await
+        .expect("seed key");
+
+    let refs = bridge.list_envelope_refs(EnvelopeKind::Key).await;
+    assert_eq!(
+        refs.len(),
+        1,
+        "3 cohort entries → 1 ref (dedupe via HashSet<envelope_hash>)"
+    );
+}
+
+// ─── Invariant 4 — key round-trip through the broader surface ───────
+
+/// Seed → list → fetch → apply round-trip. `list_keys` is unchanged
+/// from v6.1.0 (it's a point-read shape, not a fan-out — not part of
+/// the combinator collapse); this serves as a canary that the shared
+/// cache + dispatch surface still composes correctly post-refactor.
+#[tokio::test]
+async fn key_round_trips_across_combinator_refactor() {
+    let key_id = "agent-charlie";
+    let (backend, bridge) = fresh_bridge(vec![key_id.to_string()]);
+    backend
+        .put_public_key(SignedKeyRecord {
+            record: fixture_key_record(key_id, identity_type::AGENT),
+        })
+        .await
+        .expect("seed key");
+
+    // 1. list_envelope_refs surfaces the seeded key.
+    let refs = bridge.list_envelope_refs(EnvelopeKind::Key).await;
+    assert_eq!(refs.len(), 1);
+    let hash = refs[0].envelope_hash;
+
+    // 2. fetch_envelope_bytes returns the cached canonical bytes.
+    let bytes = bridge
+        .fetch_envelope_bytes(EnvelopeKind::Key, &hash)
+        .await
+        .expect("bytes cached during list");
+
+    // 3. Bytes decode to the same record.
+    let decoded: SignedKeyRecord = serde_json::from_slice(&bytes).expect("decode");
+    assert_eq!(decoded.record.key_id, key_id);
+
+    // 4. apply_envelope_bytes is idempotent on matching content
+    //    (persist returns Ok on dedup).
+    let admitted = bridge.apply_envelope_bytes(EnvelopeKind::Key, &bytes).await;
+    assert!(admitted, "idempotent re-apply succeeds");
+}
+
+// ─── Invariant 5 — no key in cohort means no refs ───────────────────
+
+/// A cohort entry that does NOT resolve to a backend row yields no
+/// refs (silent skip on `Err(_)` from the directory). This was the
+/// v6.1.0 `if let Ok(rows) = ...` semantics; the combinator preserves
+/// it via `unwrap_or_default()`. Asserted across every kind.
+#[tokio::test]
+async fn unresolved_cohort_member_silently_skipped_across_kinds() {
+    let (_backend, bridge) = fresh_bridge(vec!["nonexistent-key-id".to_string()]);
+    for kind in all_envelope_kinds() {
+        let refs = bridge.list_envelope_refs(*kind).await;
+        assert!(
+            refs.is_empty(),
+            "kind={kind:?} with unresolved cohort member MUST be empty"
+        );
+    }
+}

--- a/tests/delegation_reads_e2e.rs
+++ b/tests/delegation_reads_e2e.rs
@@ -1,0 +1,161 @@
+//! v6.2.0 (#179) — persist v9.3.0 delegation / MLS-authority reads are
+//! reachable from edge.
+//!
+//! ## Why this test exists
+//!
+//! Persist v9.3.0 (CIRISPersist#249 Cut C) introduced public free-fn
+//! readers that consolidate the delegation-graph walks every consumer
+//! was previously hand-rolling:
+//!
+//! - `reachable_under_scope(seed, scope, max_depth) -> bool`
+//! - `is_owner_bound(key_id) -> bool`
+//! - `owner_binding_chain(key_id) -> Vec<KeyId>`
+//! - `moderators_of(community_id, duty) -> Vec<KeyId>`
+//! - `duty_holders_for_community(community_id, duty) -> HashSet<KeyId>`
+//! - `duty_holders_for_content(content_sha, community_id, duty) -> HashSet<KeyId>`
+//!
+//! All on `Rust + FFI`, all taking `&dyn FederationDirectory`.
+//!
+//! ## What edge still hand-rolls (intentional — see commit message)
+//!
+//! `src/edge.rs::verify_self_at_login_delegation` walks
+//! `build_delegation_graph` from MULTIPLE trust roots and discriminates
+//! REFUSAL reasons (`RetractedAtRoot` / `MissingScope` /
+//! `SignerUnreached` / `SubstrateUnavailable` /
+//! `NoTrustRoots`) — the forensic granularity is load-bearing for the
+//! `DelegationRefusalSubReason` enum and is consumed by tests. Persist's
+//! `reachable_under_scope` answers REACHABILITY ONLY (`bool`), so a
+//! drop-in replacement would lose the forensic-refusal discrimination.
+//!
+//! This cut therefore:
+//! 1. Bumps persist to v9.3.0 so the new readers are AVAILABLE.
+//! 2. Asserts (this test) that they're REACHABLE through edge's
+//!    `Arc<dyn FederationDirectory>`.
+//! 3. Documents that the hand-rolled walk in `verify_self_at_login_delegation`
+//!    stays in place pending a v6.3.0 refusal-reason extension to
+//!    `reachable_under_scope` or a sibling `reachable_under_scope_refusal`
+//!    that returns a richer enum.
+//!
+//! ## What this test asserts
+//!
+//! 1. The five v9.3.0 free-fn readers compile against the trait object
+//!    edge holds (`&dyn FederationDirectory`).
+//! 2. On an empty backend:
+//!    - `reachable_under_scope` returns `Ok(false)` for any pair (the
+//!      walk terminates with no edges found).
+//!    - `is_owner_bound` returns `Ok(false)` for an unknown key (no
+//!      `user`-role record exists).
+//!    - `owner_binding_chain` returns `Ok(empty)` for an unknown key
+//!      (no chain exists).
+//!    - `moderators_of` returns `Ok(empty)` for an unknown community
+//!      (no authority roots resolvable).
+//!    - `duty_holders_for_community` returns `Ok(empty)` likewise.
+//!
+//! These are the empty-state shapes edge will branch on when it adopts
+//! these reads (e.g. an admission gate that calls `is_owner_bound` and
+//! refuses on `false`). The actual delegation-walk semantics are
+//! covered by persist's own test suite (see persist v9.3.0
+//! `src/store/sqlite.rs::reachable_under_scope_scoped_attenuated_walk_sqlite`
+//! and the matching memory-backend tests).
+//!
+//! ## What this test does NOT assert
+//!
+//! Functional walk semantics (attenuation, sub-delegation gating,
+//! retraction handling) require seeding `delegates_to` attestations
+//! through persist's admission gate, which requires real hybrid PQC
+//! signatures (the same blocker the existing
+//! `federation_present_attestation_appears_in_list_envelope_refs`
+//! `#[ignore]` annotation in `src/replication/bridge.rs` calls out).
+//! Those semantics are persist-side and covered there.
+
+use std::sync::Arc;
+
+use ciris_persist::federation::admission;
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::store::MemoryBackend;
+
+// ─── Assertion 1 — reachable through `&dyn FederationDirectory` ─────
+
+/// All five v9.3.0 free-fn delegation/authority reads compile and
+/// dispatch through `&dyn FederationDirectory` — the trait object edge
+/// actually holds via `Arc<dyn FederationDirectory>`.
+#[tokio::test]
+async fn v9_3_0_delegation_reads_callable_through_dyn_trait() {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+
+    // reachable_under_scope — empty graph → not reachable.
+    let reachable = admission::reachable_under_scope(
+        dir.as_ref(),
+        "issuer-key",
+        "target-key",
+        "act_on_behalf",
+        8,
+    )
+    .await
+    .expect("reachable_under_scope reachable through dyn trait");
+    assert!(
+        !reachable,
+        "empty backend → no delegation chain → reachable_under_scope false"
+    );
+
+    // is_owner_bound — unknown key → not bound.
+    let bound = admission::is_owner_bound(dir.as_ref(), "unknown-key")
+        .await
+        .expect("is_owner_bound reachable through dyn trait");
+    assert!(!bound, "empty backend → unknown key NOT owner-bound");
+
+    // owner_binding_chain — unknown key → empty chain.
+    let chain = admission::owner_binding_chain(dir.as_ref(), "unknown-key")
+        .await
+        .expect("owner_binding_chain reachable through dyn trait");
+    assert!(
+        chain.is_empty(),
+        "empty backend → no chain for unknown key, got {chain:?}"
+    );
+
+    // moderators_of — unknown community → empty moderator set.
+    let mods = admission::moderators_of(dir.as_ref(), "no-such-community", "moderate")
+        .await
+        .expect("moderators_of reachable through dyn trait");
+    assert!(
+        mods.is_empty(),
+        "empty backend → no moderators of unknown community, got {mods:?}"
+    );
+
+    // duty_holders_for_community — unknown community → empty holder
+    // set.
+    let holders =
+        admission::duty_holders_for_community(dir.as_ref(), "no-such-community", "moderate")
+            .await
+            .expect("duty_holders_for_community reachable through dyn trait");
+    assert!(
+        holders.is_empty(),
+        "empty backend → no duty holders, got {holders:?}"
+    );
+}
+
+// ─── Assertion 2 — reachability bool semantics on the self-pair ─────
+
+/// `reachable_under_scope(k, k, _, _)` — the trivial reachability claim
+/// "does k reach itself?" — is `true` if and only if persist treats the
+/// seed as the depth-0 visited node. The persist v9.3.0 implementation
+/// uses BFS with the seed at depth 0 and emits reachability only on
+/// FORWARD edges, so a self-pair on an empty graph is `false`. We
+/// assert that semantics here so any future persist regression (e.g.
+/// silently treating the seed as auto-reachable) is caught at edge's
+/// adoption boundary.
+#[tokio::test]
+async fn reachable_under_scope_self_pair_is_false_on_empty_graph() {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+
+    let self_reachable =
+        admission::reachable_under_scope(dir.as_ref(), "same-key", "same-key", "moderate", 4)
+            .await
+            .expect("reachable_under_scope reachable");
+    assert!(
+        !self_reachable,
+        "self-pair on empty graph: no edge → not reachable"
+    );
+}


### PR DESCRIPTION
## Summary

Pure family-floor pin bump. No Rust code changes in edge.

- \`ciris-persist\` v9.9.0 → **v9.10.0** ([#227](https://github.com/CIRISAI/CIRISPersist/issues/227) \`list_held_fountain_content\` publisher-facing held enumerator + v9.9.1 wheel-concurrence verify re-pin)
- \`ciris-verify-core\` / \`ciris-keyring\` / \`ciris-crypto\` v6.9.0 → **v6.11.0** (persist v9.9.1's transitive verify-family pin)
- \`pyproject\` \`ciris-persist>=9.9.0,<10\` → \`>=9.10.0,<10\`

## Forward-looking note

v9.10.0's \`list_held_fountain_content\` closes the v5.2.0 \`FountainSwarmRuntime\` publisher gap (the operator's "what content_ids do I hold?" view). Edge holds the floor here; consuming it in the publisher loop + adding \`MessageType::FountainHoldingClaim\` wire-tier dispatch ([CIRISEdge#184](https://github.com/CIRISAI/CIRISEdge/issues/184)) is the natural shape of a future v6.3.0 swarm-converger cut.

## Verification

- \`cargo fmt --all\`: clean
- \`cargo check\` (default features): clean
- \`cargo clippy --no-default-features --features \"transport-http transport-reticulum pyo3 holonomic-consent-decay\" --lib --tests\` under \`RUSTFLAGS=-D warnings\`: clean

## Test plan

- [ ] CI matrix green
- [ ] PyPI publish-pypi (tag-gated) lands v6.2.4 wheels

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln