### PR TITLE
feat(v8.4.0): adopt persist v12.0.0 + verify v8.4.0 — genesis-mesh rooting anchor (closes #253)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.3.0"
+version = "8.4.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.9.1", version = "11", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.0.0", version = "12", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -221,8 +221,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.9.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -231,7 +231,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.3.0", version = "8" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.4.0", version = "8" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1080,7 +1080,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v11.9.1", version = "11", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.0.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=11.0.0,<12",
+    "ciris-persist>=12.0.0,<13",
 ]
 dynamic = ["version"]
 

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -3138,13 +3138,30 @@ async fn resolve_announce_cold_start(
         RootingVerdict::Confirmed { chain } => chain,
         RootingVerdict::Rejected { rejection } => {
             // DirectoryError is a transient substrate fault — retryable,
-            // not a verdict on the binding. The other seven variants
-            // are terminal structural/crypto rejections: AV-42 events.
+            // not a verdict on the binding. The other terminal variants
+            // are structural/crypto rejections: AV-42 events.
             if matches!(rejection, RootingRejection::DirectoryError { .. }) {
                 tracing::warn!(
                     key_id = %key_id,
                     kind = rejection.kind(),
                     "announce rooting deferred: directory error (retryable, peer not blacklisted)",
+                );
+            } else if matches!(rejection, RootingRejection::TerminusNotInAnchor { .. }) {
+                // v8.4.0 (CIRISEdge#253 / CIRISPersist#344, v12.0.0) — the chain
+                // terminates at a real steward/accord_holder-SHAPED key whose
+                // pubkey is NOT one of the pinned HUMANITY_ACCORD holders.
+                // Distinct from `not_rooted_at_steward` (no steward terminus at
+                // all): this is the "mis-seeded anchor vs genuinely-unrooted
+                // peer" diagnostic. EXPECTED for every announce until the
+                // genesis mesh is seeded (persist v12.0.1 + the CIRISServer#140
+                // holder-app op that scrub-signs the canonical node under A1) —
+                // fail-secure, not a regression, and not a spoof by itself.
+                tracing::warn!(
+                    av = "AV-42",
+                    key_id = %key_id,
+                    kind = rejection.kind(),
+                    "announce rejected: chain terminus is not a pinned accord holder \
+                     (genesis mesh unseeded or mis-seeded anchor)",
                 );
             } else {
                 tracing::warn!(


### PR DESCRIPTION
Adopts **CIRISPersist v12.0.0** (#344/#345) — the v12.0 genesis-mesh rooting security core. `root_binding` now enforces the HUMANITY_ACCORD anchor **internally** (secure-by-default, 3-arg signature unchanged), so edge's `RootingDirectory::root_binding → persist_root_binding` compiles as-is and gets the anchor gate for free. Closes #253 (and makes #252 redundant — already closed).

## Changes
- **ciris-persist** v11.9.1 → **v12.0.0** (both Cargo entries).
- **ciris-verify family** v8.3.0 → **v8.4.0** — `ciris-keyring` + `ciris-crypto` + `ciris-verify-core`. #253 flagged only verify-core; the other two are the same CIRISVerify repo and must bump in lockstep (persist v12.0.0 pins verify v8.4.0 — any split → two `ciris_verify_core` graph versions → type break).
- **pyproject** `ciris-persist>=11.0.0,<12` → `>=12.0.0,<13`.
- **`TerminusNotInAnchor` diagnostic** in `resolve_announce_cold_start` — its own branch distinct from `not_rooted_at_steward`: the "terminus is a real steward/accord_holder shape but its pubkey is NOT a pinned accord holder" case (mis-seeded anchor vs genuinely-unrooted peer). Non-exhaustive `matches!`, build-safe.

## Behavior
Announces stay **fail-secure** until the genesis mesh is seeded (persist **v12.0.1** + CIRISServer#140), now rejecting with the precise `TerminusNotInAnchor` reason. Not a regression — nothing rooted before.

## ⚠️ Release gating
Builds green against the v12.0.0 / v8.4.0 **git tags** (cargo check + clippy `-D warnings`). But **`ciris-persist 12.0.0` is not on PyPI yet** (latest is 11.9.1). Since pyproject now pins `ciris-persist>=12.0.0`, an edge wheel published now would be **uninstallable** in cohabitation. **Do not tag/publish v8.4.0 until the persist v12.0.0 wheel is on PyPI** — bundle with the next CIRISAgent cut, ahead of persist v12.0.1. Merging to main (staging the adoption) is safe; only the tag/publish waits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)