### PR TITLE
release(v7.4.0): dual-destination architecture — named announce + explicit-hash back-compat (closes #231)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,12 +173,9 @@ jobs:
   darwin-aarch64-test:
     name: darwin-aarch64 (no pyo3)
     runs-on: macos-14
-    # CIRISEdge#229 — save the cross-repo cache on main-branch builds
-    # of this canonical macos-aarch64 lane. PR runs read but don't
-    # write; permissions stay minimal.
-    permissions:
-      contents: read
-      packages: write
+    # CIRISEdge#229 — restore only; canonical macos-aarch64 save lives
+    # on `pyo3-wheel` `darwin-aarch64` (release-profile target/).
+    # `packages: write` not needed here.
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -222,12 +219,14 @@ jobs:
         # load-bearing (edge ships darwin wheels; the teranos fork base
         # exists for macOS compat). CIRISEdge#14.
         run: cargo test --features "transport-http transport-reticulum"
-      # CIRISEdge#229 — save warm cache to GHCR on main only.
-      - uses: CIRISAI/CIRISCache/save@v1
-        if: github.ref == 'refs/heads/main'
-        with:
-          key: ${{ steps.cachekey.outputs.key }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # CIRISEdge#229 — restore only on this lane. The canonical
+      # macos-aarch64 save site is the `pyo3-wheel` `darwin-aarch64`
+      # matrix entry (release-profile target/, matches what downstream
+      # consumers build against). Saving here would write a debug-
+      # profile target/ blob over it (same canonical key, second-
+      # writer-wins is racey). Restore happens via the composite
+      # action above unconditionally — debug builds still pick up the
+      # registry layer + warm release artifacts where they match.
 
   # ─── android-ndk: per-ABI mobile cross-compile (CIRISEdge#17) ───────
   #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.3.2"
+version = "7.4.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -893,6 +893,29 @@ pub struct ReticulumTransport {
     /// Hash of edge's own registered destination — the thing we
     /// announce on startup and on the announce timer.
     local_dest_hash: DestinationHash,
+    /// v7.4.0 (CIRISEdge#231) — Reticulum-NAMED destination registered
+    /// alongside the explicit-hash one (`local_dest_hash`). Both share
+    /// the same transport identity for link encryption; they're two
+    /// routing-table entries pointing at the same underlying crypto.
+    ///
+    /// Why the dual registration:
+    ///  - Explicit-hash (`local_dest_hash`) is `sha256(fed_pubkey)[..16]`
+    ///    — addressable by anyone who knows the federation pubkey, but
+    ///    cannot announce (Leviculum guards
+    ///    `AnnounceError::ExplicitHashCannotAnnounce`). Direct-dial /
+    ///    prime_peer path.
+    ///  - Named (`local_named_dest_hash`) is the standard RNS
+    ///    `sha256(name_hash || identity_hash)[..16]` derived from
+    ///    `(EDGE_APP_NAME, EDGE_APP_ASPECT, transport_identity)`. Fully
+    ///    announceable → any RNS fabric (CIRIS or generic) learns the
+    ///    path → multi-hop routing + transport relays work for free.
+    ///
+    /// The announce loop emits under THIS hash. Inbound links to either
+    /// hash terminate at the same identity, so federation trust on the
+    /// envelope payload is invariant. Operators see `Reticulum transport
+    /// listening on ... (dest <explicit_hash>) (named-dest
+    /// <named_hash>)` on the `transport_up` interface event.
+    local_named_dest_hash: DestinationHash,
     /// v2.1.0 (CIRISPersist `LocalIdentityAggregate` RET-transport
     /// role) — the 64-byte Reticulum dual-key public material edge
     /// minted at startup: `x25519_pub (32) ‖ ed25519_pub (32)`. The
@@ -1380,7 +1403,7 @@ impl ReticulumTransport {
             &federation_ed25519_pubkey,
         );
         let mut dest = Destination::with_explicit_hash(
-            Some(identity),
+            Some(identity.clone()),
             Direction::In,
             DestinationType::Single,
             EDGE_APP_NAME,
@@ -1396,6 +1419,27 @@ impl ReticulumTransport {
             "explicit-hash destination must index by the caller-supplied hash",
         );
         node.register_destination_at(local_dest_hash, dest);
+
+        // v7.4.0 (CIRISEdge#231) — register a NAMED destination on
+        // the SAME transport identity. Its hash is the standard RNS
+        // `sha256(name_hash || identity_hash)[..16]` (NOT the
+        // federation-rooted explicit hash above). The named dest is
+        // announceable + mesh-discoverable; the explicit-hash stays
+        // for prime_peer / direct-dial back-compat (every v7.0.0–v7.3.x
+        // peer addresses by explicit hash). Two routing-table entries,
+        // one underlying identity → either inbound path reaches the
+        // same handler set.
+        let mut named_dest = Destination::new(
+            Some(identity),
+            Direction::In,
+            DestinationType::Single,
+            EDGE_APP_NAME,
+            &[EDGE_APP_ASPECT],
+        )
+        .map_err(|e| TransportError::Config(format!("named destination build: {e}")))?;
+        named_dest.set_accepts_links(true);
+        let local_named_dest_hash = *named_dest.hash();
+        node.register_destination_at(local_named_dest_hash, named_dest);
 
         // Take the single event receiver before starting, then start
         // the event loop. `listen` claims the stashed receiver.
@@ -1416,6 +1460,7 @@ impl ReticulumTransport {
             config,
             node: Arc::new(node),
             local_dest_hash,
+            local_named_dest_hash,
             local_transport_pubkey,
             local_attestation,
             events: Mutex::new(Some(events)),
@@ -1508,6 +1553,27 @@ impl ReticulumTransport {
     #[must_use]
     pub fn local_dest_hash(&self) -> [u8; 16] {
         let bytes = self.local_dest_hash.as_bytes();
+        let mut out = [0u8; 16];
+        out.copy_from_slice(bytes);
+        out
+    }
+
+    /// v7.4.0 (CIRISEdge#231) — the NAMED Reticulum destination hash,
+    /// `sha256(name_hash || transport_identity_hash)[..16]`. Distinct
+    /// from [`Self::local_dest_hash`] (which is the explicit-hash
+    /// `sha256(fed_pubkey)[..16]`); both terminate at the same
+    /// transport identity, so inbound links to EITHER reach the same
+    /// handler set.
+    ///
+    /// This is the value the periodic announce emits — RNS peers
+    /// receiving our announce store a path to THIS hash. For
+    /// mesh-routed delivery (multi-hop, transport relays), peers
+    /// should dial this hash. The explicit-hash stays the canonical
+    /// direct-dial / prime_peer address for back-compat with
+    /// v7.0.0–v7.3.x peers.
+    #[must_use]
+    pub fn local_named_dest_hash(&self) -> [u8; 16] {
+        let bytes = self.local_named_dest_hash.as_bytes();
         let mut out = [0u8; 16];
         out.copy_from_slice(bytes);
         out
@@ -2555,6 +2621,7 @@ impl Transport for ReticulumTransport {
         tracing::info!(
             addr = %self.config.listen_addr,
             dest = %self.local_dest_hash,
+            named_dest = %self.local_named_dest_hash,
             "Reticulum transport listening",
         );
 
@@ -2566,13 +2633,21 @@ impl Transport for ReticulumTransport {
                 crate::events::EventKind::TransportUp,
                 "reticulum-rs",
                 format!(
-                    "Reticulum transport listening on {} (dest {})",
-                    self.config.listen_addr, self.local_dest_hash
+                    "Reticulum transport listening on {} (dest {}, named-dest {})",
+                    self.config.listen_addr, self.local_dest_hash, self.local_named_dest_hash,
                 ),
             ));
         }
 
-        // Announce edge's own destination on startup, then on a timer.
+        // v7.4.0 (CIRISEdge#231) — announce edge's NAMED destination
+        // (the standard RNS `sha256(name_hash || identity_hash)`),
+        // NOT the explicit-hash. The explicit-hash is unannounceable
+        // by Leviculum guard — every v7.0.0–v7.3.x cut WARN-spammed
+        // on every tick because the announce loop was pointed at it.
+        // Now any RNS fabric learning our announce gets a routable
+        // path to `local_named_dest_hash`. The explicit-hash stays
+        // registered for direct-dial / prime_peer back-compat.
+        //
         // The app-data is edge's signed announce attestation
         // (CIRISEdge#15 send side) — a federation-key signature
         // binding this transport identity to `local_key_id`. When no
@@ -2581,10 +2656,10 @@ impl Transport for ReticulumTransport {
         let app_data: &[u8] = self.local_attestation.as_deref().unwrap_or(&[]);
         if let Err(e) = self
             .node
-            .announce_destination(&self.local_dest_hash, Some(app_data))
+            .announce_destination(&self.local_named_dest_hash, Some(app_data))
             .await
         {
-            tracing::warn!(error = %e, "initial announce failed");
+            tracing::warn!(error = %e, "initial announce (named destination) failed");
         }
         let mut announce_tick = tokio::time::interval(self.config.announce_interval);
         announce_tick.tick().await; // consume the immediate first tick
@@ -2594,10 +2669,10 @@ impl Transport for ReticulumTransport {
                 _ = announce_tick.tick() => {
                     if let Err(e) = self
                         .node
-                        .announce_destination(&self.local_dest_hash, Some(app_data))
+                        .announce_destination(&self.local_named_dest_hash, Some(app_data))
                         .await
                     {
-                        tracing::warn!(error = %e, "periodic announce failed");
+                        tracing::warn!(error = %e, "periodic announce (named destination) failed");
                     }
                 }
                 event = events.recv() => {


### PR DESCRIPTION
## Summary

Closes #231. v7.0.0's explicit-hash addressing decoupled fed_pubkey from RNS naming — at the cost of mesh discovery. Going straight to v7.4.0 with the right architectural fix instead of a throwaway v7.3.3 WARN-suppression patch.

## Dual-destination architecture

Register BOTH destinations on the same transport identity:

| Destination | Hash formula | Announce? | Use |
|---|---|---|---|
| **explicit-hash** (`local_dest_hash`, existing) | `sha256(fed_pubkey)[..16]` | No (Leviculum guards) | Direct-dial via `prime_peer`; back-compat with v7.0.0–v7.3.x peers |
| **named** (`local_named_dest_hash`, NEW) | `sha256(name_hash ∥ identity_hash)[..16]` | **Yes** | Announceable; mesh routing; multi-hop; transport relays |

Both share the same transport identity for link encryption — two routing-table entries pointing at the same crypto. Inbound to either dest_hash terminates at the same handler set, so the verify-layer federation trust on the signed envelope payload is invariant.

## What changes

- `ReticulumTransport::new` builds + registers the named dest alongside the explicit-hash one (clones the `Identity` — cheap, shared key material).
- `listen()` announces the named dest. Initial + periodic announce succeed. One clean log line + the `transport_up` event carries both hashes.
- New `pub fn local_named_dest_hash() -> [u8; 16]` accessor.
- `prime_peer` semantics unchanged.

## What this gets us

- WARN spam gone permanently
- RNS mesh integration: announce, multi-hop, transport relays work
- Federation trust unchanged (every envelope still fed-key-signed at the verify layer)

## Test plan

- [x] `cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [x] `tests/reticulum_loopback.rs` — 2/2 (rooted_resolution + spawn_background_listeners 2-node round-trip from v7.1.0)
- [x] `cargo fmt` — clean
- [ ] CI matrix green

## Substrate floor

Unchanged: CIRISVerify v8.3.0 / CIRISPersist v11.2.0 / Leviculum v0.8.1+ciris.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln