### PR TITLE
release(v7.0.13): adopt CIRISPersist v10.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       # invalidates on rustc change). Anonymous read — no token.
       - uses: CIRISAI/CIRISCache/restore@v1
         with:
-          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.2.2-verify7.5.0
+          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.4.0-verify7.5.0
       - uses: Swatinem/rust-cache@v2
         with:
           # Per-combo cache key so each matrix entry gets its own
@@ -163,7 +163,7 @@ jobs:
           github.ref == 'refs/heads/main'
             && matrix.combo.name == 'pyo3-full'
         with:
-          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.2.2-verify7.5.0
+          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.4.0-verify7.5.0
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ─── darwin-aarch64 — Phase 1 macOS dev path ────────────────────────

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.12"
+version = "7.0.13"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.2", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.4.0", version = "10", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1053,7 +1053,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.2.2", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.4.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## Summary

Pure substrate pin bump CIRISPersist v10.2.2 → v10.4.0. Skipping v10.3.0; both v10.3/v10.4 are additive minors edge doesn't consume.

- **v10.3.0** (CIRISPersist#288) — reserved-prefix admission on `attestation_type` (CC 3.4.1/3.4.3/3.4.5).
- **v10.4.0** (CIRISPersist#290) — `Engine.put_community_json` PyO3 binding for LensCore / SCIM-tier community provisioning.

Also bumps the CIRISCache key suffix to `persist10.4.0-verify7.5.0` so the cross-repo cache stays correctly keyed.

Substrate floor:
- `ciris-persist` v10.2.2 → v10.4.0 (both `[dependencies]` and `[dev-dependencies]`)
- `ciris-verify` family unchanged at v7.5.0
- Leviculum unchanged at v0.7.0

## Test plan

- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [ ] CI matrix green (same shape as v7.0.7–v7.0.12)

## Notes

CIRISEdge#220 (two-node delivery still times out after `prime_peer`) deferred to a focused cut — it's a substantive transport-layer investigation, not a pin-bump rider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln