### PR TITLE
release(v7.0.11): persist v10.2.1 + prime_peer/knows_peer PyO3 (closes #214)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.10"
+version = "7.0.11"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.0", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.1", version = "10", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1043,7 +1043,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.1", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -705,6 +705,138 @@ impl PyEdge {
         }
     }
 
+    /// CIRISEdge#214 — root a peer's `(dest_hash, transport-tier
+    /// ed25519)` binding into this node's local resolver, bypassing the
+    /// announce mechanism. v7.0.0 explicit-hash destinations cannot
+    /// announce by design (Leviculum guard:
+    /// `AnnounceError::ExplicitHashCannotAnnounce`), so cold-pair
+    /// discovery is **out-of-band** — peers learn each other's
+    /// `(dest_hash, ed25519)` through the directory cache or this
+    /// stable surface.
+    ///
+    /// After this call, [`Self::knows_peer`] returns `True` and
+    /// `send_inline_text(destination_key_id, ...)` resolves to the
+    /// rooted destination.
+    ///
+    /// Mirrors the Rust-internal `ReticulumTransport::inject_rooted_peer_for_test`
+    /// that `tests/reticulum_loopback.rs::prime_v7_peer_pair` calls —
+    /// promoted to a stable (non-`_for_test`) surface so the
+    /// CIRISConformance harness can drive the v7.0.0 explicit-hash
+    /// discovery cold-start from Python.
+    ///
+    /// Args:
+    /// - `destination_key_id` — peer's federation key_id (the
+    ///   `signing_key_id` peers will see on inbound envelopes).
+    /// - `reticulum_dest_hash_hex` — 16-byte RNS destination hash as
+    ///   a 32-char lowercase hex string (the peer's
+    ///   `reticulum_dest_hash_hex()` return).
+    /// - `transport_ed25519_pubkey_b64` — peer's transport-tier 32-byte
+    ///   Ed25519 verifying key, base64-standard encoded (the
+    ///   `ed25519_pub_base64` half of `transport_identity_pubkeys()`).
+    ///
+    /// Raises:
+    /// - `ValueError` if either hex / base64 is malformed or wrong length.
+    /// - `RuntimeError` if this edge has no Reticulum transport
+    ///   (`disable_reticulum=True`, or wheel built without
+    ///   `_reticulum-module`).
+    #[pyo3(signature = (destination_key_id, reticulum_dest_hash_hex, transport_ed25519_pubkey_b64))]
+    fn prime_peer(
+        &self,
+        py: Python<'_>,
+        destination_key_id: &str,
+        reticulum_dest_hash_hex: &str,
+        transport_ed25519_pubkey_b64: &str,
+    ) -> PyResult<()> {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            use base64::Engine as _;
+            let dest_hash_vec = hex::decode(reticulum_dest_hash_hex).map_err(|e| {
+                PyValueError::new_err(format!(
+                    "prime_peer: reticulum_dest_hash_hex must be lowercase hex; got {reticulum_dest_hash_hex:?}: {e}"
+                ))
+            })?;
+            let dest_hash: [u8; 16] = dest_hash_vec.as_slice().try_into().map_err(|_| {
+                PyValueError::new_err(format!(
+                    "prime_peer: reticulum_dest_hash_hex must decode to 16 bytes; got {} bytes",
+                    dest_hash_vec.len()
+                ))
+            })?;
+            let ed25519_vec = base64::engine::general_purpose::STANDARD
+                .decode(transport_ed25519_pubkey_b64)
+                .map_err(|e| {
+                    PyValueError::new_err(format!(
+                        "prime_peer: transport_ed25519_pubkey_b64 must be base64-standard: {e}"
+                    ))
+                })?;
+            let ed25519: [u8; 32] = ed25519_vec.as_slice().try_into().map_err(|_| {
+                PyValueError::new_err(format!(
+                    "prime_peer: transport_ed25519_pubkey_b64 must decode to 32 bytes; got {} bytes",
+                    ed25519_vec.len()
+                ))
+            })?;
+            let transport = self.inner.reticulum_transport().ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "prime_peer: edge has no Reticulum transport wired \
+                     (disable_reticulum=True, or wheel built without _reticulum-module)",
+                )
+            })?;
+            let destination_key_id = destination_key_id.to_owned();
+            py.detach(|| {
+                run_async(&self.executor, async move {
+                    transport
+                        .inject_rooted_peer_for_test(&destination_key_id, dest_hash, ed25519)
+                        .await;
+                });
+            });
+            Ok(())
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            let _ = (
+                destination_key_id,
+                reticulum_dest_hash_hex,
+                transport_ed25519_pubkey_b64,
+            );
+            let _ = py;
+            Err(PyRuntimeError::new_err(
+                "prime_peer: requires the _reticulum-module feature",
+            ))
+        }
+    }
+
+    /// CIRISEdge#214 — true iff `destination_key_id` is currently
+    /// reachable via the Reticulum transport's rooted-peer map.
+    /// Returns true after a successful [`Self::prime_peer`] OR after
+    /// the announce-rooting cold-start path has confirmed the peer
+    /// (v6.x path; v7.0.0 explicit-hash peers go through `prime_peer`).
+    ///
+    /// Conformance contract: the harness can poll this between
+    /// `prime_peer` calls to verify both directions of a cold-pair
+    /// rooting completed before invoking `send_inline_text`.
+    ///
+    /// Returns `False` for HTTPS-only or transport-less builds
+    /// (`disable_reticulum=True` / no `_reticulum-module`).
+    #[pyo3(signature = (destination_key_id))]
+    fn knows_peer(&self, py: Python<'_>, destination_key_id: &str) -> bool {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            let Some(transport) = self.inner.reticulum_transport() else {
+                return false;
+            };
+            let destination_key_id = destination_key_id.to_owned();
+            py.detach(|| {
+                run_async(&self.executor, async move {
+                    transport.knows_peer(&destination_key_id).await
+                })
+            })
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            let _ = (destination_key_id, py);
+            false
+        }
+    }
+
     /// Local agent's federation `key_id` — the identity peers seed
     /// into their `federation_keys` directory to root inbound traffic
     /// from this agent. CIRISAgent 2.9.4 displays this on the


### PR DESCRIPTION
## Summary

Two changes in one cut:

### 1. CIRISPersist v10.2.0 → v10.2.1 pin bump

V090 migration extends postgres `audit_log.action_type` CHECK to admit `consent_event` + `wisdom_based_deferral` (CIRISPersist#283; additive NOT VALID per the CIRISAgent#756 closed-vocab pattern). Unblocks the CIRISConformance `test_320` postgres arm. Edge doesn't consume audit_log — pure pin bump.

### 2. Closes #214 — `PyEdge.prime_peer` + `PyEdge.knows_peer`

CIRISConformance#4 (real 2-node loopback, `test_050`) needs a Python surface to root a peer out-of-band. v7.0.0 explicit-hash destinations cannot announce by design (Leviculum guard `ExplicitHashCannotAnnounce`), so cold-pair discovery is structurally out-of-band.

Edge's own loopback tests use `prime_v7_peer_pair` (Rust helper wrapping `ReticulumTransport::inject_rooted_peer_for_test`). This change promotes that to a non-`_for_test` PyO3 surface:

```python
edge_a.prime_peer(
    destination_key_id=edge_b.signer_key_id(),
    reticulum_dest_hash_hex=edge_b.reticulum_dest_hash_hex(),
    transport_ed25519_pubkey_b64=edge_b.transport_identity_pubkeys()["ed25519_pub_base64"],
)
assert edge_a.knows_peer(edge_b.signer_key_id())
```

Both methods are cfg-gated on `_reticulum-module`; raise typed `ValueError` on malformed hex/base64; run on the persist executor via `run_async`.

## Test plan

- [x] Rust contract covered by `tests/reticulum_loopback.rs::rooted_resolution_round_trips_envelope_byte_exact` (exercises `inject_rooted_peer_for_test` end-to-end; PyEdge wrappers are thin)
- [x] `cargo test --lib` — 615/615
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [ ] CI matrix — same expected shape as v7.0.7–v7.0.10
- [ ] CIRISConformance#4 / `test_050` real-loopback drivable on the v7.0.11 wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln