### PR TITLE
feat(v8.2.0): Edge::run(self: Arc<Self>) — mesh initiator leg on run()-lifecycle nodes (closes #249)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.1.0"
+version = "8.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -3356,13 +3356,28 @@ impl Edge {
 
     /// Run the listeners + dispatch loops + outbound dispatcher.
     /// Returns when the shutdown signal fires.
+    ///
+    /// v8.2.0 (CIRISEdge#249) — takes `self: Arc<Self>` instead of `self`.
+    /// The lifecycle only *clones* fields out of the edge into its spawned
+    /// tasks (it never moves the edge apart), so an `Arc` receiver keeps
+    /// the running edge callable: a node wraps its `Edge` in an `Arc`,
+    /// spawns `Arc::clone(&edge).run(shutdown_rx)`, and keeps the other
+    /// clone to issue `&self` calls — `send_opaque_request` /
+    /// `send_opaque_event` — from a separate task (e.g. an HTTP handler)
+    /// on the SAME running edge. That is the CC-0.7 mesh control-plane
+    /// **initiator** leg (`0x0000_*`); before this it was unreachable on a
+    /// `run()`-lifecycle node because `run(self)` consumed the edge.
+    /// Distinct from CIRISEdge#243 (the `init_edge_runtime` outbound
+    /// dispatcher gap) — this is the `run()` path, and it keeps run()'s
+    /// CRPL replication pre-dispatch + sweeps intact (which
+    /// `spawn_background_listeners` alone drops).
     // v0.18.0 — function grew past clippy's 100-line cap once the #33
     // background blackhole-pruner spawn landed alongside the existing
     // listener / dispatcher / sweeps / inbound spawn graph. The
     // spawn-graph composition is the construction-time contract; extracting
     // it would fragment the lifecycle invariants without adding clarity.
     #[allow(clippy::too_many_lines)]
-    pub async fn run(self, shutdown_rx: watch::Receiver<bool>) -> Result<(), EdgeError> {
+    pub async fn run(self: Arc<Self>, shutdown_rx: watch::Receiver<bool>) -> Result<(), EdgeError> {
         let (inbound_tx, mut inbound_rx) = mpsc::channel::<InboundFrame>(1024);
 
         // Spawn one listener per transport.

--- a/tests/ceg_content_discipline.rs
+++ b/tests/ceg_content_discipline.rs
@@ -274,7 +274,8 @@ where
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     tokio::spawn(async move {
-        let _ = edge.run(shutdown_rx).await;
+        // v8.2.0 (CIRISEdge#249) — `run` takes `self: Arc<Self>`.
+        let _ = std::sync::Arc::new(edge).run(shutdown_rx).await;
     });
     tokio::time::sleep(Duration::from_millis(20)).await;
 

--- a/tests/content_fetch.rs
+++ b/tests/content_fetch.rs
@@ -293,7 +293,8 @@ where
 
     let (shutdown_tx, shutdown_rx) = watch::channel(false);
     tokio::spawn(async move {
-        let _ = edge.run(shutdown_rx).await;
+        // v8.2.0 (CIRISEdge#249) — `run` takes `self: Arc<Self>`.
+        let _ = std::sync::Arc::new(edge).run(shutdown_rx).await;
     });
     // Give the listener a moment to claim the receiver before the
     // test starts pushing.

--- a/tests/opaque_conformance.rs
+++ b/tests/opaque_conformance.rs
@@ -491,7 +491,8 @@ mod loopback {
             .expect("enqueue opaque event");
         let (_sd_tx, sd_rx) = watch::channel(false);
         tokio::spawn(async move {
-            let _: Result<(), EdgeError> = edge_a.run(sd_rx).await;
+            // v8.2.0 (CIRISEdge#249) — `run` takes `self: Arc<Self>`.
+            let _: Result<(), EdgeError> = std::sync::Arc::new(edge_a).run(sd_rx).await;
         });
 
         let (_sender, kind, payload) = tokio::time::timeout(Duration::from_secs(45), rx.recv())
@@ -501,6 +502,62 @@ mod loopback {
         assert_eq!(kind, 0x0000_0001);
         assert_eq!(payload, b"event-bytes");
 
+        std::mem::forget(rt_b);
+    }
+
+    /// 4. CIRISEdge#249 — the mesh control-plane INITIATOR leg works on a
+    ///    `run()`-lifecycle node. Before #249, `Edge::run(self)` consumed
+    ///    the edge, so a node that booted via `run()` had no handle left to
+    ///    issue `send_opaque_request`. Now `run(self: Arc<Self>)` lets A
+    ///    spawn the FULL run lifecycle on one `Arc` clone AND keep another
+    ///    to initiate a request from a separate task. B answers 200 via its
+    ///    own listeners. This is the `run()`-path counterpart to the
+    ///    `spawn_background_listeners`-path round-trip in test 1, and the
+    ///    exact acceptance criterion for CIRISServer#128 Phase E.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn opaque_request_initiator_works_on_run_lifecycle() {
+        use ciris_edge::EdgeError;
+        use tokio::sync::watch;
+
+        let (edge_a, edge_b, _a_id, b_id) = two_node().await;
+
+        // B answers kind 0x0000_0002 with a 200.
+        edge_b.register_opaque_handler(0x0000_0002, |_sender_key_id, payload| {
+            assert_eq!(payload, b"seed?");
+            ciris_edge::messages::OpaqueResponse {
+                kind: 0x0000_0002,
+                status: 200,
+                payload: b"seeded".to_vec(),
+            }
+        });
+
+        let rt_a = edge_runtime("opaque-rt-a-249");
+        let rt_b = edge_runtime("opaque-rt-b-249");
+
+        // A boots on the FULL `run()` lifecycle via an `Arc` clone; the
+        // original `edge_a` handle survives for the initiator send below.
+        let (_sd_tx, sd_rx) = watch::channel(false);
+        let edge_a_run = Arc::clone(&edge_a);
+        rt_a.spawn(async move {
+            let _: Result<(), EdgeError> = edge_a_run.run(sd_rx).await;
+        });
+        let _hb = edge_b.spawn_background_listeners(rt_b.handle());
+
+        // Let A's run() lifecycle claim its listeners before initiating.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Initiator leg: issue the request from the STILL-HELD `edge_a`,
+        // proving a run()-lifecycle node can drive `send_opaque_request`.
+        let resp = edge_a
+            .send_opaque_request(&b_id, 0x0000_0002, b"seed?".to_vec(), 45_000)
+            .await
+            .expect("initiator send on a run()-lifecycle node");
+
+        assert_eq!(resp.kind, 0x0000_0002);
+        assert_eq!(resp.status, 200);
+        assert_eq!(resp.payload, b"seeded");
+
+        std::mem::forget(rt_a);
         std::mem::forget(rt_b);
     }
 }


### PR DESCRIPTION
## What

Closes **#249**. `Edge::run(self, shutdown_rx)` → `run(self: Arc<Self>, shutdown_rx)` so a node that boots on the `run()` lifecycle keeps an `Arc<Edge>` handle to issue `send_opaque_request` / `send_opaque_event` from another task — the CC-0.7 mesh control-plane **initiator** leg (`0x0000_*`).

## Why

`run(self)` consumed the edge. The responder side works (handlers registered before `run()`), but cross-node **sends** were stubbed local-only on CIRISServer (`target==self` short-circuit; else `502 mesh_send_unwired`) because no `Arc<Edge>` survived `run()`. This is the hard blocker for **CIRISServer#128 Phase E** (seed over the relay by key_id).

## How

Issue Option 1 (preferred). The `run` body only *clones* fields into its spawned tasks — it never moves the edge apart — so the body is unchanged; the `Arc` receiver just keeps the running edge callable via `Deref`. Keeps run()'s CRPL replication pre-dispatch + sweeps (distinct from #243, the `init_edge_runtime` outbound-dispatcher gap).

## Breaking (coordinated)

Rust API: `edge.run(rx)` → `Arc::new(edge).run(rx)`. Sole downstream is CIRISServer, whose `edge_mesh_requester` is written and ready to switch off its local-only stub the moment this lands (per #249). Updated the 3 in-repo test call sites.

## Test

New `opaque_request_initiator_works_on_run_lifecycle`: A boots the full `run()` lifecycle on an `Arc` clone **and** initiates `send_opaque_request` from the still-held handle; B answers 200. The run()-path counterpart to the existing `spawn_background_listeners` round-trip, and the exact Phase E acceptance criterion. Green locally; `cargo check` + `clippy --lib/-test -D warnings` clean on the pyo3/transport combos.

## Version

Cut as **v8.2.0**. It's a source-breaking Rust-API change, but edge is `publish = false` (consumed via git tag / wheel, not crates.io) and the wire is unchanged; the sole Rust consumer is coordinated. Flagging in case you'd prefer v9.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)