### PR TITLE
release(v7.0.8): PyO3 surface for CIRISEdge#208 dispatch_inbound trust gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.7"
+version = "7.0.8"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1124,6 +1124,24 @@ pub struct Edge {
     /// wire its own scorer; tests pass `MemoryTrustScoring` for
     /// deterministic fixtures.
     pub(crate) trust_scoring: Option<Arc<dyn ciris_persist::federation::TrustScoring>>,
+    /// CIRISEdge#208 — test/conformance override for
+    /// [`EdgeConfig::trust_threshold`]. When `Some(v)` ,
+    /// [`Self::dispatch_inbound_for_test`] passes `v` to `dispatch_inbound`
+    /// instead of `self.config.trust_threshold` AND forces
+    /// `trust_short_circuit_enabled = true` so the override actually
+    /// gates a single envelope. Production paths (the `Edge::run`
+    /// listener loop) ignore this field. The PyO3 surface
+    /// `PyEdge::set_trust_threshold` mutates this slot.
+    trust_threshold_override: Arc<std::sync::RwLock<Option<f64>>>,
+    /// CIRISEdge#208 — test/conformance override for
+    /// [`Self::trust_scoring`]. When `Some(scoring)`,
+    /// [`Self::dispatch_inbound_for_test`] passes `scoring` to
+    /// `dispatch_inbound` instead of the builder-wired `self.trust_scoring`.
+    /// Production paths ignore this field. The PyO3 surface
+    /// `PyEdge::install_trust_resolver` mutates this slot with a
+    /// `Python-callback-backed` impl.
+    trust_scoring_override:
+        Arc<std::sync::RwLock<Option<Arc<dyn ciris_persist::federation::TrustScoring>>>>,
     config: EdgeConfig,
 }
 
@@ -2818,6 +2836,26 @@ impl Edge {
     /// the wire-layer gate is caught from either entry point.
     pub async fn dispatch_inbound_for_test(&self, frame: InboundFrame) {
         let directory = self.verify.directory();
+        // CIRISEdge#208 — read overrides BEFORE the await so the
+        // RwLock guards stay narrow + don't cross an await point.
+        let override_scoring = self
+            .trust_scoring_override
+            .read()
+            .expect("trust_scoring_override poisoned")
+            .clone();
+        let override_threshold = *self
+            .trust_threshold_override
+            .read()
+            .expect("trust_threshold_override poisoned");
+        let trust_scoring_arc = override_scoring.clone();
+        let trust_scoring_ref = trust_scoring_arc.as_ref().or(self.trust_scoring.as_ref());
+        let trust_threshold = override_threshold.unwrap_or(self.config.trust_threshold);
+        // When an override is set, force the short-circuit ON; the
+        // conformance harness is opting INTO gating for the duration of
+        // its test (the bootstrap-permissive operator default is
+        // structurally bypassed).
+        let trust_short_circuit_enabled =
+            override_threshold.is_some() || self.config.trust_short_circuit_enabled;
         dispatch_inbound(
             frame,
             &self.verify,
@@ -2836,9 +2874,9 @@ impl Edge {
             &self.events,
             self.federation_directory.as_ref(),
             self.config.cohort_scope_enforcement,
-            self.trust_scoring.as_ref(),
-            self.config.trust_threshold,
-            self.config.trust_short_circuit_enabled,
+            trust_scoring_ref,
+            trust_threshold,
+            trust_short_circuit_enabled,
             self.config.trust_recursion_depth,
             self.config.agent_mode,
             self.config.l1_cdn_edge_enabled,
@@ -2850,6 +2888,78 @@ impl Edge {
             self.swarm_runtime.get(),
         )
         .await;
+    }
+
+    /// CIRISEdge#208 — install a runtime override for the
+    /// `dispatch_inbound` trust threshold. Used by the PyO3 surface
+    /// `PyEdge::set_trust_threshold` to drive the conformance harness's
+    /// intake-gate test. Setting forces
+    /// `trust_short_circuit_enabled = true` at the
+    /// [`Self::dispatch_inbound_for_test`] call site so the override
+    /// actually gates a single envelope (config defaults are
+    /// bootstrap-permissive). `None` clears the override.
+    pub fn set_trust_threshold_override(&self, threshold: Option<f64>) {
+        *self
+            .trust_threshold_override
+            .write()
+            .expect("trust_threshold_override poisoned") = threshold;
+    }
+
+    /// CIRISEdge#208 — install a runtime override for the
+    /// `TrustScoring` resolver consulted by the `dispatch_inbound` trust
+    /// short-circuit. Used by the PyO3 surface
+    /// `PyEdge::install_trust_resolver` to wire a Python callback as
+    /// the scorer. `None` clears the override.
+    pub fn install_trust_scoring_override(
+        &self,
+        scoring: Option<Arc<dyn ciris_persist::federation::TrustScoring>>,
+    ) {
+        *self
+            .trust_scoring_override
+            .write()
+            .expect("trust_scoring_override poisoned") = scoring;
+    }
+
+    /// CIRISEdge#208 — counterpart to
+    /// [`Self::dispatch_inbound_for_test`] that returns a stable
+    /// wire-string outcome derived from metrics deltas around the
+    /// dispatch. The conformance harness's `test_200` intake-gate test
+    /// drives this through `PyEdge::dispatch_inbound_bytes` to verify
+    /// the trust short-circuit refusal arm executes.
+    ///
+    /// Outcomes:
+    /// - `"trust_short_circuited"` — `inbound_dropped_low_trust`
+    ///   counter incremented (the #48-B arm fired).
+    /// - `"received"` — `envelopes_received_total[mt]` incremented for
+    ///   any `MessageType` (verify passed AND the envelope reached
+    ///   handler dispatch).
+    /// - `"verify_failed"` — neither counter moved; the envelope was
+    ///   dropped at the verify pipeline (signature failure, replay,
+    ///   misroute, body-too-large, schema-invalid). The harness can
+    ///   inspect tracing / metrics in detail if a finer split is
+    ///   needed.
+    pub async fn dispatch_inbound_observed_outcome_for_test(
+        &self,
+        frame: InboundFrame,
+    ) -> &'static str {
+        let before_low_trust = self.metrics.inbound_dropped_low_trust();
+        let before_received_total: u64 = {
+            let guard = self.metrics.envelopes_received_total.read();
+            guard.values().sum()
+        };
+        self.dispatch_inbound_for_test(frame).await;
+        let after_low_trust = self.metrics.inbound_dropped_low_trust();
+        let after_received_total: u64 = {
+            let guard = self.metrics.envelopes_received_total.read();
+            guard.values().sum()
+        };
+        if after_low_trust > before_low_trust {
+            "trust_short_circuited"
+        } else if after_received_total > before_received_total {
+            "received"
+        } else {
+            "verify_failed"
+        }
     }
 
     /// Rust-level accessor returning a clone of the outbound queue
@@ -5106,6 +5216,8 @@ impl EdgeBuilder {
             detector,
             canonical_peers,
             trust_scoring: self.trust_scoring,
+            trust_threshold_override: Arc::new(std::sync::RwLock::new(None)),
+            trust_scoring_override: Arc::new(std::sync::RwLock::new(None)),
             metrics: crate::observability::EdgeMetrics::new(),
             config: self.config,
         })

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -717,6 +717,142 @@ impl PyEdge {
         self.inner.signer_key_id().to_string()
     }
 
+    /// CIRISEdge#208 — install a runtime override for the
+    /// `dispatch_inbound` trust short-circuit threshold. Conformance
+    /// harness contract: setting forces the short-circuit ON for the
+    /// duration of the override (the operator's bootstrap-permissive
+    /// default of `trust_threshold = 0.0` is structurally bypassed). The
+    /// effective gate becomes:
+    ///
+    /// ```text
+    /// trust_score(signing_key_id, recursion_depth) < threshold
+    ///   ⇒ envelope dropped, "trust_short_circuited" event emitted
+    /// ```
+    ///
+    /// Pair with [`Self::install_trust_resolver`] so the threshold has a
+    /// scorer to consult. Pass a negative value to clear the override.
+    ///
+    /// Threshold must be finite (not NaN / not infinity) — `ValueError`
+    /// otherwise.
+    #[pyo3(signature = (threshold))]
+    fn set_trust_threshold(&self, threshold: f64) -> PyResult<()> {
+        if !threshold.is_finite() {
+            return Err(PyValueError::new_err(format!(
+                "trust_threshold must be a finite f64; got {threshold}"
+            )));
+        }
+        if threshold < 0.0 {
+            self.inner.set_trust_threshold_override(None);
+        } else {
+            self.inner.set_trust_threshold_override(Some(threshold));
+        }
+        Ok(())
+    }
+
+    /// CIRISEdge#208 — install a Python callback as the runtime
+    /// `TrustScoring` resolver consulted by the `dispatch_inbound` trust
+    /// short-circuit. The callback's signature is
+    /// `(signing_key_id: str, recursion_depth: int) -> float`; the
+    /// returned float is treated as a score in `[0.0, 1.0]` (out-of-range
+    /// values are clamped). A callback raising (or returning a non-numeric)
+    /// is treated as a `0.0` score, matching persist's `AdmissionGate`
+    /// unknown-key discipline.
+    ///
+    /// Pair with [`Self::set_trust_threshold`] to drive the conformance
+    /// intake-gate test.
+    ///
+    /// Pass `None` to clear the override (the builder-wired
+    /// `Arc<dyn TrustScoring>`, if any, is consulted instead).
+    #[pyo3(signature = (callback))]
+    fn install_trust_resolver(&self, callback: Option<Py<PyAny>>) -> PyResult<()> {
+        match callback {
+            None => {
+                self.inner.install_trust_scoring_override(None);
+                Ok(())
+            }
+            Some(cb) => {
+                Python::attach(|py| {
+                    if !cb.bind(py).is_callable() {
+                        return Err(PyTypeError::new_err(
+                            "install_trust_resolver: callback must be a Python callable",
+                        ));
+                    }
+                    Ok(())
+                })?;
+                let scoring: Arc<dyn ciris_persist::federation::TrustScoring> =
+                    Arc::new(PyTrustScoringAdapter { callback: cb });
+                self.inner.install_trust_scoring_override(Some(scoring));
+                Ok(())
+            }
+        }
+    }
+
+    /// CIRISEdge#208 — drive `envelope_bytes` through the
+    /// `dispatch_inbound` pipeline on the persist runtime, returning the
+    /// observed wire-string outcome.
+    ///
+    /// Mirrors the byte-shape `Edge::run` carries on the listener loop;
+    /// the harness builds an envelope, signs it via persist's
+    /// `Engine::sign_outbound_envelope` (or equivalent), then drives the
+    /// bytes through this surface to verify the
+    /// [`Self::set_trust_threshold`] + [`Self::install_trust_resolver`]
+    /// gates execute the refusal arm.
+    ///
+    /// Return shape:
+    ///
+    /// ```python
+    /// {
+    ///     "outcome": "trust_short_circuited" | "received" | "verify_failed",
+    /// }
+    /// ```
+    ///
+    /// `transport_id` defaults to `"http"` and accepts any of the
+    /// stable `TransportId` strings (`"http"`, `"reticulum-rs"`,
+    /// `"leviculum"`, `"lora"`, `"serial"`, `"i2p"`). Unknown values
+    /// fall through as the supplied string verbatim — the trust gate
+    /// doesn't consult `transport`; it's stamped on the verified
+    /// envelope for forensic logging.
+    #[pyo3(signature = (envelope_bytes, transport_id = "http"))]
+    fn dispatch_inbound_bytes(
+        &self,
+        py: Python<'_>,
+        envelope_bytes: &[u8],
+        transport_id: &str,
+    ) -> PyResult<Py<PyAny>> {
+        let bytes = envelope_bytes.to_vec();
+        let inner = self.inner.clone();
+        // Map known wire-strings to `&'static str`; unknown strings
+        // collapse to the supplied default ("http") so the harness
+        // doesn't accidentally trip a leak.
+        let tid: crate::transport::TransportId = match transport_id {
+            "reticulum-rs" => crate::transport::TransportId::RETICULUM_RS,
+            "leviculum" => crate::transport::TransportId::LEVICULUM,
+            "lora" => crate::transport::TransportId::LORA,
+            "serial" => crate::transport::TransportId::SERIAL,
+            "i2p" => crate::transport::TransportId::I2P,
+            // "http" or any unknown — collapses to HTTP per the docstring.
+            _ => crate::transport::TransportId::HTTP,
+        };
+        let outcome: &'static str = py.detach(|| {
+            run_async(&self.executor, async move {
+                let frame = crate::transport::InboundFrame {
+                    envelope_bytes: bytes,
+                    transport: tid,
+                    received_at: chrono::Utc::now(),
+                    source_key_id: None,
+                };
+                inner
+                    .dispatch_inbound_observed_outcome_for_test(frame)
+                    .await
+            })
+        });
+        Python::attach(|py| {
+            let dict = pyo3::types::PyDict::new(py);
+            dict.set_item("outcome", outcome)?;
+            Ok(dict.into_any().unbind())
+        })
+    }
+
     /// v2.4.0 (CIRISEdge#95) — fetch a remote peer's hybrid KEM
     /// pubkeys (x25519 + ML-KEM-768) from persist's federation
     /// directory for `FederationSession::initiate` consumers
@@ -2245,6 +2381,64 @@ fn hex_encode_32(bytes: &[u8; 32]) -> String {
 /// `SubscriptionHandle::unsubscribe()` → `Edge::unregister_inline_text_subscriber`
 /// drops the registry entry's sender → this `recv()` returns `None` →
 /// drainer thread exits cleanly.
+/// CIRISEdge#208 — `Arc<dyn TrustScoring>` adapter wrapping a Python
+/// callback. Installed via [`PyEdge::install_trust_resolver`]; consulted
+/// by [`Edge::dispatch_inbound_for_test`]'s trust short-circuit when a
+/// runtime override is in place.
+///
+/// The callback runs synchronously inside the persist runtime's blocking
+/// pool via `tokio::task::block_in_place`; this is correct for the
+/// `tokio::runtime::Handle::block_on` driver `dispatch_inbound_bytes`
+/// uses (multi-threaded runtime). A callback raising or returning a
+/// non-numeric is treated as a `0.0` score (matches persist's
+/// `AdmissionGate` unknown-key discipline).
+struct PyTrustScoringAdapter {
+    callback: Py<PyAny>,
+}
+
+#[async_trait::async_trait]
+impl ciris_persist::federation::TrustScoring for PyTrustScoringAdapter {
+    async fn trust_score(
+        &self,
+        key_id: &str,
+        recursion_depth: u8,
+    ) -> Result<f64, ciris_persist::federation::TrustScoringError> {
+        let key_id_owned = key_id.to_owned();
+        // `block_in_place` keeps the dispatch_inbound future on its
+        // current worker but moves the GIL-attach into a blocking context.
+        // The persist runtime is multi-threaded by construction, which is
+        // what block_in_place requires.
+        let score = tokio::task::block_in_place(|| {
+            Python::attach(|py| {
+                let depth_i32: i32 = recursion_depth.into();
+                let bound = self.callback.bind(py);
+                match bound.call1((key_id_owned.as_str(), depth_i32)) {
+                    Ok(value) => match value.extract::<f64>() {
+                        Ok(f) if f.is_finite() => f.clamp(0.0, 1.0),
+                        Ok(_) | Err(_) => {
+                            tracing::warn!(
+                                sender_key_id = %key_id_owned,
+                                "trust_resolver callback returned non-finite / non-numeric; \
+                                 treating as 0.0",
+                            );
+                            0.0
+                        }
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            sender_key_id = %key_id_owned,
+                            error = %e,
+                            "trust_resolver callback raised; treating as 0.0",
+                        );
+                        0.0
+                    }
+                }
+            })
+        });
+        Ok(score)
+    }
+}
+
 #[allow(clippy::needless_pass_by_value)] // callback is consumed by drop at function exit
 fn drain_inline_text(
     mut rx: tokio::sync::mpsc::UnboundedReceiver<(String, String)>,

--- a/tests/trust_short_circuit.rs
+++ b/tests/trust_short_circuit.rs
@@ -464,3 +464,122 @@ async fn typed_error_variant_carries_score_threshold() {
         "issue tag rides on the Display: {msg}"
     );
 }
+
+// ─── CIRISEdge#208 — runtime override surface ──────────────────────
+
+/// `set_trust_threshold_override(Some(t))` flips the trust short-circuit
+/// ON for the duration of the override AND raises the effective threshold
+/// even when `EdgeConfig::trust_threshold = 0.0` (the bootstrap-permissive
+/// default). The conformance harness drives the intake-gate test through
+/// this codepath via `PyEdge::set_trust_threshold`.
+#[tokio::test]
+async fn override_threshold_drops_envelope_under_zero_default_threshold() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Build with config threshold = 0.0 (bootstrap-permissive default);
+    // sender scored at 0.2. Production posture: the envelope is admitted.
+    let (edge, remote_signer, local_key_id) =
+        build_edge(&tmp, 0.0, true, &[("remote-peer", 0.2)]).await;
+    let m_before = edge.metrics().inbound_dropped_low_trust();
+
+    // Install a 0.5 override — now the envelope must drop because the
+    // override forces `trust_short_circuit_enabled = true` AND
+    // `effective_threshold = 0.5 > 0.2 (sender's score)`.
+    edge.set_trust_threshold_override(Some(0.5));
+
+    let outcome = build_outcome(&edge, &remote_signer, &local_key_id).await;
+    assert_eq!(
+        outcome, "trust_short_circuited",
+        "override threshold 0.5 must short-circuit a sender scored 0.2"
+    );
+    assert_eq!(
+        edge.metrics().inbound_dropped_low_trust(),
+        m_before + 1,
+        "override threshold drop must increment the metrics counter"
+    );
+
+    // Clearing the override restores the bootstrap-permissive posture.
+    edge.set_trust_threshold_override(None);
+    let after = build_outcome(&edge, &remote_signer, &local_key_id).await;
+    assert_eq!(
+        after, "received",
+        "clearing the override returns to config.trust_threshold = 0.0 (admit-all)"
+    );
+}
+
+/// `install_trust_scoring_override(Some(scorer))` overrides the builder-
+/// wired scorer for the duration of the override. Pairs with
+/// `set_trust_threshold_override` so the harness can drive a Python
+/// callback as the scorer without re-building the Edge.
+#[tokio::test]
+async fn override_scorer_supersedes_builder_wired_scorer() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Builder wires a scorer that VOUCHES for the remote at 0.9.
+    let (edge, remote_signer, local_key_id) =
+        build_edge(&tmp, 0.5, true, &[("remote-peer", 0.9)]).await;
+    let m_before = edge.metrics().inbound_dropped_low_trust();
+
+    // Override with a scorer that DENIES the remote (0.1).
+    let mut overriding = MemoryTrustScoring::new();
+    overriding.set_score("remote-peer", 0.1);
+    let overriding_arc: Arc<dyn TrustScoring> = Arc::new(overriding);
+    edge.install_trust_scoring_override(Some(overriding_arc));
+
+    let outcome = build_outcome(&edge, &remote_signer, &local_key_id).await;
+    assert_eq!(
+        outcome, "trust_short_circuited",
+        "the override scorer (0.1) must supersede the builder-wired scorer (0.9)"
+    );
+    assert_eq!(
+        edge.metrics().inbound_dropped_low_trust(),
+        m_before + 1,
+        "override scorer drop must increment the metrics counter"
+    );
+
+    // Clearing the override returns to the builder-wired scorer (0.9 ≥ 0.5).
+    edge.install_trust_scoring_override(None);
+    let after = build_outcome(&edge, &remote_signer, &local_key_id).await;
+    assert_eq!(
+        after, "received",
+        "clearing the scorer override returns to the builder-wired scorer"
+    );
+}
+
+/// `dispatch_inbound_observed_outcome_for_test` returns "verify_failed"
+/// when the envelope is dropped at the verify pipeline (signature
+/// failure, misroute, replay, body-too-large) — the third arm of the
+/// wire-string outcome triple.
+#[tokio::test]
+async fn observed_outcome_returns_verify_failed_for_misrouted_envelope() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let (edge, remote_signer, _local_key_id) =
+        build_edge(&tmp, 0.0, true, &[("remote-peer", 0.5)]).await;
+
+    // Misroute: address an envelope to a key_id that ISN'T the local
+    // signer's. The verify pipeline rejects at AV-8 (Misrouted).
+    let outcome = build_outcome(&edge, &remote_signer, "not-the-local-key").await;
+    assert_eq!(
+        outcome, "verify_failed",
+        "misrouted envelope must surface as verify_failed (neither trust drop nor handler dispatch)"
+    );
+}
+
+/// Helper: build + sign an envelope, drive through the observed-outcome
+/// dispatcher, return the wire-string outcome.
+async fn build_outcome(edge: &Edge, sender: &LocalSigner, destination: &str) -> &'static str {
+    let body = InlineText {
+        text: "208-override-test".to_string(),
+    };
+    let mut env = build_envelope(InlineText::TYPE, &sender.key_id, destination, &body, None)
+        .expect("build envelope");
+    sign_envelope(sender, &mut env)
+        .await
+        .expect("sign envelope");
+    let bytes = serde_json::to_vec(&env).expect("serialize envelope");
+    let frame = InboundFrame {
+        envelope_bytes: bytes,
+        transport: TransportId::HTTP,
+        received_at: Utc::now(),
+        source_key_id: None,
+    };
+    edge.dispatch_inbound_observed_outcome_for_test(frame).await
+}


### PR DESCRIPTION
## Summary

Closes #208. CIRISEdge#48 shipped the Rust-side `dispatch_inbound` trust short-circuit (v0.19.6) but the PyO3 surface that lets a Python caller drive a verified envelope through it was never exposed — blocking the CIRISConformance `test_200_fabric_eviction.py::test_intake_gate_refuses_below_threshold` xfail. This PR wires the missing FFI.

### Edge runtime overrides

Two `Arc<RwLock<Option<...>>>` slots on `Edge`:
- `trust_threshold_override` — overrides `EdgeConfig::trust_threshold` AND forces `trust_short_circuit_enabled = true`.
- `trust_scoring_override` — overrides the builder-wired `Arc<dyn TrustScoring>`.

Production `Edge::run` ignores them; only `dispatch_inbound_for_test` consults them.

### Wire-string outcome helper

`Edge::dispatch_inbound_observed_outcome_for_test` returns `"trust_short_circuited"` / `"received"` / `"verify_failed"` via metrics deltas.

### PyO3 surface (PyEdge methods)

- `set_trust_threshold(threshold: float) -> None`
- `install_trust_resolver(callback: Optional[Callable[[str, int], float]]) -> None`
- `dispatch_inbound_bytes(envelope_bytes: bytes, transport_id: str = "http") -> dict`

`PyTrustScoringAdapter` wraps the Python callback as `Arc<dyn TrustScoring>` via `tokio::task::block_in_place` + `Python::attach`. Raised exceptions / non-numeric returns collapse to `0.0` (matches persist's `AdmissionGate` unknown-key discipline).

## Test plan

- [x] 3 new regression tests in `tests/trust_short_circuit.rs` cover the override-threshold, override-scorer, and verify_failed-arm paths
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --test trust_short_circuit` — 12/12
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI matrix green
- [ ] (Future) CIRISConformance bumps to the v7.0.8 wheel + removes the `test_200` xfail mark

## Notes

Substrate floor unchanged from v7.0.7: CIRISVerify v7.4.0, CIRISPersist v10.1.2, Leviculum v0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln