### PR TITLE
release(v7.4.4): canonical linux-x86_64 save on pyo3-wheel (release profile) (closes #238)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,13 +67,9 @@ jobs:
   linux-x86_64-test:
     name: linux-x86_64 (${{ matrix.combo.name }})
     runs-on: ubuntu-latest
-    # v7.0.12 (CIRISEdge#216 / CIRISCache adoption) — `packages: write`
-    # is needed for the main-branch save step on the pyo3-full lane.
-    # PR/tag runs don't write; the conditional on the save step gates
-    # it. Restore is anonymous and doesn't consume any permission.
-    permissions:
-      contents: read
-      packages: write
+    # v7.4.4 (CIRISEdge#238) — restore only; the canonical linux-x86_64
+    # save now lives on `pyo3-wheel linux-x86_64` (release profile).
+    # `packages: write` no longer needed here.
     strategy:
       fail-fast: false
       matrix:
@@ -163,25 +159,20 @@ jobs:
             else
               cargo test --features "${{ matrix.combo.features }}" --lib
             fi
-      # v7.0.12 (CIRISEdge#216 / CIRISCache adoption) — save the L2
-      # cache on main-branch builds of the canonical pyo3-full lane.
-      # Only ONE matrix entry saves per workflow to keep the GHCR
-      # package small + avoid mid-matrix race writes; pyo3-full is the
-      # widest feature set so its target/ subsumes the leaner lanes'
-      # contents. PR/tag runs read but don't write; the warmer is
-      # main-branch only.
+      # CIRISEdge#229 — RESTORE only on this lane. The canonical
+      # linux-x86_64 save lives on the `pyo3-wheel` `linux-x86_64`
+      # matrix entry (release-profile `target/`, ~1 GB), matching every
+      # other PLAT in the matrix.
       #
-      # v7.3.2 (CIRISEdge#229) — saves under the canonical key
-      # computed above so sibling repos (CIRISServer, CIRISLensCore,
-      # etc.) restoring under the same (platform, rustc, p/e/v) triple
-      # land directly on the blob this lane populates.
-      - uses: CIRISAI/CIRISCache/save@v1
-        if: |
-          github.ref == 'refs/heads/main'
-            && matrix.combo.name == 'pyo3-full'
-        with:
-          key: ${{ steps.cachekey.outputs.key }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # v7.4.4 (CIRISEdge#238) — the prior canonical save site was THIS
+      # lane (`linux-x86_64-test` / `pyo3-full`). That captured a debug
+      # `target/` + every feature combo's artifacts + `incremental/`,
+      # ballooning the saved blob to ~7.5 GB. Downstream release
+      # consumers (CIRISServer wheels, conformance harness) needed
+      # release artifacts; cargo refingerprinted on the wrong profile
+      # and recompiled the substrate anyway → 7.5 GB downloaded for ~
+      # nothing. Move the save to `pyo3-wheel linux-x86_64` (release
+      # profile, ~1 GB) — same canonical key, useful blob.
 
   # ─── darwin-aarch64 — Phase 1 macOS dev path ────────────────────────
   # No pyo3 feature here per persist's matrix precedent — the abi3 wheel
@@ -1609,14 +1600,19 @@ jobs:
           path: target/release/emit_edge_extras
           retention-days: 7
       # CIRISEdge#229 — save warm cache to GHCR on main only, one save
-      # per canonical PLAT. The wheel matrix is the canonical save
-      # site for linux-aarch64, macos-aarch64, windows-x64 (the
-      # linux-x86_64-test pyo3-full lane is the canonical save site
-      # for linux-x86_64).
+      # per canonical PLAT. The wheel matrix is now the canonical save
+      # site for EVERY desktop PLAT — linux-x86_64, linux-aarch64,
+      # macos-aarch64 (`darwin-aarch64` label), windows-x64
+      # (`windows-x86_64` label). All four save a release-profile
+      # `target/` blob (~1 GB), matching what persist + verify save
+      # and what downstream release consumers can actually reuse.
+      #
+      # v7.4.4 (CIRISEdge#238) — linux-x86_64 was previously saved on
+      # the `linux-x86_64-test` `pyo3-full` lane (debug profile + all
+      # feature combos + incremental → ~7.5 GB blob). Moved here so
+      # consumers get a release blob like every other PLAT.
       - uses: CIRISAI/CIRISCache/save@v1
-        if: |
-          github.ref == 'refs/heads/main'
-            && matrix.label != 'linux-x86_64'
+        if: github.ref == 'refs/heads/main'
         with:
           key: ${{ steps.cachekey.outputs.key }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "7.4.3"
+version = "7.4.4"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]


### PR DESCRIPTION
## Summary

Closes #238. CIRISServer measured edge's linux-x86_64 CIRISCache blob at **~7.5 GB compressed** — 7.6× larger than persist's (1.5 GB) or CIRISServer's own server blob (987 MB). Cold-restore cost: 452 s on a CIRISServer CI run.

## Root cause

Linux-x86_64 canonical save was on `linux-x86_64-test` `pyo3-full` (test lane). That captured DEBUG profile `target/` + every feature combo's artifacts + `incremental/`. Useless to release consumers — cargo refingerprints on profile mismatch and recompiles the substrate anyway.

linux-x86_64 was the **only outlier**. Every other PLAT already saves from its release build lane (pyo3-wheel, android-ndk, ios-pyo3).

## Fix

Move the linux-x86_64 canonical save from `linux-x86_64-test pyo3-full` → `pyo3-wheel linux-x86_64`. Drop the `matrix.label != 'linux-x86_64'` filter on pyo3-wheel save. `packages: write` permission removed from `linux-x86_64-test` (pyo3-wheel already has it).

## Expected impact

- linux-x86_64 blob: ~7.5 GB → ~1 GB (matches every other PLAT)
- Cold-restore: ~7.5 min → seconds
- Same canonical key → consumers transparently pick up the lean blob on the next main-branch warmer pass

## Final save coverage (9 canonical PLATs, 3 save sites, all release)

| Site | PLATs |
|---|---|
| `android-ndk` | android-{arm64-v8a, x86_64, armeabi-v7a} |
| `ios-pyo3` | ios-{aarch64, aarch64-sim} |
| `pyo3-wheel` | linux-x86_64, linux-aarch64, macos-aarch64, windows-x64 |

## Substrate floor

Unchanged: CIRISVerify v8.3.0 / CIRISPersist v11.5.0 / Leviculum v0.8.1+ciris.1.

## Test plan

- [x] yaml parses
- [x] pin-skew gate — OK
- [x] 3 save sites confirmed via grep (was 4)
- [ ] CI matrix green
- [ ] On next main-branch warmer: linux-x86_64 blob size measurably drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D1dESkHmchUHZvedVdx4Ln