### PR TITLE
release(v7.4.1): adopt CIRISPersist v11.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.4.0"
+version = "7.4.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,7 +192,7 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.2.0", version = "11", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.5.0", version = "11", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1053,7 +1053,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.2.0", version = "11", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.5.0", version = "11", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
## Summary

Pure additive-minor substrate pin bump catch-up CIRISPersist v11.2.0 → v11.5.0.

- **v11.3.0** (CC 3.4.11) — CIRISPersist#307 first pass: refuse `age_self_declared:level:*`
- **v11.4.0** (CC 4.4.3.2.8) — CIRISPersist#308: affiliations 4th rostered `cohort_scope` + `crypto_tier` resolver
- **v11.5.0** (CC 3.2) — CIRISPersist#306 I1 age band substrate + user-target steward-binding gate + minor liveness; CIRISPersist#307 gate-fix

Edge doesn't consume any new APIs directly — pure pin bump. Verify family unchanged at v8.3.0. Pyproject `Requires-Dist: ciris-persist>=11.0.0,<12` already admits v11.5.0; skew gate confirms.

## Substrate floor

- ciris-persist v11.5.0
- ciris-verify family v8.3.0 (unchanged)
- Leviculum v0.8.1+ciris.1 (unchanged)

## Test plan

- [x] `RUSTFLAGS=-D warnings cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings` — clean
- [x] `cargo test --features "transport-reticulum ffi-uniffi pyo3" --lib` — 615/615
- [x] `python3 .github/scripts/check_cargo_pyproject_skew.py` — OK
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln