### PR TITLE
release(v8.6.1): re-pin persist v12.2.0 — adopt-scrub-upgrade (cohabitation lockstep)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.6.0"
+version = "8.6.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.1.0", version = "12", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.2.0", version = "12", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1080,7 +1080,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.1.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.2.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
Substrate re-pin to **CIRISPersist v12.2.0** (#351 — `adopt_scrub_upgrade`). No edge code change; verify unchanged at v8.5.0; pyproject `>=12.0.0,<13` unchanged.

persist v12.2.0's `Engine::adopt_scrub_upgrade` is the **producer** step for the in-place genesis seed — a node upgrades its own boot-time self-signed own-key row to the accord-holder-scrubbed one (the old `ON CONFLICT DO NOTHING` pinned the self-signed row forever, so no peer could root it). Server-side call; the producer counterpart to edge's **v8.6.0 Key-plane publish-own (#257)**: server upgrades the row → edge advertises the now-anchored own record → peers root it. Edge consumes no new API — this just keeps the cohabitation substrate floor aligned.

Green: `cargo check` + clippy `-D warnings` against v12.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)