### PR TITLE
release(v7.3.0): adopt CIRISPersist v11.0.0 + CIRISVerify v8.0.0

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -44,15 +44,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # libtss2 for the `tpm` keyring feature — auto-enabled by
-      # ciris-persist v1.10.0+ for Linux targets. Same dep edge's
-      # `linux-x86_64-test` job in ci.yml installs (CIRISEdge#12).
-      - name: install libtss2-dev + libsqlite3-dev (TPM + sqlite build deps)
-        # v0.19.7 (CIRISEdge#50) — `libsqlite3-dev` added alongside
-        # `libtss2-dev`. Persist v3.5.3+ drops the rusqlite `bundled`
-        # feature; the bench compile now needs the system sqlite
-        # header set. Mirrors ci.yml.
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+      # v7.3.0 (verify v8.0.0): tss-esapi removed from ciris-keyring;
+      # libsqlite3-dev is the sole remaining system build dep.
+      - name: install libsqlite3-dev (sqlite build dep)
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
 
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,20 +103,15 @@ jobs:
           haskell: true
           large-packages: false
           swap-storage: false
-      # ciris-keyring's `tpm` feature (auto-enabled for Linux targets
-      # by ciris-persist v1.10.0+, CIRISPersist#87) builds tss-esapi,
-      # which links libtss2. Cargo unions the feature across the graph
-      # so edge inherits it even though edge only asks for `software`.
-      # Closes CIRISEdge#12.
-      - name: install libtss2-dev + libsqlite3-dev (TPM + sqlite build deps)
-        # v0.19.7 (CIRISEdge#50) — added `libsqlite3-dev` alongside
-        # `libtss2-dev`. Persist v3.5.3+ dropped the rusqlite `bundled`
-        # feature in favour of dynamic linkage so the wheel + edge
-        # share ONE libsqlite3.so at runtime (closes the cross-wheel
-        # SIGSEGV CIRISEdge#50 hit at v0.19.5). The transitive build
-        # graph now needs the system header set at compile time.
-        # Mirrors persist's `.github/workflows/ci.yml` after v3.5.3.
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+      # v7.3.0 (verify v8.0.0 / persist v11.0.0): tss-esapi was removed
+      # from ciris-keyring entirely (runtime dlopen plugin is the sole
+      # TPM backend now); no libtss2 link-time dep on any target. We
+      # still install libsqlite3-dev because persist v3.5.3+ dropped
+      # rusqlite's `bundled` feature in favour of dynamic linkage so
+      # the wheel + edge share ONE libsqlite3.so at runtime (closes the
+      # cross-wheel SIGSEGV CIRISEdge#50 hit at v0.19.5).
+      - name: install libsqlite3-dev (sqlite build dep)
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: dtolnay/rust-toolchain@stable
       # v7.0.12 (CIRISEdge#216 / CIRISCache adoption) — restore the
       # cross-repo L2 cache BEFORE the per-repo Swatinem L1. The key
@@ -126,7 +121,7 @@ jobs:
       # invalidates on rustc change). Anonymous read — no token.
       - uses: CIRISAI/CIRISCache/restore@v1
         with:
-          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.6.0-verify7.6.0
+          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist11.0.0-verify8.0.0
       - uses: Swatinem/rust-cache@v2
         with:
           # Per-combo cache key so each matrix entry gets its own
@@ -163,7 +158,7 @@ jobs:
           github.ref == 'refs/heads/main'
             && matrix.combo.name == 'pyo3-full'
         with:
-          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist10.6.0-verify7.6.0
+          key: ciris-edge-linux-x86_64-${{ matrix.combo.name }}-persist11.0.0-verify8.0.0
           token: ${{ secrets.GITHUB_TOKEN }}
 
   # ─── darwin-aarch64 — Phase 1 macOS dev path ────────────────────────
@@ -990,17 +985,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # libtss2 for the `tpm` keyring feature — clippy compiles the
-      # full graph. See linux-x86_64-test above; CIRISEdge#12.
-      - name: install libtss2-dev + libsqlite3-dev (TPM + sqlite build deps)
-        # v0.19.7 (CIRISEdge#50) — added `libsqlite3-dev` alongside
-        # `libtss2-dev`. Persist v3.5.3+ dropped the rusqlite `bundled`
-        # feature in favour of dynamic linkage so the wheel + edge
-        # share ONE libsqlite3.so at runtime (closes the cross-wheel
-        # SIGSEGV CIRISEdge#50 hit at v0.19.5). The transitive build
-        # graph now needs the system header set at compile time.
-        # Mirrors persist's `.github/workflows/ci.yml` after v3.5.3.
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+      # v7.3.0 (verify v8.0.0): tss-esapi removed from ciris-keyring;
+      # only libsqlite3-dev remains as a system build dep.
+      - name: install libsqlite3-dev (sqlite build dep)
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
@@ -1029,15 +1017,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: install libtss2-dev + libsqlite3-dev (TPM + sqlite build deps)
-        # v0.19.7 (CIRISEdge#50) — added `libsqlite3-dev` alongside
-        # `libtss2-dev`. Persist v3.5.3+ dropped the rusqlite `bundled`
-        # feature in favour of dynamic linkage so the wheel + edge
-        # share ONE libsqlite3.so at runtime (closes the cross-wheel
-        # SIGSEGV CIRISEdge#50 hit at v0.19.5). The transitive build
-        # graph now needs the system header set at compile time.
-        # Mirrors persist's `.github/workflows/ci.yml` after v3.5.3.
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+      - name: install libsqlite3-dev (sqlite build dep)
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: build uniffi_bindgen_cli
@@ -1096,16 +1077,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      # libtss2 — same dep linux-x86_64-test installs (CIRISEdge#12).
-      - name: install libtss2-dev + libsqlite3-dev (TPM + sqlite build deps)
-        # v0.19.7 (CIRISEdge#50) — added `libsqlite3-dev` alongside
-        # `libtss2-dev`. Persist v3.5.3+ dropped the rusqlite `bundled`
-        # feature in favour of dynamic linkage so the wheel + edge
-        # share ONE libsqlite3.so at runtime (closes the cross-wheel
-        # SIGSEGV CIRISEdge#50 hit at v0.19.5). The transitive build
-        # graph now needs the system header set at compile time.
-        # Mirrors persist's `.github/workflows/ci.yml` after v3.5.3.
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+      - name: install libsqlite3-dev (sqlite build dep)
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: cargo bench --no-run (all features)
@@ -1210,19 +1183,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      # libtss2 for the `tpm` keyring feature on the Linux wheel
-      # builds. macOS wheels build the base keyring (no tss-esapi),
-      # so this step is Linux-only. See CIRISEdge#12.
-      # v0.19.7 (CIRISEdge#50) — also installs `libsqlite3-dev`
-      # alongside `libtss2-dev`. Persist v3.5.3+ dropped the rusqlite
-      # `bundled` feature; the wheel-build's auditwheel pass needs the
-      # system libsqlite3.so present so it can sidecar-bundle it into
+      # v7.3.0 (verify v8.0.0): tss-esapi removed from ciris-keyring;
+      # libsqlite3-dev is the sole remaining system build dep — the
+      # wheel-build's auditwheel pass needs the system libsqlite3.so
+      # present so it can sidecar-bundle it into
       # `ciris_persist.libs/`. macOS wheels link the host's Apple-
       # provided libsqlite3 (delocate handles it), so this step
       # stays Linux-only.
-      - name: install libtss2-dev + libsqlite3-dev (TPM + sqlite build deps)
+      - name: install libsqlite3-dev (sqlite build dep)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       # v2.1.1 (CIRISEdge#87 / #90 / leviculum#10) — Windows-only build
       # deps. ciris-persist's `pyo3` feature force-includes its
       # `postgres` feature, which pulls `dep:openssl` → openssl-sys.
@@ -1576,17 +1546,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      # libtss2 for the `tpm` keyring feature — build-manifest
-      # compiles the graph to emit EdgeExtras. See CIRISEdge#12.
-      - name: install libtss2-dev + libsqlite3-dev (TPM + sqlite build deps)
-        # v0.19.7 (CIRISEdge#50) — added `libsqlite3-dev` alongside
-        # `libtss2-dev`. Persist v3.5.3+ dropped the rusqlite `bundled`
-        # feature in favour of dynamic linkage so the wheel + edge
-        # share ONE libsqlite3.so at runtime (closes the cross-wheel
-        # SIGSEGV CIRISEdge#50 hit at v0.19.5). The transitive build
-        # graph now needs the system header set at compile time.
-        # Mirrors persist's `.github/workflows/ci.yml` after v3.5.3.
-        run: sudo apt-get update && sudo apt-get install -y libtss2-dev libsqlite3-dev
+      - name: install libsqlite3-dev (sqlite build dep)
+        run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.2.1"
+version = "7.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.6.0", version = "10", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.0.0", version = "11", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -216,8 +216,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.6.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -226,7 +226,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v7.6.0", version = "7" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.0.0", version = "8" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1053,7 +1053,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v10.6.0", version = "10", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.0.0", version = "11", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=10.0.0,<11",
+    "ciris-persist>=11.0.0,<12",
 ]
 dynamic = ["version"]
 

--- a/tests/delegation_reads_e2e.rs
+++ b/tests/delegation_reads_e2e.rs
@@ -8,8 +8,10 @@
 //! was previously hand-rolling:
 //!
 //! - `reachable_under_scope(seed, scope, max_depth) -> bool`
-//! - `is_owner_bound(key_id) -> bool`
-//! - `owner_binding_chain(key_id) -> Vec<KeyId>`
+//! - `is_steward_bound(key_id) -> bool` — v11.0.0 rename of
+//!   `is_owner_bound` per CC 0.5.1 §3.2 owner→steward.
+//! - `steward_binding_chain(key_id) -> Vec<KeyId>` — v11.0.0 rename of
+//!   `owner_binding_chain`.
 //! - `moderators_of(community_id, duty) -> Vec<KeyId>`
 //! - `duty_holders_for_community(community_id, duty) -> HashSet<KeyId>`
 //! - `duty_holders_for_content(content_sha, community_id, duty) -> HashSet<KeyId>`
@@ -99,16 +101,17 @@ async fn v9_3_0_delegation_reads_callable_through_dyn_trait() {
         "empty backend → no delegation chain → reachable_under_scope false"
     );
 
-    // is_owner_bound — unknown key → not bound.
-    let bound = admission::is_owner_bound(dir.as_ref(), "unknown-key")
+    // is_steward_bound — unknown key → not bound. (v7.3.0: persist v11.0.0
+    // BREAKING owner→steward rename per CC 0.5.1 §3.2.)
+    let bound = admission::is_steward_bound(dir.as_ref(), "unknown-key")
         .await
-        .expect("is_owner_bound reachable through dyn trait");
-    assert!(!bound, "empty backend → unknown key NOT owner-bound");
+        .expect("is_steward_bound reachable through dyn trait");
+    assert!(!bound, "empty backend → unknown key NOT steward-bound");
 
-    // owner_binding_chain — unknown key → empty chain.
-    let chain = admission::owner_binding_chain(dir.as_ref(), "unknown-key")
+    // steward_binding_chain — unknown key → empty chain.
+    let chain = admission::steward_binding_chain(dir.as_ref(), "unknown-key")
         .await
-        .expect("owner_binding_chain reachable through dyn trait");
+        .expect("steward_binding_chain reachable through dyn trait");
     assert!(
         chain.is_empty(),
         "empty backend → no chain for unknown key, got {chain:?}"


### PR DESCRIPTION
## Summary

Substrate MAJOR floor change. Two BREAKING upstreams absorbed.

### CIRISPersist v10.6.0 → v11.0.0 (CIRISPersist#299)

`owner` → `steward` rename per CC 0.5.1 §3.2 + new `nodes_stewarded_by` accessor. Surface on the `ciris_persist::admission` delegation readers edge consumes:

- `is_owner_bound` → `is_steward_bound`
- `owner_binding_chain` → `steward_binding_chain`

Edge consumes these only in `tests/delegation_reads_e2e.rs` — no production code change.

### CIRISVerify v7.6.0 → v8.0.0 (CIRISVerify#141)

`tss-esapi` deleted from `ciris-keyring`; runtime dlopen plugin is the sole TPM backend. Edge consumes the keyring with `features = ["software", "pqc-ml-dsa"]` (no `tpm`), so the Cargo bump is transparent at the API level.

### CI cleanup — the user-visible win

All 7 `libtss2-dev` install steps purged across `ci.yml` (×6) + `bench.yml` (×1). The keyring's tss-esapi removal means **no libtss2 link-time dep on any target**. Step name renamed, surrounding `# libtss2 for the tpm keyring feature` / `CIRISEdge#12` comments replaced with a single v7.3.0 explanation. `libsqlite3-dev` stays — persist's rusqlite went `bundled = false` since v3.5.3 (CIRISEdge#50).

CIRISCache key bumped to `persist11.0.0-verify8.0.0`.

### Pin moves

- `ciris-persist` v10.6.0 → v11.0.0 (deps + dev-deps)
- `ciris-keyring` v7.6.0 → v8.0.0, version "7" → "8"
- `ciris-crypto`  v7.6.0 → v8.0.0, version "7" → "8"
- `ciris-verify-core` v7.6.0 → v8.0.0, version "7" → "8"

## Test plan

- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [x] `cargo test --features "transport-http transport-reticulum pyo3" --test delegation_reads_e2e --test reticulum_loopback --test trust_short_circuit --test links_ffi --test routing_ffi` — all green on v11/v8 base
- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI matrix green — first build without libtss2-dev installed

## Substrate floor

- CIRISPersist v11.0.0
- CIRISVerify family v8.0.0
- Leviculum v0.8.1+ciris.1 (unchanged)

## Pyproject follow-up

The wheel `Requires-Dist: ciris-persist>=10.0.0,<11` in `pyproject.toml` still admits persist 10.x at install time. The Cargo-level v11 pin holds inside the wheel, but a v7.4.x cut should move that floor in lockstep to align the cohab firewall. Tracking separately so this cut stays scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln