### PR TITLE
test(reticulum_loopback): retry transport bind on ephemeral-port race

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -146,3 +146,64 @@ pub async fn prime_v7_peer_pair(
         .inject_rooted_peer_for_test(key_id_b, b_dest, b_ed)
         .await;
 }
+
+/// Build a [`ReticulumTransport`], retrying on the transient
+/// "address already in use" race.
+///
+/// The test suites pick loopback ports via `free_port()`, which binds an
+/// ephemeral port and immediately releases it. Between that release and
+/// the transport reclaiming the port, a parallel test (in this binary or
+/// another test binary cargo runs concurrently) can win the same port —
+/// surfacing as `Io("reticulum node start: ... Address already in use")`.
+/// On that error we rebuild from a freshly-picked config; any other error
+/// is a real failure and panics immediately.
+///
+/// `make` is invoked once per attempt and must return a *fresh* config
+/// (re-picking its ephemeral `listen_addr`) together with the matching
+/// [`ReticulumAuth`] — both are consumed by the build, so the auth signer
+/// is rebuilt per attempt. Returns the live transport plus the
+/// `listen_addr` that actually bound, so callers wiring a bootstrap peer
+/// can learn the settled port.
+#[cfg(feature = "transport-reticulum")]
+pub async fn build_reticulum_with_retry<F, Fut>(
+    mut make: F,
+) -> (
+    Arc<ciris_edge::transport::reticulum::ReticulumTransport>,
+    std::net::SocketAddr,
+)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<
+        Output = (
+            ciris_edge::transport::reticulum::ReticulumTransportConfig,
+            ciris_edge::transport::reticulum::ReticulumAuth,
+        ),
+    >,
+{
+    use ciris_edge::transport::reticulum::ReticulumTransport;
+
+    const MAX_ATTEMPTS: usize = 16;
+    let mut last_err = None;
+    for _ in 0..MAX_ATTEMPTS {
+        let (cfg, auth) = make().await;
+        let addr = cfg.listen_addr;
+        match ReticulumTransport::new(cfg, auth).await {
+            Ok(transport) => return (Arc::new(transport), addr),
+            Err(err) if is_addr_in_use(&err) => {
+                last_err = Some(err);
+                continue;
+            }
+            Err(err) => panic!("build reticulum transport: {err:?}"),
+        }
+    }
+    panic!("build reticulum transport: exhausted {MAX_ATTEMPTS} bind retries: {last_err:?}");
+}
+
+/// True if a transport build error is the transient ephemeral-port bind
+/// race from `free_port()` (see [`build_reticulum_with_retry`]) rather
+/// than a genuine configuration or crypto failure.
+#[cfg(feature = "transport-reticulum")]
+fn is_addr_in_use(err: &ciris_edge::transport::TransportError) -> bool {
+    let msg = err.to_string();
+    msg.contains("Address already in use") || msg.contains("os error 98")
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -190,8 +190,8 @@ where
         match ReticulumTransport::new(cfg, auth).await {
             Ok(transport) => return (Arc::new(transport), addr),
             Err(err) if is_addr_in_use(&err) => {
+                // Re-pick a port and rebuild on the next loop iteration.
                 last_err = Some(err);
-                continue;
             }
             Err(err) => panic!("build reticulum transport: {err:?}"),
         }

--- a/tests/reticulum_loopback.rs
+++ b/tests/reticulum_loopback.rs
@@ -28,15 +28,15 @@ use std::time::Duration;
 use chrono::Utc;
 use ciris_edge::identity::LocalSigner;
 use ciris_edge::messages::{EdgeEnvelope, MessageType, SchemaVersion};
-use ciris_edge::transport::reticulum::{
-    ReticulumAuth, ReticulumTransport, ReticulumTransportConfig,
-};
+use ciris_edge::transport::reticulum::{ReticulumAuth, ReticulumTransportConfig};
 use ciris_edge::transport::{InboundFrame, Transport};
 use ciris_edge::verify::RootingDirectory;
 use serde_json::value::RawValue;
 use tokio::sync::mpsc;
 
-use common::{directory_with, prime_v7_peer_pair, signed_record, TestFedKey};
+use common::{
+    build_reticulum_with_retry, directory_with, prime_v7_peer_pair, signed_record, TestFedKey,
+};
 
 /// Build a representative signed-shaped envelope. The signatures here
 /// are placeholder strings — the loopback test exercises *transport*
@@ -127,39 +127,38 @@ async fn rooted_resolution_round_trips_envelope_byte_exact() {
     ])
     .await;
 
-    let port_a = free_port();
+    // Node A: the receiver. Binds an ephemeral port (retried on the
+    // `free_port()` bind/release race); no bootstrap peers.
+    let (transport_a, addr_a) = build_reticulum_with_retry(|| {
+        let key = &key_a;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c = ReticulumTransportConfig::new(base.join("a/transport.id"), "edge-key-aaaa");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.announce_interval = Duration::from_secs(2);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
+    let port_a = addr_a.port();
 
-    // Node A: the receiver. Listens on `port_a`; no bootstrap peers.
-    let cfg_a = {
-        let mut c =
-            ReticulumTransportConfig::new(tmp.path().join("a/transport.id"), "edge-key-aaaa");
-        c.listen_addr = format!("127.0.0.1:{port_a}").parse().unwrap();
-        c.announce_interval = Duration::from_secs(2);
-        c
-    };
-    // Node B: the sender. Dials A as a bootstrap peer.
-    let cfg_b = {
-        let mut c =
-            ReticulumTransportConfig::new(tmp.path().join("b/transport.id"), "edge-key-bbbb");
-        c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
-        c.bootstrap_peers = vec![format!("127.0.0.1:{port_a}").parse().unwrap()];
-        c.announce_interval = Duration::from_secs(2);
-        c
-    };
-
-    let auth_a = auth_for(&key_a, directory.clone(), tmp.path()).await;
-    let auth_b = auth_for(&key_b, directory.clone(), tmp.path()).await;
-
-    let transport_a = Arc::new(
-        ReticulumTransport::new(cfg_a, auth_a)
-            .await
-            .expect("build transport A"),
-    );
-    let transport_b = Arc::new(
-        ReticulumTransport::new(cfg_b, auth_b)
-            .await
-            .expect("build transport B"),
-    );
+    // Node B: the sender. Dials A on its settled port as a bootstrap peer.
+    let (transport_b, _addr_b) = build_reticulum_with_retry(|| {
+        let key = &key_b;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c = ReticulumTransportConfig::new(base.join("b/transport.id"), "edge-key-bbbb");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.bootstrap_peers = vec![format!("127.0.0.1:{port_a}").parse().unwrap()];
+            c.announce_interval = Duration::from_secs(2);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
 
     // v7.0.0 (CIRISEdge#191 / #195) — explicit-hash destinations cannot
     // announce, so the announce-based rooting path the v6.x loopback
@@ -257,35 +256,34 @@ async fn spawn_background_listeners_drives_two_node_send_inline_text() {
     ])
     .await;
 
-    let port_a = free_port();
-    let cfg_a = {
-        let mut c =
-            ReticulumTransportConfig::new(tmp.path().join("a/transport.id"), "edge-bg-aaaa");
-        c.listen_addr = format!("127.0.0.1:{port_a}").parse().unwrap();
-        c.announce_interval = Duration::from_secs(2);
-        c
-    };
-    let cfg_b = {
-        let mut c =
-            ReticulumTransportConfig::new(tmp.path().join("b/transport.id"), "edge-bg-bbbb");
-        c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
-        c.bootstrap_peers = vec![format!("127.0.0.1:{port_a}").parse().unwrap()];
-        c.announce_interval = Duration::from_secs(2);
-        c
-    };
-
-    let auth_a = auth_for(&key_a, directory.clone(), tmp.path()).await;
-    let auth_b = auth_for(&key_b, directory.clone(), tmp.path()).await;
-    let transport_a = Arc::new(
-        ReticulumTransport::new(cfg_a, auth_a)
-            .await
-            .expect("build transport A"),
-    );
-    let transport_b = Arc::new(
-        ReticulumTransport::new(cfg_b, auth_b)
-            .await
-            .expect("build transport B"),
-    );
+    let (transport_a, addr_a) = build_reticulum_with_retry(|| {
+        let key = &key_a;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c = ReticulumTransportConfig::new(base.join("a/transport.id"), "edge-bg-aaaa");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.announce_interval = Duration::from_secs(2);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
+    let port_a = addr_a.port();
+    let (transport_b, _addr_b) = build_reticulum_with_retry(|| {
+        let key = &key_b;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c = ReticulumTransportConfig::new(base.join("b/transport.id"), "edge-bg-bbbb");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.bootstrap_peers = vec![format!("127.0.0.1:{port_a}").parse().unwrap()];
+            c.announce_interval = Duration::from_secs(2);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
     prime_v7_peer_pair(&transport_a, "edge-bg-aaaa", &transport_b, "edge-bg-bbbb").await;
 
     // Build an Edge per side — same builder shape `init_edge_runtime`


### PR DESCRIPTION
`free_port()` binds an ephemeral loopback port and immediately releases
it, then the Reticulum transport reclaims it during `node.start()`. With
the two `multi_thread` loopback tests (and the parallel `routing_ffi` /
`links_ffi` binaries) running concurrently, another bind can win the
freed port in that window — surfacing as the flaky CI failure:

    build transport B: Io("reticulum node start: I/O error:
    Address already in use (os error 98)")

Add `common::build_reticulum_with_retry`, which rebuilds the transport
from a freshly-picked config on `Address already in use` (bounded to 16
attempts) and panics immediately on any other error. It returns the
`listen_addr` that actually bound so the bootstrap-peer wiring learns
node A's settled port. Both loopback tests now build their A/B
transports through it.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VyzXZtMnP8oQD7frGWXPx9