### PR TITLE
release(v7.0.9): build_signed_inbound_envelope companion (closes #211)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.8"
+version = "7.0.9"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -853,6 +853,122 @@ impl PyEdge {
         })
     }
 
+    /// CIRISEdge#211 — build + sign an `EdgeEnvelope` from Python so the
+    /// conformance harness can mint the byte-shape
+    /// [`Self::dispatch_inbound_bytes`] expects without reverse-engineering
+    /// the wire format. Direct counterpart to the Rust-side
+    /// `tests/trust_short_circuit.rs::build_outcome` helper — same
+    /// `build_envelope` + `sign_envelope` codepath, just exposed.
+    ///
+    /// `seed_bytes` is the 32-byte raw Ed25519 seed for the
+    /// `signing_key_id`. The harness pre-generates this, registers the
+    /// derived pubkey under `signing_key_id` in persist's
+    /// `federation_keys` directory (via `Engine::put_public_key`), and
+    /// passes the same seed bytes here so the envelope's signature
+    /// verifies against the registered row.
+    ///
+    /// `body_json` is the JSON serialization of the message-type's body
+    /// (e.g. `'{"text":"hello"}'` for `"inline_text"`). The harness can
+    /// build the body from a Python dict via `json.dumps(...)`.
+    ///
+    /// `message_type` is the wire-string `MessageType` (snake_case;
+    /// e.g. `"inline_text"`, `"accord_events_batch"`,
+    /// `"contribution_submit"`).
+    ///
+    /// Returns the byte-exact `EdgeEnvelope` JSON ready to feed into
+    /// [`Self::dispatch_inbound_bytes`]. The classical signature is
+    /// always Ed25519 over the persist-canonicalized envelope; PQC
+    /// (ML-DSA-65) is OMITTED at this surface — software-only signers
+    /// don't carry a PQC half, and the conformance intake-gate test runs
+    /// under the verify pipeline's `Ed25519Fallback` policy where the
+    /// PQC field is optional.
+    #[pyo3(signature = (signing_key_id, seed_bytes, destination_key_id, message_type, body_json))]
+    fn build_signed_inbound_envelope(
+        &self,
+        py: Python<'_>,
+        signing_key_id: &str,
+        seed_bytes: &[u8],
+        destination_key_id: &str,
+        message_type: &str,
+        body_json: &str,
+    ) -> PyResult<Py<pyo3::types::PyBytes>> {
+        if seed_bytes.len() != 32 {
+            return Err(PyValueError::new_err(format!(
+                "build_signed_inbound_envelope: seed_bytes must be 32 bytes (Ed25519); got {}",
+                seed_bytes.len()
+            )));
+        }
+        let mt: crate::messages::MessageType = serde_json::from_value(serde_json::Value::String(
+            message_type.to_string(),
+        ))
+        .map_err(|e| {
+            PyValueError::new_err(format!(
+                "build_signed_inbound_envelope: message_type {message_type:?} is not a known \
+                 wire-string variant: {e}"
+            ))
+        })?;
+        let body_value: serde_json::Value = serde_json::from_str(body_json).map_err(|e| {
+            PyValueError::new_err(format!(
+                "build_signed_inbound_envelope: body_json failed to parse: {e}"
+            ))
+        })?;
+        let signing_key_id = signing_key_id.to_owned();
+        let destination_key_id = destination_key_id.to_owned();
+        let seed_owned: [u8; 32] = seed_bytes.try_into().map_err(|_| {
+            PyValueError::new_err("build_signed_inbound_envelope: seed_bytes must be 32 bytes")
+        })?;
+        let envelope_bytes: Vec<u8> = py.detach(|| {
+            run_async(&self.executor, async move {
+                // Build a fresh software signer from the seed. The seed
+                // is the wire-shape Ed25519 32-byte secret; the
+                // `Ed25519SoftwareSigner::import_key` path is the same
+                // one the persist OS-keyring fallback uses + matches the
+                // `tests/trust_short_circuit.rs::FedKey::local_signer`
+                // pattern byte-for-byte.
+                let mut sw = ciris_keyring::Ed25519SoftwareSigner::new(&signing_key_id);
+                sw.import_key(&seed_owned).map_err(|e| {
+                    PyValueError::new_err(format!(
+                        "build_signed_inbound_envelope: import_key failed: {e}"
+                    ))
+                })?;
+                let signer = crate::identity::LocalSigner::new(
+                    signing_key_id.clone(),
+                    Arc::new(sw) as Arc<dyn ciris_keyring::HardwareSigner>,
+                    None,
+                );
+
+                let mut env = crate::identity::build_envelope(
+                    mt,
+                    &signing_key_id,
+                    &destination_key_id,
+                    &body_value,
+                    None,
+                )
+                .map_err(|e| {
+                    PyValueError::new_err(format!(
+                        "build_signed_inbound_envelope: build_envelope failed: {e}"
+                    ))
+                })?;
+                crate::identity::sign_envelope(&signer, &mut env)
+                    .await
+                    .map_err(|e| {
+                        PyRuntimeError::new_err(format!(
+                            "build_signed_inbound_envelope: sign_envelope failed: {e}"
+                        ))
+                    })?;
+                serde_json::to_vec(&env).map_err(|e| {
+                    PyRuntimeError::new_err(format!(
+                        "build_signed_inbound_envelope: serialize failed: {e}"
+                    ))
+                })
+            })
+        })?;
+        Python::attach(|py| {
+            let bytes = pyo3::types::PyBytes::new(py, &envelope_bytes);
+            Ok(bytes.unbind())
+        })
+    }
+
     /// v2.4.0 (CIRISEdge#95) — fetch a remote peer's hybrid KEM
     /// pubkeys (x25519 + ML-KEM-768) from persist's federation
     /// directory for `FederationSession::initiate` consumers

--- a/tests/trust_short_circuit.rs
+++ b/tests/trust_short_circuit.rs
@@ -563,6 +563,77 @@ async fn observed_outcome_returns_verify_failed_for_misrouted_envelope() {
     );
 }
 
+/// CIRISEdge#211 — the conformance harness mints senders from raw seed
+/// bytes via `Ed25519SoftwareSigner::import_key` (the same path
+/// `PyEdge::build_signed_inbound_envelope` takes). This test mirrors the
+/// Python flow EXACTLY using `Ed25519SoftwareSigner`, not the
+/// `Ed25519Signer::from_seed` path the other tests use, and verifies the
+/// trust gate fires through the same codepath the harness's
+/// `dispatch_inbound_bytes` will hit.
+#[tokio::test]
+async fn build_signed_envelope_from_software_signer_drives_trust_gate() {
+    use ciris_keyring::Ed25519SoftwareSigner;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Builder wires `remote-peer` at 0.2 (below threshold 0.5). The seed
+    // here is the same one persist's `FedKey::new("remote-peer", 0xAA)`
+    // uses (0xAA repeating × 32) so the pubkey registered in
+    // `federation_keys` matches the pubkey the software signer derives
+    // from this seed.
+    let (edge, _ignore_remote_signer, local_key_id) =
+        build_edge(&tmp, 0.5, true, &[("remote-peer", 0.2)]).await;
+
+    // Re-build the sender via the software-signer path (the harness's
+    // path), not the `FedKey::local_signer` path.
+    let seed = [0xAAu8; 32];
+    let mut sw = Ed25519SoftwareSigner::new("remote-peer");
+    sw.import_key(&seed).expect("import seed");
+    let signer = LocalSigner::new(
+        "remote-peer".to_string(),
+        Arc::new(sw) as Arc<dyn ciris_keyring::HardwareSigner>,
+        None,
+    );
+
+    // Build → sign → serialize: byte-for-byte what
+    // `PyEdge::build_signed_inbound_envelope` produces.
+    let body = InlineText {
+        text: "211-software-signer-test".to_string(),
+    };
+    let mut env = build_envelope(InlineText::TYPE, &signer.key_id, &local_key_id, &body, None)
+        .expect("build envelope");
+    sign_envelope(&signer, &mut env)
+        .await
+        .expect("sign envelope");
+    let bytes = serde_json::to_vec(&env).expect("serialize envelope");
+
+    // Drive through `dispatch_inbound_bytes`'s underlying helper.
+    let m_before = edge.metrics().inbound_dropped_low_trust();
+    let frame = InboundFrame {
+        envelope_bytes: bytes,
+        transport: TransportId::HTTP,
+        received_at: Utc::now(),
+        source_key_id: None,
+    };
+    let outcome = edge.dispatch_inbound_observed_outcome_for_test(frame).await;
+
+    // The trust gate must fire: the harness's hand-rolled envelope (in
+    // Python) couldn't pass verify in #211's repro; THIS path proves the
+    // software-signer build pipeline DOES pass verify and reach the
+    // trust short-circuit. If this test ever regresses to
+    // "verify_failed", `build_signed_inbound_envelope` is broken at the
+    // canonicalization layer.
+    assert_eq!(
+        outcome, "trust_short_circuited",
+        "software-signer envelope must pass verify + trip the trust gate \
+         (sender 0.2 < threshold 0.5)"
+    );
+    assert_eq!(
+        edge.metrics().inbound_dropped_low_trust(),
+        m_before + 1,
+        "low-trust drop counter must increment"
+    );
+}
+
 /// Helper: build + sign an envelope, drive through the observed-outcome
 /// dispatcher, return the wire-string outcome.
 async fn build_outcome(edge: &Edge, sender: &LocalSigner, destination: &str) -> &'static str {


### PR DESCRIPTION
## Summary

Closes #211. CIRISEdge#208 (v7.0.8) shipped `dispatch_inbound_bytes` so the CIRISConformance harness can drive the trust gate from Python — but there was no Python-side way to **mint** a valid signed envelope to feed it. Hand-rolled JSON envelopes failed the verify pipeline despite passing direct `persist.verify_hybrid_via_directory`, because the pipeline's deserialize→`to_value` round-trip canonicalizes slightly differently.

This adds `PyEdge::build_signed_inbound_envelope`:

```python
envelope_bytes = edge.build_signed_inbound_envelope(
    signing_key_id="remote-peer",
    seed_bytes=os.urandom(32),
    destination_key_id=edge.signer_key_id(),
    message_type="inline_text",
    body_json='{"text": "hello"}',
)
result = edge.dispatch_inbound_bytes(envelope_bytes)
```

Internally builds `Ed25519SoftwareSigner` from the seed (`import_key`), wraps as `LocalSigner`, calls `build_envelope` + `sign_envelope` — the exact codepath the trust_short_circuit test fixture uses. ML-DSA-65 (PQC) is omitted — software signers don't carry a PQC half and the conformance intake-gate test runs under `Ed25519Fallback`.

## Test plan

- [x] New regression test `build_signed_envelope_from_software_signer_drives_trust_gate` mirrors the Python harness flow byte-for-byte; asserts `"trust_short_circuited"` outcome
- [x] `cargo test --test trust_short_circuit` — 13/13
- [x] `cargo test --lib` — 615/615
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] CI matrix green

Substrate floor unchanged: CIRISVerify v7.4.0, CIRISPersist v10.1.2, Leviculum v0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln