### PR TITLE
v8.6.2 — #320/#354: route init async through the executor vtable (fix cross-cdylib block_on deadlock + SIGABRT)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.6.1"
+version = "8.6.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.2.0", version = "12", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.3.0", version = "12", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -221,8 +221,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.2.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -231,7 +231,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.5.0", version = "8" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.6.0", version = "8" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1080,7 +1080,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.2.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.3.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/deny.toml
+++ b/deny.toml
@@ -83,6 +83,11 @@ ignore = [
     # verification stack. Persist's deny.toml documents the rationale;
     # edge inherits.
     "RUSTSEC-2026-0119",  # hickory-proto DNS encoding O(n²); edge has no DNS encode path
+    "RUSTSEC-2026-0118",  # hickory-proto NSEC3 closest-encloser DNSSEC-validation loop;
+                          # unreachable — hickory is pulled for DoH only (feature
+                          # "https-ring"), NOT the dnssec-validation feature, so the
+                          # NSEC3 proof path is never invoked. No patched 0.25.x exists
+                          # (unaffected >= 0.26.0-beta.1); clears when verify bumps hickory.
     "RUSTSEC-2025-0134",  # rustls-pemfile unmaintained
     "RUSTSEC-2026-0098",  # rustls-webpki URI-name constraint (no URI SAN validation here)
     "RUSTSEC-2026-0099",  # rustls-webpki wildcard-DNS constraint (no name-constraint certs)

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4128,7 +4128,15 @@ pub fn init_edge_runtime(
     // an intermediate `.await` (e.g. registering a transport handler
     // task) immediately has a current runtime and does not regress to
     // a "no reactor running" panic.
-    let _runtime_guard = runtime.enter();
+    // CIRISPersist#320 — do NOT `runtime.enter()` here. `runtime` is
+    // persist's `tokio::runtime::Handle` from `runtime_handle_capsule`;
+    // `Handle::enter()` is edge's tokio operating on a foreign (persist-
+    // built) Handle, which sets edge's runtime-context thread-local to
+    // persist's runtime for the whole init body — a cross-cdylib tokio
+    // aliasing hazard (CIRISPersist#156/#157). All async below now goes
+    // through `run_async` (the ABI-stable executor vtable, dispatched
+    // inside persist's `.so`), so no current-runtime context is needed
+    // and entering one is actively harmful.
 
     // v1.1.8 (CIRISEdge#58 / CIRISEdge#59 / CIRISPersist#157) — the
     // ABI-stable executor capsule. Pre-v3.13.0 persist exposes only
@@ -4412,29 +4420,42 @@ pub fn init_edge_runtime(
     // is byte-equal to the registered row — closes the `enqueue_outbound:
     // FOREIGN KEY constraint failed` regression that v7.0.5 hit on the
     // persist v10.1.1 floor.
-    let derived_signer_key_id: String = py.detach(|| {
-        runtime.block_on(async {
-            let pubkey = signer_handle.signer.public_key().await.map_err(|e| {
-                PyRuntimeError::new_err(format!(
-                    "init_edge_runtime: federation pubkey read for derive_key_id failed: {e}"
+    // #320: was `runtime.block_on(...)` on persist's cross-cdylib raw
+    // tokio Handle — deadlocks inside `Handle::block_on`'s park setup in
+    // release builds (foreign Handle, separate tokio static state). Route
+    // through persist's executor vtable instead (dispatch lands inside
+    // persist's .so). The future only calls persist async (signer +
+    // derive_key_id), so the #157 "no consumer tokio primitives" contract
+    // holds. `run_async`'s `T` must be `Send`, so we return
+    // `Result<String, String>` (PyErr is not Send) and lift to PyErr here.
+    let derived_signer_key_id: String = {
+        let signer_for_derive = signer_handle.signer.clone();
+        let key_id_for_derive = signer_handle.key_id.clone();
+        let derived_res: Result<String, String> = py.detach(|| {
+            run_async(&executor, async move {
+                let pubkey = signer_for_derive.public_key().await.map_err(|e| {
+                    format!(
+                        "init_edge_runtime: federation pubkey read for derive_key_id failed: {e}"
+                    )
+                })?;
+                if pubkey.len() != 32 {
+                    return Err(format!(
+                        "init_edge_runtime: federation pubkey is {} bytes, not Ed25519's 32 — \
+                         hardware-HSM-only keyring is unsupported for the cohabitation init \
+                         surface; use a software Ed25519 local_key_path on the Engine",
+                        pubkey.len()
+                    ));
+                }
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&pubkey);
+                Ok::<_, String>(ciris_verify_core::fedcode::derive_key_id(
+                    &key_id_for_derive,
+                    &arr,
                 ))
-            })?;
-            if pubkey.len() != 32 {
-                return Err(PyRuntimeError::new_err(format!(
-                    "init_edge_runtime: federation pubkey is {} bytes, not Ed25519's 32 — \
-                     hardware-HSM-only keyring is unsupported for the cohabitation init \
-                     surface; use a software Ed25519 local_key_path on the Engine",
-                    pubkey.len()
-                )));
-            }
-            let mut arr = [0u8; 32];
-            arr.copy_from_slice(&pubkey);
-            Ok::<_, PyErr>(ciris_verify_core::fedcode::derive_key_id(
-                &signer_handle.key_id,
-                &arr,
-            ))
-        })
-    })?;
+            })
+        });
+        derived_res.map_err(PyRuntimeError::new_err)?
+    };
     tracing::debug!(
         keystore_alias = %signer_handle.key_id,
         derived_key_id = %derived_signer_key_id,
@@ -4662,22 +4683,25 @@ pub fn init_edge_runtime(
     if !canonical_peers.is_empty() {
         let directory_for_reseed = Arc::clone(&federation_directory_for_edge);
         let canonical_peers_for_reseed = canonical_peers.clone();
-        py.detach(|| {
-            runtime
-                .block_on(async move {
-                    crate::reseed_canonical_bootstrap_peers(
-                        &directory_for_reseed,
-                        &canonical_peers_for_reseed,
-                    )
-                    .await
-                })
+        // #320: was `runtime.block_on(...)` on persist's raw Handle
+        // (release deadlock). Persist-directory-bound work → executor
+        // vtable. Lift the persist error to a Send String inside.
+        let reseed_res: Result<(), String> = py.detach(|| {
+            run_async(&executor, async move {
+                crate::reseed_canonical_bootstrap_peers(
+                    &directory_for_reseed,
+                    &canonical_peers_for_reseed,
+                )
+                .await
                 .map_err(|e| {
-                    PyRuntimeError::new_err(format!(
+                    format!(
                         "reseed_canonical_bootstrap_peers: {e} (kind={kind})",
                         kind = e.kind()
-                    ))
+                    )
                 })
-        })?;
+            })
+        });
+        reseed_res.map_err(PyRuntimeError::new_err)?;
     }
 
     // CIRISEdge#34 (v0.14.0 wiring) — pre-construct the EventBus +
@@ -4783,15 +4807,20 @@ pub fn init_edge_runtime(
         let _ = (transport_config, auth);
         None
     } else {
-        let t: Arc<ReticulumTransport> = py.detach(|| {
-            runtime
-                .block_on(async {
-                    ReticulumTransport::new(transport_config, auth)
-                        .await
-                        .map(Arc::new)
-                })
-                .map_err(|e| PyRuntimeError::new_err(format!("ReticulumTransport::new: {e}")))
-        })?;
+        // #320: was `runtime.block_on(...)` on persist's raw Handle
+        // (release deadlock). ReticulumTransport::new performs identity
+        // + attestation crypto (persist signer) with no reactor-bound
+        // tokio primitives, so it is safe on persist's runtime via the
+        // executor vtable. Returns `Result<Arc<_>, String>` (Send).
+        let t_res: Result<Arc<ReticulumTransport>, String> = py.detach(|| {
+            run_async(&executor, async move {
+                ReticulumTransport::new(transport_config, auth)
+                    .await
+                    .map(Arc::new)
+                    .map_err(|e| format!("ReticulumTransport::new: {e}"))
+            })
+        });
+        let t = t_res.map_err(PyRuntimeError::new_err)?;
         Some(t)
     };
 
@@ -5202,9 +5231,14 @@ pub fn init_edge_runtime(
     #[cfg(feature = "ffi-uniffi")]
     crate::ffi::uniffi_impl::install_edge_handle(&edge_arc);
 
-    // Suppress unused-binding warning for `runtime` — kept in scope
-    // for the init-body `runtime.enter()` guard but not stored on
-    // PyEdge post-CIRISEdge#59 (the executor handles all spawns).
+    // Suppress unused-binding warning for `runtime` (persist's raw
+    // `tokio::runtime::Handle` from `runtime_handle_capsule`). As of
+    // CIRISPersist#320 it is no longer used at all: the init-body
+    // `runtime.enter()` guard and every `runtime.block_on(...)` were
+    // replaced by `run_async` on the ABI-stable executor vtable (raw
+    // cross-cdylib `Handle::block_on` deadlocks in release builds).
+    // Edge's own async runs on `transport_runtime` (built below). We
+    // keep extracting the capsule as the persist-version-floor probe.
     let _ = runtime;
     // v2.1.0 (CIRISEdge#85 / CIRISLensCore#43) — retain a strong
     // reference to the host engine PyObject so [`PyEdge::engine`] can


### PR DESCRIPTION
Fixes the transport-bring-up **deadlock** (#320) and the postgres **SIGABRT** (#354). Closes CIRISPersist#320 (edge half) / CIRISPersist#354 (edge half).

## Root cause
`init_edge_runtime` drove its own async via `runtime.enter()` + `runtime.block_on(...)` on persist's **cross-cdylib raw `tokio::runtime::Handle`** (from `runtime_handle_capsule`). That foreign-Handle path is the CIRISPersist#156/#157 aliasing hazard:
- In **release** builds `Handle::block_on` deadlocks inside its own park/thread-register setup (edge's tokio code operating on a persist-built Handle, separate tokio static state). Debug builds happened to mask it — which is why it was intermittent.
- A panicking spawned task can unwind across the C-ABI boundary → `fatal runtime error: Rust cannot catch foreign exceptions, aborting` → SIGABRT (#354, postgres).

## Fix
Replace `runtime.enter()` + all three `runtime.block_on(...)` calls (`derived_signer_key_id`, canonical reseed, `ReticulumTransport::new`) with **`run_async` on the ABI-stable executor vtable** — dispatch lands inside persist's `.so` on persist's runtime; no edge-tokio-on-persist-Handle operation. Each future only calls persist async (signer / directory / identity+attestation crypto), honoring the #157 "no consumer tokio primitives" contract. `run_async`'s `T` must be `Send`, so the futures return `Result<_, String>` and lift to `PyErr` at the boundary. `runtime` is now unused (edge's own transport tasks already run on the edge-owned `transport_runtime`); kept only as the persist-version-floor probe.

## Re-pins (paired fix + coherence)
- **persist v12.2.0 → v12.3.0** — the capsule use-after-free / SIGSEGV fix that pairs with this deadlock fix (persist fixes the crash, this fixes the hang/abort).
- **verify v8.5.0 → v8.6.0** — coherence: persist v12.3.0 pulls verify v8.6.0; a split forks `ciris_verify_core`/`ciris-keyring` and breaks the `HardwareSigner` cast.

## Verification (release builds, cohabitation .so swap)
- `init_edge_runtime(enable_transport=True)` on **sqlite** — no crash, no hang ✅
- `init_edge_runtime(...)` on **postgres** — no SIGABRT ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)