### PR TITLE
release(v7.1.0): edge-owned transport runtime fixes 2-node delivery (closes #220)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.0.13"
+version = "7.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -2971,6 +2971,78 @@ impl Edge {
         self.queue.clone()
     }
 
+    /// CIRISEdge#220 — spawn the transport listen tasks + inbound
+    /// dispatch loop on the supplied tokio runtime handle, returning
+    /// the join handles so the caller can hold them for the lifetime
+    /// of the edge runtime.
+    ///
+    /// Use this from `init_edge_runtime` when the production code path
+    /// does NOT take ownership of `Edge` via [`Self::run`]: it spawns
+    /// the minimum-viable background tasks (one `transport.listen()`
+    /// per configured transport, plus the inbound `dispatch_inbound`
+    /// drain) so the receiver-side can accept inbound `LinkRequest`s
+    /// + drive verified envelopes to handlers.
+    ///
+    /// Out of scope: outbound dispatcher, blackhole pruner, sweeps.
+    /// Those are wired only by [`Self::run`] and aren't needed for the
+    /// from-Python `send_inline_text`/`send_durable_inline_text`
+    /// surfaces today — the send path itself runs synchronously on
+    /// the persist executor via `run_async`.
+    ///
+    /// **Runtime split:** the supplied `runtime` MUST be an edge-side
+    /// `tokio::runtime::Handle`. The listen task's
+    /// `tokio::time::interval` (announce ticker) requires an edge-tokio
+    /// Timer driver registered in edge-tokio's thread-locals — persist's
+    /// executor's runtime symbols don't satisfy that (CIRISEdge#217
+    /// closed the same class for `wait_until_async` via futures_timer;
+    /// the listener loop carries similar tokio-time primitives that
+    /// can't be runtime-agnosticised as cheaply).
+    pub fn spawn_background_listeners(
+        self: &Arc<Self>,
+        runtime: &tokio::runtime::Handle,
+    ) -> Vec<tokio::task::JoinHandle<()>> {
+        let (inbound_tx, mut inbound_rx) = mpsc::channel::<InboundFrame>(1024);
+        let mut tasks: Vec<tokio::task::JoinHandle<()>> = Vec::new();
+
+        // One listen task per registered transport. Each `listen()`
+        // owns its transport's NodeEvent loop — accepts inbound
+        // `LinkRequest`s, drives `LinkEstablished` bookkeeping, and
+        // pushes resource-completed envelopes onto `inbound_tx` as
+        // `InboundFrame`s.
+        for transport in &self.transports {
+            let t = transport.clone();
+            let tx = inbound_tx.clone();
+            tasks.push(runtime.spawn(async move {
+                if let Err(e) = t.listen(tx).await {
+                    tracing::error!(
+                        transport = ?t.id(),
+                        error = %e,
+                        "transport listen exited",
+                    );
+                }
+            }));
+        }
+        drop(inbound_tx);
+
+        // Inbound dispatch task — drain the InboundFrame channel,
+        // hand each frame to the same `dispatch_inbound` codepath the
+        // [`Self::dispatch_inbound_for_test`] seam already drives. The
+        // dispatch consults the override slots (CIRISEdge#208) BUT
+        // those default to `None` in production so the production-path
+        // behaviour is byte-equal to what [`Self::run`]'s inline loop
+        // would have done.
+        let edge_for_dispatch = Arc::clone(self);
+        tasks.push(runtime.spawn(async move {
+            while let Some(frame) = inbound_rx.recv().await {
+                edge_for_dispatch
+                    .dispatch_inbound_observed_outcome_for_test(frame)
+                    .await;
+            }
+        }));
+
+        tasks
+    }
+
     /// CIRISEdge#175 (v6.1.0, FSD §3.2) — resolve the default
     /// `cohort_scope` for a stated audience without actually
     /// publishing. Callers preview the §3.2 default-flip rule

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -326,6 +326,31 @@ pub struct PyEdge {
     /// - this is a `for_test` constructor
     #[cfg(feature = "transport-reticulum-local")]
     shared_instance_cleanup: std::sync::Mutex<Option<SharedInstanceCleanup>>,
+    /// v7.1.0 (CIRISEdge#220) — edge-owned multi-thread tokio runtime
+    /// for the transport listen tasks + inbound dispatch loop. Separate
+    /// from persist's executor because edge-tokio time/spawn primitives
+    /// inside `transport.listen()` (e.g. `tokio::time::interval` for
+    /// the announce ticker) require an edge-tokio runtime context in
+    /// edge's statically-linked tokio thread-locals. Persist's
+    /// executor's tokio symbols don't satisfy that — same cross-cdylib
+    /// tokio aliasing class CIRISEdge#217 closed for `wait_until_async`
+    /// via `futures_timer`. Holding the `Arc<Runtime>` here keeps it
+    /// alive for PyEdge's lifetime; `Drop` of PyEdge drops the Arc,
+    /// dropping the Runtime, killing the spawned listen + dispatch
+    /// tasks.
+    ///
+    /// `Vec<JoinHandle<()>>` retains the spawned task handles so they
+    /// aren't immediately dropped (a dropped JoinHandle abandons the
+    /// task; tokio keeps polling it, but the abandon semantics make
+    /// shutdown reasoning fragile). Held alongside the runtime so
+    /// drop ordering is well-defined: handles drop first
+    /// (abandon-not-cancel; tokio drains the runtime queue on drop),
+    /// then the runtime drops (cancels remaining tasks).
+    ///
+    /// `None` for `for_test` builds and HTTPS-only transport
+    /// posture — there's nothing to listen on.
+    _transport_runtime: Option<Arc<tokio::runtime::Runtime>>,
+    _transport_listener_handles: std::sync::Mutex<Vec<tokio::task::JoinHandle<()>>>,
 }
 
 /// v2.4.0 (CIRISEdge#103) — best-effort cleanup if the Python caller
@@ -452,6 +477,11 @@ impl PyEdge {
             _dev_cert_tmpdir: None,
             #[cfg(feature = "transport-reticulum-local")]
             shared_instance_cleanup: std::sync::Mutex::new(None),
+            // v7.1.0 (CIRISEdge#220) — `for_test` builds don't run
+            // background listeners; tests drive `dispatch_inbound_for_test`
+            // directly when they need the inbound path.
+            _transport_runtime: None,
+            _transport_listener_handles: std::sync::Mutex::new(Vec::new()),
         }
     }
 }
@@ -5010,6 +5040,42 @@ pub fn init_edge_runtime(
     // alive at least until PyEdge drops. Cheap: one Python refcount
     // bump.
     let engine_handle = engine.clone().unbind();
+
+    // v7.1.0 (CIRISEdge#220) — spawn the transport listen tasks +
+    // inbound dispatch loop on an edge-owned tokio runtime. Without
+    // this, B's transport receives A's broadcast LINK_REQUEST but no
+    // event consumer accepts it → no LRPROOF → A's send times out.
+    // The runtime is sized to 2 worker threads — one per listen
+    // task is the worst case for the v7.0.x transport set (Reticulum
+    // + HTTPS); the dispatch loop awaits without burning a worker
+    // continuously.
+    //
+    // Skipped when `transports.is_empty()` — HTTPS-only with no
+    // transports list ends up here; same posture as the no-op test.
+    let transport_runtime: Option<Arc<tokio::runtime::Runtime>> =
+        if edge_arc.transports().is_empty() {
+            None
+        } else {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .enable_all()
+                .worker_threads(2)
+                .thread_name("ciris-edge-transport")
+                .build()
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!(
+                        "init_edge_runtime: failed to build edge-side transport runtime: {e}"
+                    ))
+                })?;
+            Some(Arc::new(rt))
+        };
+
+    let transport_handles: Vec<tokio::task::JoinHandle<()>> =
+        if let Some(rt) = transport_runtime.as_ref() {
+            edge_arc.spawn_background_listeners(rt.handle())
+        } else {
+            Vec::new()
+        };
+
     Ok(PyEdge {
         inner: edge_arc,
         executor,
@@ -5018,6 +5084,8 @@ pub fn init_edge_runtime(
         _dev_cert_tmpdir: https_dev_cert_tmpdir,
         #[cfg(feature = "transport-reticulum-local")]
         shared_instance_cleanup: std::sync::Mutex::new(shared_instance_cleanup),
+        _transport_runtime: transport_runtime,
+        _transport_listener_handles: std::sync::Mutex::new(transport_handles),
     })
 }
 

--- a/tests/reticulum_loopback.rs
+++ b/tests/reticulum_loopback.rs
@@ -228,6 +228,165 @@ async fn rooted_resolution_round_trips_envelope_byte_exact() {
     listen_b.abort();
 }
 
+/// CIRISEdge#220 — proves `Edge::spawn_background_listeners` drives
+/// the inbound dispatch loop end-to-end so a verified envelope reaches
+/// a registered inline-text handler. Mirrors the
+/// `rooted_resolution_round_trips_envelope_byte_exact` test above but
+/// instead of manually spawning `transport.listen()` per side, it
+/// uses the v7.1.0 `Edge::spawn_background_listeners` surface —
+/// the production codepath `init_edge_runtime` invokes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[allow(clippy::too_many_lines)]
+async fn spawn_background_listeners_drives_two_node_send_inline_text() {
+    use ciris_edge::verify::HybridPolicy;
+    use ciris_edge::{Edge, EdgeConfig, InlineText};
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("warn,ciris_edge=debug")
+        .try_init();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let steward = TestFedKey::new("steward-bg-listeners", 0x01);
+    let key_a = TestFedKey::new("edge-bg-aaaa", 0x2a);
+    let key_b = TestFedKey::new("edge-bg-bbbb", 0x2b);
+    let directory = directory_with(vec![
+        signed_record(&steward, &steward, "steward"),
+        signed_record(&key_a, &steward, "agent"),
+        signed_record(&key_b, &steward, "agent"),
+    ])
+    .await;
+
+    let port_a = free_port();
+    let cfg_a = {
+        let mut c =
+            ReticulumTransportConfig::new(tmp.path().join("a/transport.id"), "edge-bg-aaaa");
+        c.listen_addr = format!("127.0.0.1:{port_a}").parse().unwrap();
+        c.announce_interval = Duration::from_secs(2);
+        c
+    };
+    let cfg_b = {
+        let mut c =
+            ReticulumTransportConfig::new(tmp.path().join("b/transport.id"), "edge-bg-bbbb");
+        c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+        c.bootstrap_peers = vec![format!("127.0.0.1:{port_a}").parse().unwrap()];
+        c.announce_interval = Duration::from_secs(2);
+        c
+    };
+
+    let auth_a = auth_for(&key_a, directory.clone(), tmp.path()).await;
+    let auth_b = auth_for(&key_b, directory.clone(), tmp.path()).await;
+    let transport_a = Arc::new(
+        ReticulumTransport::new(cfg_a, auth_a)
+            .await
+            .expect("build transport A"),
+    );
+    let transport_b = Arc::new(
+        ReticulumTransport::new(cfg_b, auth_b)
+            .await
+            .expect("build transport B"),
+    );
+    prime_v7_peer_pair(&transport_a, "edge-bg-aaaa", &transport_b, "edge-bg-bbbb").await;
+
+    // Build an Edge per side — same builder shape `init_edge_runtime`
+    // produces, just with the persist directory as the queue stub.
+    let signer_a = signer_for(&key_a, tmp.path()).await;
+    let signer_b = signer_for(&key_b, tmp.path()).await;
+    let queue = directory.clone();
+
+    let edge_a = Arc::new(
+        Edge::builder()
+            .directory(directory.clone() as Arc<dyn ciris_edge::verify::VerifyDirectory>)
+            .queue(queue.clone())
+            .signer(signer_a)
+            .transport(transport_a.clone() as Arc<dyn Transport>)
+            .reticulum_transport(transport_a.clone())
+            .config(EdgeConfig {
+                hybrid_policy: HybridPolicy::Ed25519Fallback,
+                cohort_scope_enforcement: ciris_edge::CohortScopeEnforcement::Off,
+                ..EdgeConfig::default()
+            })
+            .build()
+            .expect("build edge A"),
+    );
+    let edge_b = Arc::new(
+        Edge::builder()
+            .directory(directory.clone() as Arc<dyn ciris_edge::verify::VerifyDirectory>)
+            .queue(queue.clone())
+            .signer(signer_b)
+            .transport(transport_b.clone() as Arc<dyn Transport>)
+            .reticulum_transport(transport_b.clone())
+            .config(EdgeConfig {
+                hybrid_policy: HybridPolicy::Ed25519Fallback,
+                cohort_scope_enforcement: ciris_edge::CohortScopeEnforcement::Off,
+                ..EdgeConfig::default()
+            })
+            .build()
+            .expect("build edge B"),
+    );
+
+    // Register an inline-text subscriber on A — we want the receiver
+    // to observe the verified envelope through the dispatch loop, not
+    // just the raw InboundFrame on the inbound channel.
+    let (_sub_id, mut sub_rx) = edge_a.register_inline_text_subscriber();
+
+    // ── v7.1.0 surface under test ────────────────────────────────────
+    // Per-side edge-owned runtimes; spawn the listen + inbound dispatch
+    // tasks on each. Mirrors what `init_edge_runtime` does in production.
+    let rt_a = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .thread_name("test-edge-a-transport")
+            .build()
+            .expect("build rt A"),
+    );
+    let rt_b = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(2)
+            .thread_name("test-edge-b-transport")
+            .build()
+            .expect("build rt B"),
+    );
+    let _handles_a = edge_a.spawn_background_listeners(rt_a.handle());
+    let _handles_b = edge_b.spawn_background_listeners(rt_b.handle());
+
+    // Drive the send: B → A.
+    let msg = InlineText {
+        text: "v7.1.0 bg-listeners hello".to_string(),
+    };
+    // `send_inline` returns `EdgeError::Config("ephemeral
+    // request-response correlation not wired (Phase 2)")` AS the
+    // success-of-transport path — same as `PyEdge::send_inline_text`
+    // maps it. The transport accepted + shipped the bytes; the
+    // correlation channel TODO is a separate concern. Map it to Ok
+    // so the receiver-side assertion is what gates the test.
+    match edge_b.send_inline("edge-bg-aaaa", msg).await {
+        Ok(()) => {}
+        Err(ciris_edge::EdgeError::Config(s))
+            if s.contains("ephemeral request-response correlation not wired") => {}
+        Err(e) => panic!("send_inline B → A failed at transport: {e:?}"),
+    }
+
+    // A's inline-text subscriber must receive the text — proves the
+    // background-listener path drove verify + handler dispatch all the
+    // way to the application surface.
+    let (sender_key_id, body_text) = tokio::time::timeout(Duration::from_secs(30), sub_rx.recv())
+        .await
+        .expect("timed out waiting for inline-text on A")
+        .expect("inline-text channel closed without receive");
+    assert_eq!(sender_key_id, "edge-bg-bbbb");
+    assert_eq!(body_text, "v7.1.0 bg-listeners hello");
+
+    // Tokio runtimes can't be dropped from within an async context,
+    // so leak them; the test process exit will reclaim. Holding them
+    // until function exit (after the receive assertion) is the only
+    // contract we need.
+    std::mem::forget(rt_a);
+    std::mem::forget(rt_b);
+}
+
 /// Poll `cond` until it returns `true` or `timeout` elapses.
 #[allow(dead_code)]
 async fn wait_for<F, Fut>(timeout: Duration, mut cond: F) -> bool


### PR DESCRIPTION
## Summary

Closes #220. v7.0.11 shipped `prime_peer` (#214). v7.0.12 fixed the `wait_until_async` abort (#217). v7.0.12 cleared the panic, but **PyEdge.send_inline_text from Python still timed out** because `init_edge_runtime` never spawned `transport.listen()`. B's transport receives A's broadcast `LINK_REQUEST` but no consumer accepts the event → no LRPROOF → A's send times out.

## Fix

Edge now owns its own tokio runtime for transport tasks. `init_edge_runtime`:

1. Builds an `Arc<tokio::runtime::Runtime>` (2 worker threads) — statically-linked to edge's tokio, so edge-side `tokio::time::interval` etc. find a runtime context.
2. Calls new `Edge::spawn_background_listeners(&self, &Handle) -> Vec<JoinHandle>`, which spawns one `transport.listen()` per transport + the inbound dispatch loop.
3. Stores the runtime + handles on `PyEdge` — drop kills the tasks.

Adding a vanilla `tokio::spawn(transport.listen())` directly in `init_edge_runtime` would re-trip the cross-cdylib tokio aliasing class #217 just closed: edge-side `tokio::time::interval` (announce ticker) wants edge-tokio runtime context, persist's executor's runtime doesn't satisfy that. The dedicated edge-owned runtime resolves this cleanly.

Out of scope for v7.1.0: outbound dispatcher, blackhole pruner, sweeps. Those are wired by `Edge::run` only; not needed for ephemeral `send_inline_text`.

## Test plan

- [x] New regression test `spawn_background_listeners_drives_two_node_send_inline_text` — 2 `Edge`s over loopback TCP, `Edge::spawn_background_listeners` on each, asserts B → A inline-text reaches A's subscriber within 30s. Proves the end-to-end production codepath.
- [x] `cargo test --test reticulum_loopback` — 2/2 (rooted_resolution still passes via the manual-spawn path)
- [x] `cargo test --lib` — 615/615
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI matrix green
- [ ] CIRISConformance `test_330` 2-node round-trip flips from `xfail` to green on the v7.1.0 wheel

Substrate floor unchanged: CIRISVerify v7.5.0, CIRISPersist v10.2.2, Leviculum v0.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln