### PR TITLE
release(v7.0.3): adopt CIRISPersist v10.0.1 cohab unblock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.2"
+version = "7.0.3"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.0.0", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.0.1", version = "10", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.0.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.0.1", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## Summary

Pin bump CIRISPersist v10.0.0 → v10.0.1. Upstream fix for the `register_self_federation_key` signer-identity drift that was failing the cohab conformance harness on the v7.0.2 cut (6 failures across {linux,darwin}-aarch64/x86_64 × {sqlite,postgres}). Edge doesn't call that API directly, so this is a pure substrate pin bump — no edge-side code changes.

Persist v10.0.1's behavior change: `register_self_federation_key` now returns the derived `<label>-<fp>` id rather than the bare alias. CIRISConformance#20 needs to re-pin against the ≥10.0.1 floor.

Substrate floor:
- `ciris-persist` v10.0.0 → v10.0.1 (both `[dependencies]` and `[dev-dependencies]`)
- `ciris-verify` family unchanged at v7.2.0

## Test plan

- [x] `cargo check --features "transport-http transport-reticulum pyo3"` — clean
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI matrix green (cohab x6 expected to recover with the v10.0.1 floor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln