### PR TITLE
feat(v8.1.0): adopt directory_ops_capsule — migrate off raw-dyn federation_directory (closes #245)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.0.0"
+version = "8.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -192,10 +192,12 @@ publish = false
 # bundles a copy into `ciris_persist.libs/` so `pip install ciris-edge`
 # Just Works on any glibc≥2.34 host; `cargo`-side builds require
 # `libsqlite3-dev` (apt) / `libsqlite3` (brew) — see docs/PYPI_PUBLISH.md.
-# v8.1.x — persist v11.8.0 ships `pyo3-sqlite = ["_pyffi"]` (postgres-free
-# PyEngine FFI, CIRISPersist#328), which edge's `pyo3-sqlite` feature above
-# targets for the Windows sqlite-only wheel.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.8.0", version = "11", features = ["sqlite", "encrypted-kv"] }
+# persist v11.8.0 ships `pyo3-sqlite = ["_pyffi"]` (postgres-free PyEngine
+# FFI, CIRISPersist#328), which edge's `pyo3-sqlite` feature above targets
+# for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
+# ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
+# that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.8.2", version = "11", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1080,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.8.0", version = "11", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.8.2", version = "11", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4130,14 +4130,61 @@ pub fn init_edge_runtime(
     }
     let executor = Arc::new(executor);
 
+    // ── v8.1.0 (CIRISEdge#245 / CIRISPersist#329 + #333) — the ABI-stable
+    // directory ops proxy REPLACES the raw-`dyn` `federation_directory_capsule`.
+    // Previously edge held an `Arc<dyn FederationDirectory>` and called its
+    // trait methods through edge's OWN statically-compiled vtable indices —
+    // the CIRISPersist#320 misdispatch class (edge's `put_transport_destination`
+    // landing on the wheel's `lookup_shared_instance_lease`). Now edge extracts
+    // the `directory_ops_capsule` (a C-ABI `Directory { data, vtable }`) and
+    // hands it to persist's `build_ops_directory`, which returns an
+    // `Arc<dyn FederationDirectory>` whose every method serializes a
+    // `DirectoryOp`, calls `vtable.build_op` (dispatching INSIDE persist's
+    // `.so`, against persist's own vtable), spawns the op-future via the same
+    // `executor_capsule`, and awaits the `DirectoryOpResult`. Version skew can
+    // no longer misdispatch. Every method `federation_directory_for_edge`
+    // touches is a covered op (the base 24 + the 6 peer-mutation ops of
+    // CIRISPersist#333 / v11.8.2: add/remove_peer_record, update_peer_*).
+    if !engine.hasattr("directory_ops_capsule").unwrap_or(false) {
+        return Err(PyRuntimeError::new_err(
+            "persist v11.8.2+ required for the ABI-stable directory ops proxy — \
+             your persist version doesn't expose directory_ops_capsule. Upgrade \
+             ciris-persist (Cargo `tag = \"v11.8.2\"`, pyproject \
+             `ciris-persist>=11.8.2,<12`). See CIRISEdge#245 / CIRISPersist#329+#333.",
+        ));
+    }
+    // The `directory_ops_capsule` stores `*mut Directory as usize` (persist's
+    // `build_capsule_with_destructor`, PyCapsule tag
+    // `ciris_persist::directory_ops_v1`) — the same shape as `executor_capsule`.
+    // Extract as `usize`, cast back, bitwise-copy the `{ data, vtable }` fields.
+    // The PyCapsule destructor (set by persist) calls `vtable.drop` at Python GC;
+    // `OpsDirectory` has NO Drop impl, so edge holds only a reference copy — never
+    // the destructor responsibility — exactly like the executor above.
     #[allow(unsafe_code)]
-    let directory_arc: Arc<dyn ciris_persist::federation::FederationDirectory> = unsafe {
-        extract_capsule::<Arc<dyn ciris_persist::federation::FederationDirectory>, _, _>(
-            &engine,
-            "federation_directory_capsule",
-            Arc::clone,
-        )?
+    let directory_handle: ciris_persist::ffi::directory_capsule::Directory = unsafe {
+        extract_capsule::<usize, _, _>(&engine, "directory_ops_capsule", |raw_usize| {
+            let ptr = *raw_usize as *const ciris_persist::ffi::directory_capsule::Directory;
+            // SAFETY: `raw_usize` is the `Box::into_raw`'d `*mut Directory`
+            // persist stored; the Box is alive for the PyCapsule's lifetime
+            // (its destructor runs `Box::from_raw` + `vtable.drop` at GC),
+            // rooted in the Python `engine` object outliving this extraction.
+            let d = &*ptr;
+            ciris_persist::ffi::directory_capsule::Directory {
+                data: d.data,
+                vtable: d.vtable,
+            }
+        })?
     };
+    let directory_arc: Arc<dyn ciris_persist::federation::FederationDirectory> =
+        ciris_persist::ffi::directory_capsule::build_ops_directory(
+            directory_handle,
+            Arc::clone(&executor),
+        )
+        .map_err(|e| {
+            PyRuntimeError::new_err(format!(
+                "init_edge_runtime: build_ops_directory (directory_ops_capsule) failed: {e}"
+            ))
+        })?;
     #[allow(unsafe_code)]
     let queue_dispatch: BackendDispatch = unsafe {
         extract_capsule::<BackendDispatch, _, _>(
@@ -4173,26 +4220,30 @@ pub fn init_edge_runtime(
     // implement `FederationDirectory` AND `OutboundQueue`, so we can
     // lift them to all three trait objects edge holds.
     //
-    // `directory_arc` from the federation_directory_capsule is the
-    // already-coerced `Arc<dyn FederationDirectory>` from persist's
-    // perspective; we cross-check it points at the same backend the
-    // BackendDispatch arm carries (debug assertion only; in production
-    // persist's `*_capsule` methods are carved from the engine's one
-    // `BackendDispatch`, so the invariant holds by construction).
+    // v8.1.0 (CIRISEdge#245) — `directory_arc` is now the ops-proxy
+    // `Arc<dyn FederationDirectory>` from `build_ops_directory` (every call
+    // dispatches inside persist's `.so`), NOT the raw-`dyn`
+    // federation_directory_capsule. `verify_dir` / `rooting_dir` /
+    // `blackhole_rules` / `derived_schema` below still lift the CONCRETE
+    // `Arc<{Sqlite,Postgres}Backend>` out of the `outbound_queue_capsule`
+    // `BackendDispatch` — those edge blanket impls bind `F: Sized` so they
+    // need a concrete type, and that path is a monomorphized concrete call
+    // (NOT the raw-`dyn` vtable-index misdispatch #245/#320 targets), so it
+    // stays as-is.
     debug_assert!(
         Arc::strong_count(&directory_arc) >= 1,
-        "federation_directory_capsule produced a live Arc",
+        "build_ops_directory produced a live Arc",
     );
     // v0.15.1 (CIRISEdge#26 mutation surface) — retain the
     // `Arc<dyn FederationDirectory>` for the UniFFI peer-mutation
     // entry points (`peer_add` / `peer_remove` /
     // `peer_set_{alias,trust,notes,policy}`). These need the concrete
     // FederationDirectory trait object — distinct from `verify_dir`
-    // (which is an `Arc<dyn VerifyDirectory>` adapter). Both
-    // ultimately reference the same backend (persist's
-    // `federation_directory_capsule` is carved from the engine's one
-    // `BackendDispatch`), but the trait-object identities differ
-    // because edge holds two separate `dyn`-trait views.
+    // (which is an `Arc<dyn VerifyDirectory>` adapter). Both ultimately
+    // reach the same backend (the ops proxy and the `outbound_queue_capsule`
+    // BackendDispatch are both carved from the engine's one backend), but
+    // the trait-object identities differ because edge holds two separate
+    // `dyn`-trait views.
     let federation_directory_for_edge: Arc<dyn ciris_persist::federation::FederationDirectory> =
         directory_arc;
 


### PR DESCRIPTION
## What

Closes **#245**. Replaces the raw-`dyn` `federation_directory_capsule` with persist's ABI-stable `directory_ops_capsule` (CIRISPersist#322/#329/#333, **v11.8.2**), closing the CIRISPersist#320 vtable-misdispatch class for edge's directory surface.

## Why

`federation_directory_for_edge` was an `Arc<dyn FederationDirectory>` whose trait methods edge dispatched through its **own** statically-compiled vtable indices. Under any persist-vs-wheel skew that misdispatches silently — the #320 bring-up hang (edge's `put_transport_destination` landed on the wheel's `lookup_shared_instance_lease`).

## How

`init_edge_runtime` extracts the `directory_ops_capsule` (C-ABI `Directory { data, vtable }`, tag `ciris_persist::directory_ops_v1`, `*mut Directory as usize` — same shape as `executor_capsule`) and hands it to `build_ops_directory(directory, executor)`. The returned `Arc<dyn FederationDirectory>` serializes each call to a `DirectoryOp`, runs `vtable.build_op` **inside persist's `.so`** (persist's own vtable), spawns the op-future via the existing `executor_capsule`, and awaits the `DirectoryOpResult`. Skew can no longer misdispatch.

- **Ownership** mirrors the executor: `OpsDirectory` has no `Drop`, so edge holds only a bitwise reference-copy of `{ data, vtable }`; the PyCapsule destructor owns the single `vtable.drop` at GC (rooted in the engine for the process).
- **ABI check** inside `build_ops_directory` (refuses on `!= DIRECTORY_ABI_VERSION`), plus a `hasattr` guard with a clear pin-floor message.
- **Coverage**: every method the handle invokes is a covered op — the base 24 + the 6 peer-mutation ops (CIRISPersist#333: `add`/`remove_peer_record`, `update_peer_{alias,trust,notes,policy}`) that `peer_add`/`peer_remove`/`peer_set_*` and the init `reseed_canonical_bootstrap_peers` require.
- **Out of scope**: `verify_dir`/`rooting_dir`/`blackhole_rules`/`derived_schema` stay on the concrete `outbound_queue_capsule` BackendDispatch (edge blanket impls bind `F: Sized`; a monomorphized concrete call is not the raw-`dyn` vtable-index misdispatch #245/#320 targets).

## Substrate

ciris-persist v11.6.0 → **v11.8.2** (dep + dev-dep). `cargo check` + `cargo clippy --lib -D warnings` clean on the `pyo3`/`transport-http`/`transport-reticulum`/`ffi-uniffi` combo. Exercised end-to-end in CI by the init + `tests/peer_mutation_ffi.rs` integration lanes (init reseed → `add_peer_record` through the proxy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)