### PR TITLE
release(v8.7.2): re-pin persist v12.5.0 — CC 0.9.3 gates (closes #272)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.7.1"
+version = "8.7.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.4.0", version = "12", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.5.0", version = "12", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.4.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.5.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
Substrate re-pin to **CIRISPersist v12.5.0** (CC 0.9.3 conformance batch, #309/#238/#359). No edge code change; **verify unchanged at v8.7.0** (edge is already there — pins stay in lockstep, no `ciris_verify_core` split); pyproject `>=12.0.0,<13` unchanged.

CC 0.9.3 gates are substrate-enforced and compose without edge change:
- **#238** — federation `put_attestation` for a `community` with no live `moderate`-holder is now rejected (`Error::CommunityHasNoModerator`). Edge's replication apply routes through `put_attestation(...).is_ok()`, so a rejected attestation is simply **refused** (not admitted, no crash) — handled by the existing refusal path.
- age/capacity surfaces (#309) are available but optional — edge does no age/capacity gating (tracked at #227).

Green: `cargo check` + clippy `-D warnings`; `ciris_verify_core` unified at v8.7.0 (`cargo tree -d`, no split).

🤖 Generated with [Claude Code](https://claude.com/claude-code)