### PR TITLE
release(v6.3.0): swarm-converger wire-up + latency-aware diversity policy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.3"
+version = "6.2.4"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.10.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.11.0", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.11.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.11.0", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.10.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.4"
+version = "6.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.1.0"
+version = "6.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.2.0", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.2.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.3.0", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.2.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.2"
+version = "6.2.3"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.9.0", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.9.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.1"
+version = "6.2.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.7.1", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.1", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "6.2.0"
+version = "6.2.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0", version = "9", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0", version = "9", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.0", version = "6" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v6.6.1", version = "6" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.3.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v9.4.0", version = "9", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.2.0,<10",
+    "ciris-persist>=9.4.0,<10",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.4.1,<10",
+    "ciris-persist>=9.9.0,<10",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.4.0,<10",
+    "ciris-persist>=9.4.1,<10",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=9.9.0,<10",
+    "ciris-persist>=9.10.0,<10",
 ]
 dynamic = ["version"]
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1667,13 +1667,10 @@ impl Edge {
     ///
     /// - [`Self::swarm_runtime_handle`] returns the registered
     ///   runtime (None until install).
-    /// - The operator's inbound dispatch path may call
+    /// - The operator's inbound dispatch path routes verified
+    ///   [`MessageType::FountainHoldingClaim`] envelopes into
     ///   [`crate::swarm::FountainSwarmRuntime::register_observed_claim`]
-    ///   on verified holding-claim bodies. (v5.2.0 does not yet
-    ///   add a wire-tier `MessageType::FountainHoldingClaim`
-    ///   discriminator — the integration point is exposed at the
-    ///   API surface so a follow-up cut can wire the dispatch
-    ///   routing without re-touching `Edge::run`.)
+    ///   (CIRISEdge#184 v6.3.0 — the v5.2.0 deferral closed here).
     ///
     /// Idempotent: a second call is silently ignored (first wins).
     pub fn install_swarm_runtime(&self, runtime: Arc<crate::swarm::FountainSwarmRuntime>) {
@@ -2850,6 +2847,7 @@ impl Edge {
             self.config.delegation_graph_max_depth,
             self.canonical_peers.clone(),
             self.blob_chunk_source.as_ref(),
+            self.swarm_runtime.get(),
         )
         .await;
     }
@@ -3249,6 +3247,11 @@ impl Edge {
         let delegation_trust_roots = self.canonical_peers.clone();
         // CIRISEdge#55 v3.4.0-pre1 — server-side responder hook.
         let blob_chunk_source = self.blob_chunk_source.clone();
+        // CIRISEdge#184 (v6.3.0) — swarm-runtime inbound hook for
+        // verified `MessageType::FountainHoldingClaim` envelopes.
+        // Clone of the `Arc<OnceLock<Arc<FountainSwarmRuntime>>>`; the
+        // OnceLock load inside the dispatch is a cheap atomic.
+        let swarm_runtime = self.swarm_runtime.clone();
         // CIRISEdge#119 v3.5.1 — opt-in replication routing. When the
         // OnceLock has been populated by
         // `Edge::install_replication_routing`, the inbound loop
@@ -3328,6 +3331,7 @@ impl Edge {
                     let l1_cdn_edge_external_uri_base_clone = l1_cdn_edge_external_uri_base.clone();
                     let delegation_trust_roots_clone = delegation_trust_roots.clone();
                     let blob_chunk_source_clone = blob_chunk_source.clone();
+                    let swarm_runtime_clone = swarm_runtime.clone();
                     tokio::spawn(async move {
                         dispatch_inbound(
                             frame,
@@ -3358,6 +3362,7 @@ impl Edge {
                             delegation_graph_max_depth,
                             delegation_trust_roots_clone,
                             blob_chunk_source_clone.as_ref(),
+                            swarm_runtime_clone.get(),
                         ).await;
                     });
                 }
@@ -3528,6 +3533,7 @@ impl Edge {
         trust_scoring,
         delegation_trust_roots,
         blob_chunk_source,
+        swarm_runtime,
     ),
     fields(
         transport_id = %frame.transport.0,
@@ -3599,6 +3605,13 @@ async fn dispatch_inbound(
     // inbound `BlobChunkFetch` envelopes. None → silently drop the
     // envelope (same posture as ContentFetch in edge#21 phase 1).
     blob_chunk_source: Option<&Arc<dyn crate::blob_swarm::BlobChunkSource>>,
+    // CIRISEdge#184 (v6.3.0) — optional swarm orchestration runtime.
+    // When set (via `Edge::install_swarm_runtime`), verified inbound
+    // `MessageType::FountainHoldingClaim` envelopes are routed into
+    // `register_observed_claim`. When None, the envelope is observed
+    // (verify still runs) but no runtime hook fires — same posture as
+    // `blob_chunk_source` for the chunked-blob swarm.
+    swarm_runtime: Option<&Arc<crate::swarm::FountainSwarmRuntime>>,
 ) {
     let received_at = frame.received_at;
     let transport = frame.transport;
@@ -4455,6 +4468,33 @@ async fn dispatch_inbound(
     // (the body is already a `RawValue`), and keeping the two paths
     // independent is structurally simpler than threading a parsed
     // body through the erased dispatch.
+    // CIRISEdge#184 (v6.3.0) — swarm-converger wire-up. Verified
+    // `MessageType::FountainHoldingClaim` envelopes route into the
+    // installed runtime's `register_observed_claim`. AV-9 verify-then-
+    // dispatch invariant is preserved because we're past the verify
+    // gate at this point. When no runtime is installed, the envelope
+    // is observed but no hook fires (same posture as `blob_chunk_source`
+    // for the chunked-blob swarm).
+    if envelope.message_type == MessageType::FountainHoldingClaim {
+        if let Some(runtime) = swarm_runtime {
+            match serde_json::from_str::<crate::holonomic::swarm_rarity::FountainHoldingClaim>(
+                envelope.body.get(),
+            ) {
+                Ok(claim) => {
+                    runtime.register_observed_claim(claim).await;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        transport = ?transport,
+                        sender_key_id = %envelope.signing_key_id,
+                        "FountainHoldingClaim body parse failed at dispatch (CIRISEdge#184)",
+                    );
+                }
+            }
+        }
+    }
+
     if envelope.message_type == MessageType::InlineText {
         match serde_json::from_str::<crate::messages::InlineText>(envelope.body.get()) {
             Ok(inline) => {

--- a/src/holonomic/swarm_rarity.rs
+++ b/src/holonomic/swarm_rarity.rs
@@ -366,6 +366,17 @@ impl FountainCompressRequest {
     }
 }
 
+/// CIRISEdge#184 (v6.3.0) — `Message` impl tying the substrate body
+/// type to its wire discriminator [`crate::messages::MessageType::FountainHoldingClaim`].
+/// Ephemeral, fire-and-forget — the substrate composes whether or not
+/// peers respond, and stale observations age out via the runtime's
+/// TTL prune.
+impl crate::handler::Message for FountainHoldingClaim {
+    const TYPE: crate::messages::MessageType = crate::messages::MessageType::FountainHoldingClaim;
+    const DELIVERY: crate::handler::Delivery = crate::handler::Delivery::Ephemeral;
+    type Response = ();
+}
+
 /// Compute the local rarity score for a `(content_id, symbol_id)` tuple
 /// over a set of observed [`FountainHoldingClaim`]s. **Lower = rarer =
 /// keep**.
@@ -602,6 +613,87 @@ pub fn should_eject_above_target(
         EjectionVerdict::EjectToTier
     } else {
         EjectionVerdict::Keep
+    }
+}
+
+/// CIRISEdge#184 (v6.3.0) — **latency-aware diversity refinement** of
+/// [`should_eject_above_target`].
+///
+/// Layered on top of the v1 substrate verdict: this function calls
+/// [`should_eject_above_target`] first; only when the base verdict is
+/// `EjectToTier` AND a `diversity_score` is supplied does the diversity
+/// gate engage. This preserves the locked v1 byte-determinism contract
+/// on the substrate verdict (CEG 1.0 §R conformance vectors) — the
+/// diversity refinement is a *policy-tier* refinement on top of the
+/// substrate-tier verdict, not a wire break.
+///
+/// ## Inputs
+///
+/// - `holders_observed` / `policy` / `consent` / `local_symbol_rarity`
+///   — passed straight through to [`should_eject_above_target`].
+/// - `diversity_score`: the local peer's diversity contribution to
+///   the holder set, computed via
+///   [`crate::swarm::diversity::diversity_contribution`]. `None` falls
+///   back to the substrate-tier verdict (no refinement).
+/// - `diversity_floor`: the threshold below which "local position is
+///   sufficiently clustered → safe to eject." Typically the median
+///   diversity score across holders we have RTT data for; the runtime
+///   estimates this on its converger tick.
+///
+/// ## Semantics
+///
+/// - Base verdict `Keep` → return `Keep` (substrate dominates).
+/// - Base verdict `EjectHardDelete` → return `EjectHardDelete`
+///   (revocation dominates; diversity does NOT override §3.2.3).
+/// - Base verdict `EjectToTier` + `diversity_score = None` → return
+///   `EjectToTier` (rarity-only fallback).
+/// - Base verdict `EjectToTier` + `Some(score) < diversity_floor` →
+///   return `EjectToTier` (local position is clustered; ejecting
+///   preserves geographic spread).
+/// - Base verdict `EjectToTier` + `Some(score) >= diversity_floor` →
+///   return `Keep` (local position uniquely contributes diversity;
+///   retain even though the swarm is over-target).
+///
+/// **Wire-determinism note**: this function is **policy-tier**, not
+/// substrate-tier. Two peers running with different RTT observers may
+/// reach DIFFERENT verdicts from the same observed-claims input —
+/// that's the intended degree of freedom (each peer optimizes its
+/// local geographic spread). The substrate's
+/// [`should_eject_above_target`] remains the byte-determined
+/// conformance surface; CEG 1.0 §R vectors continue to apply against
+/// the substrate function unchanged.
+#[must_use]
+pub fn should_eject_with_diversity(
+    holders_observed: u32,
+    policy: &crate::holonomic::fountain_defaults::FountainPolicy,
+    consent: ConsentState,
+    local_symbol_rarity: RarityScore,
+    diversity_score: Option<f64>,
+    diversity_floor: Option<f64>,
+) -> EjectionVerdict {
+    let base = should_eject_above_target(holders_observed, policy, consent, local_symbol_rarity);
+    match base {
+        EjectionVerdict::EjectToTier => {
+            // Diversity refinement: only fire when BOTH a score AND a
+            // floor are present. Either-missing → fall back to the
+            // substrate verdict.
+            match (diversity_score, diversity_floor) {
+                (Some(score), Some(floor)) => {
+                    if score < floor {
+                        // Clustered local position → safe to eject.
+                        EjectionVerdict::EjectToTier
+                    } else {
+                        // Diverse local position → retain for spread.
+                        EjectionVerdict::Keep
+                    }
+                }
+                _ => EjectionVerdict::EjectToTier,
+            }
+        }
+        // Base verdict Keep / EjectHardDelete / EjectAggregatedTierOnly
+        // pass through unchanged. Diversity does NOT override
+        // revocation (§3.2.3) or the keep-because-rare invariant.
+        other => other,
     }
 }
 
@@ -1432,5 +1524,102 @@ mod tests {
         // potential.
         let v = should_eject_above_target(100, &policy, ConsentState::Revoked, RarityScore(50));
         assert_eq!(v, EjectionVerdict::EjectHardDelete);
+    }
+
+    // ─── CIRISEdge#184 (v6.3.0) — diversity refinement ─────────────
+
+    #[test]
+    fn diversity_none_falls_back_to_rarity_only() {
+        // No diversity score → behavior IDENTICAL to should_eject_above_target.
+        let policy = crate::holonomic::fountain_defaults::recommended_policy();
+        let base = should_eject_above_target(35, &policy, ConsentState::Active, RarityScore(20));
+        let with_div = should_eject_with_diversity(
+            35,
+            &policy,
+            ConsentState::Active,
+            RarityScore(20),
+            None,
+            None,
+        );
+        assert_eq!(base, with_div);
+    }
+
+    #[test]
+    fn diversity_low_score_keeps_eject() {
+        // 35 holders + common symbol + low diversity (clustered) →
+        // still EjectToTier.
+        let policy = crate::holonomic::fountain_defaults::recommended_policy();
+        let v = should_eject_with_diversity(
+            35,
+            &policy,
+            ConsentState::Active,
+            RarityScore(20),
+            Some(0.05), // clustered → low score
+            Some(0.30), // median floor
+        );
+        assert_eq!(v, EjectionVerdict::EjectToTier);
+    }
+
+    #[test]
+    fn diversity_high_score_flips_eject_to_keep() {
+        // 35 holders + common symbol + high diversity (topologically
+        // unique) → flip to Keep.
+        let policy = crate::holonomic::fountain_defaults::recommended_policy();
+        let v = should_eject_with_diversity(
+            35,
+            &policy,
+            ConsentState::Active,
+            RarityScore(20),
+            Some(0.50), // diverse → high score
+            Some(0.30), // median floor
+        );
+        assert_eq!(v, EjectionVerdict::Keep);
+    }
+
+    #[test]
+    fn diversity_does_not_override_revocation() {
+        // Revoked + sky-high diversity → still EjectHardDelete.
+        let policy = crate::holonomic::fountain_defaults::recommended_policy();
+        let v = should_eject_with_diversity(
+            100,
+            &policy,
+            ConsentState::Revoked,
+            RarityScore(50),
+            Some(99.0),
+            Some(0.10),
+        );
+        assert_eq!(v, EjectionVerdict::EjectHardDelete);
+    }
+
+    #[test]
+    fn diversity_does_not_override_keep_when_rare() {
+        // Rare symbol → substrate says Keep; diversity refinement
+        // can't override "preserve rare copy" invariant.
+        let policy = crate::holonomic::fountain_defaults::recommended_policy();
+        let v = should_eject_with_diversity(
+            35,
+            &policy,
+            ConsentState::Active,
+            RarityScore(2), // rare (below target_holders/2 = 15)
+            Some(0.01),     // clustered — would normally argue for eject
+            Some(0.50),
+        );
+        assert_eq!(v, EjectionVerdict::Keep);
+    }
+
+    #[test]
+    fn diversity_score_with_no_floor_falls_back() {
+        // Score present but floor missing → diversity gate doesn't
+        // engage; substrate verdict survives.
+        let policy = crate::holonomic::fountain_defaults::recommended_policy();
+        let v = should_eject_with_diversity(
+            35,
+            &policy,
+            ConsentState::Active,
+            RarityScore(20),
+            Some(0.99),
+            None,
+        );
+        assert_eq!(v, EjectionVerdict::EjectToTier);
     }
 }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -242,6 +242,25 @@ pub enum MessageType {
     /// downweight policy in their own `PeerResolver`. Body:
     /// [`Withdraws`].
     Withdraws,
+
+    // ─── CIRISEdge#184 (v6.3.0) — swarm-converger wire-up ───────────
+    /// Federation-level fountain holding claim. Signed wire discriminator
+    /// for the substrate's
+    /// [`crate::holonomic::swarm_rarity::FountainHoldingClaim`] body
+    /// (locked v1 canonical-bytes layout per
+    /// [`crate::holonomic::swarm_rarity::HOLDING_CLAIM_DOMAIN`]). The
+    /// FountainSwarmRuntime publisher emits one envelope per held
+    /// `content_id` per cohort peer on each `publish_cadence` tick;
+    /// inbound dispatch routes verified envelopes into
+    /// [`crate::swarm::FountainSwarmRuntime::register_observed_claim`].
+    ///
+    /// Ephemeral, fire-and-forget — the substrate composes whether or
+    /// not peers respond, and stale observations age out via the
+    /// runtime's TTL prune.
+    ///
+    /// Closes the v5.2.0 wire-tier deferral (the runtime's publisher
+    /// shipped `canonical_bytes` raw until this discriminator landed).
+    FountainHoldingClaim,
 }
 
 /// CIRISEdge#37 — `testimonial_witness` envelope slot per FSD-002

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -415,268 +415,231 @@ impl FederationDirectoryReplicationBridge {
         refs
     }
 
-    async fn list_attestations(&self) -> Vec<EnvelopeRef> {
+    // ─── v6.2.0 (#179, CIRISPersist#249 Cut D) — generic cohort fan-out ──
+    //
+    // The 9 per-kind blocks below collapsed into a single
+    // [`Self::fan_out_for_member`] combinator + 9 call sites. The
+    // structural pattern is uniform across kinds (cohort iterate → per-key
+    // `list_*_for` → `persist_row_hash` decode → HashSet dedupe → wrap in
+    // `Signed*` → cache + emit `EnvelopeRef`); only the per-row
+    // projections (timestamp accessor, hash accessor) and the wrapper
+    // differ. Persist v9.3.0 keeps the `list_*_for_member` surface
+    // uniform across kinds, so one parameterized combinator replaces the
+    // hand-unrolled cases without changing wire-format behavior.
+    //
+    // `Row`-generic by inference: the closures fix the row type per call
+    // site without requiring dyn-compatibility on the directory trait.
+    // Async via boxed future on the per-key fetch (the directory trait is
+    // already `async_trait`-boxed).
+    async fn fan_out_for_member<Row, Signed, FetchFut, F, W, H>(
+        &self,
+        kind: EnvelopeKind,
+        mut fetch: F,
+        wrap: W,
+        timestamp: impl Fn(&Row) -> chrono::DateTime<chrono::Utc>,
+        hash: H,
+    ) -> Vec<EnvelopeRef>
+    where
+        F: FnMut(String) -> FetchFut,
+        FetchFut: std::future::Future<Output = Vec<Row>>,
+        W: Fn(&Row) -> Signed,
+        Signed: serde::Serialize,
+        H: Fn(&Row) -> &str,
+    {
         let mut refs = Vec::new();
         let mut seen: HashSet<[u8; 32]> = HashSet::new();
         for key_id in (self.cohort)() {
-            // Union: attestations ABOUT this key + attestations FROM
-            // this key. The dedupe by hash collapses cross-references.
-            let about = self
-                .directory
-                .list_attestations_for(&key_id)
-                .await
-                .unwrap_or_default();
-            let from = self
-                .directory
-                .list_attestations_by(&key_id)
-                .await
-                .unwrap_or_default();
-            for row in about.into_iter().chain(from) {
-                if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                    if !seen.insert(hash) {
-                        continue;
-                    }
-                    let bytes = serde_json::to_vec(&SignedAttestation {
-                        attestation: row.clone(),
-                    })
-                    .unwrap_or_default();
-                    self.cache_insert(EnvelopeKind::Attestation, hash, bytes)
-                        .await;
-                    refs.push(EnvelopeRef {
-                        envelope_hash: hash,
-                        seq: Self::ms_seq(row.asserted_at),
-                    });
+            let rows = fetch(key_id).await;
+            for row in rows {
+                let Some(envelope_hash) = Self::decode_hash(hash(&row)) else {
+                    continue;
+                };
+                if !seen.insert(envelope_hash) {
+                    continue;
                 }
+                let signed = wrap(&row);
+                let bytes = serde_json::to_vec(&signed).unwrap_or_default();
+                self.cache_insert(kind, envelope_hash, bytes).await;
+                refs.push(EnvelopeRef {
+                    envelope_hash,
+                    seq: Self::ms_seq(timestamp(&row)),
+                });
             }
         }
         refs
+    }
+
+    async fn list_attestations(&self) -> Vec<EnvelopeRef> {
+        // Union: attestations ABOUT this key + attestations FROM this key.
+        // The dedupe by hash collapses cross-references. This is the only
+        // kind whose per-key list is the chain of two `list_*` reads;
+        // every other kind hits one `list_*_for` surface.
+        self.fan_out_for_member(
+            EnvelopeKind::Attestation,
+            |key_id| async move {
+                let about = self
+                    .directory
+                    .list_attestations_for(&key_id)
+                    .await
+                    .unwrap_or_default();
+                let from = self
+                    .directory
+                    .list_attestations_by(&key_id)
+                    .await
+                    .unwrap_or_default();
+                about.into_iter().chain(from).collect()
+            },
+            |row| SignedAttestation {
+                attestation: row.clone(),
+            },
+            |row| row.asserted_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_revocations(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.revocations_for(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedRevocation {
-                            revocation: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::Revocation, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.revoked_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::Revocation,
+            |key_id| async move {
+                self.directory
+                    .revocations_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedRevocation {
+                revocation: row.clone(),
+            },
+            |row| row.revoked_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_identity_occurrences(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.list_identity_occurrences_for(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedIdentityOccurrence {
-                            identity_occurrence: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::IdentityOccurrence, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.asserted_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::IdentityOccurrence,
+            |key_id| async move {
+                self.directory
+                    .list_identity_occurrences_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedIdentityOccurrence {
+                identity_occurrence: row.clone(),
+            },
+            |row| row.asserted_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_families(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.list_families_for_member(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedFamily {
-                            family: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::Family, hash, bytes).await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.founded_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::Family,
+            |key_id| async move {
+                self.directory
+                    .list_families_for_member(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedFamily {
+                family: row.clone(),
+            },
+            |row| row.founded_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_communities(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.list_communities_for_member(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedCommunity {
-                            community: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::Community, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.founded_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::Community,
+            |key_id| async move {
+                self.directory
+                    .list_communities_for_member(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedCommunity {
+                community: row.clone(),
+            },
+            |row| row.founded_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_identity_occurrence_revocations(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self
-                .directory
-                .list_identity_occurrence_revocations_for(&key_id)
-                .await
-            {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedIdentityOccurrenceRevocation {
-                            identity_occurrence_revocation: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::IdentityOccurrenceRevocation, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.revoked_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::IdentityOccurrenceRevocation,
+            |key_id| async move {
+                self.directory
+                    .list_identity_occurrence_revocations_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedIdentityOccurrenceRevocation {
+                identity_occurrence_revocation: row.clone(),
+            },
+            |row| row.revoked_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_family_membership_revocations(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self
-                .directory
-                .list_family_membership_revocations_for(&key_id)
-                .await
-            {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedFamilyMembershipRevocation {
-                            family_membership_revocation: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::FamilyMembershipRevocation, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.removed_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::FamilyMembershipRevocation,
+            |key_id| async move {
+                self.directory
+                    .list_family_membership_revocations_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedFamilyMembershipRevocation {
+                family_membership_revocation: row.clone(),
+            },
+            |row| row.removed_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_community_membership_revocations(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self
-                .directory
-                .list_community_membership_revocations_for(&key_id)
-                .await
-            {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedCommunityMembershipRevocation {
-                            community_membership_revocation: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::CommunityMembershipRevocation, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.removed_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::CommunityMembershipRevocation,
+            |key_id| async move {
+                self.directory
+                    .list_community_membership_revocations_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedCommunityMembershipRevocation {
+                community_membership_revocation: row.clone(),
+            },
+            |row| row.removed_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     async fn list_location_proofs(&self) -> Vec<EnvelopeRef> {
-        let mut refs = Vec::new();
-        let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
-            if let Ok(rows) = self.directory.list_location_proofs_for(&key_id).await {
-                for row in rows {
-                    if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
-                        if !seen.insert(hash) {
-                            continue;
-                        }
-                        let bytes = serde_json::to_vec(&SignedLocationProof {
-                            location_proof: row.clone(),
-                        })
-                        .unwrap_or_default();
-                        self.cache_insert(EnvelopeKind::LocationProof, hash, bytes)
-                            .await;
-                        refs.push(EnvelopeRef {
-                            envelope_hash: hash,
-                            seq: Self::ms_seq(row.asserted_at),
-                        });
-                    }
-                }
-            }
-        }
-        refs
+        self.fan_out_for_member(
+            EnvelopeKind::LocationProof,
+            |key_id| async move {
+                self.directory
+                    .list_location_proofs_for(&key_id)
+                    .await
+                    .unwrap_or_default()
+            },
+            |row| SignedLocationProof {
+                location_proof: row.clone(),
+            },
+            |row| row.asserted_at,
+            |row| row.persist_row_hash.as_str(),
+        )
+        .await
     }
 
     // ── v2 operational-data list_* ─────────────────────────────────

--- a/src/swarm/diversity.rs
+++ b/src/swarm/diversity.rs
@@ -1,0 +1,412 @@
+//! CIRISEdge#184 (v6.3.0) — latency-aware diversity policy for the
+//! over-target ejection decision.
+//!
+//! ## Design principle
+//!
+//! When the federation holds more than `H` copies of a `content_id`
+//! (the swarm is over-target), the existing
+//! [`crate::holonomic::swarm_rarity::should_eject_above_target`]
+//! decides whether the local peer ejects. The v5.2.0 heuristic was
+//! **rarity-only** — every over-target holder is equally eligible.
+//!
+//! **Refinement**: bias the ejection decision by **per-peer latency
+//! diversity**. Low-latency peers are topologically clustered (same
+//! metro / same AS / same continent). Ejecting copies from low-
+//! latency peers **first** maximizes geographic/topological copy
+//! spread; the surviving copies sit on peers that are RTT-distant
+//! from each other.
+//!
+//! ## Local-peer decision
+//!
+//! Each holder runs this independently against the same observation
+//! set:
+//!
+//! > Of the H+ peers currently holding `content_id X` (per the
+//! > observed `FountainHoldingClaim` map), my "diversity contribution"
+//! > is the sum of RTT from me to every other holder. Low diversity
+//! > contribution → I'm clustered with the others, ejecting me costs
+//! > little → I SHOULD eject. High diversity contribution → I'm
+//! > topologically far from the others, ejecting me costs spread → I
+//! > should KEEP.
+//!
+//! When [`crate::holonomic::swarm_rarity::should_eject_above_target`]
+//! returns `Eject`, the local peer pre-orders the eviction priority
+//! across competing content_ids by ascending diversity contribution:
+//! the content_ids where my position is least diverse get evicted
+//! first; the content_ids where my position uniquely contributes
+//! diversity get retained longest.
+//!
+//! This makes the substrate's ALM topology (which already takes
+//! [`crate::holonomic::deterministic_topology::ReachabilityObservation`]
+//! as an input per CEG §19.4) a load-bearing diversity primitive,
+//! not just a routing one.
+//!
+//! ## RTT sources
+//!
+//! Two production sources, one test fallback:
+//!
+//! - [`TopologyRttObserver`] — reads RTT from the latest ALM topology
+//!   snapshot's [`crate::holonomic::deterministic_topology::ReachabilityObservation`]
+//!   set. The same observations CEG §19.4 already consumes; this
+//!   module re-uses them as the diversity input. **Recommended
+//!   production source.**
+//! - **Reticulum link-layer**: a transport-tier impl (filed for
+//!   v6.4.0) that queries the RNS link layer's per-peer current
+//!   RTT. Not implemented in v6.3.0 — the trait is stable so the
+//!   transport surface can land without re-touching the runtime.
+//! - [`NullRttObserver`] — returns `None` for every peer. The
+//!   default fallback when no observer is wired; diversity-aware
+//!   ejection degrades to rarity-only (the
+//!   [`should_eject_above_target`] verdict is unchanged).
+//!
+//! [`should_eject_above_target`]: crate::holonomic::swarm_rarity::should_eject_above_target
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::holonomic::deterministic_topology::ReachabilityObservation;
+
+/// Per-peer RTT source for the latency-aware diversity policy.
+///
+/// Production impls query the live RNS link layer or read the latest
+/// ALM topology snapshot; the test fallback ([`NullRttObserver`])
+/// returns `None` for every peer.
+///
+/// `rtt_to` returns `None` when the observer has no measurement for
+/// the given peer — the diversity calculation substitutes the median
+/// observed RTT in that case (see [`diversity_contribution`]) so a
+/// peer we haven't probed yet doesn't drag the score toward "less
+/// diverse" purely from data sparsity.
+pub trait PeerRttObserver: Send + Sync {
+    /// Best current estimate of one-way RTT from THIS peer to the
+    /// peer identified by `peer_key_id`. `None` when no measurement
+    /// is available.
+    fn rtt_to(&self, peer_key_id: &str) -> Option<Duration>;
+}
+
+/// Default fallback observer — returns `None` for every peer.
+/// Diversity-aware ejection then degrades to rarity-only (the
+/// [`crate::holonomic::swarm_rarity::should_eject_above_target`]
+/// verdict is unchanged from v5.2.0).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullRttObserver;
+
+impl PeerRttObserver for NullRttObserver {
+    fn rtt_to(&self, _peer_key_id: &str) -> Option<Duration> {
+        None
+    }
+}
+
+/// Production observer that reads RTT from the latest ALM topology
+/// snapshot's [`ReachabilityObservation`] set (CEG §19.4 input).
+///
+/// Construction takes a snapshot of observations + the local peer's
+/// `key_id`; `rtt_to(peer)` returns the observed RTT on the directed
+/// edge `local → peer` if present, else `None`. The observation set
+/// is treated as a frozen snapshot — a fresh observer is constructed
+/// whenever the ALM topology recomputes.
+///
+/// RTT-from-the-publisher is the simplest signal: if RTT is symmetric
+/// enough, "RTT from me to peer P" approximates "RTT from any common
+/// observer to peer P." The diversity contribution uses the LOCAL
+/// RTT-to-other-holders as the diversity input — no federation-level
+/// coordination required (the determinism comes from each peer
+/// computing its own score against the same observed-claims map).
+pub struct TopologyRttObserver {
+    /// `peer_key_id` → observed RTT (only edges originating at the
+    /// local peer are stored). Pre-computed at construction so
+    /// `rtt_to` is O(log n).
+    by_peer: BTreeMap<String, Duration>,
+}
+
+impl std::fmt::Debug for TopologyRttObserver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TopologyRttObserver")
+            .field("peer_count", &self.by_peer.len())
+            .finish()
+    }
+}
+
+impl TopologyRttObserver {
+    /// Construct from a slice of observations + the local peer's
+    /// `key_id`. Only edges `from_peer_id == local_peer_id` are
+    /// indexed — the rest are dropped. When multiple observations
+    /// exist for the same destination, the LATEST (highest
+    /// `observed_at_unix_ms`) wins.
+    #[must_use]
+    pub fn from_observations(
+        observations: &[ReachabilityObservation],
+        local_peer_id: &str,
+    ) -> Self {
+        let mut by_peer: BTreeMap<String, (Duration, u64)> = BTreeMap::new();
+        for obs in observations {
+            if obs.from_peer_id != local_peer_id {
+                continue;
+            }
+            let rtt = Duration::from_millis(u64::from(obs.observed_rtt_ms));
+            let ts = obs.observed_at_unix_ms;
+            by_peer
+                .entry(obs.to_peer_id.clone())
+                .and_modify(|prev| {
+                    if ts > prev.1 {
+                        *prev = (rtt, ts);
+                    }
+                })
+                .or_insert((rtt, ts));
+        }
+        Self {
+            by_peer: by_peer.into_iter().map(|(k, (rtt, _))| (k, rtt)).collect(),
+        }
+    }
+}
+
+impl PeerRttObserver for TopologyRttObserver {
+    fn rtt_to(&self, peer_key_id: &str) -> Option<Duration> {
+        self.by_peer.get(peer_key_id).copied()
+    }
+}
+
+/// Type-erased Arc handle to a [`PeerRttObserver`]. Used by the
+/// runtime so concrete observer impls can be swapped per deployment.
+pub type RttObserverHandle = Arc<dyn PeerRttObserver>;
+
+/// Compute the local peer's diversity contribution to the holder set
+/// for one `content_id`.
+///
+/// **Score = sum of RTT (seconds) from local to every OTHER holder.**
+/// Higher sum = more diverse position. Missing RTT measurements
+/// default to the median observed RTT across the holders we DID
+/// measure — this avoids penalizing peers we haven't probed yet by
+/// counting them as "RTT 0" (which would make every unknown holder
+/// look like a clustered neighbor).
+///
+/// Returns `None` when no RTT data is available at all — the caller
+/// then degrades to rarity-only. Returns `Some(0.0)` when the only
+/// holder is the local peer (empty `others`).
+///
+/// # Determinism
+///
+/// The score is **local** — each peer computes its own. No federation
+/// coordination needed; the ALM topology determinism already aligns
+/// the input set (every peer sees the same observed-claims map).
+/// Stable across calls with byte-equal inputs.
+#[must_use]
+pub fn diversity_contribution(rtt: &dyn PeerRttObserver, others: &[String]) -> Option<f64> {
+    if others.is_empty() {
+        return Some(0.0);
+    }
+    let observed: Vec<Duration> = others.iter().filter_map(|p| rtt.rtt_to(p)).collect();
+    if observed.is_empty() {
+        return None;
+    }
+    let median = median_duration(&observed);
+    let total: f64 = others
+        .iter()
+        .map(|p| rtt.rtt_to(p).unwrap_or(median).as_secs_f64())
+        .sum();
+    Some(total)
+}
+
+/// Median of a non-empty slice of durations. Pre-condition: `xs`
+/// non-empty — caller MUST check.
+fn median_duration(xs: &[Duration]) -> Duration {
+    debug_assert!(!xs.is_empty(), "median_duration over empty slice");
+    let mut sorted: Vec<Duration> = xs.to_vec();
+    sorted.sort_unstable();
+    let mid = sorted.len() / 2;
+    if sorted.len() % 2 == 1 {
+        sorted[mid]
+    } else {
+        // Even count — average the two middle values. Saturating-add
+        // because `Duration + Duration` panics on overflow.
+        let a = sorted[mid - 1];
+        let b = sorted[mid];
+        (a + b) / 2
+    }
+}
+
+/// Compute diversity scores for every content_id under consideration.
+///
+/// The map's values are `Option<f64>` so callers can distinguish
+/// "no RTT data → fall back to rarity-only" from "score = 0.0 (local
+/// is the only holder)" — see [`diversity_contribution`].
+///
+/// Used by the converger: when multiple content_ids are simultaneously
+/// over-target, the converger drains in ASCENDING score order — the
+/// least-diverse positions go first.
+#[must_use]
+pub fn diversity_scores_for(
+    rtt: &dyn PeerRttObserver,
+    others_by_content: &BTreeMap<String, Vec<String>>,
+) -> BTreeMap<String, Option<f64>> {
+    others_by_content
+        .iter()
+        .map(|(cid, others)| (cid.clone(), diversity_contribution(rtt, others)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct StaticRtt(BTreeMap<String, Duration>);
+    impl PeerRttObserver for StaticRtt {
+        fn rtt_to(&self, p: &str) -> Option<Duration> {
+            self.0.get(p).copied()
+        }
+    }
+
+    fn rtt_from(pairs: &[(&str, u64)]) -> StaticRtt {
+        StaticRtt(
+            pairs
+                .iter()
+                .map(|(p, ms)| ((*p).to_string(), Duration::from_millis(*ms)))
+                .collect(),
+        )
+    }
+
+    #[test]
+    fn null_observer_returns_none() {
+        let n = NullRttObserver;
+        assert_eq!(n.rtt_to("anyone"), None);
+    }
+
+    #[test]
+    fn diversity_contribution_empty_others_is_zero() {
+        let r = rtt_from(&[]);
+        assert_eq!(diversity_contribution(&r, &[]), Some(0.0));
+    }
+
+    #[test]
+    fn diversity_contribution_no_observations_is_none() {
+        let r = NullRttObserver;
+        let others: Vec<String> = vec!["a".into(), "b".into()];
+        assert_eq!(diversity_contribution(&r, &others), None);
+    }
+
+    #[test]
+    fn diversity_contribution_sums_observed_rtts() {
+        // local sees 50ms to a, 200ms to b, 350ms to c
+        let r = rtt_from(&[("a", 50), ("b", 200), ("c", 350)]);
+        let others: Vec<String> = vec!["a".into(), "b".into(), "c".into()];
+        let score = diversity_contribution(&r, &others).expect("some");
+        // 0.050 + 0.200 + 0.350 = 0.600
+        assert!((score - 0.600).abs() < 1e-9, "got {score}");
+    }
+
+    #[test]
+    fn diversity_contribution_missing_uses_median() {
+        // local sees a=100, b=300; c is unknown → median(100,300)=200
+        let r = rtt_from(&[("a", 100), ("b", 300)]);
+        let others: Vec<String> = vec!["a".into(), "b".into(), "c".into()];
+        let score = diversity_contribution(&r, &others).expect("some");
+        // 0.100 + 0.300 + 0.200 = 0.600
+        assert!((score - 0.600).abs() < 1e-9, "got {score}");
+    }
+
+    #[test]
+    fn low_rtt_cluster_scores_lower_than_high_rtt_position() {
+        // 5 holders. local (alice) is in a low-rtt metro with bob+carol;
+        // dave+eve are continents away.
+        // alice's diversity is sum of rtt to {bob, carol, dave, eve}.
+        let low_rtt = rtt_from(&[("bob", 5), ("carol", 8), ("dave", 200), ("eve", 220)]);
+        // bob: clustered with alice + carol, distant from dave + eve
+        let bob_view = rtt_from(&[("alice", 5), ("carol", 6), ("dave", 195), ("eve", 210)]);
+        // dave: alone with eve, distant from alice + bob + carol
+        let dave_view = rtt_from(&[("alice", 200), ("bob", 195), ("carol", 205), ("eve", 15)]);
+        let alice_others: Vec<String> = ["bob", "carol", "dave", "eve"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+        let dave_others: Vec<String> = ["alice", "bob", "carol", "eve"]
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect();
+
+        let alice_score = diversity_contribution(&low_rtt, &alice_others).expect("some");
+        let bob_score = diversity_contribution(&bob_view, &alice_others).expect("some");
+        let dave_score = diversity_contribution(&dave_view, &dave_others).expect("some");
+
+        // Dave is the topology outlier: highest contribution = should KEEP.
+        // Alice and bob are clustered: lower contribution = eligible to EJECT.
+        assert!(
+            dave_score > alice_score,
+            "dave={dave_score} should exceed alice={alice_score}"
+        );
+        assert!(
+            dave_score > bob_score,
+            "dave={dave_score} should exceed bob={bob_score}"
+        );
+    }
+
+    #[test]
+    fn topology_rtt_observer_indexes_local_outbound_edges() {
+        let obs = vec![
+            ReachabilityObservation {
+                from_peer_id: "alice".into(),
+                to_peer_id: "bob".into(),
+                observed_rtt_ms: 50,
+                observed_at_unix_ms: 1_000,
+            },
+            ReachabilityObservation {
+                from_peer_id: "alice".into(),
+                to_peer_id: "carol".into(),
+                observed_rtt_ms: 200,
+                observed_at_unix_ms: 1_000,
+            },
+            // bob → alice — should NOT be indexed for alice's observer
+            ReachabilityObservation {
+                from_peer_id: "bob".into(),
+                to_peer_id: "alice".into(),
+                observed_rtt_ms: 55,
+                observed_at_unix_ms: 1_000,
+            },
+        ];
+        let observer = TopologyRttObserver::from_observations(&obs, "alice");
+        assert_eq!(observer.rtt_to("bob"), Some(Duration::from_millis(50)));
+        assert_eq!(observer.rtt_to("carol"), Some(Duration::from_millis(200)));
+        assert_eq!(observer.rtt_to("alice"), None);
+        // 'dave' was never observed
+        assert_eq!(observer.rtt_to("dave"), None);
+    }
+
+    #[test]
+    fn topology_rtt_observer_picks_latest_observation() {
+        let obs = vec![
+            ReachabilityObservation {
+                from_peer_id: "alice".into(),
+                to_peer_id: "bob".into(),
+                observed_rtt_ms: 50,
+                observed_at_unix_ms: 1_000,
+            },
+            ReachabilityObservation {
+                from_peer_id: "alice".into(),
+                to_peer_id: "bob".into(),
+                observed_rtt_ms: 120,
+                observed_at_unix_ms: 2_000,
+            },
+        ];
+        let observer = TopologyRttObserver::from_observations(&obs, "alice");
+        // Later observation wins.
+        assert_eq!(observer.rtt_to("bob"), Some(Duration::from_millis(120)));
+    }
+
+    #[test]
+    fn diversity_scores_for_orders_content_ids() {
+        let r = rtt_from(&[("p1", 10), ("p2", 100), ("p3", 500)]);
+        let mut others = BTreeMap::new();
+        others.insert(
+            "clustered".to_string(),
+            vec!["p1".to_string(), "p1".to_string()], // both p1 — score = 2*0.010
+        );
+        others.insert(
+            "diverse".to_string(),
+            vec!["p2".to_string(), "p3".to_string()], // score = 0.100 + 0.500 = 0.6
+        );
+        let scores = diversity_scores_for(&r, &others);
+        let c = scores.get("clustered").unwrap().expect("some");
+        let d = scores.get("diverse").unwrap().expect("some");
+        assert!(c < d, "clustered={c} should be less than diverse={d}");
+    }
+}

--- a/src/swarm/mod.rs
+++ b/src/swarm/mod.rs
@@ -45,13 +45,19 @@
 //!
 //! See [`runtime`] for the live runtime + scheduler.
 
+pub mod diversity;
 pub mod persist_fountain_evict;
 pub mod runtime;
 
+pub use diversity::{
+    diversity_contribution, diversity_scores_for, NullRttObserver, PeerRttObserver,
+    RttObserverHandle, TopologyRttObserver,
+};
 pub use persist_fountain_evict::{
     FountainEvictError, FountainEvictHardDelete, FountainHoldingsSource, FountainTierEvict,
     HeldFountainContent, NoopFountainHoldingsSource, PersistFountainEvictHardDelete,
 };
 pub use runtime::{
     FountainSwarmRuntime, ObservedClaim, SwarmEvent, SwarmRuntimeConfig, SwarmRuntimeEventSink,
+    SwarmRuntimeOptions,
 };

--- a/src/swarm/runtime.rs
+++ b/src/swarm/runtime.rs
@@ -48,15 +48,18 @@ use std::time::Duration;
 use tokio::sync::{watch, RwLock};
 use tokio::task::JoinHandle;
 
+use super::diversity::{diversity_contribution, NullRttObserver, PeerRttObserver};
 use super::persist_fountain_evict::{
     FountainEvictError, FountainEvictHardDelete, FountainHoldingsSource, FountainTierEvict,
     HeldFountainContent,
 };
 use crate::holonomic::fountain_defaults::{recommended_policy, FountainPolicy};
 use crate::holonomic::swarm_rarity::{
-    compute_rarity_score, should_eject_above_target, ConsentState, EjectionVerdict,
+    compute_rarity_score, should_eject_with_diversity, ConsentState, EjectionVerdict,
     FountainHoldingClaim, RarityScore,
 };
+use crate::identity::{build_envelope, sign_envelope, LocalSigner};
+use crate::messages::MessageType;
 use crate::transport::Transport;
 
 /// `target_holders` default — the recommended `H` from §R-policy
@@ -180,10 +183,51 @@ pub enum SwarmEvent {
 /// return quickly).
 pub type SwarmRuntimeEventSink = Arc<dyn Fn(SwarmEvent) + Send + Sync>;
 
+/// CIRISEdge#184 (v6.3.0) — optional plumbing for the swarm runtime.
+///
+/// Threaded into [`FountainSwarmRuntime::start_with_options`]; the
+/// legacy [`FountainSwarmRuntime::start`] constructs one with every
+/// field defaulted and forwards.
+///
+/// - `signer`: when `Some`, the publisher wraps each
+///   [`FountainHoldingClaim`] body in a signed
+///   [`crate::messages::EdgeEnvelope`] with discriminator
+///   [`crate::messages::MessageType::FountainHoldingClaim`]. When
+///   `None`, the publisher falls back to the v5.2.0 path that ships
+///   the substrate's `canonical_bytes` raw (tests + bootstrap nodes
+///   without a wired signer still drive the runtime).
+/// - `rtt_observer`: latency source for the diversity-aware ejection
+///   policy. `None` defaults to [`NullRttObserver`] — diversity
+///   gating then degrades to rarity-only (the substrate verdict).
+///
+/// All optionals MAY be `None`; the runtime stays operational on every
+/// combination of present/absent fields. New optionals land here
+/// without changing the public `start` signature.
+#[derive(Clone, Default)]
+pub struct SwarmRuntimeOptions {
+    /// Outbound-envelope signer. When `None`, publisher emits raw
+    /// canonical_bytes (v5.2.0 path) — used by tests and bootstrap.
+    pub signer: Option<Arc<LocalSigner>>,
+    /// Per-peer RTT source for the diversity-aware ejection policy.
+    /// `None` defaults to [`NullRttObserver`] (rarity-only fallback).
+    pub rtt_observer: Option<Arc<dyn PeerRttObserver>>,
+}
+
+impl std::fmt::Debug for SwarmRuntimeOptions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SwarmRuntimeOptions")
+            .field("signer_present", &self.signer.is_some())
+            .field("rtt_observer_present", &self.rtt_observer.is_some())
+            .finish()
+    }
+}
+
 /// Live swarm-orchestration runtime — publisher + converger tasks +
-/// shutdown handle. Construct via [`Self::start`]; hold for the
-/// lifetime of the application; call [`Self::shutdown`] to stop the
-/// background tasks.
+/// shutdown handle. Construct via [`Self::start`] (v5.2.0 minimal
+/// surface) or [`Self::start_with_options`] (v6.3.0+ for signed-
+/// envelope publishing and latency-diversity converger); hold for
+/// the lifetime of the application; call [`Self::shutdown`] to stop
+/// the background tasks.
 pub struct FountainSwarmRuntime {
     config: SwarmRuntimeConfig,
     observed: Arc<RwLock<ObservedClaims>>,
@@ -247,6 +291,32 @@ impl ObservedClaims {
     fn content_ids(&self) -> Vec<String> {
         self.inner.keys().cloned().collect()
     }
+
+    /// CIRISEdge#184 (v6.3.0) — peer ids observed holding
+    /// `content_id`. Sorted-map iteration → stable order.
+    fn peer_ids_for(&self, content_id: &str) -> Vec<String> {
+        self.inner
+            .get(content_id)
+            .map_or_else(Vec::new, |m| m.keys().cloned().collect())
+    }
+}
+
+/// CIRISEdge#184 (v6.3.0) — median diversity score across the
+/// content_ids we have RTT data for. `None` when no content has a
+/// score (every entry is `None`); the converger then falls back to
+/// rarity-only verdicts.
+fn median_diversity(scores: &BTreeMap<String, Option<f64>>) -> Option<f64> {
+    let mut present: Vec<f64> = scores.values().filter_map(|s| *s).collect();
+    if present.is_empty() {
+        return None;
+    }
+    present.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mid = present.len() / 2;
+    if present.len() % 2 == 1 {
+        Some(present[mid])
+    } else {
+        Some((present[mid - 1] + present[mid]) / 2.0)
+    }
 }
 
 impl FountainSwarmRuntime {
@@ -272,8 +342,44 @@ impl FountainSwarmRuntime {
         local_peer_id: String,
         sink: Option<SwarmRuntimeEventSink>,
     ) -> Self {
+        Self::start_with_options(
+            config,
+            holdings,
+            tier_evict,
+            hard_delete,
+            transport,
+            cohort,
+            local_peer_id,
+            sink,
+            SwarmRuntimeOptions::default(),
+        )
+    }
+
+    /// CIRISEdge#184 (v6.3.0) — extended constructor with optional
+    /// signer (for [`MessageType::FountainHoldingClaim`] envelope
+    /// publishing) and latency-diversity observer (for the converger's
+    /// over-target ejection heuristic). See [`SwarmRuntimeOptions`].
+    ///
+    /// When both options are `None` the runtime is byte-equivalent to
+    /// [`Self::start`].
+    #[allow(clippy::too_many_arguments, clippy::needless_pass_by_value)]
+    pub fn start_with_options(
+        config: SwarmRuntimeConfig,
+        holdings: Arc<dyn FountainHoldingsSource>,
+        tier_evict: Arc<dyn FountainTierEvict>,
+        hard_delete: Arc<dyn FountainEvictHardDelete + Send + Sync>,
+        transport: Arc<dyn Transport>,
+        cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
+        local_peer_id: String,
+        sink: Option<SwarmRuntimeEventSink>,
+        options: SwarmRuntimeOptions,
+    ) -> Self {
         let observed = Arc::new(RwLock::new(ObservedClaims::default()));
         let (cancel_tx, cancel_rx) = watch::channel(false);
+        let rtt_observer: Arc<dyn PeerRttObserver> = options
+            .rtt_observer
+            .clone()
+            .unwrap_or_else(|| Arc::new(NullRttObserver));
 
         let publisher_task = {
             let holdings = Arc::clone(&holdings);
@@ -283,9 +389,10 @@ impl FountainSwarmRuntime {
             let cancel_rx = cancel_rx.clone();
             let sink = sink.clone();
             let local_peer = local_peer_id.clone();
+            let signer = options.signer.clone();
             tokio::spawn(async move {
                 run_publisher(
-                    holdings, transport, cohort, local_peer, cadence, cancel_rx, sink,
+                    holdings, transport, cohort, local_peer, cadence, cancel_rx, sink, signer,
                 )
                 .await;
             })
@@ -297,6 +404,8 @@ impl FountainSwarmRuntime {
             let tier_evict = Arc::clone(&tier_evict);
             let hard_delete = Arc::clone(&hard_delete);
             let cfg = config.clone();
+            let local_peer = local_peer_id.clone();
+            let rtt = Arc::clone(&rtt_observer);
             tokio::spawn(async move {
                 run_converger(
                     observed,
@@ -306,6 +415,8 @@ impl FountainSwarmRuntime {
                     cfg,
                     cancel_rx,
                     sink,
+                    local_peer,
+                    rtt,
                 )
                 .await;
             })
@@ -366,6 +477,7 @@ async fn run_publisher(
     cadence: Duration,
     mut cancel_rx: watch::Receiver<bool>,
     sink: Option<SwarmRuntimeEventSink>,
+    signer: Option<Arc<LocalSigner>>,
 ) {
     let mut ticker = tokio::time::interval(cadence);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -384,6 +496,7 @@ async fn run_publisher(
                     cohort.as_ref(),
                     &local_peer_id,
                     sink.as_ref(),
+                    signer.as_ref(),
                 )
                 .await
                 {
@@ -400,6 +513,7 @@ async fn publish_tick(
     cohort: &(dyn Fn() -> Vec<String> + Send + Sync),
     local_peer_id: &str,
     sink: Option<&SwarmRuntimeEventSink>,
+    signer: Option<&Arc<LocalSigner>>,
 ) -> Result<usize, FountainEvictError> {
     let held = holdings.list_held_fountain_content().await?;
     let peers = cohort();
@@ -412,18 +526,36 @@ async fn publish_tick(
             content.symbol_ids.clone(),
             observed_at_unix_ms,
         );
-        // v5.2.0: ship the wire bytes as the substrate's
-        // canonical projection (a future cut will route this through
-        // the full envelope-signing path once a `MessageType::FountainHoldingClaim`
-        // wire discriminator lands; for now the canonical_bytes is
-        // the byte-form the federation cohort consumes).
-        let envelope_bytes = claim.canonical_bytes();
         for peer in &peers {
             // Skip self — the cohort callback typically already
             // excludes the local peer, but defense in depth.
             if peer == local_peer_id {
                 continue;
             }
+            // v6.3.0 (CIRISEdge#184): when a signer is wired, ship a
+            // signed `MessageType::FountainHoldingClaim` EdgeEnvelope.
+            // When no signer (test surface or bootstrap), fall back to
+            // the v5.2.0 substrate-canonical_bytes path so existing
+            // tests + bootstrap topologies keep working.
+            let envelope_bytes = match signer {
+                Some(sig) => {
+                    match build_and_sign_holding_claim_envelope(sig, local_peer_id, peer, &claim)
+                        .await
+                    {
+                        Ok(bytes) => bytes,
+                        Err(e) => {
+                            tracing::warn!(
+                                peer = %peer,
+                                content_id = %content.content_id,
+                                error = %e,
+                                "swarm_runtime.publisher: envelope build/sign failed; falling back to canonical_bytes",
+                            );
+                            claim.canonical_bytes()
+                        }
+                    }
+                }
+                None => claim.canonical_bytes(),
+            };
             if let Err(e) = transport.send(peer, &envelope_bytes).await {
                 tracing::warn!(
                     peer = %peer,
@@ -444,6 +576,43 @@ async fn publish_tick(
     Ok(count)
 }
 
+/// CIRISEdge#184 (v6.3.0) — build + sign a
+/// [`MessageType::FountainHoldingClaim`] envelope wrapping the
+/// `claim` body. Returns the JSON-serialized envelope bytes ready for
+/// `Transport::send`.
+async fn build_and_sign_holding_claim_envelope(
+    signer: &Arc<LocalSigner>,
+    local_peer_id: &str,
+    destination_peer_id: &str,
+    claim: &FountainHoldingClaim,
+) -> Result<Vec<u8>, FountainEvictError> {
+    // `local_peer_id` is the peer-id the runtime was constructed with;
+    // when a signer is configured, it should match `signer.key_id` —
+    // a soft mismatch is logged but not fatal (the canonical_bytes-on-
+    // failure path still keeps the runtime live).
+    if signer.key_id != local_peer_id {
+        tracing::debug!(
+            signer_key_id = %signer.key_id,
+            local_peer_id,
+            "swarm_runtime.publisher: signer key_id differs from local_peer_id",
+        );
+    }
+    let mut envelope = build_envelope(
+        MessageType::FountainHoldingClaim,
+        &signer.key_id,
+        destination_peer_id,
+        claim,
+        None,
+    )
+    .map_err(|e| FountainEvictError::HardDeleteFailed(format!("build_envelope: {e}")))?;
+    sign_envelope(signer, &mut envelope)
+        .await
+        .map_err(|e| FountainEvictError::HardDeleteFailed(format!("sign_envelope: {e}")))?;
+    serde_json::to_vec(&envelope)
+        .map_err(|e| FountainEvictError::HardDeleteFailed(format!("envelope serialize: {e}")))
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn run_converger(
     observed: Arc<RwLock<ObservedClaims>>,
     holdings: Arc<dyn FountainHoldingsSource>,
@@ -452,6 +621,8 @@ async fn run_converger(
     config: SwarmRuntimeConfig,
     mut cancel_rx: watch::Receiver<bool>,
     sink: Option<SwarmRuntimeEventSink>,
+    local_peer_id: String,
+    rtt: Arc<dyn PeerRttObserver>,
 ) {
     let mut ticker = tokio::time::interval(config.observe_cadence);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -471,6 +642,8 @@ async fn run_converger(
                     &hard_delete,
                     &config,
                     sink.as_ref(),
+                    &local_peer_id,
+                    rtt.as_ref(),
                 )
                 .await;
             }
@@ -478,7 +651,7 @@ async fn run_converger(
     }
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 async fn converger_tick(
     observed: &Arc<RwLock<ObservedClaims>>,
     holdings: &Arc<dyn FountainHoldingsSource>,
@@ -486,6 +659,8 @@ async fn converger_tick(
     hard_delete: &Arc<dyn FountainEvictHardDelete + Send + Sync>,
     config: &SwarmRuntimeConfig,
     sink: Option<&SwarmRuntimeEventSink>,
+    local_peer_id: &str,
+    rtt: &dyn PeerRttObserver,
 ) {
     // Prune stale claims first so the rarity math sees a live view.
     let dropped = observed
@@ -517,7 +692,50 @@ async fn converger_tick(
     let content_ids = observed_snapshot.content_ids();
     drop(observed_snapshot);
 
-    for content_id in content_ids {
+    // CIRISEdge#184 (v6.3.0) — first pass: gather per-content_id
+    // diversity contributions so the second pass can drain in
+    // ascending-diversity order (multi-content ordering: the least-
+    // diverse positions go first when ejecting under pressure).
+    let mut per_content_diversity: BTreeMap<String, Option<f64>> = BTreeMap::new();
+    for content_id in &content_ids {
+        let snapshot = observed.read().await;
+        let others: Vec<String> = snapshot
+            .peer_ids_for(content_id)
+            .into_iter()
+            .filter(|p| p != local_peer_id)
+            .collect();
+        drop(snapshot);
+        per_content_diversity.insert(content_id.clone(), diversity_contribution(rtt, &others));
+    }
+
+    // Estimate the diversity floor — the median across the contents
+    // we DID measure. Content-ids without a score (no RTT data) drop
+    // out of the median estimation; they'll still get processed in
+    // the loop below, just with rarity-only verdicts.
+    let diversity_floor = median_diversity(&per_content_diversity);
+
+    // Second pass: process content_ids in ASCENDING diversity-score
+    // order so the converger drains the least-diverse positions
+    // first under pressure. Content-ids with no diversity score sort
+    // last (they degrade to rarity-only — substrate verdict still
+    // applies, but no diversity-driven multi-content ordering).
+    let mut ordered: Vec<(String, Option<f64>)> = content_ids
+        .iter()
+        .map(|cid| {
+            (
+                cid.clone(),
+                per_content_diversity.get(cid).copied().unwrap_or(None),
+            )
+        })
+        .collect();
+    ordered.sort_by(|(_, a), (_, b)| match (a, b) {
+        (Some(x), Some(y)) => x.partial_cmp(y).unwrap_or(std::cmp::Ordering::Equal),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+
+    for (content_id, diversity_score) in ordered {
         let snapshot = observed.read().await;
         let observed_count = snapshot.distinct_holders(&content_id);
         let all_claims = snapshot.all_claims_for(&content_id);
@@ -546,8 +764,18 @@ async fn converger_tick(
             RarityScore(0)
         };
 
-        let verdict =
-            should_eject_above_target(observed_count, &config.policy, consent, local_symbol_rarity);
+        // CIRISEdge#184 (v6.3.0) — diversity refinement on top of
+        // the substrate verdict. When either the score OR the floor
+        // is None, the sibling function reduces to the substrate's
+        // `should_eject_above_target` (rarity-only fallback).
+        let verdict = should_eject_with_diversity(
+            observed_count,
+            &config.policy,
+            consent,
+            local_symbol_rarity,
+            diversity_score,
+            diversity_floor,
+        );
 
         match verdict {
             EjectionVerdict::Keep => {

--- a/tests/active_roster_e2e.rs
+++ b/tests/active_roster_e2e.rs
@@ -1,0 +1,111 @@
+//! v6.2.0 (#179) — persist v9.3.0 `active_*` roster reads are reachable
+//! from edge via the `FederationDirectory` trait object.
+//!
+//! ## Why this test exists
+//!
+//! Persist v9.3.0 introduced four server-side memberships-MINUS-
+//! revocations folds:
+//!
+//! - `active_community_members(community) -> Vec<CommunityMember>`
+//! - `active_family_members(family) -> Vec<FamilyMember>`
+//! - `list_communities_for_member_active(member) -> Vec<Community>`
+//! - `list_families_for_member_active(member) -> Vec<Family>`
+//!
+//! Before v9.3.0, any consumer that wanted the LIVE roster had to ship
+//! both memberships + revocations as separate reads and fold them
+//! client-side. v9.3.0 closes that gap: the fold is exactly one read.
+//!
+//! ## What edge does with them today
+//!
+//! `grep -rn 'list_community_members\|list_family_members\|memberships_for'
+//! src/` finds zero edge-side sites that hand-roll the
+//! membership+revocation fold. The edge bridge (`src/replication/bridge.rs`)
+//! ships BOTH streams independently on the wire — that is the
+//! anti-entropy invariant and MUST stay independent. So the v6.2.0 cut's
+//! contribution for ask #2 is: prove the new active reads are reachable
+//! through edge's `Arc<dyn FederationDirectory>` so any FUTURE edge
+//! feature that needs a live roster uses the one-read fold rather than
+//! hand-rolling.
+//!
+//! ## What this test asserts
+//!
+//! 1. The four `active_*` reads are reachable through the trait object
+//!    edge holds (`Arc<dyn FederationDirectory>`), i.e. they're on the
+//!    trait surface, not on a backend-specific type.
+//! 2. On an empty backend, the inverse reads
+//!    (`list_*_for_member_active`) return an empty `Vec`, NOT an error
+//!    — the consumer can treat "no live memberships" as a valid empty
+//!    result.
+//! 3. On an empty backend, the forward reads (`active_*_members`)
+//!    return `Err(InvalidArgument)` for an unknown group_key_id —
+//!    confirming the trait contract documented in persist v9.3.0's
+//!    `FederationDirectory` ("Error::InvalidArgument if the family is
+//!    unknown"). This is the trait-shape edge must adapt to.
+//!
+//! ## What this test does NOT assert
+//!
+//! The functional revocation-subtraction semantics of `active_*_members`
+//! are covered by persist's own test suite (see
+//! `src/store/memory.rs::active_community_members_subtracts_effective_revocation`
+//! / `active_family_members_future_revocation_keeps_member` in persist
+//! v9.3.0). Asserting them from edge would require synthesizing real
+//! hybrid PQC signatures (the same blocker the existing
+//! `federation_present_attestation_appears_in_list_envelope_refs`
+//! `#[ignore]` annotation calls out). The trait-surface reachability
+//! this test asserts is what edge's adoption needs.
+
+use std::sync::Arc;
+
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::store::MemoryBackend;
+
+// ─── Assertion 1 — reachable through `dyn FederationDirectory` ──────
+
+/// The four v9.3.0 reads compile against the trait object edge actually
+/// holds: `Arc<dyn FederationDirectory>`. If persist regressed any of
+/// them off the trait into an inherent method, this test would fail to
+/// compile.
+#[tokio::test]
+async fn v9_3_0_active_reads_callable_through_dyn_trait() {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+
+    // 1 + 2 — the two `list_*_for_member_active` inverse reads return
+    // Ok(empty) for a member with no rosters. This is the consumer-side
+    // shape edge will adopt: "what live groups is this member in?".
+    let families = dir
+        .list_families_for_member_active("nonexistent-member")
+        .await
+        .expect("list_families_for_member_active reachable through dyn FederationDirectory");
+    assert!(families.is_empty(), "empty backend: no families");
+
+    let communities = dir
+        .list_communities_for_member_active("nonexistent-member")
+        .await
+        .expect("list_communities_for_member_active reachable through dyn FederationDirectory");
+    assert!(communities.is_empty(), "empty backend: no communities");
+}
+
+// ─── Assertion 2 — InvalidArgument on unknown group ─────────────────
+
+/// The forward reads (`active_*_members`) name a specific group and
+/// must error if that group doesn't exist. This is the trait-contract
+/// edge must adapt to when consuming the fold (it's NOT silent-empty
+/// like the inverse).
+#[tokio::test]
+async fn active_members_invalid_argument_on_unknown_group() {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+
+    let community_err = dir.active_community_members("no-such-community").await;
+    assert!(
+        community_err.is_err(),
+        "active_community_members on unknown community → Err(InvalidArgument)"
+    );
+
+    let family_err = dir.active_family_members("no-such-family").await;
+    assert!(
+        family_err.is_err(),
+        "active_family_members on unknown family → Err(InvalidArgument)"
+    );
+}

--- a/tests/bridge_combinator_e2e.rs
+++ b/tests/bridge_combinator_e2e.rs
@@ -1,0 +1,233 @@
+//! v6.2.0 (#179, CIRISPersist#249 Cut D) — `fan_out_for_member`
+//! combinator equivalence + dispatch-completeness invariants.
+//!
+//! The bridge's 9 per-kind cohort fan-outs collapsed into a single
+//! parameterized combinator (`fan_out_for_member`). This integration
+//! test fences the refactor by asserting:
+//!
+//! 1. **Dispatch completeness** — `list_envelope_refs(kind)` returns a
+//!    well-formed `Vec<EnvelopeRef>` (possibly empty) for every
+//!    `EnvelopeKind` variant. No panics, no `unimplemented!()`. This is
+//!    the structural invariant the per-kind unrolling provided
+//!    implicitly via the `match` arms.
+//!
+//! 2. **Empty-backend → empty refs across ALL kinds** — the combinator
+//!    handles the no-rows case identically to the v6.1.0 hand-unrolled
+//!    code. (The v6.1.0 implementation used per-block
+//!    `if let Ok(rows) = ...` which silently absorbed errors; the
+//!    combinator uses `unwrap_or_default()` for the same semantics.)
+//!
+//! 3. **Cohort-iteration shape preserved** — repeated cohort entries
+//!    yielding the same `key_id` deduplicate per the
+//!    `seen: HashSet<[u8; 32]>` dedupe; this invariant matters for the
+//!    9 base kinds + the 3 `*_since` operational kinds (which also
+//!    dedupe by hash, just from a different source).
+//!
+//! 4. **Key-kind round-trip continues to work** — the seeded-key
+//!    round-trip exercises `list_keys` (still hand-written; not part of
+//!    the combinator collapse since it's a point-read shape, not a
+//!    fan-out shape). This serves as the canary that the broader
+//!    refactor didn't perturb the shared cache + dispatch surface.
+//!
+//! ## What's NOT asserted here (intentional)
+//!
+//! - The persist-side `put_attestation` admission gate requires real
+//!   hybrid PQC signatures (per the existing
+//!   `federation_present_attestation_appears_in_list_envelope_refs`
+//!   `#[ignore]` annotation). This test does not synthesize those; the
+//!   existing per-kind unit tests inside `src/replication/bridge.rs`
+//!   already cover the seed-and-list round trip for keys, and the
+//!   structural shape this file asserts is what the combinator
+//!   refactor needs to preserve.
+//!
+//! - Wire-format byte stability across the refactor is covered by
+//!   `tests/replication_wire_proptest.rs` (which proptests the
+//!   serialization/deserialization round-trip of every `EnvelopeKind`
+//!   variant) — the combinator does not touch wire-frame serialization;
+//!   it only changes the host-side enumeration shape.
+
+use std::sync::Arc;
+
+use ciris_persist::federation::types::{algorithm, identity_type, KeyRecord, SignedKeyRecord};
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::store::MemoryBackend;
+
+use ciris_edge::replication::bridge::{CohortProvider, FederationDirectoryReplicationBridge};
+use ciris_edge::replication::{EnvelopeKind, ReplicationDirectory};
+
+// ─── Helpers ────────────────────────────────────────────────────────
+
+fn fresh_bridge(cohort: Vec<String>) -> (Arc<MemoryBackend>, FederationDirectoryReplicationBridge) {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+    let cohort_cb: CohortProvider = Arc::new(move || cohort.clone());
+    let bridge = FederationDirectoryReplicationBridge::new(dir, cohort_cb);
+    (backend, bridge)
+}
+
+fn fixture_key_record(key_id: &str, identity_type_: &str) -> KeyRecord {
+    let now = chrono::Utc::now();
+    KeyRecord {
+        key_id: key_id.to_string(),
+        pubkey_ed25519_base64: "0".repeat(44),
+        pubkey_ml_dsa_65_base64: None,
+        algorithm: algorithm::HYBRID.to_string(),
+        identity_type: identity_type_.to_string(),
+        identity_ref: format!("{identity_type_}-ref-{key_id}"),
+        valid_from: now,
+        valid_until: None,
+        registration_envelope: serde_json::json!({
+            "key_id": key_id,
+            "identity_type": identity_type_,
+        }),
+        original_content_hash: "0".repeat(64),
+        scrub_signature_classical: "x".repeat(88),
+        scrub_signature_pqc: None,
+        scrub_key_id: key_id.to_string(),
+        scrub_timestamp: now,
+        pqc_completed_at: None,
+        persist_row_hash: String::new(),
+        roles: Vec::new(),
+        attestation_evidence: None,
+    }
+}
+
+/// Every `EnvelopeKind` variant — both the 9 base kinds the v6.2.0
+/// combinator collapses AND the 3 operational `*_since` kinds (which
+/// also went through the same structural review per #179).
+fn all_envelope_kinds() -> &'static [EnvelopeKind] {
+    &[
+        EnvelopeKind::Key,
+        EnvelopeKind::Attestation,
+        EnvelopeKind::Revocation,
+        EnvelopeKind::IdentityOccurrence,
+        EnvelopeKind::Family,
+        EnvelopeKind::Community,
+        EnvelopeKind::IdentityOccurrenceRevocation,
+        EnvelopeKind::FamilyMembershipRevocation,
+        EnvelopeKind::CommunityMembershipRevocation,
+        EnvelopeKind::LocationProof,
+        EnvelopeKind::Organization,
+        EnvelopeKind::OrgMembership,
+        EnvelopeKind::PartnerRecord,
+    ]
+}
+
+// ─── Invariant 1 — dispatch completeness ────────────────────────────
+
+/// Every `EnvelopeKind` resolves to a well-formed (possibly empty) ref
+/// list. This is the load-bearing invariant the combinator must
+/// preserve: each per-kind site of the v6.1.0 9× unrolling becomes ONE
+/// call site through the combinator, and missing one would surface as a
+/// `match`-arm gap in `list_envelope_refs`.
+#[tokio::test]
+async fn every_envelope_kind_dispatches_through_combinator() {
+    let (_backend, bridge) = fresh_bridge(vec!["agent-alpha".to_string()]);
+    for kind in all_envelope_kinds() {
+        let refs = bridge.list_envelope_refs(*kind).await;
+        // No panic; empty is fine — backend is empty.
+        assert!(
+            refs.is_empty(),
+            "kind={kind:?} empty-backend MUST yield empty refs, got {refs:?}"
+        );
+    }
+}
+
+// ─── Invariant 2 — empty backend, every kind ────────────────────────
+
+/// Empty cohort + empty backend: every kind yields empty. Sanity that
+/// the combinator's early `cohort.is_empty()` shortcut + the directory
+/// trait's empty-list response don't perturb each other.
+#[tokio::test]
+async fn empty_cohort_yields_empty_refs_across_all_kinds() {
+    let (_backend, bridge) = fresh_bridge(Vec::new());
+    for kind in all_envelope_kinds() {
+        let refs = bridge.list_envelope_refs(*kind).await;
+        assert!(refs.is_empty(), "kind={kind:?} expected empty");
+    }
+}
+
+// ─── Invariant 3 — cohort dedupe via the combinator's HashSet ────────
+
+/// The combinator's `seen: HashSet<[u8; 32]>` dedupe fires when the
+/// cohort callback yields the same `key_id` more than once. Seed one
+/// Key, list with a cohort that names that key 3 times — exactly one
+/// ref surfaces.
+#[tokio::test]
+async fn cohort_duplicates_dedupe_to_single_ref() {
+    let key_id = "agent-bravo";
+    let (backend, bridge) = fresh_bridge(vec![
+        key_id.to_string(),
+        key_id.to_string(),
+        key_id.to_string(),
+    ]);
+    backend
+        .put_public_key(SignedKeyRecord {
+            record: fixture_key_record(key_id, identity_type::AGENT),
+        })
+        .await
+        .expect("seed key");
+
+    let refs = bridge.list_envelope_refs(EnvelopeKind::Key).await;
+    assert_eq!(
+        refs.len(),
+        1,
+        "3 cohort entries → 1 ref (dedupe via HashSet<envelope_hash>)"
+    );
+}
+
+// ─── Invariant 4 — key round-trip through the broader surface ───────
+
+/// Seed → list → fetch → apply round-trip. `list_keys` is unchanged
+/// from v6.1.0 (it's a point-read shape, not a fan-out — not part of
+/// the combinator collapse); this serves as a canary that the shared
+/// cache + dispatch surface still composes correctly post-refactor.
+#[tokio::test]
+async fn key_round_trips_across_combinator_refactor() {
+    let key_id = "agent-charlie";
+    let (backend, bridge) = fresh_bridge(vec![key_id.to_string()]);
+    backend
+        .put_public_key(SignedKeyRecord {
+            record: fixture_key_record(key_id, identity_type::AGENT),
+        })
+        .await
+        .expect("seed key");
+
+    // 1. list_envelope_refs surfaces the seeded key.
+    let refs = bridge.list_envelope_refs(EnvelopeKind::Key).await;
+    assert_eq!(refs.len(), 1);
+    let hash = refs[0].envelope_hash;
+
+    // 2. fetch_envelope_bytes returns the cached canonical bytes.
+    let bytes = bridge
+        .fetch_envelope_bytes(EnvelopeKind::Key, &hash)
+        .await
+        .expect("bytes cached during list");
+
+    // 3. Bytes decode to the same record.
+    let decoded: SignedKeyRecord = serde_json::from_slice(&bytes).expect("decode");
+    assert_eq!(decoded.record.key_id, key_id);
+
+    // 4. apply_envelope_bytes is idempotent on matching content
+    //    (persist returns Ok on dedup).
+    let admitted = bridge.apply_envelope_bytes(EnvelopeKind::Key, &bytes).await;
+    assert!(admitted, "idempotent re-apply succeeds");
+}
+
+// ─── Invariant 5 — no key in cohort means no refs ───────────────────
+
+/// A cohort entry that does NOT resolve to a backend row yields no
+/// refs (silent skip on `Err(_)` from the directory). This was the
+/// v6.1.0 `if let Ok(rows) = ...` semantics; the combinator preserves
+/// it via `unwrap_or_default()`. Asserted across every kind.
+#[tokio::test]
+async fn unresolved_cohort_member_silently_skipped_across_kinds() {
+    let (_backend, bridge) = fresh_bridge(vec!["nonexistent-key-id".to_string()]);
+    for kind in all_envelope_kinds() {
+        let refs = bridge.list_envelope_refs(*kind).await;
+        assert!(
+            refs.is_empty(),
+            "kind={kind:?} with unresolved cohort member MUST be empty"
+        );
+    }
+}

--- a/tests/delegation_reads_e2e.rs
+++ b/tests/delegation_reads_e2e.rs
@@ -1,0 +1,161 @@
+//! v6.2.0 (#179) — persist v9.3.0 delegation / MLS-authority reads are
+//! reachable from edge.
+//!
+//! ## Why this test exists
+//!
+//! Persist v9.3.0 (CIRISPersist#249 Cut C) introduced public free-fn
+//! readers that consolidate the delegation-graph walks every consumer
+//! was previously hand-rolling:
+//!
+//! - `reachable_under_scope(seed, scope, max_depth) -> bool`
+//! - `is_owner_bound(key_id) -> bool`
+//! - `owner_binding_chain(key_id) -> Vec<KeyId>`
+//! - `moderators_of(community_id, duty) -> Vec<KeyId>`
+//! - `duty_holders_for_community(community_id, duty) -> HashSet<KeyId>`
+//! - `duty_holders_for_content(content_sha, community_id, duty) -> HashSet<KeyId>`
+//!
+//! All on `Rust + FFI`, all taking `&dyn FederationDirectory`.
+//!
+//! ## What edge still hand-rolls (intentional — see commit message)
+//!
+//! `src/edge.rs::verify_self_at_login_delegation` walks
+//! `build_delegation_graph` from MULTIPLE trust roots and discriminates
+//! REFUSAL reasons (`RetractedAtRoot` / `MissingScope` /
+//! `SignerUnreached` / `SubstrateUnavailable` /
+//! `NoTrustRoots`) — the forensic granularity is load-bearing for the
+//! `DelegationRefusalSubReason` enum and is consumed by tests. Persist's
+//! `reachable_under_scope` answers REACHABILITY ONLY (`bool`), so a
+//! drop-in replacement would lose the forensic-refusal discrimination.
+//!
+//! This cut therefore:
+//! 1. Bumps persist to v9.3.0 so the new readers are AVAILABLE.
+//! 2. Asserts (this test) that they're REACHABLE through edge's
+//!    `Arc<dyn FederationDirectory>`.
+//! 3. Documents that the hand-rolled walk in `verify_self_at_login_delegation`
+//!    stays in place pending a v6.3.0 refusal-reason extension to
+//!    `reachable_under_scope` or a sibling `reachable_under_scope_refusal`
+//!    that returns a richer enum.
+//!
+//! ## What this test asserts
+//!
+//! 1. The five v9.3.0 free-fn readers compile against the trait object
+//!    edge holds (`&dyn FederationDirectory`).
+//! 2. On an empty backend:
+//!    - `reachable_under_scope` returns `Ok(false)` for any pair (the
+//!      walk terminates with no edges found).
+//!    - `is_owner_bound` returns `Ok(false)` for an unknown key (no
+//!      `user`-role record exists).
+//!    - `owner_binding_chain` returns `Ok(empty)` for an unknown key
+//!      (no chain exists).
+//!    - `moderators_of` returns `Ok(empty)` for an unknown community
+//!      (no authority roots resolvable).
+//!    - `duty_holders_for_community` returns `Ok(empty)` likewise.
+//!
+//! These are the empty-state shapes edge will branch on when it adopts
+//! these reads (e.g. an admission gate that calls `is_owner_bound` and
+//! refuses on `false`). The actual delegation-walk semantics are
+//! covered by persist's own test suite (see persist v9.3.0
+//! `src/store/sqlite.rs::reachable_under_scope_scoped_attenuated_walk_sqlite`
+//! and the matching memory-backend tests).
+//!
+//! ## What this test does NOT assert
+//!
+//! Functional walk semantics (attenuation, sub-delegation gating,
+//! retraction handling) require seeding `delegates_to` attestations
+//! through persist's admission gate, which requires real hybrid PQC
+//! signatures (the same blocker the existing
+//! `federation_present_attestation_appears_in_list_envelope_refs`
+//! `#[ignore]` annotation in `src/replication/bridge.rs` calls out).
+//! Those semantics are persist-side and covered there.
+
+use std::sync::Arc;
+
+use ciris_persist::federation::admission;
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::store::MemoryBackend;
+
+// ─── Assertion 1 — reachable through `&dyn FederationDirectory` ─────
+
+/// All five v9.3.0 free-fn delegation/authority reads compile and
+/// dispatch through `&dyn FederationDirectory` — the trait object edge
+/// actually holds via `Arc<dyn FederationDirectory>`.
+#[tokio::test]
+async fn v9_3_0_delegation_reads_callable_through_dyn_trait() {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+
+    // reachable_under_scope — empty graph → not reachable.
+    let reachable = admission::reachable_under_scope(
+        dir.as_ref(),
+        "issuer-key",
+        "target-key",
+        "act_on_behalf",
+        8,
+    )
+    .await
+    .expect("reachable_under_scope reachable through dyn trait");
+    assert!(
+        !reachable,
+        "empty backend → no delegation chain → reachable_under_scope false"
+    );
+
+    // is_owner_bound — unknown key → not bound.
+    let bound = admission::is_owner_bound(dir.as_ref(), "unknown-key")
+        .await
+        .expect("is_owner_bound reachable through dyn trait");
+    assert!(!bound, "empty backend → unknown key NOT owner-bound");
+
+    // owner_binding_chain — unknown key → empty chain.
+    let chain = admission::owner_binding_chain(dir.as_ref(), "unknown-key")
+        .await
+        .expect("owner_binding_chain reachable through dyn trait");
+    assert!(
+        chain.is_empty(),
+        "empty backend → no chain for unknown key, got {chain:?}"
+    );
+
+    // moderators_of — unknown community → empty moderator set.
+    let mods = admission::moderators_of(dir.as_ref(), "no-such-community", "moderate")
+        .await
+        .expect("moderators_of reachable through dyn trait");
+    assert!(
+        mods.is_empty(),
+        "empty backend → no moderators of unknown community, got {mods:?}"
+    );
+
+    // duty_holders_for_community — unknown community → empty holder
+    // set.
+    let holders =
+        admission::duty_holders_for_community(dir.as_ref(), "no-such-community", "moderate")
+            .await
+            .expect("duty_holders_for_community reachable through dyn trait");
+    assert!(
+        holders.is_empty(),
+        "empty backend → no duty holders, got {holders:?}"
+    );
+}
+
+// ─── Assertion 2 — reachability bool semantics on the self-pair ─────
+
+/// `reachable_under_scope(k, k, _, _)` — the trivial reachability claim
+/// "does k reach itself?" — is `true` if and only if persist treats the
+/// seed as the depth-0 visited node. The persist v9.3.0 implementation
+/// uses BFS with the seed at depth 0 and emits reachability only on
+/// FORWARD edges, so a self-pair on an empty graph is `false`. We
+/// assert that semantics here so any future persist regression (e.g.
+/// silently treating the seed as auto-reachable) is caught at edge's
+/// adoption boundary.
+#[tokio::test]
+async fn reachable_under_scope_self_pair_is_false_on_empty_graph() {
+    let backend = Arc::new(MemoryBackend::new());
+    let dir: Arc<dyn FederationDirectory> = backend.clone();
+
+    let self_reachable =
+        admission::reachable_under_scope(dir.as_ref(), "same-key", "same-key", "moderate", 4)
+            .await
+            .expect("reachable_under_scope reachable");
+    assert!(
+        !self_reachable,
+        "self-pair on empty graph: no edge → not reachable"
+    );
+}

--- a/tests/https_per_messagetype_roundtrip.rs
+++ b/tests/https_per_messagetype_roundtrip.rs
@@ -487,6 +487,20 @@ async fn https_round_trip_withdraws() {
     .await;
 }
 
+#[tokio::test]
+async fn https_round_trip_fountain_holding_claim() {
+    // CIRISEdge#184 (v6.3.0) — swarm-converger wire-up. Body shape
+    // mirrors `FountainHoldingClaim` minus the hybrid-PQC signature
+    // fields (signatures ride the envelope layer, not the body —
+    // matches the substrate's locked v1 canonical bytes contract).
+    https_envelope_round_trip(
+        0x1b,
+        "FountainHoldingClaim",
+        br#"{"peer_id":"alice","content_id":"shard-X","symbol_ids":[1,2,3],"observed_at_unix_ms":1700000000,"claim_version":1}"#,
+    )
+    .await;
+}
+
 // ─── Cross-cutting: mTLS-required rejects un-directoried client ────-
 
 #[tokio::test]
@@ -593,6 +607,7 @@ async fn https_per_messagetype_bearer_rejects_missing_token() {
 // corresponding `https_round_trip_<variant>` test above.
 
 #[test]
+#[allow(clippy::too_many_lines)]
 fn all_message_types_have_https_round_trip_test() {
     // Maintenance gate: each arm names the wire discriminator that
     // the round-trip test above sends. A new MessageType variant
@@ -628,6 +643,7 @@ fn all_message_types_have_https_round_trip_test() {
             MessageType::GoalDeclaration => "GoalDeclaration",
             MessageType::GoalRetirement => "GoalRetirement",
             MessageType::Withdraws => "Withdraws",
+            MessageType::FountainHoldingClaim => "FountainHoldingClaim",
         }
     }
 
@@ -689,6 +705,7 @@ fn all_message_types_have_https_round_trip_test() {
         (MessageType::GoalDeclaration, "GoalDeclaration"),
         (MessageType::GoalRetirement, "GoalRetirement"),
         (MessageType::Withdraws, "Withdraws"),
+        (MessageType::FountainHoldingClaim, "FountainHoldingClaim"),
     ] {
         let serde_repr = serde_json::to_value(variant).expect("serde MessageType");
         assert_eq!(

--- a/tests/swarm_converger_e2e.rs
+++ b/tests/swarm_converger_e2e.rs
@@ -1,0 +1,396 @@
+//! v6.3.0 (CIRISEdge#184) — swarm-converger wire-up + latency-
+//! diversity policy end-to-end smoke.
+//!
+//! Closes the v5.2.0 deferrals at the wire layer
+//! (`MessageType::FountainHoldingClaim` discriminator + dispatch
+//! route), plus the new latency-aware diversity refinement of the
+//! over-target ejection decision.
+//!
+//! ## Test plan
+//!
+//! 1. **Wire-format round-trip**: `MessageType::FountainHoldingClaim`
+//!    discriminator string is `"FountainHoldingClaim"`; the body
+//!    serializes via `EdgeEnvelope` and round-trips byte-for-byte.
+//! 2. **Diversity-aware ejection**: five-peer cluster where two are
+//!    low-RTT to the local peer and three are high-RTT. Over-target
+//!    condition. Assert the local peer's `should_eject_with_diversity`
+//!    returns `Eject` when it's in the low-RTT cluster, and `Keep`
+//!    when it's in the high-RTT cluster.
+//! 3. **Null observer fallback**: with `None` diversity score,
+//!    behavior matches the v5.2.0 rarity-only baseline.
+//! 4. **Multi-content ordering**: when a peer is over-target across
+//!    multiple content_ids simultaneously, the converger
+//!    pre-orders by ascending diversity score (least-diverse first).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use ciris_edge::holonomic::fountain_defaults::recommended_policy;
+use ciris_edge::holonomic::swarm_rarity::{
+    should_eject_above_target, should_eject_with_diversity, ConsentState, EjectionVerdict,
+    FountainHoldingClaim, RarityScore,
+};
+use ciris_edge::messages::{EdgeEnvelope, MessageType, SchemaVersion};
+use ciris_edge::swarm::{
+    diversity_contribution, diversity_scores_for, NullRttObserver, PeerRttObserver,
+};
+
+// ─── Wire-format round-trip ──────────────────────────────────────
+
+/// Test fixture: build an `EdgeEnvelope` around a `FountainHoldingClaim`
+/// body with empty signatures (we're asserting the wire shape, not
+/// the verify path).
+fn fixture_envelope(claim: &FountainHoldingClaim) -> EdgeEnvelope {
+    let body_value = serde_json::to_value(claim).expect("body serialize");
+    let body = serde_json::value::to_raw_value(&body_value).expect("body raw");
+    EdgeEnvelope {
+        edge_schema_version: SchemaVersion::V1_0_0,
+        signing_key_id: "alice".to_string(),
+        destination_key_id: "bob".to_string(),
+        message_type: MessageType::FountainHoldingClaim,
+        sent_at: chrono::Utc::now(),
+        nonce: [0u8; 16],
+        body,
+        signature: String::new(),
+        signature_pqc: None,
+        in_reply_to: None,
+        testimonial_witness: None,
+        key_boundary_scope: None,
+        cohort_scope: None,
+    }
+}
+
+#[test]
+fn fountain_holding_claim_message_type_serializes_to_expected_wire_string() {
+    let m = MessageType::FountainHoldingClaim;
+    let s = serde_json::to_string(&m).expect("serialize");
+    // MessageType has no #[serde(rename_all = ...)] so the wire form
+    // is the bare PascalCase variant name in double quotes. This is
+    // the discriminator the registry CEG §11 cross-reference comment
+    // names — locked here as a regression gate.
+    assert_eq!(s, "\"FountainHoldingClaim\"");
+
+    // Deserialize round-trip — the wire string is the discriminator
+    // peers MUST recognize.
+    let parsed: MessageType =
+        serde_json::from_str("\"FountainHoldingClaim\"").expect("deserialize");
+    assert_eq!(parsed, MessageType::FountainHoldingClaim);
+}
+
+#[test]
+fn fountain_holding_claim_envelope_round_trips_byte_for_byte() {
+    let claim = FountainHoldingClaim::new(
+        "alice".to_string(),
+        "content-X".to_string(),
+        vec![1, 2, 3],
+        1_700_000_000,
+    );
+    let env = fixture_envelope(&claim);
+    let serialized = serde_json::to_string(&env).expect("envelope serialize");
+    let parsed: EdgeEnvelope = serde_json::from_str(&serialized).expect("envelope deserialize");
+    assert_eq!(parsed.message_type, MessageType::FountainHoldingClaim);
+    assert_eq!(parsed.signing_key_id, "alice");
+    assert_eq!(parsed.destination_key_id, "bob");
+
+    // The body must decode to a FountainHoldingClaim and match the
+    // original.
+    let body: FountainHoldingClaim = serde_json::from_str(parsed.body.get()).expect("body decode");
+    assert_eq!(body.peer_id, "alice");
+    assert_eq!(body.content_id, "content-X");
+    assert_eq!(body.symbol_ids, vec![1, 2, 3]);
+    assert_eq!(body.observed_at_unix_ms, 1_700_000_000);
+}
+
+// ─── Diversity-aware ejection ─────────────────────────────────────
+
+/// Test fixture: static RTT observer constructed from `(peer, ms)`
+/// pairs.
+struct StaticRtt(BTreeMap<String, Duration>);
+impl PeerRttObserver for StaticRtt {
+    fn rtt_to(&self, p: &str) -> Option<Duration> {
+        self.0.get(p).copied()
+    }
+}
+fn rtt_from(pairs: &[(&str, u64)]) -> StaticRtt {
+    StaticRtt(
+        pairs
+            .iter()
+            .map(|(p, ms)| ((*p).to_string(), Duration::from_millis(*ms)))
+            .collect(),
+    )
+}
+
+#[test]
+fn diversity_aware_low_rtt_peer_ejects_high_rtt_peer_keeps() {
+    // Five-peer cluster. Two peers (bob, carol) sit in the same metro
+    // as alice (RTT ~5-10ms); two peers (dave, eve) are continents
+    // away (~200ms). The other holders (from alice's perspective) are
+    // {bob, carol, dave, eve}.
+    //
+    // observed_count = 35 holders (well above target+grace=34).
+    // local_symbol is common (rarity_score=20 > target/2=15).
+    //
+    // We compare two views:
+    //
+    // - Alice's view: low-RTT cluster with bob+carol. Her diversity
+    //   contribution = 0.005 + 0.008 + 0.200 + 0.220 = 0.433s.
+    //   The substrate verdict is `EjectToTier`; her position is in the
+    //   bottom of the cluster diversity-wise (clustered with bob+carol),
+    //   so the refined verdict stays `EjectToTier`.
+    //
+    // - Dave's view: clustered with eve, distant from alice+bob+carol.
+    //   His diversity contribution = 0.200 + 0.195 + 0.205 + 0.015 = 0.615s
+    //   (uses dave's local RTT-to-others measurement).
+    //   When the floor sits at ~0.5s (the population median), dave's
+    //   score is ABOVE the floor → flip to `Keep` (he uniquely carries
+    //   the high-RTT spread).
+    let policy = recommended_policy();
+    let holders_observed = 35u32;
+    let local_symbol_rarity = RarityScore(20);
+    let consent = ConsentState::Active;
+
+    let alice_rtt = rtt_from(&[("bob", 5), ("carol", 8), ("dave", 200), ("eve", 220)]);
+    let dave_rtt = rtt_from(&[("alice", 200), ("bob", 195), ("carol", 205), ("eve", 15)]);
+
+    let alice_others: Vec<String> = ["bob", "carol", "dave", "eve"]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    let dave_others: Vec<String> = ["alice", "bob", "carol", "eve"]
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+    let alice_score = diversity_contribution(&alice_rtt, &alice_others).expect("some");
+    let dave_score = diversity_contribution(&dave_rtt, &dave_others).expect("some");
+
+    // The floor sits between alice and dave; dave uniquely contributes
+    // diversity, alice is in the clustered low-RTT bucket.
+    let floor = (alice_score + dave_score) / 2.0;
+    assert!(
+        alice_score < floor && floor < dave_score,
+        "floor={floor} must split alice={alice_score} and dave={dave_score}"
+    );
+
+    let alice_verdict = should_eject_with_diversity(
+        holders_observed,
+        &policy,
+        consent,
+        local_symbol_rarity,
+        Some(alice_score),
+        Some(floor),
+    );
+    assert_eq!(
+        alice_verdict,
+        EjectionVerdict::EjectToTier,
+        "alice is clustered → ejecting her preserves spread"
+    );
+
+    let dave_verdict = should_eject_with_diversity(
+        holders_observed,
+        &policy,
+        consent,
+        local_symbol_rarity,
+        Some(dave_score),
+        Some(floor),
+    );
+    assert_eq!(
+        dave_verdict,
+        EjectionVerdict::Keep,
+        "dave uniquely carries diversity → KEEP under over-target"
+    );
+}
+
+#[test]
+fn null_observer_falls_back_to_rarity_only_baseline() {
+    // With a NullRttObserver, every diversity_contribution call
+    // returns None → the converger's `should_eject_with_diversity`
+    // call reduces to `should_eject_above_target` (rarity-only).
+    let policy = recommended_policy();
+    let consent = ConsentState::Active;
+    let null = NullRttObserver;
+
+    let others: Vec<String> = vec!["bob".into(), "carol".into()];
+    let score = diversity_contribution(&null, &others);
+    assert!(
+        score.is_none(),
+        "null observer must produce no diversity signal"
+    );
+
+    // Substrate verdict and diversity-refined verdict MUST match when
+    // either input is None.
+    for (holders, rarity) in [
+        (35u32, RarityScore(20)), // over target, common → EjectToTier
+        (25u32, RarityScore(20)), // under target → Keep
+        (35u32, RarityScore(5)),  // over target, rare → Keep
+    ] {
+        let base = should_eject_above_target(holders, &policy, consent, rarity);
+        let refined =
+            should_eject_with_diversity(holders, &policy, consent, rarity, None, Some(0.30));
+        assert_eq!(
+            base, refined,
+            "null diversity must mirror rarity-only for ({holders}, {rarity:?})"
+        );
+        let refined2 =
+            should_eject_with_diversity(holders, &policy, consent, rarity, Some(0.50), None);
+        assert_eq!(
+            base, refined2,
+            "no floor must mirror rarity-only for ({holders}, {rarity:?})"
+        );
+    }
+}
+
+#[test]
+fn multi_content_ordering_evicts_least_diverse_first() {
+    // Three content_ids local peer is observing. content-A is
+    // clustered (low diversity score), content-B is balanced,
+    // content-C is uniquely diverse (high score). When the converger
+    // drains under over-target pressure, the order is A → B → C.
+    let r = rtt_from(&[("p1", 5), ("p2", 8), ("p3", 100), ("p4", 200), ("p5", 500)]);
+    let mut others = BTreeMap::new();
+    // content-A: clustered with p1 + p2 only → low score
+    others.insert(
+        "content-A".to_string(),
+        vec!["p1".to_string(), "p2".to_string()],
+    );
+    // content-B: balanced — one near, one far
+    others.insert(
+        "content-B".to_string(),
+        vec!["p1".to_string(), "p4".to_string()],
+    );
+    // content-C: uniquely far from all → high score
+    others.insert(
+        "content-C".to_string(),
+        vec!["p4".to_string(), "p5".to_string()],
+    );
+
+    let scores = diversity_scores_for(&r, &others);
+    let a = scores.get("content-A").unwrap().expect("some");
+    let b = scores.get("content-B").unwrap().expect("some");
+    let c = scores.get("content-C").unwrap().expect("some");
+    assert!(a < b, "content-A must be less diverse than content-B");
+    assert!(b < c, "content-B must be less diverse than content-C");
+
+    // The converger sorts ascending — content-A first under pressure.
+    let mut ordered: Vec<(String, f64)> = vec![
+        ("content-A".to_string(), a),
+        ("content-B".to_string(), b),
+        ("content-C".to_string(), c),
+    ];
+    ordered.sort_by(|x, y| x.1.partial_cmp(&y.1).unwrap_or(std::cmp::Ordering::Equal));
+    assert_eq!(ordered[0].0, "content-A");
+    assert_eq!(ordered[1].0, "content-B");
+    assert_eq!(ordered[2].0, "content-C");
+}
+
+// ─── Round-trip via runtime ───────────────────────────────────────
+
+use async_trait::async_trait;
+use ciris_edge::swarm::{
+    FountainEvictHardDelete, FountainHoldingsSource, FountainSwarmRuntime, FountainTierEvict,
+    NoopFountainHoldingsSource, SwarmRuntimeConfig,
+};
+use ciris_edge::transport::{
+    InboundFrame, Transport, TransportError, TransportId, TransportSendOutcome,
+};
+
+#[derive(Default)]
+struct RecordingTransport {
+    sends: std::sync::Mutex<Vec<(String, Vec<u8>)>>,
+}
+#[async_trait]
+impl Transport for RecordingTransport {
+    fn id(&self) -> TransportId {
+        TransportId::HTTP
+    }
+    async fn send(
+        &self,
+        destination_key_id: &str,
+        envelope_bytes: &[u8],
+    ) -> Result<TransportSendOutcome, TransportError> {
+        self.sends
+            .lock()
+            .unwrap()
+            .push((destination_key_id.to_string(), envelope_bytes.to_vec()));
+        Ok(TransportSendOutcome::Delivered)
+    }
+    async fn listen(
+        &self,
+        _sink: tokio::sync::mpsc::Sender<InboundFrame>,
+    ) -> Result<(), TransportError> {
+        unimplemented!("e2e doesn't drive listen")
+    }
+}
+
+#[derive(Default)]
+struct NopTier;
+#[async_trait]
+impl FountainTierEvict for NopTier {
+    async fn evict_fountain_content_to_tier(
+        &self,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<(), ciris_edge::swarm::FountainEvictError> {
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct NopHard;
+impl FountainEvictHardDelete for NopHard {
+    fn evict_fountain_content_hard_delete(
+        &self,
+        _: &str,
+        _: &str,
+    ) -> Result<(), ciris_edge::swarm::FountainEvictError> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn runtime_round_trip_with_published_claim_via_register_observed_claim() {
+    // This is the same shape as the v5.2.0 e2e test, retained as a
+    // baseline gate: the runtime's `register_observed_claim` is the
+    // hook the new wire-route calls into; if the route works at the
+    // dispatch layer (covered by unit tests), this end-to-end driver
+    // confirms the runtime still composes after the v6.3.0 changes.
+    let alice_holdings: Arc<dyn FountainHoldingsSource> = Arc::new(NoopFountainHoldingsSource);
+    let alice_tx = Arc::new(RecordingTransport::default());
+    let alice_tier: Arc<dyn FountainTierEvict> = Arc::new(NopTier);
+    let alice_hard: Arc<dyn FountainEvictHardDelete + Send + Sync> = Arc::new(NopHard);
+    let alice_cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+    let rt = FountainSwarmRuntime::start(
+        SwarmRuntimeConfig {
+            publish_cadence: Duration::from_secs(60),
+            observe_cadence: Duration::from_secs(60),
+            ..Default::default()
+        },
+        alice_holdings,
+        alice_tier,
+        alice_hard,
+        alice_tx as Arc<dyn Transport>,
+        alice_cohort,
+        "alice".to_string(),
+        None,
+    );
+
+    rt.register_observed_claim(FountainHoldingClaim::new(
+        "bob",
+        "shard-X",
+        vec![1, 2, 3],
+        1_700_000_000,
+    ))
+    .await;
+
+    let observed = rt.observed_handle();
+    let g = observed.read().await;
+    let inner = format!("{g:?}");
+    assert!(
+        inner.contains("shard-X"),
+        "observed map must contain shard-X; got {inner}"
+    );
+    drop(g);
+    let mut rt = rt;
+    rt.shutdown().await;
+}


### PR DESCRIPTION
## Summary

Closes the two v5.2.0 deferrals (wire-format `MessageType` + publisher loop) **AND** adds the latency-aware diversity heuristic for over-target ejection (closes [CIRISEdge#184](https://github.com/CIRISAI/CIRISEdge/issues/184)).

### Wire-tier closure
- New `MessageType::FountainHoldingClaim` wire discriminator. Serde wire-string is **`"FountainHoldingClaim"`** (PascalCase per existing convention).
- Inbound `dispatch_inbound` routes verified envelopes into `FountainSwarmRuntime::register_observed_claim` (AV-9 verify-then-dispatch invariant preserved).
- Publisher loop signs an `EdgeEnvelope` when a `LocalSigner` is wired via the new `SwarmRuntimeOptions { signer, rtt_observer }`; falls back to v5.2.0 raw-canonical_bytes when no signer (test fixtures + bootstrap). Legacy `FountainSwarmRuntime::start(...)` preserved as thin wrapper — no callers break.
- Added to the `https_per_messagetype_roundtrip` conformance suite (30/30 variants now covered).

### Latency-aware diversity policy
- New module `src/swarm/diversity.rs`:
  - `PeerRttObserver` trait
  - `TopologyRttObserver` (production: reads RTT from the latest ALM topology snapshot's `ReachabilityObservation` set — CEG §19.4 input re-used as a diversity input, not just routing)
  - `NullRttObserver` (test fallback)
  - `diversity_contribution(rtt, others) -> Option<f64>` — sum of RTT (seconds) to other holders; missing RTT defaults to median; `None` when no data → rarity-only fallback
  - `diversity_scores_for(...)` — bulk-compute for multi-content ordering
- `holonomic::swarm_rarity::should_eject_with_diversity` is a sibling of the locked v1 `should_eject_above_target`. Substrate v1 byte-determinism stays intact (CEG 1.0 §R conformance vectors continue to apply against the substrate function unchanged); diversity is a **policy-tier** refinement, not a wire break.
- Semantics: base verdict `EjectToTier` + diversity score `< floor` → eject (clustered position); `>= floor` → flip to `Keep` (diverse position). Verdicts `Keep` / `EjectHardDelete` / `EjectAggregatedTierOnly` pass through unchanged — diversity does NOT override §3.2.3 revocation or the keep-because-rare invariant.

### Converger drains least-diverse first
- First pass: compute per-content diversity scores + floor (median across measured contents).
- Second pass: process content_ids in ASCENDING score order — least-diverse positions go first under multi-content ejection pressure.
- When no RTT data is available, behavior is byte-equivalent to the v5.2.0 rarity-only path.

### Diversity-score formula
```
score = sum over others { rtt(self → peer).unwrap_or(median_observed) }
floor = median across content-ids with observed scores
eject iff score < floor   (only when base verdict already says EjectToTier)
```

## Test plan
- [x] `swarm_rarity`: 36/36 pass (6 new diversity-refinement tests)
- [x] `swarm` module: 33/33 pass (10 new diversity tests)
- [x] `swarm_converger_e2e` (NEW): 6/6 pass — wire format roundtrip, diversity-aware ejection (5-peer cluster), null-observer fallback, multi-content ordering, runtime round-trip
- [x] `swarm_runtime_e2e` (v5.2.0 baseline): 1/1 pass
- [x] `https_per_messagetype_roundtrip`: 30/30 pass (1 new variant)
- [x] Total lib: 645/645 pass
- [x] `cargo fmt --all -- --check` clean
- [x] `RUSTFLAGS="-D warnings" cargo clippy --no-default-features --features "transport-http transport-reticulum pyo3 holonomic-consent-decay" --lib --tests` clean
- [x] MSRV 1.75 honored; persist v9.10.0 + verify-family v6.11.0 pins held

## Upstream gaps
- Reticulum link-layer RTT impl deferred to v6.4.0: the `PeerRttObserver` trait surface is stable so the transport-tier impl can land without re-touching the runtime.
- CIRISRegistry#107 (§11 absorption) will receive a separate comment naming the new wire discriminator + the latency-diversity refinement of CEG §19.4 (filed once this PR merges).

References: CIRISEdge#184, CIRISEdge#143, CIRISPersist#227

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln