### PR TITLE
release(v7.0.2): fix links_ffi + reticulum_loopback against v7.0.0 announce-bypass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,14 +118,20 @@ jobs:
           # artifacts; sharing the cache would cause recompile thrash).
           key: ${{ matrix.combo.name }}
       - name: cargo test --features "${{ matrix.combo.features }}"
-        # pyo3-full runs --all-targets to exercise the integration
-        # test suite (transport_http_hardening, reticulum_loopback,
-        # https_per_messagetype_roundtrip, etc.); the transport-lane
-        # entries run --lib only because the integration suites need
-        # the full pyo3 + http stack to link.
+        # pyo3-full runs --tests to exercise the integration test suite
+        # (transport_http_hardening, reticulum_loopback,
+        # https_per_messagetype_roundtrip, etc.) plus all lib tests; the
+        # transport-lane entries run --lib only because the integration
+        # suites need the full pyo3 + http stack to link.
+        #
+        # `--tests` deliberately EXCLUDES benches (criterion's measurement
+        # runs at N=2048 take 10+ minutes per Join/Leave point). Bench
+        # compile-gating is covered by the separate "cargo bench --no-run
+        # (all features)" job; actual perf measurements belong on a
+        # nightly cron, not the per-PR critical path.
         run: |
           if [ "${{ matrix.combo.all_targets }}" = "true" ]; then
-            cargo test --features "${{ matrix.combo.features }}" --all-targets
+            cargo test --features "${{ matrix.combo.features }}" --tests
           else
             cargo test --features "${{ matrix.combo.features }}" --lib
           fi

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.1"
+version = "7.0.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -3258,7 +3258,7 @@ enum LocalInstanceRole {
     clippy::too_many_lines,
     clippy::fn_params_excessive_bools
 )]
-fn init_edge_runtime(
+pub fn init_edge_runtime(
     py: Python<'_>,
     engine: Bound<'_, PyAny>,
     identity_path: &str,
@@ -5526,8 +5526,16 @@ impl PyStoreAndForward {
     }
 }
 
-#[pymodule]
-fn ciris_edge(m: &Bound<'_, PyModule>) -> PyResult<()> {
+/// Register the full `ciris_edge` PyO3 surface against the supplied
+/// module. Re-applies the v4.3.1 / CIRISEdge#156 one-wheel re-export
+/// mechanism the v7.x refactor dropped: sibling cdylibs (e.g.
+/// CIRISServer) call this from their own `#[pymodule]` shim to
+/// re-host edge's `#[pyclass]`es + `init_edge_runtime` without an
+/// independent `ciris_edge` import (the published wheel's pymodule
+/// shim simply delegates here so both paths emit the identical
+/// surface — same classes, same constants, same functions). Closes
+/// CIRISEdge#199.
+pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // v1.1.7 (CIRISEdge#58) — diagnostic harness, gated under the
     // `debug-tools` Cargo feature. Default release wheels (where the
     // feature is OFF) compile NONE of this: no panic hook install,
@@ -5634,6 +5642,14 @@ fn ciris_edge(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyStoreAndForward>()?;
 
     Ok(())
+}
+
+/// `ciris_edge` `#[pymodule]` shim — delegates to [`register`] so the
+/// published wheel and any sibling cdylib that calls `register`
+/// directly emit the byte-equal pyo3 surface (CIRISEdge#199).
+#[pymodule]
+fn ciris_edge(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    register(m)
 }
 
 #[cfg(test)]

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1562,6 +1562,49 @@ impl ReticulumTransport {
             .map(|p| p.dest_hash.into_bytes())
     }
 
+    /// v7.0.0 (CIRISEdge#191 / #195) test seam — install a synthetic
+    /// rooted-peer entry that bypasses the announce-rooting cold-start.
+    ///
+    /// v7.0.0 explicit-hash destinations cannot announce (Leviculum
+    /// guard: `AnnounceError::ExplicitHashCannotAnnounce`), so loopback
+    /// tests that previously waited for B to receive A's announce now
+    /// have no announce to wait for. Production peers learn each
+    /// other's `(dest_hash, transport-tier ed25519)` binding via the
+    /// v6.0.0 directory-cache anti-entropy path (CIRISEdge#175) — this
+    /// accessor is the test-only analogue that pre-installs the same
+    /// binding without depending on that out-of-band path being wired
+    /// up in the test fixture.
+    ///
+    /// `dest_hash` should be the peer's explicit-hash
+    /// (`sha256(fed_pubkey)[..16]`) and `signing_key_ed25519` the
+    /// peer's transport-tier Ed25519 verifying key (the 32 bytes that
+    /// sign link proofs). After this call, `knows_peer(key_id)` returns
+    /// true and `link_open(dest_hash, ..)` finds the entry.
+    #[doc(hidden)]
+    pub async fn inject_rooted_peer_for_test(
+        &self,
+        destination_key_id: &str,
+        dest_hash: [u8; 16],
+        signing_key_ed25519: [u8; 32],
+    ) {
+        let mut peers = self.peers.lock().await;
+        peers.insert(
+            destination_key_id.to_string(),
+            RootedPeer {
+                peer: ResolvedPeer {
+                    dest_hash: DestinationHash::new(dest_hash),
+                    signing_key: signing_key_ed25519,
+                },
+                epoch: 0,
+                chain: ProvenanceChain {
+                    key_id: destination_key_id.to_string(),
+                    chain: Vec::new(),
+                    terminates_at_steward_bootstrap: false,
+                },
+            },
+        );
+    }
+
     // ─── CIRISEdge#32 (v0.14.0) Links FFI surface ───────────────────
     //
     // The Reticulum link lifecycle is normally an internal substrate

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -114,3 +114,35 @@ pub async fn directory_with(records: Vec<KeyRecord>) -> Arc<SqliteBackend> {
     }
     backend
 }
+
+/// v7.0.0 (CIRISEdge#191 / #195) — cross-install each transport's
+/// `(dest_hash, transport-tier ed25519)` binding into the OTHER
+/// transport's rooted-peer map, bypassing the announce path that
+/// explicit-hash addressing forbids.
+///
+/// Production peers learn this binding via the v6.0.0 directory-cache
+/// anti-entropy path (CIRISEdge#175); this helper is the test-only
+/// analogue. After this call, each transport's `knows_peer(<peer>)`
+/// returns true and `link_open(peer_dest_hash, ..)` finds the entry —
+/// the same observable state the legacy announce-rooting produced
+/// before v7.0.0 broke the announce.
+#[cfg(feature = "transport-reticulum")]
+pub async fn prime_v7_peer_pair(
+    transport_a: &ciris_edge::transport::reticulum::ReticulumTransport,
+    key_id_a: &str,
+    transport_b: &ciris_edge::transport::reticulum::ReticulumTransport,
+    key_id_b: &str,
+) {
+    let a_dest = transport_a.local_dest_hash();
+    let b_dest = transport_b.local_dest_hash();
+    let mut a_ed = [0u8; 32];
+    a_ed.copy_from_slice(&transport_a.local_transport_pubkey()[32..64]);
+    let mut b_ed = [0u8; 32];
+    b_ed.copy_from_slice(&transport_b.local_transport_pubkey()[32..64]);
+    transport_b
+        .inject_rooted_peer_for_test(key_id_a, a_dest, a_ed)
+        .await;
+    transport_a
+        .inject_rooted_peer_for_test(key_id_b, b_dest, b_ed)
+        .await;
+}

--- a/tests/links_ffi.rs
+++ b/tests/links_ffi.rs
@@ -38,7 +38,7 @@ use ciris_edge::transport::{InboundFrame, Transport, TransportError};
 use ciris_edge::verify::RootingDirectory;
 use tokio::sync::mpsc;
 
-use common::{directory_with, signed_record, TestFedKey};
+use common::{directory_with, prime_v7_peer_pair, signed_record, TestFedKey};
 
 /// Pick an ephemeral loopback TCP port.
 fn free_port() -> u16 {
@@ -143,20 +143,31 @@ async fn paired_transports(
     let (tx_a, rx_a) = mpsc::channel::<InboundFrame>(16);
     let (tx_b, _rx_b) = mpsc::channel::<InboundFrame>(16);
 
+    // v7.0.0 (CIRISEdge#191 / #195) — explicit-hash destinations
+    // cannot announce, so the announce-based rooting path the v6.x
+    // loopback tests relied on is wedged by design. Pre-install the
+    // `(dest_hash, transport-tier ed25519)` binding both directions —
+    // this is the test-only analogue of the v6.0.0 directory-cache
+    // anti-entropy path (CIRISEdge#175) production uses.
+    prime_v7_peer_pair(
+        &transport_a,
+        "edge-link-aaaa",
+        &transport_b,
+        "edge-link-bbbb",
+    )
+    .await;
+
     let la = transport_a.clone();
     let lb = transport_b.clone();
     let listen_a = tokio::spawn(async move { la.listen(tx_a).await });
     let listen_b = tokio::spawn(async move { lb.listen(tx_b).await });
 
-    // Wait until B has rooted A.
-    let discovered = wait_for(Duration::from_secs(30), || {
-        let t = transport_b.clone();
-        async move { t.knows_peer("edge-link-aaaa").await }
-    })
-    .await;
+    // Sanity: post-prime, B knows A (and A knows B). No await on the
+    // announce mechanism — explicit-hash destinations can't announce.
+    let discovered = transport_b.knows_peer("edge-link-aaaa").await;
     assert!(
         discovered,
-        "node B did not root node A within 30s — Reticulum loopback discovery wedged"
+        "post-prime `knows_peer` must be true — v7.0.0 explicit-hash discovery is out-of-band",
     );
 
     (
@@ -170,6 +181,7 @@ async fn paired_transports(
     )
 }
 
+#[allow(dead_code)]
 async fn wait_for<F, Fut>(timeout: Duration, mut cond: F) -> bool
 where
     F: FnMut() -> Fut,

--- a/tests/pruner_lifecycle.rs
+++ b/tests/pruner_lifecycle.rs
@@ -133,16 +133,32 @@ async fn pruner_skips_when_no_blackhole_rules_wired() {
     // `None` from `blackhole_rules_handle`, and the conditional spawn
     // site (`if let Some(rules) = ...`) is by construction skipped.
     //
-    // Build a `ReticulumTransport` with `ReticulumAuth::default()`
-    // (all fields `None`) and assert the accessor returns `None`.
+    // Build a `ReticulumTransport` with `ReticulumAuth::default()` plus a
+    // federation signer (v7.0.0 explicit-hash addressing requires one at
+    // construction — `ReticulumAuth.signer == None` rejects honest at
+    // `ReticulumTransport::new`). Every other auth field stays default,
+    // including `blackhole_rules: None`, which is the surface under test.
+    use ciris_edge::identity::LocalSigner;
     use ciris_edge::transport::reticulum::{
         ReticulumAuth, ReticulumTransport, ReticulumTransportConfig,
     };
+    use ciris_keyring::Ed25519SoftwareSigner;
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let identity_path = tmp.path().join("test-identity");
     let config = ReticulumTransportConfig::new(identity_path, "test-key".to_string());
-    let auth = ReticulumAuth::default();
+
+    let mut seed = [0x11u8; 32];
+    for (i, b) in "test-key".bytes().take(32).enumerate() {
+        seed[i] = b;
+    }
+    let mut sw = Ed25519SoftwareSigner::new("test-key");
+    sw.import_key(&seed).expect("import test seed");
+    let signer = Arc::new(LocalSigner::new("test-key".to_string(), Arc::new(sw), None));
+    let auth = ReticulumAuth {
+        signer: Some(signer),
+        ..ReticulumAuth::default()
+    };
     let transport = ReticulumTransport::new(config, auth)
         .await
         .expect("build transport");

--- a/tests/reticulum_loopback.rs
+++ b/tests/reticulum_loopback.rs
@@ -36,7 +36,7 @@ use ciris_edge::verify::RootingDirectory;
 use serde_json::value::RawValue;
 use tokio::sync::mpsc;
 
-use common::{directory_with, signed_record, TestFedKey};
+use common::{directory_with, prime_v7_peer_pair, signed_record, TestFedKey};
 
 /// Build a representative signed-shaped envelope. The signatures here
 /// are placeholder strings — the loopback test exercises *transport*
@@ -161,6 +161,14 @@ async fn rooted_resolution_round_trips_envelope_byte_exact() {
             .expect("build transport B"),
     );
 
+    // v7.0.0 (CIRISEdge#191 / #195) — explicit-hash destinations cannot
+    // announce, so the announce-based rooting path the v6.x loopback
+    // tests relied on is wedged by design. Pre-install the
+    // `(dest_hash, transport-tier ed25519)` binding both directions —
+    // production peers learn the same binding via the v6.0.0 directory-
+    // cache anti-entropy path (CIRISEdge#175).
+    prime_v7_peer_pair(&transport_a, "edge-key-aaaa", &transport_b, "edge-key-bbbb").await;
+
     // Drive both listeners. A's sink is what we assert on.
     let (tx_a, mut rx_a) = mpsc::channel::<InboundFrame>(16);
     let (tx_b, _rx_b) = mpsc::channel::<InboundFrame>(16);
@@ -170,17 +178,11 @@ async fn rooted_resolution_round_trips_envelope_byte_exact() {
     let listen_a = tokio::spawn(async move { la.listen(tx_a).await });
     let listen_b = tokio::spawn(async move { lb.listen(tx_b).await });
 
-    // Wait for B to ROOT A's announce attestation — `knows_peer`
-    // returns true only once the cold-start path (root_binding +
-    // attestation verify + hybrid policy) has accepted the binding.
-    let discovered = wait_for(Duration::from_secs(30), || {
-        let t = transport_b.clone();
-        async move { t.knows_peer("edge-key-aaaa").await }
-    })
-    .await;
+    // Post-prime sanity — no await on the announce mechanism.
+    let discovered = transport_b.knows_peer("edge-key-aaaa").await;
     assert!(
         discovered,
-        "node B did not root node A's announce attestation within 30s",
+        "post-prime `knows_peer` must be true — v7.0.0 explicit-hash discovery is out-of-band",
     );
 
     // Round-trip one envelope B → A.
@@ -227,6 +229,7 @@ async fn rooted_resolution_round_trips_envelope_byte_exact() {
 }
 
 /// Poll `cond` until it returns `true` or `timeout` elapses.
+#[allow(dead_code)]
 async fn wait_for<F, Fut>(timeout: Duration, mut cond: F) -> bool
 where
     F: FnMut() -> Fut,

--- a/tests/routing_ffi.rs
+++ b/tests/routing_ffi.rs
@@ -44,7 +44,7 @@ use ciris_edge::transport::{InboundFrame, Transport, TransportError};
 use ciris_edge::verify::RootingDirectory;
 use tokio::sync::mpsc;
 
-use common::{directory_with, signed_record, TestFedKey};
+use common::{directory_with, prime_v7_peer_pair, signed_record, TestFedKey};
 
 /// Pick an ephemeral loopback TCP port.
 fn free_port() -> u16 {
@@ -177,6 +177,18 @@ async fn paired_transports(
             .expect("build transport B"),
     );
 
+    // v7.0.0 (CIRISEdge#191 / #195) — explicit-hash destinations cannot
+    // announce; pre-install both directions of the rooted-peer binding
+    // out-of-band (test analogue of the v6.0.0 directory-cache anti-
+    // entropy path, CIRISEdge#175).
+    prime_v7_peer_pair(
+        &transport_a,
+        "edge-routing-aaaa",
+        &transport_b,
+        "edge-routing-bbbb",
+    )
+    .await;
+
     let (tx_a, _rx_a) = mpsc::channel::<InboundFrame>(16);
     let (tx_b, _rx_b) = mpsc::channel::<InboundFrame>(16);
 
@@ -185,20 +197,17 @@ async fn paired_transports(
     let listen_a = tokio::spawn(async move { la.listen(tx_a).await });
     let listen_b = tokio::spawn(async move { lb.listen(tx_b).await });
 
-    // Wait for B to root A.
-    let discovered = wait_for(Duration::from_secs(30), || {
-        let t = transport_b.clone();
-        async move { t.knows_peer("edge-routing-aaaa").await }
-    })
-    .await;
+    // Post-prime sanity — no announce-mechanism dependency.
+    let discovered = transport_b.knows_peer("edge-routing-aaaa").await;
     assert!(
         discovered,
-        "node B did not root node A within 30s — Reticulum loopback discovery wedged"
+        "post-prime `knows_peer` must be true — v7.0.0 explicit-hash discovery is out-of-band",
     );
 
     (transport_a, transport_b, listen_a, listen_b)
 }
 
+#[allow(dead_code)]
 async fn wait_for<F, Fut>(timeout: Duration, mut cond: F) -> bool
 where
     F: FnMut() -> Fut,


### PR DESCRIPTION
## Summary

Bundles three v7.0.x adoption follow-ups into a single v7.0.2 cut:

**1. v7.0.0 announce-bypass test fallout (links_ffi + reticulum_loopback)** — explicit-hash destinations cannot announce by design (Leviculum guard: `AnnounceError::ExplicitHashCannotAnnounce`).

- New `#[doc(hidden)] ReticulumTransport::inject_rooted_peer_for_test` seam.
- New `tests/common::prime_v7_peer_pair` helper — cross-installs both transports' `(dest_hash, transport-tier ed25519)` bindings.
- `paired_transports` (links_ffi + routing_ffi) + `rooted_resolution_round_trips_envelope_byte_exact` (reticulum_loopback) call `prime_v7_peer_pair` before listeners spawn.

Test-only analogue of the v6.0.0 directory-cache anti-entropy path (CIRISEdge#175).

**2. v7.0.0 signer-required test fallout (pruner_lifecycle)** — `pruner_skips_when_no_blackhole_rules_wired` built a transport with `ReticulumAuth::default()` (signer=None); v7.0.0 rejects that at construction. Inject a deterministic software signer using the same per-key_id seed pattern as `leviculum_interface_diversity::test_auth`.

**3. Closes #199 — restore `pub fn ffi::pyo3::register` + `pub init_edge_runtime`** — the v4.3.1 / CIRISEdge#156 one-wheel re-export mechanism the v7.x refactor dropped. The `#[pymodule]` shim now delegates to `pub fn register`, so the published wheel's emitted surface stays byte-equal while CIRISServer can call `ciris_edge::ffi::pyo3::register` to re-host the full surface (init_edge_runtime included).

## Test plan

- [x] `cargo test --features "transport-reticulum ffi-uniffi" --test reticulum_loopback` — 1/1
- [x] `cargo test --features "transport-reticulum ffi-uniffi" --test links_ffi` — 8/8
- [x] `cargo test --features "transport-reticulum ffi-uniffi" --test routing_ffi` — 23/23
- [x] `cargo test --features "transport-reticulum ffi-uniffi" --test pruner_lifecycle` — 4/4
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [ ] CI `pyo3-full` job recovers to green

## Notes

Cohabitation jobs are red on an unrelated upstream gap (CIRISPersist v10.0.0 wheel API skew).
