### PR TITLE
release(v7.0.7): adopt CIRISVerify v7.4.0 + CIRISPersist v10.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.6"
+version = "7.0.7"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.1", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.2", version = "10", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.2.0", version = "7" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.1", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.1.2", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## Summary

Pure substrate pin bump:
- `ciris-verify` family v7.2.0 → v7.4.0 (minor — scope-native privacy derivations on the wheel via CIRISVerify#82; also carries v7.3.0's `ciris_verify.rns_destination_hash` addition)
- `ciris-persist` v10.1.1 → v10.1.2

Substrate lockstep discipline: verify → persist → edge bumps land together so the federation matrix stays at the same floor.

Edge-side surface unchanged; no API consumers re-wired.

CIRISEdge#205 (Phase 4 `RequireTransportBinding` cutover) is now substrate-ready (v7.3.0 shipped `rns_destination_hash` on the wheel) but deferred to v7.1.0 — the resolver-path wiring + `transport_destination` directory reads + policy/floor gate are a substantive minor-level cut, not a patch.

## Test plan

- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [ ] CI matrix — same expected shape as v7.0.4–v7.0.6 (edge-side green; cohab x6 stays red on CIRISConformance#20 harness gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln