### PR TITLE
release(v7.2.0): persist v10.5.0 + leviculum v0.8.1+ciris.1 + #219 PyEdge.add_rnode_channel_interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.1.0"
+version = "7.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.4.0", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.5.0", version = "10", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -534,8 +534,8 @@ tempfile       = { version = "3", optional = true }
 # currency with zero source-side changes on edge's side. `.recv().await`
 # unchanged. Future leviculum upstream releases land via the one-command
 # `scripts/ciris-sync-upstream.sh` rebase upstream-side now.
-reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.7.0", version = "0.7", optional = true }
-reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.7.0", version = "0.7", optional = true }
+reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.8.1+ciris.1", version = "0.8", optional = true }
+reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.8.1+ciris.1", version = "0.8", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in
@@ -1053,7 +1053,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.4.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.5.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1131,6 +1131,133 @@ impl PyEdge {
         })
     }
 
+    /// v7.2.0 (CIRISEdge#219) — runtime hot-plug a phone-attached LoRa
+    /// (RNode-firmware) radio over a host-driven byte channel. The
+    /// caller supplies a Python `(read_cb, write_cb)` pair that bridges
+    /// to whatever bus the host OS exposes — Android USB host
+    /// (`UsbDeviceConnection.bulkTransfer`), Android BLE
+    /// (`BluetoothGatt`), iOS BLE (`CBPeripheral`). Edge wraps the
+    /// callbacks as a `leviculum::RNodeChannelFactory` and registers
+    /// the resulting RNode interface on the running `ReticulumNode`
+    /// without rebuilding the node.
+    ///
+    /// Returns an `RNodeChannelHandle` — **hold it to keep the radio
+    /// attached; let it GC or call `detach()` to tear it down.**
+    /// Dropping the handle signals the leviculum interface task to
+    /// stop; the node's event loop detaches the interface and removes
+    /// it from routing cleanly.
+    ///
+    /// Callback contract (executed inside an async tokio task on
+    /// edge's transport runtime, bridged via
+    /// `tokio::task::block_in_place` + `Python::attach`):
+    ///
+    /// - `read_cb(max_bytes: int) -> bytes` — return up to `max_bytes`
+    ///   of bytes received from the radio. Should block until at least
+    ///   one byte is available or the bus closes. Return empty bytes to
+    ///   signal channel close (triggers a reconnect attempt).
+    ///   Exceptions are logged + treated as channel close.
+    /// - `write_cb(payload: bytes) -> None` — send `payload` to the
+    ///   radio. Should block until the bytes are accepted by the bus.
+    ///   Exceptions are logged + treated as channel close.
+    ///
+    /// Both callbacks must be Send-safe — the adapter holds them
+    /// across thread boundaries.
+    ///
+    /// LoRa parameters (passed as a dict for forward compatibility):
+    /// `frequency_hz`, `bandwidth_hz`, `tx_power_dbm`, `sf`, `cr`,
+    /// optional `st_alock`, `lt_alock`, `flow_control`, `buffer_size`.
+    /// Defaults match the leviculum `RNODE_DEFAULT_BUFFER_SIZE` /
+    /// flow-control conventions.
+    ///
+    /// Raises:
+    /// - `RuntimeError` if this edge has no Reticulum transport
+    ///   (`disable_reticulum=True` / wheel built without
+    ///   `_reticulum-module`) or the node isn't running.
+    /// - `ValueError` on malformed callbacks (not callable) or
+    ///   out-of-range LoRa params.
+    #[pyo3(signature = (read_cb, write_cb, frequency_hz, bandwidth_hz, tx_power_dbm, sf, cr, *, st_alock=None, lt_alock=None, flow_control=true, buffer_size=16))]
+    #[allow(clippy::too_many_arguments)]
+    fn add_rnode_channel_interface(
+        &self,
+        read_cb: Py<PyAny>,
+        write_cb: Py<PyAny>,
+        frequency_hz: u32,
+        bandwidth_hz: u32,
+        tx_power_dbm: u8,
+        sf: u8,
+        cr: u8,
+        st_alock: Option<u16>,
+        lt_alock: Option<u16>,
+        flow_control: bool,
+        buffer_size: usize,
+    ) -> PyResult<PyRNodeChannelHandle> {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            Python::attach(|py| {
+                if !read_cb.bind(py).is_callable() || !write_cb.bind(py).is_callable() {
+                    return Err(PyTypeError::new_err(
+                        "add_rnode_channel_interface: read_cb and write_cb must be callable",
+                    ));
+                }
+                Ok(())
+            })?;
+            let transport = self.inner.reticulum_transport().ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "add_rnode_channel_interface: edge has no Reticulum transport \
+                     (disable_reticulum=True, or wheel built without _reticulum-module)",
+                )
+            })?;
+            let factory: Arc<dyn reticulum_std::interfaces::RNodeChannelFactory> =
+                Arc::new(PyRNodeChannelFactory {
+                    read_cb,
+                    write_cb,
+                    chunk_size: buffer_size.max(1) * 1024,
+                });
+            let config = reticulum_std::interfaces::RNodeChannelConfig {
+                factory,
+                frequency: frequency_hz,
+                bandwidth: bandwidth_hz,
+                tx_power: tx_power_dbm,
+                sf,
+                cr,
+                st_alock,
+                lt_alock,
+                flow_control,
+                buffer_size,
+            };
+            let handle = transport
+                .node()
+                .spawn_rnode_channel_interface(config)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!(
+                        "add_rnode_channel_interface: spawn_rnode_channel_interface: {e}"
+                    ))
+                })?;
+            Ok(PyRNodeChannelHandle {
+                inner: std::sync::Mutex::new(Some(handle)),
+            })
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            let _ = (
+                read_cb,
+                write_cb,
+                frequency_hz,
+                bandwidth_hz,
+                tx_power_dbm,
+                sf,
+                cr,
+                st_alock,
+                lt_alock,
+                flow_control,
+                buffer_size,
+            );
+            Err(PyRuntimeError::new_err(
+                "add_rnode_channel_interface: requires the _reticulum-module feature",
+            ))
+        }
+    }
+
     /// v2.4.0 (CIRISEdge#95) — fetch a remote peer's hybrid KEM
     /// pubkeys (x25519 + ML-KEM-768) from persist's federation
     /// directory for `FederationSession::initiate` consumers
@@ -2673,6 +2800,173 @@ fn hex_encode_32(bytes: &[u8; 32]) -> String {
 struct PyTrustScoringAdapter {
     callback: Py<PyAny>,
 }
+
+/// CIRISEdge#219 — `Arc<dyn RNodeChannelFactory>` adapter wrapping a
+/// pair of Python callbacks (`read_cb`, `write_cb`) as a duplex byte
+/// channel to an RNode-firmware radio.
+///
+/// On each `open()` (called per (re)connection attempt by the
+/// leviculum reconnect loop), the adapter creates a fresh
+/// `tokio::io::duplex(chunk_size)` pair and spawns two
+/// `tokio::task::spawn_blocking` adapters:
+/// - one polls `read_cb` and forwards bytes onto the duplex's WRITE
+///   half (host → leviculum direction);
+/// - one drains the duplex's READ half and pushes bytes via
+///   `write_cb` (leviculum → host direction).
+///
+/// The two adapter tasks bridge sync Python ↔ async Rust via
+/// `Python::attach`. A callback raising (or returning empty bytes
+/// from read_cb) terminates the channel + triggers leviculum's
+/// reconnect (which calls `open()` again).
+#[cfg(feature = "_reticulum-module")]
+struct PyRNodeChannelFactory {
+    read_cb: Py<PyAny>,
+    write_cb: Py<PyAny>,
+    chunk_size: usize,
+}
+
+#[cfg(feature = "_reticulum-module")]
+impl reticulum_std::interfaces::RNodeChannelFactory for PyRNodeChannelFactory {
+    fn open(&self) -> reticulum_std::interfaces::RNodeChannelOpenFuture {
+        let read_cb = Python::attach(|py| self.read_cb.clone_ref(py));
+        let write_cb = Python::attach(|py| self.write_cb.clone_ref(py));
+        let chunk = self.chunk_size;
+        Box::pin(async move {
+            // (host → leviculum half) reads from the Python callback,
+            // writes to `leviculum_rx` which the interface reads.
+            let (leviculum_rx, host_to_lev_tx) = tokio::io::duplex(chunk);
+            // (leviculum → host half) writes to `leviculum_tx` which
+            // the interface fills; the reader half feeds `write_cb`.
+            let (lev_to_host_rx, leviculum_tx) = tokio::io::duplex(chunk);
+
+            // Spawn the host→lev pump (read_cb → host_to_lev_tx).
+            let chunk_for_read = chunk;
+            tokio::task::spawn(async move {
+                use tokio::io::AsyncWriteExt as _;
+                let mut sink = host_to_lev_tx;
+                loop {
+                    let bytes_opt = tokio::task::block_in_place(|| {
+                        Python::attach(|py| {
+                            let cb = read_cb.bind(py);
+                            match cb.call1((chunk_for_read,)) {
+                                Ok(value) => match value.extract::<Vec<u8>>() {
+                                    Ok(b) if b.is_empty() => None,
+                                    Ok(b) => Some(b),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            error = %e,
+                                            "rnode_channel: read_cb returned non-bytes; \
+                                             treating as channel close",
+                                        );
+                                        None
+                                    }
+                                },
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        "rnode_channel: read_cb raised; \
+                                         treating as channel close",
+                                    );
+                                    None
+                                }
+                            }
+                        })
+                    });
+                    let Some(bytes) = bytes_opt else { break };
+                    if sink.write_all(&bytes).await.is_err() {
+                        // leviculum dropped the receiver — channel torn down.
+                        break;
+                    }
+                }
+            });
+
+            // Spawn the lev→host pump (lev_to_host_rx → write_cb).
+            tokio::task::spawn(async move {
+                use tokio::io::AsyncReadExt as _;
+                let mut source = lev_to_host_rx;
+                let mut buf = vec![0u8; chunk];
+                loop {
+                    let n = match source.read(&mut buf).await {
+                        Ok(0) | Err(_) => break, // EOF or error → tear down
+                        Ok(n) => n,
+                    };
+                    let chunk_bytes = buf[..n].to_vec();
+                    let ok = tokio::task::block_in_place(|| {
+                        Python::attach(|py| {
+                            let cb = write_cb.bind(py);
+                            let py_bytes = pyo3::types::PyBytes::new(py, &chunk_bytes);
+                            match cb.call1((py_bytes,)) {
+                                Ok(_) => true,
+                                Err(e) => {
+                                    tracing::warn!(
+                                        error = %e,
+                                        bytes_len = chunk_bytes.len(),
+                                        "rnode_channel: write_cb raised; \
+                                         treating as channel close",
+                                    );
+                                    false
+                                }
+                            }
+                        })
+                    });
+                    if !ok {
+                        break;
+                    }
+                }
+            });
+
+            Ok::<
+                reticulum_std::interfaces::RNodeChannelHalves,
+                Box<dyn std::error::Error + Send + Sync>,
+            >((Box::new(leviculum_rx), Box::new(leviculum_tx)))
+        })
+    }
+}
+
+/// CIRISEdge#219 — Python-facing handle for a runtime-attached
+/// RNode interface. Returned by
+/// [`PyEdge::add_rnode_channel_interface`]. **Hold it to keep the
+/// radio attached; let it GC or call `detach()` to tear it down.**
+///
+/// The inner `RNodeChannelHandle` lives in a `Mutex<Option<...>>` so
+/// `detach()` can take it once; subsequent `detach()` calls are
+/// no-ops. Python GC drops the pyclass which drops the inner Option,
+/// which drops the leviculum handle, which signals the interface
+/// task to stop.
+#[cfg(feature = "_reticulum-module")]
+#[pyclass(name = "RNodeChannelHandle", module = "ciris_edge", unsendable)]
+pub struct PyRNodeChannelHandle {
+    inner: std::sync::Mutex<Option<reticulum_std::interfaces::RNodeChannelHandle>>,
+}
+
+#[cfg(feature = "_reticulum-module")]
+#[pymethods]
+impl PyRNodeChannelHandle {
+    /// Detach the radio + tear down the interface now. Idempotent —
+    /// repeated calls are no-ops. Equivalent to letting the handle
+    /// GC.
+    fn detach(&self) {
+        let _ = self
+            .inner
+            .lock()
+            .expect("rnode_channel_handle poisoned")
+            .take();
+    }
+
+    /// `True` iff the radio is still attached (the handle hasn't been
+    /// dropped/detached). Read-only probe for operators.
+    #[getter]
+    fn attached(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("rnode_channel_handle poisoned")
+            .is_some()
+    }
+}
+
+#[cfg(not(feature = "_reticulum-module"))]
+#[pyclass(name = "RNodeChannelHandle", module = "ciris_edge", unsendable)]
+pub struct PyRNodeChannelHandle;
 
 #[async_trait::async_trait]
 impl ciris_persist::federation::TrustScoring for PyTrustScoringAdapter {
@@ -6194,6 +6488,12 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // public fabric node (CIRISServer) operates it for asleep mobile
     // edges.
     m.add_class::<PyStoreAndForward>()?;
+
+    // CIRISEdge#219 (v7.2.0) — runtime hot-plug handle for a phone-
+    // attached RNode radio (USB-CDC / BLE-bridged). Returned by
+    // `PyEdge.add_rnode_channel_interface`; holds the leviculum
+    // `RNodeChannelHandle` so dropping it cleanly detaches the radio.
+    m.add_class::<PyRNodeChannelHandle>()?;
 
     Ok(())
 }

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1476,6 +1476,18 @@ impl ReticulumTransport {
         self.local_transport_pubkey
     }
 
+    /// v7.2.0 (CIRISEdge#219) — accessor for the internal
+    /// `ReticulumNode`. Used by `PyEdge::add_rnode_channel_interface`
+    /// to invoke `ReticulumNode::spawn_rnode_channel_interface` for
+    /// runtime hot-plug of a phone-attached RNode radio. The handle
+    /// is `pub(crate)` so external crates can't bypass the
+    /// transport's invariants; the PyO3 wrapper lives in
+    /// `src/ffi/pyo3.rs` (same crate).
+    #[must_use]
+    pub(crate) fn node(&self) -> &Arc<ReticulumNode> {
+        &self.node
+    }
+
     /// v2.2.2 (CIRISEdge#97) — return edge's announced RNS destination
     /// hash: the 16-byte `*dest.hash()` value Reticulum computes at
     /// `Destination` construction time over the identity + app aspects
@@ -2686,24 +2698,16 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             // trust-on-first-use (CIRISEdge#15, AV-42).
             resolve_announce_cold_start(&announce, ctx).await;
         }
-        NodeEvent::LinkRequest { link_id, .. } => {
-            match ctx.node.accept_link(&link_id).await {
-                Ok(_) => {
-                    // Auto-accept inbound resources on the link so
-                    // envelope transfers reassemble without app
-                    // intervention.
-                    let _ = ctx
-                        .node
-                        .set_resource_strategy(&link_id, ResourceStrategy::AcceptAll);
-                }
-                Err(e) => tracing::warn!(error = %e, "accept_link failed"),
-            }
-        }
+        // v7.2.0: Leviculum v0.8.x upstream auto-accepts inbound link
+        // requests internally — the v0.7.x `NodeEvent::LinkRequest` +
+        // `node.accept_link(...)` dance is gone. We now hear the
+        // already-accepted link via `LinkEstablished` directly on the
+        // responder side; the resource strategy + bookkeeping run there.
         NodeEvent::LinkEstablished { link_id, .. } => {
-            // On the responder side, ensure inbound resources are
-            // accepted (the LinkRequest branch already set this for
-            // links we accepted; this also covers initiator links so
-            // ACK envelopes pushed back are reassembled).
+            // Auto-accept inbound resources so envelope transfers
+            // reassemble without app intervention. Covers BOTH responder
+            // (the link the peer just initiated against us) and
+            // initiator (so ACK envelopes pushed back are reassembled).
             let _ = ctx
                 .node
                 .set_resource_strategy(&link_id, ResourceStrategy::AcceptAll);

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1482,7 +1482,11 @@ impl ReticulumTransport {
     /// runtime hot-plug of a phone-attached RNode radio. The handle
     /// is `pub(crate)` so external crates can't bypass the
     /// transport's invariants; the PyO3 wrapper lives in
-    /// `src/ffi/pyo3.rs` (same crate).
+    /// `src/ffi/pyo3.rs` (same crate). Cfg-gated on `pyo3` because
+    /// the PyEdge wrapper is the sole consumer — non-`pyo3` builds
+    /// (lib tests, the `transport-reticulum`-only matrix combo) would
+    /// trip `-D dead_code` otherwise.
+    #[cfg(feature = "pyo3")]
     #[must_use]
     pub(crate) fn node(&self) -> &Arc<ReticulumNode> {
         &self.node

--- a/tests/pruner_lifecycle.rs
+++ b/tests/pruner_lifecycle.rs
@@ -146,7 +146,17 @@ async fn pruner_skips_when_no_blackhole_rules_wired() {
 
     let tmp = tempfile::tempdir().expect("tempdir");
     let identity_path = tmp.path().join("test-identity");
-    let config = ReticulumTransportConfig::new(identity_path, "test-key".to_string());
+    let mut config = ReticulumTransportConfig::new(identity_path, "test-key".to_string());
+    // v7.2.0 (CIRISEdge#220 follow-up): Leviculum v0.8.x is stricter
+    // about port binding — the default `0.0.0.0:4242` listen_addr
+    // collides with sibling tests when the pyo3-full lane runs `--tests`
+    // in parallel. Pick an ephemeral port instead so each test is
+    // self-isolated.
+    let ephemeral = std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral")
+        .local_addr()
+        .expect("local addr");
+    config.listen_addr = ephemeral;
 
     let mut seed = [0x11u8; 32];
     for (i, b) in "test-key".bytes().take(32).enumerate() {


### PR DESCRIPTION
## Summary

Three bundled changes:

1. **Persist v10.4.0 → v10.5.0** (CIRISPersist#293) — reject non-lowercase-hex `subject_key_ids[]` at emit admission. Closes the second cohab `test_240` stale xfail mark.
2. **Leviculum v0.7.0 → v0.8.1+ciris.1** — upstream catch-up + CIRIS-fork carry. v0.8.1+ciris.1 adds the runtime hot-plug `ReticulumNode::spawn_rnode_channel_interface`. Upstream rename absorbed: `NodeEvent::LinkRequest` + `node.accept_link()` are gone; the existing `LinkEstablished` arm covers it.
3. **Closes #219 — `PyEdge.add_rnode_channel_interface`**. Hot-plug an RNode-firmware LoRa radio from Python over a host-driven duplex byte channel. Returns an `RNodeChannelHandle` — hold = attached, drop = detached.

```python
handle = edge.add_rnode_channel_interface(
    read_cb=lambda max_bytes: usb_connection.bulk_in.read(max_bytes),
    write_cb=lambda payload: usb_connection.bulk_out.write(payload),
    frequency_hz=868_000_000, bandwidth_hz=125_000,
    tx_power_dbm=17, sf=7, cr=5,
)
```

`PyRNodeChannelFactory` wraps the Python callbacks as a duplex byte channel via `tokio::io::duplex` + pumps using `tokio::task::block_in_place` + `Python::attach`. `PyRNodeChannelHandle` drops cleanly through the leviculum tear-down path.

Companion host-app shims tracked at [CIRISAgent#899](https://github.com/CIRISAI/CIRISAgent/issues/899) (Android USB host, e.g. HelTec WiFi LoRa 32 / HTIT-WB32LAF with RNode firmware via CP2102/CH9102 bridge), [#900](https://github.com/CIRISAI/CIRISAgent/issues/900) (Android BLE), [#901](https://github.com/CIRISAI/CIRISAgent/issues/901) (iOS BLE). iOS USB-CDC deferred pending MFi.

## Test plan

- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --test reticulum_loopback --test links_ffi --test routing_ffi --test trust_short_circuit` — all green on the Leviculum v0.8.1+ciris.1 base
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI matrix green (first build against Leviculum v0.8.x — bigger upstream delta than the usual pin bump)
- [ ] Cohab `test_240` reserved-prefix xfail flips green on the v10.5.0 floor

## Substrate floor

- `ciris-persist` v10.5.0
- `ciris-verify` family v7.5.0 (unchanged)
- Leviculum v0.8.1+ciris.1 (was v0.7.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln