### PR TITLE
release(v7.2.1): adopt CIRISPersist v10.6.0 + CIRISVerify v7.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
       # invalidates on rustc change). Anonymous read — no token.
       - uses: CIRISAI/CIRISCache/restore@v1
         with:
-          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.4.0-verify7.5.0
+          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.6.0-verify7.6.0
       - uses: Swatinem/rust-cache@v2
         with:
           # Per-combo cache key so each matrix entry gets its own
@@ -163,7 +163,7 @@ jobs:
           github.ref == 'refs/heads/main'
             && matrix.combo.name == 'pyo3-full'
         with:
-          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.4.0-verify7.5.0
+          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.6.0-verify7.6.0
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ─── darwin-aarch64 — Phase 1 macOS dev path ────────────────────────

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.2.0"
+version = "7.2.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.5.0", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.6.0", version = "10", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.5.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.5.0", version = "7" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1053,7 +1053,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.5.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.6.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## Summary

Pure substrate pin bump:
- **CIRISPersist v10.5.0 → v10.6.0** (CIRISPersist#295) — exposes `local_derived_key_id()` on the pyo3 Engine surface; internal re-pin to CIRISVerify v7.6.0.
- **CIRISVerify family v7.5.0 → v7.6.0** — lockstep with persist's internal pin.

Edge doesn't consume `local_derived_key_id` directly; this is a pure pin bump, no edge-side code changes. Also bumps the CIRISCache key suffix to `persist10.6.0-verify7.6.0` (v7.2.0 left it on the v7.0.13-era pins).

Substrate floor:
- ciris-persist v10.6.0
- ciris-verify family v7.6.0
- Leviculum v0.8.1+ciris.1 (unchanged)

## Test plan

- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln