### PR TITLE
release(v7.0.5): adopt CIRISPersist v10.1.1 — withdraws/eviction hybrid-PQC closure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.4"
+version = "7.0.5"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.0", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.1", version = "10", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.1", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## Summary

Pin bump CIRISPersist v10.1.0 → v10.1.1. Closes the last live #275 surface: `register_self_federation_key` now stores the ML-DSA-65 pubkey + hybrid-signs, so federation-tier withdraws no longer hit `verify_hybrid_pqc_fields_mismatch`. The withdraws/eviction path was the audit-caught lurking site that survived v10.1.0's hardening pass.

Edge doesn't call `register_*federation_key` directly — pure substrate pin bump, no edge-side code changes.

Substrate floor:
- `ciris-persist` v10.1.0 → v10.1.1 (both `[dependencies]` and `[dev-dependencies]`)
- `ciris-verify` family unchanged at v7.2.0
- Leviculum unchanged at v0.7.0

## Test plan

- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [ ] CI matrix — cohab x6 still gated on CIRISConformance#20 (harness API drift), informational per the closed wheel-skew pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln