### PR TITLE
release(v7.0.12): persist v10.2.2 + verify v7.5.0 + fix #217 + CIRISCache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
   linux-x86_64-test:
     name: linux-x86_64 (${{ matrix.combo.name }})
     runs-on: ubuntu-latest
+    # v7.0.12 (CIRISEdge#216 / CIRISCache adoption) — `packages: write`
+    # is needed for the main-branch save step on the pyo3-full lane.
+    # PR/tag runs don't write; the conditional on the save step gates
+    # it. Restore is anonymous and doesn't consume any permission.
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -111,6 +118,15 @@ jobs:
         # Mirrors persist's `.github/workflows/ci.yml` after v3.5.3.
         run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
       - uses: dtolnay/rust-toolchain@stable
+      # v7.0.12 (CIRISEdge#216 / CIRISCache adoption) — restore the
+      # cross-repo L2 cache BEFORE the per-repo Swatinem L1. The key
+      # is derived from the substrate triple + matrix combo so every
+      # repo that pins the same triple shares the same cache bucket;
+      # rustc version is implicit in the cache contents (Swatinem
+      # invalidates on rustc change). Anonymous read — no token.
+      - uses: CIRISAI/CIRISCache/restore@v1
+        with:
+          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.2.2-verify7.5.0
       - uses: Swatinem/rust-cache@v2
         with:
           # Per-combo cache key so each matrix entry gets its own
@@ -135,6 +151,20 @@ jobs:
           else
             cargo test --features "${{ matrix.combo.features }}" --lib
           fi
+      # v7.0.12 (CIRISEdge#216 / CIRISCache adoption) — save the L2
+      # cache on main-branch builds of the canonical pyo3-full lane.
+      # Only ONE matrix entry saves per workflow to keep the GHCR
+      # package small + avoid mid-matrix race writes; pyo3-full is the
+      # widest feature set so its target/ subsumes the leaner lanes'
+      # contents. PR/tag runs read but don't write; the warmer is
+      # main-branch only.
+      - uses: CIRISAI/CIRISCache/save@v1
+        if: |
+          github.ref == 'refs/heads/main'
+            && matrix.combo.name == 'pyo3-full'
+        with:
+          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.2.2-verify7.5.0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   # ─── darwin-aarch64 — Phase 1 macOS dev path ────────────────────────
   # No pyo3 feature here per persist's matrix precedent — the abi3 wheel

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.11"
+version = "7.0.12"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.1", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.2", version = "10", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,12 +226,22 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.4.0", version = "7" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
 async-trait = "0.1"
 futures     = "0.3"
+# v7.0.12 (CIRISEdge#217) — runtime-agnostic Delay primitive for
+# transport hot-path timeouts. The cross-cdylib tokio aliasing class
+# (each cdylib statically links its own tokio; thread-locals don't
+# alias) makes `tokio::time::sleep` / `tokio::time::Instant::now()`
+# panic with "no reactor running" when a future driven on persist's
+# tokio runtime tries to await edge-side tokio time primitives. The
+# transport's `wait_until_async` poll helper now uses
+# `futures_timer::Delay` (runtime-agnostic) + `std::time::Instant`
+# instead, dodging the runtime-context check.
+futures-timer = "3"
 
 # Wire format / serde. RawValue is required for canonical-bytes
 # preservation per FSD §3.4 — we sign canonical bytes and verify the
@@ -1043,7 +1053,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.1", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.2", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -3562,20 +3562,29 @@ fn apply_interface_config(
 /// or `timeout` elapses. Returns whether the condition was met. Used
 /// by `send` to wait on link establishment + resource completion
 /// without owning the `NodeEvent` loop (which `listen` owns).
+///
+/// v7.0.12 (CIRISEdge#217) — uses `futures_timer::Delay` +
+/// `std::time::Instant` instead of `tokio::time::*` so the poll is
+/// runtime-agnostic. The cross-cdylib tokio aliasing class makes
+/// `tokio::time::sleep` panic with "no reactor running" when this
+/// helper is awaited on a thread whose tokio thread-locals belong to
+/// persist's runtime — the bootstrapping-node failure mode in #217.
+/// `cond()`'s own awaits (typically `tokio::sync::Mutex::lock`) don't
+/// need a Timer driver, just state-machine polling.
 async fn wait_until_async<F, Fut>(timeout: Duration, interval: Duration, mut cond: F) -> bool
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = bool>,
 {
-    let deadline = tokio::time::Instant::now() + timeout;
+    let start = std::time::Instant::now();
     loop {
         if cond().await {
             return true;
         }
-        if tokio::time::Instant::now() >= deadline {
+        if start.elapsed() >= timeout {
             return false;
         }
-        tokio::time::sleep(interval).await;
+        futures_timer::Delay::new(interval).await;
     }
 }
 


### PR DESCRIPTION
## Summary

Three changes bundled:

### 1. Substrate lockstep: persist v10.2.1→v10.2.2, verify v7.4.0→v7.5.0

Persist v10.2.2 was built against verify v7.5.0; cross-cdylib libsqlite3 cascade discipline requires the edge verify-family pin to track in lockstep. `cargo update` transitively pulled v7.5.0 into the lock; the Cargo.toml tag bump (v7.4.0 → v7.5.0 for `ciris-keyring`, `ciris-crypto`, `ciris-verify-core`) locks it in.

### 2. Closes #217 — runtime-agnostic `wait_until_async`

v7.0.11's `prime_peer` shipped #214 but the bootstrapping node aborts with an uncatchable `fatal runtime error: Rust cannot catch foreign exceptions, aborting` panic — `wait_until_async` (used by `send` to wait on link establishment + resource completion) calls `tokio::time::sleep` + `tokio::time::Instant::now()`, which need a tokio Timer driver registered in tokio's thread-local. Edge statically links its own tokio (separate from persist's); on persist's runtime worker thread, edge-side tokio sees no runtime context → panic.

Fix: replace `tokio::time::*` with `futures_timer::Delay` + `std::time::Instant`. `futures_timer` is runtime-agnostic. `cond()`'s own awaits (typically `tokio::sync::Mutex::lock`) don't need a Timer driver.

Unblocks real 2-node `send_inline_text` from Python on the bootstrapping node — the actual use case CIRISConformance#4 / `test_050` exercises.

### 3. CIRISCache adoption (#216)

`linux-x86_64-test` matrix gets a CIRISCache restore step (anonymous, no token) BEFORE the existing Swatinem L1, keyed on `ciris-edge-linux-x86_64-<combo>-persist10.2.2-verify7.5.0`. Canonical pyo3-full lane on main-branch builds runs the save step (`packages: write`); PR/tag runs read but don't write.

## Test plan

- [x] 615/615 lib tests pass
- [x] 13/13 trust_short_circuit tests pass
- [x] `reticulum_loopback` / `links_ffi` / `routing_ffi` round-trips pass through the new `futures_timer`-based `wait_until_async`
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI matrix green — first run with CIRISCache restore (cache miss expected)
- [ ] CIRISConformance harness can drive 2-node `send_inline_text` without aborting

Substrate floor: CIRISVerify v7.5.0 / CIRISPersist v10.2.2 / Leviculum v0.7.0.

Closes #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln