### PR TITLE
feat(v8.6.0): Key-plane publish-own — node advertises its OWN + anchored records (closes #257)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.5.1"
+version = "8.6.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2052,12 +2052,23 @@ impl PyEdge {
     ///   transport was registered at init.
     /// - `ValueError("unknown EnvelopeKind: {token}")` if a kind
     ///   string in `peers` doesn't match the 10 wire tokens.
-    #[pyo3(signature = (peers, cadence_seconds = None))]
+    #[pyo3(signature = (peers, cadence_seconds = None, key_publish_set = None))]
     fn start_replication(
         &self,
         py: Python<'_>,
         peers: Vec<(String, String)>,
         cadence_seconds: Option<u64>,
+        // CIRISEdge#257 — the Key-plane publish set: the node's OWN key_id
+        // + held rooting-relevant / anchored key_ids (records whose
+        // scrub_key_id points at a trusted anchor). When `Some`, the `Key`
+        // `EnvelopeKind` advertises THESE (KERI publish-own) instead of the
+        // cohort-members'-own — the mesh-seed path (a node is never in its
+        // own consent cohort, so without this it never advertises its own
+        // scrub-signed record and no verifier can root it). The server
+        // computes the set (it holds the anchor knowledge); edge wraps it
+        // into the bridge's Key-plane selector. `None` preserves the
+        // pre-#257 cohort projection.
+        key_publish_set: Option<Vec<String>>,
     ) -> PyResult<PyReplicationHandle> {
         let directory = self
             .inner
@@ -2080,6 +2091,14 @@ impl PyEdge {
             config.scheduler.cadence = std::time::Duration::from_secs(secs);
         }
 
+        // CIRISEdge#257 — wrap the server-supplied Key-plane publish set
+        // into the bridge's Key-plane selector (a `CohortProvider`).
+        let key_selector: Option<crate::replication::bridge::CohortProvider> =
+            key_publish_set.map(|set| {
+                std::sync::Arc::new(move || set.clone())
+                    as crate::replication::bridge::CohortProvider
+            });
+
         let executor = self.executor.clone();
         let runtime = py.detach(|| {
             run_async(&executor, async move {
@@ -2088,6 +2107,7 @@ impl PyEdge {
                     transport,
                     typed_peers,
                     config,
+                    key_selector,
                 )
                 .await
             })

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -188,6 +188,18 @@ pub struct OperationalProviders {
 pub struct FederationDirectoryReplicationBridge {
     directory: Arc<dyn FederationDirectory>,
     cohort: CohortProvider,
+    /// CIRISEdge#257 — the Key-plane publish-set selector. When `Some`,
+    /// [`Self::list_keys`] projects THIS set (the node's OWN record + held
+    /// rooting-relevant / anchored records) instead of the `cohort`. A
+    /// node is never in its own consent cohort, so without this it would
+    /// never advertise its own scrub-signed key record and no verifier
+    /// could ever root it — the mesh-seed blocker. `None` preserves the
+    /// pre-#257 cohort-members'-own projection (back-compat). The server
+    /// supplies the selector (own + anchored) via
+    /// [`Self::with_key_selector`]; edge only provides the hook (all
+    /// replication logic lives in edge — the engine does not hard-code
+    /// the Key-plane projection).
+    key_selector: Option<CohortProvider>,
     cache: Mutex<BridgeCache>,
     config: BridgeConfig,
     /// v2 operational-data admission providers. `None` = v2 admission
@@ -215,6 +227,7 @@ impl FederationDirectoryReplicationBridge {
         Self {
             directory,
             cohort,
+            key_selector: None,
             cache,
             config,
             operational: None,
@@ -247,10 +260,25 @@ impl FederationDirectoryReplicationBridge {
         Self {
             directory,
             cohort,
+            key_selector: None,
             cache,
             config,
             operational: Some(operational),
         }
+    }
+
+    /// CIRISEdge#257 — install the Key-plane publish-set selector. When
+    /// set, [`Self::list_keys`] advertises the key_ids THIS callback yields
+    /// (the node's OWN record + held anchored records) rather than the
+    /// cohort's members'-own. `None` restores the cohort projection. The
+    /// server computes the own+anchored set (it holds the anchor knowledge);
+    /// edge just projects it through `lookup_public_key` — the KERI
+    /// publish-own model (the controller publishes its own establishment
+    /// record; verifiers pull-and-verify).
+    #[must_use]
+    pub fn with_key_selector(mut self, selector: Option<CohortProvider>) -> Self {
+        self.key_selector = selector;
+        self
     }
 
     async fn cache_insert(&self, kind: EnvelopeKind, hash: [u8; 32], bytes: Vec<u8>) {
@@ -387,14 +415,17 @@ impl FederationDirectoryReplicationBridge {
         u64::try_from(timestamp.timestamp_millis()).unwrap_or(0)
     }
 
-    /// Project the cohort-yielded key_ids through
-    /// `lookup_public_key`, emit one `EnvelopeRef` per resolved
-    /// record. The cohort callback yields the set we anti-entropy
-    /// with; each member's KeyRecord goes on the wire.
+    /// Project the Key-plane publish set through `lookup_public_key`, emit
+    /// one `EnvelopeRef` per resolved record. The set is the
+    /// [`Self::key_selector`] (CIRISEdge#257 — the node's OWN record + held
+    /// anchored records, KERI publish-own) when installed, else the
+    /// `cohort` (pre-#257 cohort-members'-own). The projection is identical
+    /// either way; only the set of key_ids differs.
     async fn list_keys(&self) -> Vec<EnvelopeRef> {
         let mut refs = Vec::new();
         let mut seen: HashSet<[u8; 32]> = HashSet::new();
-        for key_id in (self.cohort)() {
+        let publish_set = self.key_selector.as_ref().unwrap_or(&self.cohort);
+        for key_id in publish_set() {
             if let Ok(Some(row)) = self.directory.lookup_public_key(&key_id).await {
                 if let Some(hash) = Self::decode_hash(&row.persist_row_hash) {
                     if !seen.insert(hash) {
@@ -1116,6 +1147,49 @@ mod tests {
         // on matching content (persist returns Ok on dedup).
         let admitted = bridge.apply_envelope_bytes(EnvelopeKind::Key, &bytes).await;
         assert!(admitted, "idempotent re-apply succeeds");
+    }
+
+    /// CIRISEdge#257 — the Key-plane selector publishes the node's OWN
+    /// record + a third-party anchored record even though neither is in the
+    /// node's consent cohort (KERI publish-own). Without the selector,
+    /// `list_keys` projects the cohort and would never carry them — the
+    /// mesh-seed blocker (a verifier can't root a key it never received).
+    #[tokio::test]
+    async fn key_selector_publishes_own_and_anchored_not_cohort() {
+        let cohort_member = "peer-in-cohort";
+        let own_key = "this-node-own";
+        let anchored = "third-party-anchored";
+
+        // Cohort contains ONLY the peer — never own / anchored (a node is
+        // not in its own consent cohort).
+        let (backend, bridge) = make_bridge(&[cohort_member.to_string()]);
+        for k in [cohort_member, own_key, anchored] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+        }
+
+        // Pre-#257 projection: the cohort → only the cohort member's own.
+        let cohort_refs = bridge.list_envelope_refs(EnvelopeKind::Key).await;
+        assert_eq!(
+            cohort_refs.len(),
+            1,
+            "cohort projection advertises only cohort members' own"
+        );
+
+        // Install the Key-plane publish set {own, anchored}: publish-own.
+        let publish_set = vec![own_key.to_string(), anchored.to_string()];
+        let selector: CohortProvider = Arc::new(move || publish_set.clone());
+        let bridge = bridge.with_key_selector(Some(selector));
+        let refs = bridge.list_envelope_refs(EnvelopeKind::Key).await;
+        assert_eq!(
+            refs.len(),
+            2,
+            "selector advertises the node's own + the anchored record, not the cohort"
+        );
     }
 
     /// Bridge dedupes the same key when listed across multiple cohort

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -144,6 +144,13 @@ impl ReplicationRuntime {
         transport: Arc<dyn Transport>,
         peers: Vec<ReplicationPeer>,
         config: ReplicationRuntimeConfig,
+        // CIRISEdge#257 — the Key-plane publish-set selector. `Some` yields
+        // the node's OWN + held anchored records (KERI publish-own) for the
+        // `Key` `EnvelopeKind`; `None` preserves the pre-#257 cohort
+        // projection. The server computes this set (it holds the anchor
+        // knowledge) and hands it to edge alongside the consent-derived
+        // cohort — edge only provides the hook.
+        key_selector: Option<CohortProvider>,
     ) -> Self {
         // Cohort callback: yields the set of peer_key_ids we
         // anti-entropy with, snapshotted at construction. Hot-adds
@@ -157,11 +164,14 @@ impl ReplicationRuntime {
         let cohort_snapshot: Vec<String> = peers.iter().map(|p| p.peer_key_id.clone()).collect();
         let cohort: CohortProvider = Arc::new(move || cohort_snapshot.clone());
 
-        let bridge = Arc::new(FederationDirectoryReplicationBridge::with_config(
-            Arc::clone(&directory),
-            cohort,
-            config.bridge,
-        ));
+        let bridge = Arc::new(
+            FederationDirectoryReplicationBridge::with_config(
+                Arc::clone(&directory),
+                cohort,
+                config.bridge,
+            )
+            .with_key_selector(key_selector),
+        );
 
         let registry = Arc::new(ReplicationRegistry::new());
 
@@ -444,6 +454,7 @@ mod tests {
             transport,
             Vec::new(),
             ReplicationRuntimeConfig::default(),
+            None,
         )
         .await;
         assert!(rt.registry().is_empty().await);
@@ -466,6 +477,7 @@ mod tests {
             transport,
             peers,
             ReplicationRuntimeConfig::default(),
+            None,
         )
         .await;
         let registry = rt.registry();
@@ -487,6 +499,7 @@ mod tests {
             transport,
             Vec::new(),
             ReplicationRuntimeConfig::default(),
+            None,
         )
         .await;
         rt.register_peer("agent-bob", EnvelopeKind::Attestation)
@@ -508,6 +521,7 @@ mod tests {
             transport,
             Vec::new(),
             ReplicationRuntimeConfig::default(),
+            None,
         )
         .await;
         rt.register_initiator_peer("agent-carol", EnvelopeKind::Key)
@@ -538,6 +552,7 @@ mod tests {
             transport,
             Vec::new(),
             ReplicationRuntimeConfig::default(),
+            None,
         )
         .await;
         rt.register_initiator_peer("agent-dave", EnvelopeKind::Attestation)
@@ -579,6 +594,7 @@ mod tests {
             transport,
             initial,
             ReplicationRuntimeConfig::default(),
+            None,
         )
         .await;
         assert_eq!(rt.registry().len().await, 2);
@@ -625,6 +641,7 @@ mod tests {
             transport,
             Vec::new(),
             ReplicationRuntimeConfig::default(),
+            None,
         )
         .await;
         rt.shutdown().await;


### PR DESCRIPTION
The mesh-seed mechanism fix. Closes #257.

## Problem
The replication Key plane advertised **cohort-members'-own** records — `list_keys` projected the consent cohort through `lookup_public_key`. A node is never in its own consent cohort, so it **never advertised its own scrub-signed key record**, nor any third-party **anchored** record (`scrub_key_id → accord holder`). A freshly scrub-signed key rooting at the HUMANITY_ACCORD anchor had no anti-entropy path to any verifier — the mechanism-level cause of the `rooting_not_rooted_at_steward` seed blocker.

## Fix — KERI publish-own
- **`FederationDirectoryReplicationBridge`** gains an optional Key-plane `key_selector` (`with_key_selector`). When set, `list_keys` projects THAT set (own + held anchored records) instead of the cohort — same projection, different key_id set. `None` = pre-#257 cohort projection (back-compat).
- **`ReplicationRuntime::start`** takes `key_selector: Option<CohortProvider>` (coordinated Rust-API evolution — the server hands edge the selector alongside the consent-derived cohort; all replication logic stays in edge).
- **PyEdge `start_replication`** gains an **additive** `key_publish_set: Option<Vec<String>>` kwarg; edge wraps it into the selector. The server computes own+anchored (it holds the anchor knowledge).

## Apply-side (issue ask 2)
Already persist's authority: `apply_key` → `put_public_key`, whose R1/Q1 anti-rollback merge gives content-addressed idempotency + first-seen.

## Test
`key_selector_publishes_own_and_anchored_not_cohort`: own + anchored publish under the selector (2 refs) though neither is in the cohort (1). Runtime + bridge tests + clippy `-D warnings` green.

Unblocks CIRISServer mesh seeding — the server wires the Key-plane selector (own + anchored) via `start_replication(key_publish_set=…)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)