### PR TITLE
feat(v8.5.1): §Q B5 consumption accounting — sum content_bytes by cohort_scope (persist v12.1.0, #260)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.5.0"
+version = "8.5.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.0.2", version = "12", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.1.0", version = "12", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1080,7 +1080,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.0.2", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.1.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/replication/storage_contention.rs
+++ b/src/replication/storage_contention.rs
@@ -31,8 +31,11 @@
 //! [`StorageBudgetV1::verify`] / [`CorpusWantV1::verify`] before acting on
 //! them (CIRISEdge#258 Cut 1).
 
+use std::collections::BTreeMap;
+
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine as _;
+use ciris_persist::fountain::FountainHeldMeta;
 use serde::{Deserialize, Serialize};
 
 /// The `self` / `family` `cohort_scope` values that MUST NOT appear in a
@@ -438,6 +441,34 @@ fn is_sorted_dedup<'a>(it: impl Iterator<Item = &'a str>) -> bool {
     true
 }
 
+// ── B5 consumption accounting (edge-internal) ─────────────────────────
+
+/// CC 6.1.5.2 §Q **B5 consumption accounting** — sum the durable bytes
+/// actually held, grouped by `cohort_scope`, recomputed **edge-internally**
+/// from what persist holds. Consumption is NEVER trusted from the wire; it
+/// is reconciled against real bytes so a forged `StorageBudgetV1` cannot
+/// become a force-evict channel (B5 consumption-challengeability).
+///
+/// Input is persist's [`FountainHeldMeta`] rows
+/// (`FederationDirectory::list_held_fountain_content`, enriched with
+/// `content_bytes` + `cohort_scope` as of CIRISPersist v12.1.0 / #349).
+/// Content whose signed envelope declares no scope (`cohort_scope: None`)
+/// rolls up under the `None` key — **unattributed budget** (CIRISEdge#260).
+///
+/// Producers of edge-published fountain content that should draw from a
+/// scope's budget MUST set the `cohort_scope` key in the content's signed
+/// envelope; persist round-trips it verbatim (it does not infer scope), and
+/// unscoped content lands as `None` here.
+#[must_use]
+pub fn consumption_by_scope(held: &[FountainHeldMeta]) -> BTreeMap<Option<String>, u64> {
+    let mut acc: BTreeMap<Option<String>, u64> = BTreeMap::new();
+    for meta in held {
+        let bucket = acc.entry(meta.cohort_scope.clone()).or_default();
+        *bucket = bucket.saturating_add(meta.content_bytes);
+    }
+    acc
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,5 +659,39 @@ mod tests {
         let mut tampered = w.clone();
         tampered.size_cap_bytes = 1;
         assert!(tampered.verify(&ed_pub, &pqc_pub).is_err());
+    }
+
+    fn held(scope: Option<&str>, content_bytes: u64) -> FountainHeldMeta {
+        FountainHeldMeta {
+            content_id: "cid".into(),
+            corpus_kind: "corpus.text".into(),
+            pqc_key_id: "pub".into(),
+            original_content_length: content_bytes,
+            n_source: 10,
+            k_repair: 5,
+            min_viable_symbols: 10,
+            symbol_size: 100,
+            held_symbols: 10,
+            content_bytes,
+            cohort_scope: scope.map(String::from),
+            recoverable: true,
+            admitted_at: "2026-07-03T00:00:00Z".into(),
+        }
+    }
+
+    #[test]
+    fn consumption_sums_content_bytes_by_scope() {
+        let rows = vec![
+            held(Some("community"), 100),
+            held(Some("community"), 250),
+            held(Some("affiliations"), 40),
+            held(None, 7), // unscoped envelope → unattributed budget
+        ];
+        let by = consumption_by_scope(&rows);
+        assert_eq!(by.get(&Some("community".to_string())), Some(&350));
+        assert_eq!(by.get(&Some("affiliations".to_string())), Some(&40));
+        assert_eq!(by.get(&None), Some(&7));
+        assert_eq!(by.len(), 3);
+        assert!(consumption_by_scope(&[]).is_empty());
     }
 }


### PR DESCRIPTION
Adopts **CIRISPersist v12.1.0** (#349) and consumes the enriched held-content surface for CC 6.1.5.2 §Q **B5 consumption accounting**. Closes #260; the B5-accounting slice of §Q Cut 2 (#258).

- **ciris-persist v12.0.2 → v12.1.0** (both entries). `FountainHeldMeta` now carries `content_bytes: u64` + `cohort_scope: Option<String>` (additive; `#[serde(default)]`; no migration — scope rides the already-stored signed envelope).
- **`consumption_by_scope(&[FountainHeldMeta]) -> BTreeMap<Option<String>, u64>`** — sums the durable bytes actually held, grouped by `cohort_scope`, recomputed **edge-internally** (never trusted from the wire — B5 consumption-challengeability). Unscoped content (`cohort_scope: None`) → unattributed budget.

**Producer note:** edge-published fountain content that should draw from a scope's budget MUST set the `cohort_scope` key in its signed envelope — persist round-trips it verbatim, does not infer it.

11 unit tests + clippy `-D warnings` green. Remaining Cut 2 work (descent-order arbitration + enumeration/pin filter) tracked in #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)