### PR TITLE
release(v9.0.0): adopt persist v13.0.0 + conformance/codec/CI batch (#278 #267 #266 #192 #193 #242)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1125,13 +1125,25 @@ jobs:
           echo "OK: bindings match the UDL."
 
   # ─── license-audit: cargo deny (license + advisories) ───────────────
+  #
+  # Runner-native (issue #242, pattern proven in CIRISVerify#158):
+  # EmbarkStudios/cargo-deny-action@v2 is a Docker container action
+  # whose musl rustup printed `error: override toolchain
+  # 'stable-x86_64-unknown-linux-musl' is not installed` on every run,
+  # and the container didn't inherit the workflow-level CARGO_NET_*
+  # flake hardening. taiki-e/install-action drops a prebuilt
+  # cargo-deny binary on the runner instead. The invocation below
+  # replicates the container action's exact defaults
+  # (`--log-level warn --all-features check` → all four gates in
+  # deny.toml: licenses, advisories, bans, sources).
   license-audit:
     name: cargo deny (license + advisories)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      - uses: taiki-e/install-action@cargo-deny
+      - run: cargo deny --log-level warn --all-features check
 
   # ─── benches: per-PR compile gate for the criterion bench suite ─────
   #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.6.0", version = "12", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.0.0", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v12.6.0", version = "12", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.0.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "8.8.0"
+version = "9.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/benches/common/mock_directory.rs
+++ b/benches/common/mock_directory.rs
@@ -142,6 +142,7 @@ pub fn signed_record(
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence,
+        consent_role: None,
     }
 }
 

--- a/conformance_vectors/19_7/aggregation_meta/canonical_bytes_v2.json
+++ b/conformance_vectors/19_7/aggregation_meta/canonical_bytes_v2.json
@@ -1,0 +1,20 @@
+{
+  "vector_id": "aggregation_meta/canonical_bytes_v2",
+  "description": "AggregationMetaV1 §19.7.1.2 v2 preimage — v1 layout followed by a trailing big-endian u32(n_eff) (CIRISVerify#167 dominance surface). Matches CIRISVerify v8.7.0's authored vector byte-for-byte.",
+  "domain_separator_hex": "4147472d4d4554412d76310000000000",
+  "version": 2,
+  "content_id": "content-root-fixed",
+  "corpus_kind": "trace",
+  "tier": 2,
+  "aggregation_algorithm_id": "raptorq-pyramid-v1",
+  "source_count": 3,
+  "source_member_ids": [
+    "src-001",
+    "src-002",
+    "src-003"
+  ],
+  "member_commitment_hex": "a10bc0ec2399f1cd431be79a863385a4b895987dae604aaf2ec3532f3753bd9d",
+  "noise_floor_descriptor": "mean+stddev",
+  "n_eff": 3,
+  "expected_canonical_bytes_hex": "4147472d4d4554412d763100000000000000000200000012636f6e74656e742d726f6f742d66697865640000000574726163650000000200000012726170746f72712d707972616d69642d763100000003a10bc0ec2399f1cd431be79a863385a4b895987dae604aaf2ec3532f3753bd9d0000000b6d65616e2b73746464657600000003"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=12.0.0,<13",
+    "ciris-persist>=13.0.0,<14",
 ]
 dynamic = ["version"]
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -6806,6 +6806,7 @@ mod delegation_gate_tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/emission/budget.rs
+++ b/src/emission/budget.rs
@@ -157,18 +157,33 @@ impl BudgetMeter {
 
     /// Record one real emission against `scope`.
     pub fn record_real(&self, scope: &ScopeKey) {
+        self.record_real_at(scope, Instant::now());
+    }
+
+    /// Record one real emission at an explicit instant — test seam,
+    /// mirroring [`Self::query_at`]. The PyO3 conformance surface
+    /// (CIRISEdge#192 `EmissionScheduler`) drives the meter on a
+    /// virtual clock so a 24 h observation window collapses to
+    /// milliseconds of wall time.
+    pub fn record_real_at(&self, scope: &ScopeKey, now: Instant) {
         let mut g = self.inner.lock();
         if let Some(b) = g.get_mut(scope) {
-            b.roll_if_expired(Instant::now());
+            b.roll_if_expired(now);
             b.counters.real = b.counters.real.saturating_add(1);
         }
     }
 
     /// Record one cover emission against `scope`.
     pub fn record_cover(&self, scope: &ScopeKey) {
+        self.record_cover_at(scope, Instant::now());
+    }
+
+    /// Record one cover emission at an explicit instant — test seam,
+    /// mirroring [`Self::query_at`]. See [`Self::record_real_at`].
+    pub fn record_cover_at(&self, scope: &ScopeKey, now: Instant) {
         let mut g = self.inner.lock();
         if let Some(b) = g.get_mut(scope) {
-            b.roll_if_expired(Instant::now());
+            b.roll_if_expired(now);
             b.counters.cover = b.counters.cover.saturating_add(1);
         }
     }

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -6347,6 +6347,618 @@ impl PyStoreAndForward {
     }
 }
 
+// ─── CIRISEdge#193 — scope_privacy derivation reach-through ─────────
+//
+// Thin PyO3 wrappers over the §2.2 / §2.4 SCOPE_PRIVACY derivation
+// helpers `crate::scope_privacy` re-exports from verify's
+// `ciris_crypto::scope_privacy` (the first conformant impl per FSD
+// §9). CIRISConformance's `test_400_scope_privacy_record_id.py`
+// currently reproduces verify's KAT vectors with a clean-room Python
+// oracle; these wrappers let the suite verify edge's published wheel
+// byte-for-byte against the same vectors, closing the round-trip.
+//
+// The issue sketch named the first `derive_record_id` argument
+// `group_dek` ("the MLS exporter_secret") — that conflates the §2.2
+// and §2.4 stages. The Rust authority surface takes the §2.2
+// *subkeys* (`K_record_id` / `K_symbol`), so the wrappers mirror the
+// Rust signatures exactly and ALSO expose the §2.2 subkey expanders
+// (`k_record_id` / `k_symbol`) so Python callers can run the full
+// exporter_secret → subkey → record_id/symbol_key chain.
+//
+// Bytes in / bytes out — no redacted-Debug newtypes cross the FFI
+// (same posture as the CIRISEdge#123 realtime_av wrappers above).
+
+/// §2.2 — derive the `K_record_id` subkey from the MLS group's raw
+/// 32-byte `exporter_secret` (bare `HKDF-SHA256-Expand`, info =
+/// `LABEL_RECORD_ID`; deliberately NOT RFC 9420 `ExpandWithLabel` —
+/// see `ciris_crypto::scope_privacy` for the cross-impl warning).
+/// Returns the 32-byte subkey. CIRISEdge#193.
+#[pyfunction]
+fn k_record_id(exporter_secret: &[u8]) -> PyResult<Vec<u8>> {
+    let exporter = fixed_bytes::<32>("exporter_secret", exporter_secret)?;
+    Ok(crate::scope_privacy::k_record_id(&exporter).to_vec())
+}
+
+/// §2.2 — derive the `K_symbol` subkey from the MLS group's raw
+/// 32-byte `exporter_secret` (bare `HKDF-SHA256-Expand`, info =
+/// `LABEL_SYMBOL`). Returns the 32-byte subkey. CIRISEdge#193.
+#[pyfunction]
+fn k_symbol(exporter_secret: &[u8]) -> PyResult<Vec<u8>> {
+    let exporter = fixed_bytes::<32>("exporter_secret", exporter_secret)?;
+    Ok(crate::scope_privacy::k_symbol(&exporter).to_vec())
+}
+
+/// Map the pinned §2.4 `"typ"` integer table onto
+/// [`crate::scope_privacy::RecordType`]. `0` is reserved; out-of-set
+/// values raise `ValueError` (strict allowlist, AV-7 posture).
+fn record_type_from_uint(record_type: u64) -> PyResult<crate::scope_privacy::RecordType> {
+    use crate::scope_privacy::RecordType;
+    match record_type {
+        1 => Ok(RecordType::SelfRecord),
+        2 => Ok(RecordType::FamilyRecord),
+        3 => Ok(RecordType::CommunityRecord),
+        4 => Ok(RecordType::FederationRecord),
+        other => Err(PyValueError::new_err(format!(
+            "record_type: expected the pinned §2.4 integer table \
+             (1=self, 2=family, 3=community, 4=federation; 0 reserved), got {other}"
+        ))),
+    }
+}
+
+/// §2.4 — `record_id = HMAC-SHA3-256(K_record_id,
+/// CBOR_dCE({v, epc, iid, typ}))` (RFC 8949 §4.2.1 deterministic
+/// CBOR preimage). CIRISEdge#193.
+///
+/// - `k_record_id` — the 32-byte §2.2 subkey (see [`k_record_id`]).
+/// - `internal_id` — the caller's private record identifier bytes.
+/// - `record_type` — pinned integer table: 1=self, 2=family,
+///   3=community, 4=federation (0 reserved; `ValueError` otherwise).
+/// - `mls_group_epoch` — the MLS group epoch (`epc`).
+///
+/// Returns the 32-byte HMAC output. Reproduces verify v6.3.0's §9
+/// KAT vectors byte-for-byte (pinned in `src/scope_privacy.rs`).
+#[pyfunction]
+fn derive_record_id(
+    k_record_id: &[u8],
+    internal_id: &[u8],
+    record_type: u64,
+    mls_group_epoch: u64,
+) -> PyResult<Vec<u8>> {
+    let k = fixed_bytes::<32>("k_record_id", k_record_id)?;
+    let typ = record_type_from_uint(record_type)?;
+    Ok(crate::scope_privacy::derive_record_id(&k, internal_id, typ, mls_group_epoch).to_vec())
+}
+
+/// §2.4 — `symbol_key = HKDF-SHA3-256(salt = record_id,
+/// ikm = K_symbol, info = LABEL_SYMBOL || u16_be(symbol_index))`.
+/// CIRISEdge#193.
+///
+/// - `k_symbol` — the 32-byte §2.2 subkey (see [`k_symbol`]).
+/// - `record_id` — the 32-byte [`derive_record_id`] output (HKDF salt).
+/// - `symbol_index` — RaptorQ symbol index (u16; out-of-range raises
+///   `OverflowError` at conversion).
+///
+/// Returns the 32-byte HKDF output.
+#[pyfunction]
+fn derive_symbol_key(k_symbol: &[u8], record_id: &[u8], symbol_index: u16) -> PyResult<Vec<u8>> {
+    let ks = fixed_bytes::<32>("k_symbol", k_symbol)?;
+    let rid = fixed_bytes::<32>("record_id", record_id)?;
+    Ok(crate::scope_privacy::derive_symbol_key(&ks, &rid, symbol_index).to_vec())
+}
+
+// ─── CIRISEdge#192 — wheel-driven EmissionScheduler (virtual clock) ──
+//
+// CIRISConformance PR #19's Poisson / cluster KS-tests
+// (`test_420_scope_privacy_poisson.py`, `test_430_scope_privacy_cluster_ks.py`)
+// verify the §3.1 emission discipline against a first-principles
+// Python simulator because the production `emission::Scheduler` is
+// (a) internal to the Rust send-path and (b) driven by real tokio
+// timers — a 24 h observation window can't be fast-forwarded.
+//
+// This surface closes both gaps with ONE pyclass instead of the
+// issue's `EmissionScheduler` + `AcceleratedTimeMode` pair: a
+// process-global `std::time::Instant` substitution cannot be done
+// from a wheel (no clock-injection seam exists below tokio), so the
+// accelerated clock is scoped to the scheduler instance — `tick()`
+// JUMPS the virtual clock to the next Poisson fire instead of
+// sleeping, and `advance(ns)` exposes the `AcceleratedTimeMode.advance`
+// verb for driving budget-window rolls without emitting.
+//
+// Crucially this is NOT a reimplementation: every load-bearing
+// production primitive is the real one —
+//
+//   - `emission::PoissonScheduler` — the ChaCha20-CSPRNG `Exp(λ)`
+//     inverse-CDF sampler (seedable for deterministic KS runs),
+//   - `emission::BudgetMeter` — the §3.1 lifetime-average λ
+//     inequality book-keeper, driven through its `query_at` /
+//     `record_*_at` explicit-instant test seams,
+//   - `emission::fragment_payload` — the 1.4 KB fragmentation path,
+//   - `emission::seal_envelope` / `EmissionHeader::cover` — the
+//     uniform XChaCha20-Poly1305 AEAD framing for real AND cover.
+//
+// Only the tokio timer loop is replaced (by the virtual clock); the
+// real-vs-cover dispatch decision is a line-for-line mirror of
+// `emission::scheduler::run_scope_loop`.
+
+/// Parse the Python-facing scope string onto the scheduler-local
+/// [`crate::emission::ScopeKey`]. Accepted forms: `"federation"`,
+/// `"self"`, `"family"`, `"family:<id>"`, `"community:<id>"`.
+fn parse_emission_scope(scope: &str) -> PyResult<crate::emission::ScopeKey> {
+    use crate::emission::ScopeKey;
+    match scope {
+        "federation" => return Ok(ScopeKey::federation()),
+        "self" => return Ok(ScopeKey::self_scope()),
+        "family" => return Ok(ScopeKey::family(None)),
+        _ => {}
+    }
+    if let Some(id) = scope.strip_prefix("family:") {
+        if !id.is_empty() {
+            return Ok(ScopeKey::family(Some(id.to_string())));
+        }
+    }
+    if let Some(id) = scope.strip_prefix("community:") {
+        if !id.is_empty() {
+            return Ok(ScopeKey::community(id.to_string()));
+        }
+    }
+    Err(PyValueError::new_err(format!(
+        "scope: expected \"federation\" | \"self\" | \"family\" | \
+         \"family:<id>\" | \"community:<id>\", got {scope:?}"
+    )))
+}
+
+/// Per-scope state inside [`EmissionSimInner`].
+struct EmissionSimScope {
+    /// Scheduler-local scope key (parsed once at construction).
+    key: crate::emission::ScopeKey,
+    /// Per-scope AEAD key the envelopes are sealed under
+    /// (`[0u8; 32]` unless the caller supplied `scope_keys`).
+    aead_key: [u8; 32],
+    /// Real-fragment queue — `(header, payload)` pairs mirroring the
+    /// production scheduler's `QueuedFragment`.
+    queue: std::collections::VecDeque<(crate::emission::EmissionHeader, Vec<u8>)>,
+    /// Virtual-clock timestamp of this scope's next Poisson fire.
+    /// `None` when λ ≤ 0 (scope disabled).
+    next_fire_ns: Option<u64>,
+    /// Lifetime real-envelope count (denominator source for
+    /// `lifetime_avg_lambda`).
+    real_emitted: u64,
+    /// Lifetime cover-envelope count.
+    cover_emitted: u64,
+}
+
+/// One emission produced by [`EmissionSimInner::tick`] — the Rust
+/// shape the pymethod projects into the Python dict.
+struct SimEmission {
+    /// Scope string (as registered).
+    scope: String,
+    /// Virtual-clock fire time (nanoseconds).
+    t_ns: u64,
+    /// `true` = real publication fragment; `false` = synthetic cover.
+    real: bool,
+    /// `(fragment_id, fragment_index, fragment_count)` for real
+    /// emissions; `None` for cover.
+    fragment: Option<(u32, u32, u32)>,
+    /// The sealed 1400-byte wire envelope.
+    envelope: Vec<u8>,
+}
+
+/// Interior state of [`PyEmissionScheduler`], guarded by one mutex.
+/// The substrate logic lives here (plain Rust, unit-testable without
+/// an interpreter); the pymethods own GIL discipline + dict-shape
+/// projection only — the same split the rest of this file follows.
+struct EmissionSimInner {
+    /// The production `Exp(λ)` CSPRNG sampler.
+    poisson: crate::emission::PoissonScheduler,
+    /// The production §3.1 budget meter, driven at virtual instants.
+    budget: crate::emission::BudgetMeter,
+    /// Wall-clock anchor: virtual instant = `base + (now_ns - start_ns)`.
+    base: std::time::Instant,
+    /// Virtual-clock origin (constructor's `start_ns`).
+    start_ns: u64,
+    /// Current virtual time (nanoseconds).
+    now_ns: u64,
+    /// Per-scope state, keyed by the caller's scope string. BTreeMap
+    /// so seeded runs draw from the shared CSPRNG in a deterministic
+    /// scope order (HashMap iteration order would break
+    /// `rng_seed`-reproducibility).
+    scopes: std::collections::BTreeMap<String, EmissionSimScope>,
+}
+
+impl EmissionSimInner {
+    /// Project the virtual clock onto an `Instant` for the
+    /// `BudgetMeter` `*_at` seams.
+    fn virtual_instant(&self) -> std::time::Instant {
+        self.base + Duration::from_nanos(self.now_ns.saturating_sub(self.start_ns))
+    }
+
+    /// Enqueue a real publication — mirrors
+    /// [`crate::emission::Scheduler::submit`] on the virtual clock.
+    fn submit(
+        &mut self,
+        scope: &str,
+        record_id: [u8; 32],
+        fragment_id: u32,
+        payload: &[u8],
+    ) -> PyResult<u32> {
+        let now_ms = self.now_ns / 1_000_000;
+        let Some(state) = self.scopes.get_mut(scope) else {
+            return Err(PyValueError::new_err(format!(
+                "EmissionScheduler.submit: scope {scope:?} not registered"
+            )));
+        };
+        let set = crate::emission::fragment_payload(
+            state.key.scope,
+            record_id,
+            fragment_id,
+            now_ms,
+            payload,
+        )
+        .map_err(|e| PyValueError::new_err(format!("EmissionScheduler.submit: {e}")))?;
+        // Bounded by `fragment_payload`'s own u32 check.
+        let count = u32::try_from(set.fragments.len())
+            .expect("fragment_payload's u32 check ensures len <= u32::MAX");
+        for f in set.fragments {
+            state.queue.push_back((f.header, f.payload));
+        }
+        Ok(count)
+    }
+
+    /// Advance the virtual clock to the earliest pending Poisson fire
+    /// and emit — the accelerated-time mirror of
+    /// `emission::scheduler::run_scope_loop`'s timer-fire body.
+    fn tick(&mut self) -> PyResult<Option<SimEmission>> {
+        use crate::emission::{seal_envelope, BudgetState, EmissionHeader, MAX_PAYLOAD_BYTES};
+
+        // Earliest fire across scopes; `(t, name)` tuple ordering
+        // tie-breaks equal timestamps lexicographically so seeded
+        // runs stay deterministic.
+        let next = self
+            .scopes
+            .iter()
+            .filter_map(|(name, s)| s.next_fire_ns.map(|t| (t, name.clone())))
+            .min();
+        let Some((fire_ns, name)) = next else {
+            return Ok(None); // every scope disabled (λ ≤ 0)
+        };
+        self.now_ns = self.now_ns.max(fire_ns);
+        let now_ms = self.now_ns / 1_000_000;
+        let virt = self.virtual_instant();
+
+        let state = self.scopes.get_mut(&name).expect("scope present");
+        let scope_key = state.key.clone();
+
+        // Decide real vs. cover on timer fire — same dispatch as the
+        // production loop: real only when under budget AND queued.
+        let budget_state = self.budget.query_at(&scope_key, virt);
+        let real_head = match budget_state {
+            BudgetState::UnderBudget { .. } => state.queue.pop_front(),
+            BudgetState::OverBudget { .. } | BudgetState::Unconfigured => None,
+        };
+
+        // Nonce + cover bytes from the same peer-local CSPRNG stream
+        // the interval samples come from (FSD §3.1).
+        let mut nonce = [0u8; ciris_crypto::xchacha::NONCE_LEN];
+        self.poisson.fill_bytes(&mut nonce);
+
+        let (header, payload, real) = if let Some((header, payload)) = real_head {
+            (header, payload, true)
+        } else {
+            let header = EmissionHeader::cover(scope_key.scope, now_ms);
+            let mut cover_payload = vec![0u8; MAX_PAYLOAD_BYTES];
+            self.poisson.fill_bytes(&mut cover_payload);
+            (header, cover_payload, false)
+        };
+
+        let envelope = seal_envelope(&state.aead_key, &nonce, &header, &payload)
+            .map_err(|e| PyRuntimeError::new_err(format!("EmissionScheduler.tick: seal: {e}")))?;
+
+        if real {
+            self.budget.record_real_at(&scope_key, virt);
+            state.real_emitted += 1;
+        } else {
+            self.budget.record_cover_at(&scope_key, virt);
+            state.cover_emitted += 1;
+        }
+
+        // Re-arm this scope's timer: next fire = this fire + Exp(λ).
+        state.next_fire_ns = self
+            .poisson
+            .next_interval(&scope_key)
+            .map(|d| fire_ns.saturating_add(u64::try_from(d.as_nanos()).unwrap_or(u64::MAX)));
+
+        let fragment = real.then_some((
+            header.fragment_id,
+            header.fragment_index,
+            header.fragment_count,
+        ));
+        Ok(Some(SimEmission {
+            scope: name,
+            t_ns: fire_ns,
+            real,
+            fragment,
+            envelope: envelope.bytes,
+        }))
+    }
+}
+
+/// v8.9.0 (CIRISEdge#192) — wheel-driven §3.1 Poisson emission
+/// scheduler on an accelerated (virtual) clock, for CIRISConformance's
+/// Poisson / cluster KS-tests and CIRISServer's SCOPE_PRIVACY
+/// operator-side observability (CIRISServer#38).
+///
+/// ```python
+/// sched = ciris_edge.EmissionScheduler(
+///     {"community:alpha": 2.0, "self": 0.5},   # λ per scope (emissions/s)
+///     rng_seed=b"\x42" * 32,                    # None → OsRng (production rule)
+///     target_real_per_window=100,
+///     window_secs=10.0,
+///     scope_keys={"community:alpha": b"\x11" * 32},  # AEAD keys; default zeros
+///     start_ns=0,
+/// )
+/// sched.submit("community:alpha", record_id, 7, b"payload")
+/// e = sched.tick()
+/// # {"scope": "community:alpha", "t_ns": 412_318_559, "kind": "real",
+/// #  "fragment_id": 7, "fragment_index": 0, "fragment_count": 1,
+/// #  "envelope": b"..." }  # 1400-byte sealed wire envelope
+/// sched.lifetime_avg_lambda("community:alpha")  # observed λ over virtual time
+/// ```
+///
+/// `tick()` advances the virtual clock to the earliest pending
+/// `Exp(λ_scope)` fire (no sleeping — a 24 h window replays in
+/// milliseconds) and emits exactly what the production
+/// `emission::Scheduler` would: a real fragment when under budget and
+/// queued, a CSPRNG-padded cover envelope otherwise, both sealed with
+/// the uniform XChaCha20-Poly1305 framing. `advance(ns)` subsumes the
+/// issue's proposed `AcceleratedTimeMode.advance` — see the section
+/// comment above for why the accelerated clock is instance-scoped
+/// rather than a process-global `Instant` substitution.
+///
+/// Seeding: `rng_seed` fixes the peer-local ChaCha20 CSPRNG so KS
+/// runs are reproducible. Production emission NEVER seeds from public
+/// inputs (FSD §3.1 jitter-seed-source rule) — the default `None`
+/// draws from `OsRng`, same as the production constructor.
+#[pyclass(name = "EmissionScheduler", module = "ciris_edge")]
+pub struct PyEmissionScheduler {
+    /// Substrate state — one lock, held only for the duration of each
+    /// synchronous pymethod (pure compute; no I/O, no awaits, so no
+    /// `py.detach` needed).
+    inner: parking_lot::Mutex<EmissionSimInner>,
+}
+
+impl std::fmt::Debug for PyEmissionScheduler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Mirrors `emission::Scheduler`'s Debug posture: only the
+        // scope count is human-meaningful; the rest is opaque shared
+        // state (CSPRNG, budget meter, queues).
+        let g = self.inner.lock();
+        f.debug_struct("EmissionScheduler")
+            .field("scopes", &g.scopes.len())
+            .field("now_ns", &g.now_ns)
+            .finish_non_exhaustive()
+    }
+}
+
+#[pymethods]
+impl PyEmissionScheduler {
+    /// Construct a scheduler over `lambda_per_scope` (scope string →
+    /// λ in emissions/second; λ ≤ 0 registers the scope disabled).
+    /// Scope strings: `"federation"` | `"self"` | `"family"` |
+    /// `"family:<id>"` | `"community:<id>"`.
+    ///
+    /// - `rng_seed` — optional 32-byte CSPRNG seed for deterministic
+    ///   runs; `None` seeds from `OsRng` (the production rule).
+    /// - `target_real_per_window` / `window_secs` — the §3.1
+    ///   [`crate::emission::BudgetMeter`] configuration, applied to
+    ///   every scope.
+    /// - `scope_keys` — optional per-scope 32-byte AEAD keys; scopes
+    ///   without an entry seal under `[0u8; 32]` (fine for
+    ///   timing-only KS-tests; supply real keys to unseal envelopes).
+    ///   Naming an unregistered scope raises `ValueError` (typo guard).
+    /// - `start_ns` — virtual-clock origin (e.g. a unix-nanos anchor
+    ///   if the test wants realistic `emitted_at_unix_ms` headers).
+    #[new]
+    #[pyo3(signature = (lambda_per_scope, *, rng_seed=None, target_real_per_window=100, window_secs=10.0, scope_keys=None, start_ns=0))]
+    #[allow(clippy::needless_pass_by_value)] // pyo3 surface takes owned maps
+    fn new(
+        lambda_per_scope: std::collections::HashMap<String, f64>,
+        rng_seed: Option<&[u8]>,
+        target_real_per_window: u32,
+        window_secs: f64,
+        scope_keys: Option<std::collections::HashMap<String, Vec<u8>>>,
+        start_ns: u64,
+    ) -> PyResult<Self> {
+        use crate::emission::{BudgetMeter, PoissonScheduler};
+
+        if lambda_per_scope.is_empty() {
+            return Err(PyValueError::new_err(
+                "lambda_per_scope must name at least one scope",
+            ));
+        }
+        if !window_secs.is_finite() || window_secs <= 0.0 {
+            return Err(PyValueError::new_err(format!(
+                "window_secs must be finite and > 0, got {window_secs}"
+            )));
+        }
+        for (name, lambda) in &lambda_per_scope {
+            if !lambda.is_finite() {
+                return Err(PyValueError::new_err(format!(
+                    "lambda_per_scope[{name:?}] must be finite, got {lambda}"
+                )));
+            }
+        }
+
+        let poisson = match rng_seed {
+            Some(seed) => PoissonScheduler::from_seed(fixed_bytes::<32>("rng_seed", seed)?),
+            None => PoissonScheduler::new(),
+        };
+        let budget = BudgetMeter::new();
+        let window = Duration::from_secs_f64(window_secs);
+
+        let mut keys_by_scope = scope_keys.unwrap_or_default();
+        let mut scopes = std::collections::BTreeMap::new();
+        // Sorted registration order — with a fixed rng_seed the
+        // per-scope draws must not depend on HashMap iteration order.
+        let mut names: Vec<&String> = lambda_per_scope.keys().collect();
+        names.sort();
+        for name in names {
+            let lambda = lambda_per_scope[name];
+            let key = parse_emission_scope(name)?;
+            let aead_key = match keys_by_scope.remove(name) {
+                Some(k) => fixed_bytes::<32>("scope_keys value", &k)?,
+                None => [0u8; 32],
+            };
+            poisson.set_rate(key.clone(), lambda);
+            budget.configure(key.clone(), target_real_per_window, window);
+            scopes.insert(
+                name.clone(),
+                EmissionSimScope {
+                    key,
+                    aead_key,
+                    queue: std::collections::VecDeque::new(),
+                    next_fire_ns: None,
+                    real_emitted: 0,
+                    cover_emitted: 0,
+                },
+            );
+        }
+        if let Some(stray) = keys_by_scope.keys().next() {
+            return Err(PyValueError::new_err(format!(
+                "scope_keys names a scope absent from lambda_per_scope: {stray:?}"
+            )));
+        }
+
+        let mut inner = EmissionSimInner {
+            poisson,
+            budget,
+            base: std::time::Instant::now(),
+            start_ns,
+            now_ns: start_ns,
+            scopes,
+        };
+        // Arm every scope's first fire (BTreeMap order → deterministic
+        // CSPRNG draw order under a fixed seed).
+        for s in inner.scopes.values_mut() {
+            s.next_fire_ns = inner
+                .poisson
+                .next_interval(&s.key)
+                .map(|d| start_ns.saturating_add(u64::try_from(d.as_nanos()).unwrap_or(u64::MAX)));
+        }
+        Ok(Self {
+            inner: parking_lot::Mutex::new(inner),
+        })
+    }
+
+    /// Enqueue a real publication at `scope`. Fragments `payload`
+    /// into 1.4 KB envelopes exactly like the production scheduler
+    /// (`record_id` = the FSD §2.4 32-byte record_id; `fragment_id` =
+    /// the per-emitter monotonic counter). Returns the fragment
+    /// count. Raises `ValueError` for an unregistered scope or an
+    /// empty/oversized payload.
+    fn submit(
+        &self,
+        scope: &str,
+        record_id: &[u8],
+        fragment_id: u32,
+        payload: &[u8],
+    ) -> PyResult<u32> {
+        let rid = fixed_bytes::<32>("record_id", record_id)?;
+        self.inner.lock().submit(scope, rid, fragment_id, payload)
+    }
+
+    /// Advance the virtual clock to the earliest pending Poisson fire
+    /// and emit one envelope. Returns `None` iff every scope is
+    /// disabled (λ ≤ 0); otherwise a dict:
+    ///
+    /// ```python
+    /// {
+    ///   "scope": str,        # as registered, e.g. "community:alpha"
+    ///   "t_ns": int,         # virtual fire time (KS-test observable)
+    ///   "kind": "real" | "cover",
+    ///   "fragment_id": int | None,     # None for cover
+    ///   "fragment_index": int | None,
+    ///   "fragment_count": int | None,
+    ///   "envelope": bytes,   # sealed 1400-byte wire envelope
+    /// }
+    /// ```
+    fn tick<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, pyo3::types::PyDict>>> {
+        let Some(e) = self.inner.lock().tick()? else {
+            return Ok(None);
+        };
+        let dict = pyo3::types::PyDict::new(py);
+        dict.set_item("scope", &e.scope)?;
+        dict.set_item("t_ns", e.t_ns)?;
+        dict.set_item("kind", if e.real { "real" } else { "cover" })?;
+        if let Some((id, index, count)) = e.fragment {
+            dict.set_item("fragment_id", id)?;
+            dict.set_item("fragment_index", index)?;
+            dict.set_item("fragment_count", count)?;
+        } else {
+            dict.set_item("fragment_id", py.None())?;
+            dict.set_item("fragment_index", py.None())?;
+            dict.set_item("fragment_count", py.None())?;
+        }
+        dict.set_item("envelope", pyo3::types::PyBytes::new(py, &e.envelope))?;
+        Ok(Some(dict))
+    }
+
+    /// Push the virtual clock forward by `ns` nanoseconds WITHOUT
+    /// emitting — the issue's `AcceleratedTimeMode.advance` verb.
+    /// Budget windows roll against the advanced clock on the next
+    /// `tick()`; pending Poisson fires whose time has been skipped
+    /// still emit (at their original `t_ns`) on subsequent ticks.
+    fn advance(&self, ns: u64) {
+        let mut g = self.inner.lock();
+        g.now_ns = g.now_ns.saturating_add(ns);
+    }
+
+    /// Current virtual-clock reading (nanoseconds).
+    fn now_ns(&self) -> u64 {
+        self.inner.lock().now_ns
+    }
+
+    /// Observed lifetime-average emission rate for `scope`:
+    /// `(real + cover) / virtual_elapsed_seconds`. The §3.1 KS-test
+    /// compares this against the configured λ. Returns `0.0` before
+    /// the first tick (zero elapsed time). Raises `ValueError` for an
+    /// unregistered scope.
+    fn lifetime_avg_lambda(&self, scope: &str) -> PyResult<f64> {
+        let g = self.inner.lock();
+        let Some(s) = g.scopes.get(scope) else {
+            return Err(PyValueError::new_err(format!(
+                "EmissionScheduler.lifetime_avg_lambda: scope {scope:?} not registered"
+            )));
+        };
+        let elapsed_ns = g.now_ns.saturating_sub(g.start_ns);
+        if elapsed_ns == 0 {
+            return Ok(0.0);
+        }
+        // f64 precision: exact for counts < 2^53 / elapsed < ~104 days
+        // of nanoseconds; KS tolerances dwarf the rounding either way.
+        #[allow(clippy::cast_precision_loss)]
+        let rate = (s.real_emitted + s.cover_emitted) as f64 / (elapsed_ns as f64 / 1e9);
+        Ok(rate)
+    }
+
+    /// Per-scope counters snapshot:
+    /// `{scope: {"real": int, "cover": int, "queue_depth": int,
+    /// "lambda": float}}`. Mirrors the production
+    /// `SchedulerHandle::stats` shape plus the configured λ.
+    fn stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, pyo3::types::PyDict>> {
+        let g = self.inner.lock();
+        let dict = pyo3::types::PyDict::new(py);
+        for (name, s) in &g.scopes {
+            let entry = pyo3::types::PyDict::new(py);
+            entry.set_item("real", s.real_emitted)?;
+            entry.set_item("cover", s.cover_emitted)?;
+            entry.set_item("queue_depth", s.queue.len())?;
+            entry.set_item("lambda", g.poisson.rate(&s.key))?;
+            dict.set_item(name, entry)?;
+        }
+        Ok(dict)
+    }
+}
+
 /// Register the full `ciris_edge` PyO3 surface against the supplied
 /// module. Re-applies the v4.3.1 / CIRISEdge#156 one-wheel re-export
 /// mechanism the v7.x refactor dropped: sibling cdylibs (e.g.
@@ -6467,6 +7079,23 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // `PyEdge.add_rnode_channel_interface`; holds the leviculum
     // `RNodeChannelHandle` so dropping it cleanly detaches the radio.
     m.add_class::<PyRNodeChannelHandle>()?;
+
+    // CIRISEdge#193 — SCOPE_PRIVACY §2.2 / §2.4 derivation
+    // reach-through. Lets CIRISConformance's record_id
+    // reproducibility suite (test_400) verify the published edge
+    // wheel byte-for-byte against verify's §9 KAT vectors instead of
+    // only the clean-room Python oracle.
+    m.add_function(wrap_pyfunction!(k_record_id, m)?)?;
+    m.add_function(wrap_pyfunction!(k_symbol, m)?)?;
+    m.add_function(wrap_pyfunction!(derive_record_id, m)?)?;
+    m.add_function(wrap_pyfunction!(derive_symbol_key, m)?)?;
+
+    // CIRISEdge#192 — wheel-driven §3.1 Poisson emission scheduler on
+    // a virtual (accelerated) clock. Lets CIRISConformance's Poisson +
+    // cluster KS-tests (test_420 / test_430) observe inter-emission
+    // intervals from the production sampler/budget/AEAD primitives
+    // instead of a first-principles Python simulator.
+    m.add_class::<PyEmissionScheduler>()?;
 
     Ok(())
 }
@@ -6883,6 +7512,300 @@ mod tests {
         let decoded = SealedAvChunk::from_bytes(&out[0].1).expect("wire round-trip");
         assert_eq!(decoded.codec_id, CODEC_OPAQUE);
         assert_eq!(decoded.layer, ChunkLayer::BASE);
+    }
+
+    // ─── CIRISEdge#193 — scope_privacy reach-through tests ──────────
+
+    fn hex(bytes: &[u8]) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            write!(s, "{b:02x}").unwrap();
+        }
+        s
+    }
+
+    /// The #193 pyfunctions reproduce verify v6.3.0's pinned §9 KAT
+    /// vectors through the PyO3 call path — the same bytes
+    /// `src/scope_privacy.rs::tests::conformance_vectors` asserts on
+    /// the Rust re-export path. If these drift, the wheel-facing
+    /// surface has diverged from the cross-impl authority.
+    #[test]
+    fn pyo3_scope_privacy_pyfunctions_reproduce_verify_kats() {
+        // §2.2 subkeys — exporter = [0x42; 32].
+        let exporter = [0x42u8; 32];
+        assert_eq!(
+            hex(&k_record_id(&exporter).expect("k_record_id")),
+            "49209926b0439f10d73d63317758b9ec19492429368c6aa67e33232da586af99",
+        );
+        assert_eq!(
+            hex(&k_symbol(&exporter).expect("k_symbol")),
+            "3c973c828a218053dc909c51337ae256164437353bde347ee4bac6874888450f",
+        );
+        // §2.4 record_id vector 1 — CommunityRecord (typ=3), epoch=7.
+        let k = [0x11u8; 32];
+        let rid = derive_record_id(&k, b"record-0001", 3, 7).expect("derive_record_id");
+        assert_eq!(
+            hex(&rid),
+            "5428ddb514a8f8692cc4f254f3550ea75790f5069673e42afb6ef318517a0b21",
+        );
+        // §2.4 symbol_key — pyfunction output matches the Rust
+        // authority call byte-for-byte, and is index-sensitive.
+        let ks = [0x22u8; 32];
+        let rid32 = fixed_bytes::<32>("rid", &rid).expect("32-byte rid");
+        let sk0 = derive_symbol_key(&ks, &rid, 0).expect("derive_symbol_key");
+        assert_eq!(
+            sk0,
+            crate::scope_privacy::derive_symbol_key(&ks, &rid32, 0).to_vec()
+        );
+        let sk1 = derive_symbol_key(&ks, &rid, 1).expect("derive_symbol_key idx 1");
+        assert_ne!(sk0, sk1, "symbol_key must be index-sensitive");
+    }
+
+    /// #193 strict-allowlist posture: reserved / out-of-set
+    /// `record_type` integers and wrong-length keys reject with
+    /// `ValueError` diagnostics.
+    #[test]
+    fn pyo3_scope_privacy_rejects_bad_inputs() {
+        l3_init_python();
+        let k = [0x11u8; 32];
+        for bad_typ in [0u64, 5, 255] {
+            let err = derive_record_id(&k, b"x", bad_typ, 0)
+                .expect_err("reserved/unknown record_type must reject");
+            let s = format!("{err}");
+            assert!(s.contains("record_type"), "diagnostic names field: {s}");
+        }
+        let err = derive_record_id(&[0u8; 31], b"x", 1, 0).expect_err("31-byte key must reject");
+        let s = format!("{err}");
+        assert!(s.contains("k_record_id"), "diagnostic names field: {s}");
+        let err = derive_symbol_key(&k, &[0u8; 33], 0).expect_err("33-byte record_id must reject");
+        let s = format!("{err}");
+        assert!(s.contains("record_id"), "diagnostic names field: {s}");
+    }
+
+    // ─── CIRISEdge#192 — EmissionScheduler (virtual clock) tests ────
+
+    /// Build a single-scope seeded scheduler — the KS-test fixture
+    /// shape (`community:alpha`, deterministic ChaCha20 stream).
+    fn seeded_sched(lambda: f64, target_real_per_window: u32) -> PyEmissionScheduler {
+        let mut lambdas = std::collections::HashMap::new();
+        lambdas.insert("community:alpha".to_string(), lambda);
+        let mut keys = std::collections::HashMap::new();
+        keys.insert("community:alpha".to_string(), vec![0x42u8; 32]);
+        PyEmissionScheduler::new(
+            lambdas,
+            Some(&[0x77u8; 32]),
+            target_real_per_window,
+            1_000_000.0, // one huge window — no mid-test rolls
+            Some(keys),
+            0,
+        )
+        .expect("scheduler construction")
+    }
+
+    /// Covers flow when the queue is empty; the virtual clock is
+    /// non-decreasing; the observed lifetime-average λ converges on
+    /// the configured rate — the §3.1 property the conformance
+    /// KS-test measures, here as a cheap 5%-tolerance smoke gate.
+    #[test]
+    fn pyo3_emission_scheduler_covers_and_lifetime_lambda() {
+        let sched = seeded_sched(5.0, 100);
+        let n = 5_000;
+        let mut last_t = 0u64;
+        for _ in 0..n {
+            let e = sched
+                .inner
+                .lock()
+                .tick()
+                .expect("tick")
+                .expect("enabled scope always fires");
+            assert!(!e.real, "empty queue → cover");
+            assert!(e.fragment.is_none(), "cover carries no fragment info");
+            assert_eq!(
+                e.envelope.len(),
+                crate::emission::ENVELOPE_BYTES,
+                "wire-format constant"
+            );
+            assert!(e.t_ns >= last_t, "virtual clock is non-decreasing");
+            last_t = e.t_ns;
+        }
+        let avg = sched
+            .lifetime_avg_lambda("community:alpha")
+            .expect("registered scope");
+        let rel_err = (avg - 5.0).abs() / 5.0;
+        assert!(rel_err < 0.05, "avg {avg} too far from λ=5 ({rel_err})");
+        assert_eq!(sched.now_ns(), last_t, "clock parked at the last fire");
+    }
+
+    /// A submitted publication emits as a real envelope on the next
+    /// fire, unseals as `EnvelopeType::Real` with the caller's
+    /// fragment_id under the scope AEAD key, then covers resume —
+    /// mirrors `emission::scheduler::tests::real_drains_queue_then_cover_resumes`
+    /// through the PyO3 surface.
+    #[test]
+    fn pyo3_emission_scheduler_real_then_cover_and_unseal() {
+        let sched = seeded_sched(5.0, 100);
+        let count = sched
+            .submit("community:alpha", &[0x33u8; 32], 7, b"hello world")
+            .expect("submit");
+        assert_eq!(count, 1, "single-envelope payload");
+
+        let first = sched.inner.lock().tick().expect("tick").expect("fires");
+        assert!(first.real, "queued fragment emits first");
+        assert_eq!(first.fragment, Some((7, 0, 1)));
+        let key = [0x42u8; 32];
+        let (hdr, payload) =
+            crate::emission::unseal_envelope(&key, &first.envelope).expect("unseal");
+        assert_eq!(hdr.envelope_type, crate::emission::EnvelopeType::Real);
+        assert_eq!(hdr.fragment_id, 7);
+        assert_eq!(hdr.record_id, [0x33u8; 32]);
+        assert_eq!(&payload[..11], b"hello world");
+
+        let second = sched.inner.lock().tick().expect("tick").expect("fires");
+        assert!(!second.real, "queue drained → cover resumes");
+
+        let stats = sched.inner.lock();
+        let s = stats.scopes.get("community:alpha").expect("scope");
+        assert_eq!((s.real_emitted, s.cover_emitted), (1, 1));
+    }
+
+    /// Budget back-pressure: with `target_real_per_window = 1`, the
+    /// second queued fragment stays queued and the fire emits cover
+    /// (`BudgetState::OverBudget` forces cover) — the §3.1
+    /// lifetime-average inequality enforced through the wheel path.
+    #[test]
+    fn pyo3_emission_scheduler_budget_backpressures_real() {
+        let sched = seeded_sched(5.0, 1);
+        sched
+            .submit("community:alpha", &[0x33u8; 32], 1, b"first")
+            .expect("submit 1");
+        sched
+            .submit("community:alpha", &[0x44u8; 32], 2, b"second")
+            .expect("submit 2");
+
+        let first = sched.inner.lock().tick().expect("tick").expect("fires");
+        assert!(first.real, "budget of 1 admits the first real");
+        let second = sched.inner.lock().tick().expect("tick").expect("fires");
+        assert!(!second.real, "over budget → cover despite non-empty queue");
+        let g = sched.inner.lock();
+        let s = g.scopes.get("community:alpha").expect("scope");
+        assert_eq!(s.queue.len(), 1, "second fragment back-pressured");
+    }
+
+    /// Same `rng_seed` → identical inter-emission timing sequence.
+    /// This is what lets the conformance KS-test publish its vectors.
+    #[test]
+    fn pyo3_emission_scheduler_seed_reproducible() {
+        let a = seeded_sched(5.0, 100);
+        let b = seeded_sched(5.0, 100);
+        for i in 0..10 {
+            let ta = a.inner.lock().tick().expect("tick").expect("fires").t_ns;
+            let tb = b.inner.lock().tick().expect("tick").expect("fires").t_ns;
+            assert_eq!(ta, tb, "draw {i} diverged under a fixed seed");
+        }
+    }
+
+    /// `advance` (the folded-in `AcceleratedTimeMode.advance` verb)
+    /// pushes the virtual clock without emitting, and λ ≤ 0 scopes
+    /// never fire (`tick()` → `None`).
+    #[test]
+    fn pyo3_emission_scheduler_advance_and_disabled_scope() {
+        let sched = seeded_sched(5.0, 100);
+        assert_eq!(sched.now_ns(), 0);
+        sched.advance(1_000_000_000);
+        assert_eq!(sched.now_ns(), 1_000_000_000);
+        assert!(
+            sched
+                .lifetime_avg_lambda("community:alpha")
+                .expect("registered")
+                .abs()
+                < f64::EPSILON,
+            "no emissions yet — advance alone must not fabricate rate"
+        );
+
+        let mut lambdas = std::collections::HashMap::new();
+        lambdas.insert("self".to_string(), 0.0);
+        let disabled = PyEmissionScheduler::new(lambdas, None, 100, 10.0, None, 0)
+            .expect("zero-λ construction is valid");
+        assert!(
+            disabled.inner.lock().tick().expect("tick").is_none(),
+            "λ=0 scope never fires"
+        );
+    }
+
+    /// Constructor validation: unknown scope strings, stray
+    /// `scope_keys` entries, non-positive windows, and non-finite λ
+    /// all reject with `ValueError` diagnostics.
+    #[test]
+    fn pyo3_emission_scheduler_rejects_config_errors() {
+        l3_init_python();
+        let lam = |name: &str, l: f64| {
+            let mut m = std::collections::HashMap::new();
+            m.insert(name.to_string(), l);
+            m
+        };
+
+        let err = PyEmissionScheduler::new(lam("bogus", 1.0), None, 100, 10.0, None, 0)
+            .expect_err("unknown scope string");
+        assert!(format!("{err}").contains("scope"));
+
+        let mut stray = std::collections::HashMap::new();
+        stray.insert("community:other".to_string(), vec![0u8; 32]);
+        let err = PyEmissionScheduler::new(lam("self", 1.0), None, 100, 10.0, Some(stray), 0)
+            .expect_err("stray scope_keys entry");
+        assert!(format!("{err}").contains("scope_keys"));
+
+        let err = PyEmissionScheduler::new(lam("self", 1.0), None, 100, 0.0, None, 0)
+            .expect_err("zero window");
+        assert!(format!("{err}").contains("window_secs"));
+
+        let err = PyEmissionScheduler::new(lam("self", f64::NAN), None, 100, 10.0, None, 0)
+            .expect_err("NaN λ");
+        assert!(format!("{err}").contains("finite"));
+
+        let err = PyEmissionScheduler::new(lam("self", 1.0), Some(&[0u8; 16]), 100, 10.0, None, 0)
+            .expect_err("16-byte seed");
+        assert!(format!("{err}").contains("rng_seed"));
+    }
+
+    /// The `tick()` pymethod's dict projection carries the documented
+    /// keys — exercised through an attached interpreter since the
+    /// substrate-level coverage above drives the Rust inner directly.
+    #[test]
+    fn pyo3_emission_scheduler_tick_dict_shape() {
+        l3_init_python();
+        let sched = seeded_sched(5.0, 100);
+        Python::attach(|py| {
+            let d = sched.tick(py).expect("tick").expect("enabled scope fires");
+            for key in [
+                "scope",
+                "t_ns",
+                "kind",
+                "fragment_id",
+                "fragment_index",
+                "fragment_count",
+                "envelope",
+            ] {
+                assert!(
+                    d.contains(key).expect("contains"),
+                    "tick dict missing {key}"
+                );
+            }
+            let kind: String = d
+                .get_item("kind")
+                .expect("get kind")
+                .expect("kind present")
+                .extract()
+                .expect("str");
+            assert_eq!(kind, "cover");
+            let scope: String = d
+                .get_item("scope")
+                .expect("get scope")
+                .expect("scope present")
+                .extract()
+                .expect("str");
+            assert_eq!(scope, "community:alpha");
+        });
     }
 }
 

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -7076,6 +7076,7 @@ mod pyo3_tier2_tests {
                 // rows carry None. Steward identity_type is not
                 // accord-holder so the V048 CHECK admits None.
                 attestation_evidence: None,
+                consent_role: None,
             };
             backend
                 .put_public_key(SignedKeyRecord { record })

--- a/src/holonomic/aggregation.rs
+++ b/src/holonomic/aggregation.rs
@@ -8,12 +8,28 @@
 //! thousand pictures) persists below the floor forever, so the federation
 //! remembers all of history in **O(log T)** via N→1 aggregation.
 //!
-//! This module is the **producer** side of §19.7. CIRISVerify v5.10.0 authored
-//! the §19.7 wire vectors (since no reference impl predated the contract);
-//! this module emits byte-for-byte identical bytes from edge's producer path
-//! so the round-trip lifts §19.7 from RC-grade to 1.0.
+//! # The canonical shapes are verify's now (CIRISEdge#267 / CIRISVerify#167)
 //!
-//! # Wire shape (LOCKED at v1 per §19.7.1)
+//! [`AggregationMetaV1`], its `signing_preimage`, the §19.7.1.2 dominance
+//! surface ([`effective_source_count`] + [`passes_dominance_gate`]), the
+//! §19.7.1.1 [`member_commitment`] Merkle, and the PQC-mandatory ingest gate
+//! ([`verify_aggregation_meta`]) live in
+//! [`ciris_verify_core::holonomic::aggregation`], the canonical home for every
+//! §19/§Q signed shape, on verify's shared `Preimage` builder + bound-hybrid
+//! gate (verify v8.7.0). Edge **re-exports** them here so the producer path
+//! keeps one import path, and adds only the producer-side tier assembly below.
+//!
+//! Edge previously carried a standalone v1-only reimplementation (v4.3.0 /
+//! CIRISEdge#152) — its own `push_lp` preimage discipline and a serde-derived
+//! struct. That predated the #167 wire change; #267 dropped it in favor of
+//! verify's, exactly as #269 did for the §Q storage-contention shapes. The
+//! domain separator is byte-identical (`AGG-META-v1\0\0\0\0\0`) and a
+//! **version-1** tier's preimage is **byte-identical** to the pre-#167 layout,
+//! so every already-signed v1 tier and the committed
+//! `conformance_vectors/19_7/aggregation_meta/canonical_bytes.json` golden
+//! verify unchanged.
+//!
+//! # Wire shape (§19.7.1, v2 gated per §19.7.1.2 / CIRISVerify#167)
 //!
 //! ```text
 //! signing_preimage =
@@ -26,124 +42,120 @@
 //!     || u32_be(source_count)
 //!     || member_commitment[32]     // fixed 32 bytes
 //!     || lp(noise_floor_descriptor)
+//!     [|| u32_be(n_eff)  iff version >= 2]   // §19.7.1.2 signed dominance surface
 //! ```
+//!
+//! The v2 trailing `u32_be(n_eff)` makes the fold's **effective** source count
+//! checkable: `source_count` is raw N and `member_commitment` is unweighted,
+//! so a composite where one source supplies ~90% of the mass (the 900/1000
+//! case, CC 6.1.2 noise floor) was previously indistinguishable from a
+//! balanced fold. Downstream dominance gates ([`passes_dominance_gate`])
+//! require a *signed* `n_eff` — a v1 tier fails closed.
 //!
 //! # member_commitment (LOCKED at v1 per §19.7.1.1)
 //!
 //! The Merkle root over the tier's source member ids, using the §19.1
-//! WholenessWitness construction **reused verbatim**:
-//!
-//! 1. Each `source_member_id` is hashed: `leaf = SHA-256(utf8(member_id))`
-//! 2. Leaves lex-sorted (the WW-2 sort discipline)
-//! 3. Binary Merkle tree with odd-node duplicate-last (CT convention)
-//! 4. Empty input → `SHA-256(b"WW-v1-empty")` sentinel (= `2280d27f...49563464f`)
-//!
-//! Reusing [`compute_merkle_root`](super::wholeness_witness::compute_merkle_root)
-//! ensures the federation runs one Merkle scheme across both §19.1 witness leaves
-//! and §19.7 member commitments — no schema fork.
+//! WholenessWitness construction **reused verbatim** (`leaf =
+//! SHA-256(utf8(member_id))`, lex-sort, odd-node duplicate-last, `WW-v1-empty`
+//! empty sentinel) — one Merkle scheme across §19.1 + §19.7, no schema fork.
 
-use serde::{Deserialize, Serialize};
+// ── the canonical §19.7 shapes + verify gates (verify-owned) ──────────
+pub use ciris_verify_core::holonomic::aggregation::{
+    descend_order, effective_source_count, member_commitment, passes_dominance_gate,
+    verify_aggregation_meta, verify_member_commitment, AggregationMetaV1,
+    AggregationMetaVerification,
+};
+pub use ciris_verify_core::holonomic::preimage::DOMAIN_AGG_META as AGG_META_DOMAIN;
 
-use super::wholeness_witness::compute_merkle_root;
+/// §19.7.1.1 producer alias — the historical edge name for verify's canonical
+/// [`member_commitment`], kept so producer call-sites and the #57 freeze-gate
+/// vector tests read unchanged across the #267 re-export cut.
+pub use ciris_verify_core::holonomic::aggregation::member_commitment as compute_member_commitment;
 
-/// Locked v1 domain-separation tag for [`AggregationMetaV1`] signed bytes.
-/// 16 bytes, null-padded.
-pub const AGG_META_DOMAIN: &[u8; 16] = b"AGG-META-v1\0\0\0\0\0";
-
-/// Locked v1 schema version pinned into the signed preimage.
+/// Locked v1 schema version — the pre-#167 layout (no signed `n_eff`).
+/// Preserved for the committed v1 goldens; **new tiers MUST be v2**
+/// ([`AGG_META_VERSION_V2`]) so downstream can dominance-gate.
 pub const AGG_META_VERSION: u32 = 1;
 
-/// One tier of the §19.7 memory pyramid — which content, at what aggregation
-/// tier, over which source members, by which mechanical operator.
+/// §19.7.1.2 schema version (CIRISVerify#167 / CC 6.1.2): the v1 layout plus a
+/// trailing big-endian `u32(n_eff)` in the signed preimage. What
+/// [`assemble_tier_meta_v2`] emits.
+pub const AGG_META_VERSION_V2: u32 = 2;
+
+/// §19.7.1.2 producer side (CIRISEdge#267): assemble a **version-2** tier meta
+/// from the per-member source ids and content masses — computing
+/// `source_count` (raw fan-in N), the §19.7.1.1 [`member_commitment`] Merkle,
+/// and the effective source count `n_eff = round((Σmᵢ)² / Σmᵢ²)`
+/// ([`effective_source_count`], the inverse-Simpson / participation ratio) so
+/// the emitted meta carries the signed dominance surface downstream gates
+/// check. A balanced fold of N equal-mass sources has `n_eff == N`; the
+/// 900/1000-dominated case collapses toward `n_eff ≈ 1` and
+/// [`passes_dominance_gate`] rejects it.
 ///
-/// A substrate wire shape (NOT a §4 attestation); byte layout pinned by §19.7.1.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct AggregationMetaV1 {
-    /// Schema version (`1`).
-    pub version: u32,
-    /// The root content this pyramid is for.
-    pub content_id: String,
-    /// `"trace" | "blob" | "av_chunk" | …`.
-    pub corpus_kind: String,
-    /// `0` = source granularity; higher = more aggregated.
-    pub tier: u32,
-    /// Opaque codec id, e.g. `"raptorq-pyramid-v1"`.
-    pub aggregation_algorithm_id: String,
-    /// N members aggregated into this tier (the descent fan-in).
-    pub source_count: u32,
-    /// §19.7.1.1 Merkle root over the source member ids (raw 32 bytes).
-    pub member_commitment: [u8; 32],
-    /// What survives below the floor (codec-specific, canonical).
-    pub noise_floor_descriptor: String,
-}
-
-impl AggregationMetaV1 {
-    /// Build the §19.7.1 canonical signing preimage (normative byte order).
-    ///
-    /// Two implementations of §19.7.1 MUST produce byte-identical output from
-    /// byte-identical input. Verified against CIRISVerify v5.10.0's authored
-    /// vectors in `tests/conformance_vectors_v19_7.rs`.
-    #[must_use]
-    pub fn signing_preimage(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(
-            16 + 4
-                + (4 + self.content_id.len())
-                + (4 + self.corpus_kind.len())
-                + 4
-                + (4 + self.aggregation_algorithm_id.len())
-                + 4
-                + 32
-                + (4 + self.noise_floor_descriptor.len()),
-        );
-        out.extend_from_slice(AGG_META_DOMAIN);
-        out.extend_from_slice(&self.version.to_be_bytes());
-        push_lp(&mut out, self.content_id.as_bytes());
-        push_lp(&mut out, self.corpus_kind.as_bytes());
-        out.extend_from_slice(&self.tier.to_be_bytes());
-        push_lp(&mut out, self.aggregation_algorithm_id.as_bytes());
-        out.extend_from_slice(&self.source_count.to_be_bytes());
-        out.extend_from_slice(&self.member_commitment);
-        push_lp(&mut out, self.noise_floor_descriptor.as_bytes());
-        out
-    }
-}
-
-fn push_lp(out: &mut Vec<u8>, bytes: &[u8]) {
-    let len: u32 = u32::try_from(bytes.len()).expect("lp field length exceeds u32");
-    out.extend_from_slice(&len.to_be_bytes());
-    out.extend_from_slice(bytes);
-}
-
-/// §19.7.1.1 — compute the `member_commitment` Merkle root over a tier's
-/// source member ids. Reuses the §19.1 WholenessWitness construction
-/// **verbatim**: pass the UTF-8 bytes of each member id as a leaf;
-/// [`compute_merkle_root`] handles lex-sort + leaf hashing + odd-node
-/// duplicate-last + the `WW-v1-empty` empty sentinel.
+/// `member_masses[i]` is the content mass of `source_member_ids[i]`
+/// (codec-specific — e.g. source bytes folded into the tier). The two slices
+/// MUST be index-aligned; masses need not be pre-sorted (`n_eff` is
+/// order-independent) and `member_commitment` lex-sorts internally.
 ///
-/// Two implementations of §19.7.1.1 MUST produce byte-identical 32-byte output
-/// from byte-identical input. Matches CIRISVerify v5.10.0's
-/// `holonomic::aggregation::member_commitment` byte-for-byte.
+/// Signing is the caller's: the returned meta's
+/// [`signing_preimage`](AggregationMetaV1::signing_preimage) covers `n_eff`
+/// (version ≥ 2), so the bound-hybrid signature binds the dominance surface.
+///
+/// **#266 gap note:** the §19.7 pyramid *fold operator* (CIRISEdge#266) is the
+/// in-tree call-site that will drive this when it assembles tiers from held
+/// fountain content; until it lands, this is the complete producer surface
+/// for the #167 wire change, exercised by the conformance vectors.
+///
+/// # Panics
+///
+/// If `source_member_ids` and `member_masses` lengths differ, or the fan-in
+/// exceeds `u32::MAX` (a tier cannot represent it on the wire).
 #[must_use]
-pub fn compute_member_commitment(source_member_ids: &[String]) -> [u8; 32] {
-    let leaves: Vec<Vec<u8>> = source_member_ids
-        .iter()
-        .map(|id| id.as_bytes().to_vec())
-        .collect();
-    compute_merkle_root(&leaves)
+pub fn assemble_tier_meta_v2(
+    content_id: &str,
+    corpus_kind: &str,
+    tier: u32,
+    aggregation_algorithm_id: &str,
+    source_member_ids: &[String],
+    member_masses: &[f64],
+    noise_floor_descriptor: &str,
+) -> AggregationMetaV1 {
+    assert_eq!(
+        source_member_ids.len(),
+        member_masses.len(),
+        "source_member_ids and member_masses must be index-aligned"
+    );
+    let source_count =
+        u32::try_from(source_member_ids.len()).expect("tier fan-in exceeds u32 wire range");
+    AggregationMetaV1 {
+        version: AGG_META_VERSION_V2,
+        content_id: content_id.to_string(),
+        corpus_kind: corpus_kind.to_string(),
+        tier,
+        aggregation_algorithm_id: aggregation_algorithm_id.to_string(),
+        source_count,
+        member_commitment: member_commitment(source_member_ids),
+        noise_floor_descriptor: noise_floor_descriptor.to_string(),
+        n_eff: effective_source_count(member_masses),
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn fixed_meta() -> AggregationMetaV1 {
-        // Matches CIRISVerify v5.10.0's authored vector at
-        // tests/vectors/holonomic_v19_7/aggregation_meta/canonical_bytes.json
-        // so the byte-equality assertion proves cross-impl conformance.
-        let source_ids: Vec<String> = ["src-001", "src-002", "src-003"]
+    fn fixed_source_ids() -> Vec<String> {
+        ["src-001", "src-002", "src-003"]
             .into_iter()
             .map(String::from)
-            .collect();
+            .collect()
+    }
+
+    fn fixed_meta() -> AggregationMetaV1 {
+        // Matches CIRISVerify's authored vector at
+        // tests/vectors/holonomic_v19_7/aggregation_meta/canonical_bytes.json
+        // so the byte-equality assertion proves cross-impl conformance.
+        let source_ids = fixed_source_ids();
         let member_commitment = compute_member_commitment(&source_ids);
         AggregationMetaV1 {
             version: AGG_META_VERSION,
@@ -154,7 +166,19 @@ mod tests {
             source_count: 3,
             member_commitment,
             noise_floor_descriptor: "mean+stddev".to_string(),
+            // Neutral placeholder on a v1 tier — NOT in the v1 preimage
+            // (asserted below), NOT accepted by passes_dominance_gate.
+            n_eff: 3,
         }
+    }
+
+    fn hex(bytes: &[u8]) -> String {
+        use std::fmt::Write;
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            write!(&mut s, "{b:02x}").expect("hex write");
+        }
+        s
     }
 
     #[test]
@@ -168,48 +192,59 @@ mod tests {
     fn signing_preimage_matches_verify_v5_10_0_vector_byte_for_byte() {
         // Locked v1 expected bytes from CIRISVerify v5.10.0's authored vector
         // (src/ciris-verify-core/tests/vectors/holonomic_v19_7/aggregation_meta/canonical_bytes.json).
+        // A v1 preimage MUST stay byte-identical across the #167 v2 cut.
         let expected_hex = "4147472d4d4554412d763100000000000000000100000012636f6e74656e742d726f6f742d66697865640000000574726163650000000200000012726170746f72712d707972616d69642d763100000003a10bc0ec2399f1cd431be79a863385a4b895987dae604aaf2ec3532f3753bd9d0000000b6d65616e2b737464646576";
-        let actual = fixed_meta().signing_preimage();
-        let mut actual_hex = String::with_capacity(actual.len() * 2);
-        for b in &actual {
-            use std::fmt::Write;
-            write!(&mut actual_hex, "{b:02x}").expect("hex write");
-        }
         assert_eq!(
-            actual_hex, expected_hex,
-            "AggregationMetaV1 preimage MUST match Verify v5.10.0 byte-for-byte"
+            hex(&fixed_meta().signing_preimage()),
+            expected_hex,
+            "AggregationMetaV1 v1 preimage MUST match Verify's authored vector byte-for-byte"
         );
+    }
+
+    #[test]
+    fn v2_signing_preimage_matches_verify_v8_7_0_vector_byte_for_byte() {
+        // §19.7.1.2 (CIRISVerify#167): locked v2 expected bytes from verify
+        // v8.7.0's authored vector (.../aggregation_meta/canonical_bytes_v2.json)
+        // — the v1 layout with version=2 and a trailing u32_be(n_eff)=3.
+        let expected_hex = "4147472d4d4554412d763100000000000000000200000012636f6e74656e742d726f6f742d66697865640000000574726163650000000200000012726170746f72712d707972616d69642d763100000003a10bc0ec2399f1cd431be79a863385a4b895987dae604aaf2ec3532f3753bd9d0000000b6d65616e2b73746464657600000003";
+        let mut meta = fixed_meta();
+        meta.version = AGG_META_VERSION_V2;
+        assert_eq!(
+            hex(&meta.signing_preimage()),
+            expected_hex,
+            "AggregationMetaV1 v2 preimage MUST match Verify v8.7.0's authored vector byte-for-byte"
+        );
+    }
+
+    #[test]
+    fn v1_preimage_is_byte_identical_regardless_of_n_eff() {
+        // Backward-compat pin (#167): a v1 tier ignores n_eff in the preimage,
+        // so every pre-#167 signature/vector verifies unchanged.
+        let mut a = fixed_meta();
+        let mut b = fixed_meta();
+        a.n_eff = 7;
+        b.n_eff = 999;
+        assert_eq!(a.signing_preimage(), b.signing_preimage());
     }
 
     #[test]
     fn member_commitment_empty_returns_ww_v1_sentinel() {
         // The §19.7.1.1 / §19.1 shared sentinel: empty input → SHA-256("WW-v1-empty").
-        let root = compute_member_commitment(&[]);
-        let mut hex = String::with_capacity(64);
-        for b in &root {
-            use std::fmt::Write;
-            write!(&mut hex, "{b:02x}").expect("hex write");
-        }
         assert_eq!(
-            hex,
+            hex(&compute_member_commitment(&[])),
             "2280d27f232100367e86211b5349fe0d6fbaee98e4c2b489a86008049563464f"
         );
     }
 
     #[test]
     fn member_commitment_lex_sorts_internally() {
-        // Verify v5.10.0's authored vector at member_commitment/three_unsorted.json
-        // uses ["m3", "m1", "m2"] (unsorted) → expects 1bfd0a8a... Our impl must
-        // produce the same root from the same unsorted input.
+        // Verify's authored vector at member_commitment/three_unsorted.json
+        // uses ["m3", "m1", "m2"] (unsorted) → expects 1bfd0a8a... The
+        // re-exported impl must produce the same root from unsorted input.
         let source: Vec<String> = ["m3", "m1", "m2"].into_iter().map(String::from).collect();
-        let root = compute_member_commitment(&source);
-        let mut hex = String::with_capacity(64);
-        for b in &root {
-            use std::fmt::Write;
-            write!(&mut hex, "{b:02x}").expect("hex write");
-        }
         assert_eq!(
-            hex, "1bfd0a8a367f375a67ad08b3f19cf1a6d82876e753eea631a698d7dcca58226d",
+            hex(&compute_member_commitment(&source)),
+            "1bfd0a8a367f375a67ad08b3f19cf1a6d82876e753eea631a698d7dcca58226d",
             "member_commitment must lex-sort source ids (WW-2 discipline)"
         );
     }
@@ -220,27 +255,94 @@ mod tests {
         // compute_member_commitment over the documented source ids; otherwise
         // the AggregationMetaV1's signed preimage carries a commitment that
         // verifiers reject as inconsistent.
-        let source_ids: Vec<String> = ["src-001", "src-002", "src-003"]
-            .into_iter()
-            .map(String::from)
-            .collect();
-        let expected = compute_member_commitment(&source_ids);
-        let meta = fixed_meta();
-        assert_eq!(meta.member_commitment, expected);
+        let expected = compute_member_commitment(&fixed_source_ids());
+        assert_eq!(fixed_meta().member_commitment, expected);
+    }
+
+    #[test]
+    fn assemble_tier_meta_v2_computes_n_eff_and_commitment() {
+        // Producer side (#267 slice 2): a balanced 3-fold → version=2,
+        // n_eff == source_count == 3, commitment = §19.7.1.1 Merkle.
+        let ids = fixed_source_ids();
+        let meta = assemble_tier_meta_v2(
+            "content-root-fixed",
+            "trace",
+            2,
+            "raptorq-pyramid-v1",
+            &ids,
+            &[10.0, 10.0, 10.0],
+            "mean+stddev",
+        );
+        assert_eq!(meta.version, AGG_META_VERSION_V2);
+        assert_eq!(meta.source_count, 3);
+        assert_eq!(meta.n_eff, 3, "balanced fold: n_eff == N");
+        assert_eq!(meta.member_commitment, compute_member_commitment(&ids));
+        assert!(
+            passes_dominance_gate(&meta, 0.5),
+            "a balanced v2 fold passes the dominance gate"
+        );
+        // And the emitted meta signs the v2 layout (trailing u32_be(n_eff)).
+        let pre = meta.signing_preimage();
+        assert_eq!(&pre[pre.len() - 4..], 3u32.to_be_bytes());
+    }
+
+    #[test]
+    fn assemble_tier_meta_v2_dominated_fold_fails_dominance_gate() {
+        // CC 6.1.2 / the 900/1000 case: one source holds 90% of the mass →
+        // n_eff collapses toward 1 and the emitted tier is gate-rejected,
+        // which is the whole point of signing n_eff (#167).
+        let ids: Vec<String> = (0..1000).map(|i| format!("src-{i:04}")).collect();
+        let mut masses = vec![900.0];
+        masses.extend(std::iter::repeat_n(100.0 / 999.0, 999));
+        let meta = assemble_tier_meta_v2(
+            "content-root-dominated",
+            "trace",
+            1,
+            "raptorq-pyramid-v1",
+            &ids,
+            &masses,
+            "mean+stddev",
+        );
+        assert_eq!(meta.source_count, 1000);
+        assert!(
+            meta.n_eff <= 2,
+            "900/1000-dominated fold must have n_eff ≈ 1, got {}",
+            meta.n_eff
+        );
+        assert!(!passes_dominance_gate(&meta, 0.5));
+        assert!(
+            !passes_dominance_gate(&meta, 0.1),
+            "even a lenient floor rejects it"
+        );
+    }
+
+    #[test]
+    fn dominance_gate_fails_closed_on_v1() {
+        // A v1 tier has no *signed* n_eff — whatever placeholder it carries,
+        // the gate fails closed (verify-owned behavior, pinned here because
+        // edge's producer relied on it when choosing to emit v2).
+        let m = fixed_meta(); // version 1, n_eff placeholder = 3 = source_count
+        assert!(!passes_dominance_gate(&m, 0.5));
     }
 
     #[test]
     fn signing_preimage_changes_on_any_field_mutation() {
-        // Every field MUST appear in the canonical preimage. Mutate each in turn
-        // and assert the preimage changes — guards against future field-omission
-        // regressions that would break the cross-impl byte-equality.
-        let base = fixed_meta().signing_preimage();
+        // Every field MUST appear in the canonical preimage (v2: including
+        // n_eff). Mutate each in turn and assert the preimage changes —
+        // guards against future field-omission regressions that would break
+        // the cross-impl byte-equality.
+        let v2_meta = || {
+            let mut m = fixed_meta();
+            m.version = AGG_META_VERSION_V2;
+            m
+        };
+        let base = v2_meta().signing_preimage();
 
-        let mut m = fixed_meta();
+        let mut m = v2_meta();
         m.version += 1;
         assert_ne!(m.signing_preimage(), base, "version must affect preimage");
 
-        let mut m = fixed_meta();
+        let mut m = v2_meta();
         m.content_id.push_str("-mutated");
         assert_ne!(
             m.signing_preimage(),
@@ -248,7 +350,7 @@ mod tests {
             "content_id must affect preimage"
         );
 
-        let mut m = fixed_meta();
+        let mut m = v2_meta();
         m.corpus_kind = "blob".to_string();
         assert_ne!(
             m.signing_preimage(),
@@ -256,11 +358,11 @@ mod tests {
             "corpus_kind must affect preimage"
         );
 
-        let mut m = fixed_meta();
+        let mut m = v2_meta();
         m.tier += 1;
         assert_ne!(m.signing_preimage(), base, "tier must affect preimage");
 
-        let mut m = fixed_meta();
+        let mut m = v2_meta();
         m.aggregation_algorithm_id = "av1-svc-quality-v1".to_string();
         assert_ne!(
             m.signing_preimage(),
@@ -268,7 +370,7 @@ mod tests {
             "aggregation_algorithm_id must affect preimage"
         );
 
-        let mut m = fixed_meta();
+        let mut m = v2_meta();
         m.source_count += 1;
         assert_ne!(
             m.signing_preimage(),
@@ -276,7 +378,7 @@ mod tests {
             "source_count must affect preimage"
         );
 
-        let mut m = fixed_meta();
+        let mut m = v2_meta();
         m.member_commitment[0] ^= 0xff;
         assert_ne!(
             m.signing_preimage(),
@@ -284,12 +386,20 @@ mod tests {
             "member_commitment must affect preimage"
         );
 
-        let mut m = fixed_meta();
+        let mut m = v2_meta();
         m.noise_floor_descriptor = "max".to_string();
         assert_ne!(
             m.signing_preimage(),
             base,
             "noise_floor_descriptor must affect preimage"
+        );
+
+        let mut m = v2_meta();
+        m.n_eff += 1;
+        assert_ne!(
+            m.signing_preimage(),
+            base,
+            "n_eff must affect the v2 preimage (§19.7.1.2 signed dominance surface)"
         );
     }
 }

--- a/src/holonomic/mod.rs
+++ b/src/holonomic/mod.rs
@@ -67,6 +67,14 @@
 //!   CIRISPersist v8.4.0's ingest gate (verify_aggregation_meta now
 //!   ENFORCED at store path).
 //!
+//! - **v9.0.0** (CIRISEdge#267 / CIRISVerify#167) — [`aggregation`] adopts
+//!   verify v8.7.0's canonical §19.7.1.2 **v2 preimage + signed `n_eff`**
+//!   dominance surface (CC 6.1.2 noise floor): edge drops its standalone v1
+//!   reimplementation and re-exports verify's shapes/gates (the #269
+//!   storage-contention pattern), keeping only the producer-side
+//!   [`assemble_tier_meta_v2`](aggregation::assemble_tier_meta_v2) tier
+//!   assembly. v1 preimages stay byte-identical; new tiers emit version 2.
+//!
 //! See `docs/ROADMAP_TO_V4.md` for the cut sequence and the
 //! CIRISRegistry#85 + #89 absorption gates for normative CEG status.
 //!

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1076,6 +1076,7 @@ mod tests {
             persist_row_hash: String::new(),
             roles: Vec::new(),
             attestation_evidence: None,
+            consent_role: None,
         }
     }
 

--- a/src/transport/realtime_av_codec/fountain.rs
+++ b/src/transport/realtime_av_codec/fountain.rs
@@ -423,6 +423,253 @@ pub fn retention_priority(svc_quality: u8, symbol_id: u32, n_source: u32) -> u8 
 }
 
 // ─────────────────────────────────────────────────────────────────
+// N→1 aggregation / resampling operator (CIRISEdge#266)
+// ─────────────────────────────────────────────────────────────────
+
+/// Which mechanical N→1 collapse [`aggregate_symbols`] applies
+/// (CIRISEdge#266, CC 6.1.2 / §19.7 operator-2 collapse).
+///
+/// §19.7's descent axis demands that the composite be **derived
+/// from** the member payloads — erasure is only measurable against a
+/// composite that was actually computed from what it replaced. Each
+/// variant is a deterministic pure-byte operator; none consults
+/// RaptorQ state, so the composite carries no side channel back to
+/// any individual member beyond the op's own residual bound.
+///
+/// ## Seam to `AggregationMetaV1` (integrator note, #266 / #267)
+///
+/// This module does NOT touch the §19.7.1 wire shape. The producer
+/// path stamps [`Self::algorithm_id`] into
+/// [`crate::holonomic::aggregation::AggregationMetaV1::aggregation_algorithm_id`]
+/// unchanged; a sibling cut (#267) is consuming verify's
+/// AggregationMetaV1 v2 shapes, and this operator plugs into either
+/// v1 or v2 metadata via that one opaque string — no meta-type
+/// rework here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AggregateOp {
+    /// Byte-wise rounded mean across all N members (each member
+    /// nearest-neighbor resampled to the composite length first).
+    /// Residual fidelity of any member vs the composite is
+    /// chance-level (≈ the byte-collision floor), well under `1/N`.
+    Mean,
+    /// Round-robin decimation: composite position `i` is taken from
+    /// member `i mod N` (after resampling). Each member contributes
+    /// exactly ~`1/N` of the composite's positions, so per-member
+    /// residual fidelity sits AT the `1/N_eff` bound — the canonical
+    /// worst-case-compliant operator for the §19.7 erasure gate.
+    Decimate,
+    /// Mipmap-style reduction: block-mean over all N members AND
+    /// over N adjacent positions, shrinking the composite to
+    /// `ceil(len / N)` bytes (a true N× total-data collapse, like
+    /// one mipmap level). Residual fidelity is chance-level.
+    Mipmap,
+}
+
+impl AggregateOp {
+    /// Canonical opaque codec id for this operator — the value the
+    /// producer path stamps into `AggregationMetaV1
+    /// .aggregation_algorithm_id` (§19.7.1). Locked strings; a new
+    /// collapse semantics gets a new `-vN` suffix, never a mutation.
+    #[must_use]
+    pub const fn algorithm_id(self) -> &'static str {
+        match self {
+            AggregateOp::Mean => "fountain-mean-v1",
+            AggregateOp::Decimate => "fountain-decimate-v1",
+            AggregateOp::Mipmap => "fountain-mipmap-v1",
+        }
+    }
+}
+
+/// The N→1 composite produced by [`aggregate_symbols`]
+/// (CIRISEdge#266). Carries the fan-in (`n_members`) so a
+/// conformance gate can compute its own `1/N_eff` bound, plus the
+/// operator that produced it (for `algorithm_id` stamping).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Composite {
+    /// Composite payload bytes. Length = max member length for
+    /// [`AggregateOp::Mean`] / [`AggregateOp::Decimate`];
+    /// `ceil(max_len / n_members)` for [`AggregateOp::Mipmap`].
+    pub bytes: Vec<u8>,
+    /// The descent fan-in N — how many members were collapsed.
+    /// Mirrors `AggregationMetaV1.source_count`.
+    pub n_members: u32,
+    /// The operator that produced `bytes`.
+    pub op: AggregateOp,
+    /// The resample basis (max member length in bytes) the members
+    /// were normalized to before collapsing.
+    pub source_len: u64,
+}
+
+impl Composite {
+    /// The §19.7 aggregation-erasure gate bound: `max(ε, 1/N_eff)`
+    /// (CIRISEdge#266). A member is *erased* iff its
+    /// [`residual_fidelity`] vs this composite does not exceed this
+    /// bound. At `n_members == 1` the bound is `1.0` — a 1→1
+    /// "collapse" erases nothing, by construction.
+    #[must_use]
+    pub fn erasure_bound(&self, epsilon: f64) -> f64 {
+        epsilon.max(1.0 / f64::from(self.n_members.max(1)))
+    }
+}
+
+/// Errors from [`aggregate_symbols`]. Degenerate inputs are refused
+/// loudly rather than silently producing an empty composite the
+/// erasure gate would vacuously pass.
+#[derive(thiserror::Error, Debug)]
+pub enum AggregateError {
+    /// The member set is empty — there is nothing to collapse.
+    #[error("no members: N→1 aggregation requires at least one member")]
+    NoMembers,
+    /// A member has zero bytes and cannot be resampled. `0` is the
+    /// offending member's index.
+    #[error("empty member at index {0}: zero-length payloads cannot be resampled")]
+    EmptyMember(usize),
+    /// More members than `u32` can carry (the `AggregationMetaV1
+    /// .source_count` / `Composite.n_members` width). `0` is the count.
+    #[error("too many members: {0} exceeds the u32 source_count width")]
+    TooManyMembers(usize),
+}
+
+/// Nearest-neighbor 1-D resample of `src` to exactly `dst_len`
+/// bytes: output position `i` reads `src[i * src_len / dst_len]`.
+/// Identity when `dst_len == src_len`. `src` MUST be non-empty and
+/// `dst_len` non-zero (guarded by [`aggregate_symbols`]'s input
+/// validation).
+fn resample_nearest(src: &[u8], dst_len: usize) -> Vec<u8> {
+    debug_assert!(!src.is_empty() && dst_len > 0);
+    (0..dst_len)
+        .map(|i| {
+            // u128 intermediate: i * src_len can overflow usize on
+            // 32-bit targets for large payloads.
+            #[allow(clippy::cast_possible_truncation)] // result < src_len by construction
+            let idx = ((i as u128 * src.len() as u128) / dst_len as u128) as usize;
+            src[idx]
+        })
+        .collect()
+}
+
+/// Collapse N member payloads into one composite — the pub N→1
+/// aggregation/resampling operator (CIRISEdge#266, CC 6.1.2 / §19.7
+/// operator-2).
+///
+/// The composite is computed **from** the members: hard-delete the
+/// members afterwards and each one's [`residual_fidelity`] vs the
+/// composite is bounded by [`Composite::erasure_bound`]
+/// (`max(ε, 1/N_eff)`) — the measurable aggregation-erasure property
+/// the CIRISConformance noise-floor gate (CIRISConformance#55)
+/// drives. This replaces the fabricated-independent-blob modeling in
+/// CIRISServer's `tests/noise_floor.rs`, which proved `< 1/N` only
+/// by construction.
+///
+/// Members of unequal length are nearest-neighbor resampled to the
+/// max member length before collapsing (the "resampling" half of the
+/// operator). Deterministic: identical `(members, op)` inputs
+/// produce a byte-identical composite.
+///
+/// # Errors
+///
+/// - [`AggregateError::NoMembers`] — empty member set.
+/// - [`AggregateError::EmptyMember`] — a zero-length member.
+/// - [`AggregateError::TooManyMembers`] — fan-in exceeds `u32`.
+pub fn aggregate_symbols(members: &[&[u8]], op: AggregateOp) -> Result<Composite, AggregateError> {
+    if members.is_empty() {
+        return Err(AggregateError::NoMembers);
+    }
+    if let Some(idx) = members.iter().position(|m| m.is_empty()) {
+        return Err(AggregateError::EmptyMember(idx));
+    }
+    let n_members =
+        u32::try_from(members.len()).map_err(|_| AggregateError::TooManyMembers(members.len()))?;
+
+    let n = members.len();
+    let max_len = members.iter().map(|m| m.len()).max().unwrap_or(1);
+    let resampled: Vec<Vec<u8>> = members
+        .iter()
+        .map(|m| resample_nearest(m, max_len))
+        .collect();
+
+    let bytes = match op {
+        AggregateOp::Mean => {
+            // Byte-wise rounded mean. Sum fits u64: 255 * u32::MAX < 2^40.
+            let n_u64 = n as u64;
+            (0..max_len)
+                .map(|i| {
+                    let sum: u64 = resampled.iter().map(|m| u64::from(m[i])).sum();
+                    #[allow(clippy::cast_possible_truncation)] // rounded mean of u8s is <= 255
+                    let byte = ((sum + n_u64 / 2) / n_u64) as u8;
+                    byte
+                })
+                .collect()
+        }
+        AggregateOp::Decimate => {
+            // Round-robin interleave: position i comes from member i mod N.
+            (0..max_len).map(|i| resampled[i % n][i]).collect()
+        }
+        AggregateOp::Mipmap => {
+            // Block-mean over all members AND over N adjacent
+            // positions — one mipmap level: total bytes shrink N×.
+            let out_len = max_len.div_ceil(n);
+            (0..out_len)
+                .map(|i| {
+                    let start = i * n;
+                    let end = ((i + 1) * n).min(max_len);
+                    // u128 accumulator: n members × n positions × 255
+                    // can exceed u64 for pathological fan-ins.
+                    let mut sum: u128 = 0;
+                    let mut count: u128 = 0;
+                    for member in &resampled {
+                        for &b in &member[start..end] {
+                            sum += u128::from(b);
+                            count += 1;
+                        }
+                    }
+                    #[allow(clippy::cast_possible_truncation)] // rounded mean of u8s is <= 255
+                    let byte = ((sum + count / 2) / count) as u8;
+                    byte
+                })
+                .collect()
+        }
+    };
+
+    Ok(Composite {
+        bytes,
+        n_members,
+        op,
+        source_len: max_len as u64,
+    })
+}
+
+/// Canonical per-member residual-fidelity measure for the §19.7
+/// aggregation-erasure gate (CIRISEdge#266): the fraction of
+/// byte-exact matches between the member (nearest-neighbor resampled
+/// to the composite's length — the same normalization
+/// [`aggregate_symbols`] applies) and the composite bytes. Range
+/// `0.0..=1.0`; `1.0` means the member is fully recoverable from the
+/// composite (no erasure), chance-level (≈ `1/256` for
+/// high-entropy bytes) means indistinguishable from noise.
+///
+/// Takes raw byte slices (not [`Composite`]) so a conformance
+/// harness can also score arbitrary blobs — e.g. demonstrate that a
+/// fabricated independent composite scores chance-level against
+/// EVERY member, which is exactly why the fabricated version proves
+/// nothing (the #266 complaint).
+#[must_use]
+pub fn residual_fidelity(member: &[u8], composite_bytes: &[u8]) -> f64 {
+    if member.is_empty() || composite_bytes.is_empty() {
+        return 0.0;
+    }
+    let normalized = resample_nearest(member, composite_bytes.len());
+    let matches = normalized
+        .iter()
+        .zip(composite_bytes.iter())
+        .filter(|(a, b)| a == b)
+        .count();
+    #[allow(clippy::cast_precision_loss)] // lengths ≪ 2^52; exact in f64
+    let fidelity = matches as f64 / composite_bytes.len() as f64;
+    fidelity
+}
+
+// ─────────────────────────────────────────────────────────────────
 // Tests
 // ─────────────────────────────────────────────────────────────────
 
@@ -769,5 +1016,203 @@ mod tests {
             max_svc0 < min_svc1,
             "max_svc0={max_svc0} >= min_svc1={min_svc1}"
         );
+    }
+
+    // ─── N→1 aggregation-erasure operator (CIRISEdge#266) ────────
+
+    /// High-entropy, deterministic, per-seed-distinct member payloads.
+    /// SHA-256 in counter mode — the `deterministic_payload` linear
+    /// ramp is a degenerate input for byte-mean operators (shifted
+    /// copies of one ramp correlate), so erasure tests need real
+    /// mixing.
+    fn distinct_member(seed: u8, len: usize) -> Vec<u8> {
+        let mut out = Vec::with_capacity(len + 32);
+        let mut counter = 0u64;
+        while out.len() < len {
+            let mut h = Sha256::new();
+            h.update([seed]);
+            h.update(counter.to_be_bytes());
+            out.extend_from_slice(&h.finalize());
+            counter += 1;
+        }
+        out.truncate(len);
+        out
+    }
+
+    /// The #266 gate ε — the noise-floor tolerance term in
+    /// `max(ε, 1/N_eff)`.
+    const EPSILON: f64 = 0.05;
+
+    #[test]
+    fn aggregate_mean_erases_individual_members() {
+        // The core #266 property: compute the REAL composite from N
+        // members, then per-member residual fidelity vs the
+        // composite is ≤ max(ε, 1/N_eff). Mean is chance-level.
+        let members: Vec<Vec<u8>> = (0..4).map(|k| distinct_member(k, 4096)).collect();
+        let refs: Vec<&[u8]> = members.iter().map(Vec::as_slice).collect();
+
+        let composite = aggregate_symbols(&refs, AggregateOp::Mean).expect("aggregate");
+        assert_eq!(composite.n_members, 4);
+        assert_eq!(composite.bytes.len(), 4096);
+
+        let bound = composite.erasure_bound(EPSILON);
+        assert!(
+            (bound - 0.25).abs() < f64::EPSILON,
+            "bound = max(0.05, 1/4)"
+        );
+        for (k, member) in members.iter().enumerate() {
+            // Self-fidelity baseline: the member IS fully
+            // recoverable from itself.
+            assert!((residual_fidelity(member, member) - 1.0).abs() < f64::EPSILON);
+            let rf = residual_fidelity(member, &composite.bytes);
+            assert!(
+                rf <= bound,
+                "member {k}: residual fidelity {rf} exceeds erasure bound {bound}"
+            );
+            // Mean is chance-level — far below even ε alone.
+            assert!(rf <= EPSILON, "member {k}: mean rf {rf} above chance-level");
+        }
+    }
+
+    #[test]
+    fn aggregate_decimate_sits_at_one_over_n() {
+        // Decimate is the worst-case-compliant operator: each member
+        // contributes exactly ~1/N of composite positions, so rf
+        // lands AT the 1/N_eff bound (plus the byte-collision floor)
+        // — and, crucially, ABOVE chance, proving the composite is
+        // genuinely derived from the members (not a fabricated blob).
+        let members: Vec<Vec<u8>> = (10..14).map(|k| distinct_member(k, 4096)).collect();
+        let refs: Vec<&[u8]> = members.iter().map(Vec::as_slice).collect();
+
+        let composite = aggregate_symbols(&refs, AggregateOp::Decimate).expect("aggregate");
+        let bound = composite.erasure_bound(EPSILON);
+        for (k, member) in members.iter().enumerate() {
+            let rf = residual_fidelity(member, &composite.bytes);
+            assert!(
+                rf <= bound + EPSILON,
+                "member {k}: decimate rf {rf} exceeds 1/N bound {bound} + ε"
+            );
+            assert!(
+                rf >= 1.0 / (2.0 * 4.0),
+                "member {k}: decimate rf {rf} below 1/(2N) — composite not derived from member"
+            );
+        }
+    }
+
+    #[test]
+    fn aggregate_mipmap_erases_individual_members() {
+        // Mipmap collapses resolution too: composite is
+        // ceil(4096/4) = 1024 bytes of block-means. Chance-level rf.
+        let members: Vec<Vec<u8>> = (20..24).map(|k| distinct_member(k, 4096)).collect();
+        let refs: Vec<&[u8]> = members.iter().map(Vec::as_slice).collect();
+
+        let composite = aggregate_symbols(&refs, AggregateOp::Mipmap).expect("aggregate");
+        assert_eq!(composite.bytes.len(), 1024, "one mipmap level = N× shrink");
+        assert_eq!(composite.source_len, 4096);
+
+        let bound = composite.erasure_bound(EPSILON);
+        for (k, member) in members.iter().enumerate() {
+            let rf = residual_fidelity(member, &composite.bytes);
+            assert!(
+                rf <= bound,
+                "member {k}: mipmap rf {rf} exceeds erasure bound {bound}"
+            );
+        }
+    }
+
+    #[test]
+    fn aggregate_composite_derived_and_deterministic() {
+        // Determinism: identical inputs → byte-identical composite.
+        // Sensitivity: perturbing ONE member changes the composite —
+        // the anti-fabrication property (#266: the fabricated blob
+        // was independent of the members by construction).
+        let members: Vec<Vec<u8>> = (30..34).map(|k| distinct_member(k, 2048)).collect();
+        let refs: Vec<&[u8]> = members.iter().map(Vec::as_slice).collect();
+
+        for op in [
+            AggregateOp::Mean,
+            AggregateOp::Decimate,
+            AggregateOp::Mipmap,
+        ] {
+            let a = aggregate_symbols(&refs, op).expect("aggregate a");
+            let b = aggregate_symbols(&refs, op).expect("aggregate b");
+            assert_eq!(a, b, "{op:?}: composite not deterministic");
+
+            // Perturb member 0 at position 0 (position 0 belongs to
+            // member 0 in the decimate round-robin) by ±128 so the
+            // delta survives mean rounding (128/4 = 32 for mean,
+            // 128/16 = 8 for mipmap block-mean).
+            let mut perturbed = members.clone();
+            perturbed[0][0] = perturbed[0][0].wrapping_add(128);
+            let refs_p: Vec<&[u8]> = perturbed.iter().map(Vec::as_slice).collect();
+            let c = aggregate_symbols(&refs_p, op).expect("aggregate perturbed");
+            assert_ne!(
+                a.bytes, c.bytes,
+                "{op:?}: composite insensitive to member content — fabricated-blob smell"
+            );
+        }
+    }
+
+    #[test]
+    fn aggregate_unequal_member_lengths_resampled() {
+        // The "resampling" half of the operator: members of unequal
+        // length are nearest-neighbor normalized to the max length,
+        // and the erasure bound still holds per member.
+        let members = [
+            distinct_member(40, 4096),
+            distinct_member(41, 1000),
+            distinct_member(42, 977),
+        ];
+        let refs: Vec<&[u8]> = members.iter().map(|m| m.as_slice()).collect();
+
+        let composite = aggregate_symbols(&refs, AggregateOp::Mean).expect("aggregate");
+        assert_eq!(
+            composite.bytes.len(),
+            4096,
+            "composite at max member length"
+        );
+        assert_eq!(composite.n_members, 3);
+
+        let bound = composite.erasure_bound(EPSILON);
+        for (k, member) in members.iter().enumerate() {
+            let rf = residual_fidelity(member, &composite.bytes);
+            assert!(rf <= bound, "member {k}: rf {rf} exceeds bound {bound}");
+        }
+    }
+
+    #[test]
+    fn aggregate_single_member_no_erasure() {
+        // N_eff = 1: a 1→1 "collapse" erases nothing — mean of one
+        // member is the member, rf = 1.0, and the gate bound is 1.0
+        // (max(ε, 1/1)), so the gate is vacuously satisfied. This
+        // pins the 1/N_eff semantics from the #266 ask.
+        let member = distinct_member(50, 1024);
+        let composite =
+            aggregate_symbols(&[member.as_slice()], AggregateOp::Mean).expect("aggregate single");
+        assert_eq!(composite.bytes, member);
+        let rf = residual_fidelity(&member, &composite.bytes);
+        assert!((rf - 1.0).abs() < f64::EPSILON);
+        assert!((composite.erasure_bound(EPSILON) - 1.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn aggregate_rejects_degenerate_inputs() {
+        // Empty member set and zero-length members are refused loud
+        // — a vacuous composite would trivially pass the gate.
+        let res = aggregate_symbols(&[], AggregateOp::Mean);
+        assert!(matches!(res, Err(AggregateError::NoMembers)));
+
+        let a = distinct_member(60, 64);
+        let res = aggregate_symbols(&[a.as_slice(), &[]], AggregateOp::Decimate);
+        assert!(matches!(res, Err(AggregateError::EmptyMember(1))));
+    }
+
+    #[test]
+    fn aggregate_algorithm_ids_locked() {
+        // The AggregationMetaV1.aggregation_algorithm_id seam
+        // (§19.7.1): these strings are wire-visible and locked at v1.
+        assert_eq!(AggregateOp::Mean.algorithm_id(), "fountain-mean-v1");
+        assert_eq!(AggregateOp::Decimate.algorithm_id(), "fountain-decimate-v1");
+        assert_eq!(AggregateOp::Mipmap.algorithm_id(), "fountain-mipmap-v1");
     }
 }

--- a/tests/accord_carrier_verify.rs
+++ b/tests/accord_carrier_verify.rs
@@ -173,6 +173,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence,
+        consent_role: None,
     }
 }
 

--- a/tests/blob_swarm_scheduler.rs
+++ b/tests/blob_swarm_scheduler.rs
@@ -112,6 +112,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/bridge_combinator_e2e.rs
+++ b/tests/bridge_combinator_e2e.rs
@@ -89,6 +89,7 @@ fn fixture_key_record(key_id: &str, identity_type_: &str) -> KeyRecord {
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/canonical_peer.rs
+++ b/tests/canonical_peer.rs
@@ -114,6 +114,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/ceg_content_discipline.rs
+++ b/tests/ceg_content_discipline.rs
@@ -126,6 +126,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/cohort_scope_persist_backed.rs
+++ b/tests/cohort_scope_persist_backed.rs
@@ -105,6 +105,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/cohort_scope_refusal.rs
+++ b/tests/cohort_scope_refusal.rs
@@ -112,6 +112,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -97,6 +97,7 @@ pub fn signed_record(subject: &TestFedKey, signer: &TestFedKey, identity_type: &
         // carry None; the V048 CHECK admits None for any
         // identity_type that isn't 'accord_holder'.
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/conformance_vectors_v19_7.rs
+++ b/tests/conformance_vectors_v19_7.rs
@@ -10,7 +10,8 @@
 //! fixtures.
 
 use ciris_edge::holonomic::aggregation::{
-    compute_member_commitment, AggregationMetaV1, AGG_META_DOMAIN, AGG_META_VERSION,
+    assemble_tier_meta_v2, compute_member_commitment, AggregationMetaV1, AGG_META_DOMAIN,
+    AGG_META_VERSION, AGG_META_VERSION_V2,
 };
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -84,6 +85,10 @@ fn vector_aggregation_meta_canonical_bytes_three_source_pyramid() {
         source_count: 3,
         member_commitment,
         noise_floor_descriptor: "mean+stddev".to_string(),
+        // §19.7.1.2 (#167): a v1 tier carries n_eff as a neutral, un-signed
+        // placeholder — the v1 preimage below MUST be byte-identical to the
+        // pre-#167 layout regardless of this value.
+        n_eff: 3,
     };
     let vector = AggregationMetaCanonicalVector {
         vector_id: "aggregation_meta/canonical_bytes".to_string(),
@@ -104,6 +109,83 @@ fn vector_aggregation_meta_canonical_bytes_three_source_pyramid() {
         expected_canonical_bytes_hex: hex_encode(&meta.signing_preimage()),
     };
     emit_or_verify("aggregation_meta/canonical_bytes.json", &vector);
+}
+
+// ─────────────────── §19.7.1.2 AggregationMetaV1 v2 (CIRISVerify#167) ──
+
+/// The v2 vector shape — the v1 vector plus the signed effective source
+/// count `n_eff` (CIRISEdge#267 / CIRISVerify#167 dominance surface).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct AggregationMetaCanonicalVectorV2 {
+    vector_id: String,
+    description: String,
+    domain_separator_hex: String,
+    version: u32,
+    content_id: String,
+    corpus_kind: String,
+    tier: u32,
+    aggregation_algorithm_id: String,
+    source_count: u32,
+    source_member_ids: Vec<String>,
+    member_commitment_hex: String,
+    noise_floor_descriptor: String,
+    n_eff: u32,
+    expected_canonical_bytes_hex: String,
+}
+
+#[test]
+fn vector_aggregation_meta_canonical_bytes_v2_three_source_pyramid() {
+    // Same fixed three-source pyramid as the v1 vector, assembled through the
+    // #267 producer path: version = 2, n_eff computed from balanced per-member
+    // masses (inverse-Simpson → n_eff == N == 3), preimage = v1 layout + a
+    // trailing u32_be(n_eff).
+    let source_ids: Vec<String> = ["src-001", "src-002", "src-003"]
+        .into_iter()
+        .map(String::from)
+        .collect();
+    let meta = assemble_tier_meta_v2(
+        "content-root-fixed",
+        "trace",
+        2,
+        "raptorq-pyramid-v1",
+        &source_ids,
+        &[1.0, 1.0, 1.0],
+        "mean+stddev",
+    );
+    assert_eq!(meta.version, AGG_META_VERSION_V2);
+    assert_eq!(meta.n_eff, 3, "balanced 3-fold: n_eff == source_count");
+
+    // Cross-impl parity pin: verify v8.7.0's authored golden at
+    // src/ciris-verify-core/tests/vectors/holonomic_v19_7/aggregation_meta/canonical_bytes_v2.json.
+    // A v2 preimage MUST reproduce it byte-for-byte, independent of the
+    // committed edge vector below.
+    let verify_authored_hex = "4147472d4d4554412d763100000000000000000200000012636f6e74656e742d726f6f742d66697865640000000574726163650000000200000012726170746f72712d707972616d69642d763100000003a10bc0ec2399f1cd431be79a863385a4b895987dae604aaf2ec3532f3753bd9d0000000b6d65616e2b73746464657600000003";
+    let canonical_hex = hex_encode(&meta.signing_preimage());
+    assert_eq!(
+        canonical_hex, verify_authored_hex,
+        "v2 preimage MUST match CIRISVerify v8.7.0's authored vector byte-for-byte"
+    );
+
+    let vector = AggregationMetaCanonicalVectorV2 {
+        vector_id: "aggregation_meta/canonical_bytes_v2".to_string(),
+        description: "AggregationMetaV1 §19.7.1.2 v2 preimage — v1 layout followed by a \
+                      trailing big-endian u32(n_eff) (CIRISVerify#167 dominance surface). \
+                      Matches CIRISVerify v8.7.0's authored vector byte-for-byte."
+            .to_string(),
+        domain_separator_hex: hex_encode(AGG_META_DOMAIN),
+        version: meta.version,
+        content_id: meta.content_id.clone(),
+        corpus_kind: meta.corpus_kind.clone(),
+        tier: meta.tier,
+        aggregation_algorithm_id: meta.aggregation_algorithm_id.clone(),
+        source_count: meta.source_count,
+        source_member_ids: source_ids,
+        member_commitment_hex: hex_encode(&meta.member_commitment),
+        noise_floor_descriptor: meta.noise_floor_descriptor.clone(),
+        n_eff: meta.n_eff,
+        expected_canonical_bytes_hex: canonical_hex,
+    };
+    emit_or_verify("aggregation_meta/canonical_bytes_v2.json", &vector);
 }
 
 // ──────────────────────────── §19.7.1.1 member_commitment ────────────

--- a/tests/content_fetch.rs
+++ b/tests/content_fetch.rs
@@ -121,6 +121,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         // rows; the V048 CHECK enforces presence ONLY when
         // identity_type='accord_holder'.
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/federation_announcement.rs
+++ b/tests/federation_announcement.rs
@@ -123,6 +123,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         // rows; admission CHECK requires Some only when identity_type
         // is 'accord_holder'.
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/https_per_messagetype_roundtrip.rs
+++ b/tests/https_per_messagetype_roundtrip.rs
@@ -127,6 +127,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/https_pyedge_init.rs
+++ b/tests/https_pyedge_init.rs
@@ -111,6 +111,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/multimedia_tier.rs
+++ b/tests/multimedia_tier.rs
@@ -121,6 +121,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/observability_metrics.rs
+++ b/tests/observability_metrics.rs
@@ -107,6 +107,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/observability_tracing.rs
+++ b/tests/observability_tracing.rs
@@ -157,6 +157,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/peer_mutation_ffi.rs
+++ b/tests/peer_mutation_ffi.rs
@@ -108,6 +108,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/probe_pattern_observer_integration.rs
+++ b/tests/probe_pattern_observer_integration.rs
@@ -113,6 +113,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/reachability_integration.rs
+++ b/tests/reachability_integration.rs
@@ -109,6 +109,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/steward_topology.rs
+++ b/tests/steward_topology.rs
@@ -111,6 +111,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/subscribe_resource_events.rs
+++ b/tests/subscribe_resource_events.rs
@@ -92,6 +92,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/tier3_fetch_content_and_feed.rs
+++ b/tests/tier3_fetch_content_and_feed.rs
@@ -103,6 +103,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/transport_http_hardening.rs
+++ b/tests/transport_http_hardening.rs
@@ -112,6 +112,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/trust_recursion_depth_wired.rs
+++ b/tests/trust_recursion_depth_wired.rs
@@ -139,6 +139,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 

--- a/tests/trust_short_circuit.rs
+++ b/tests/trust_short_circuit.rs
@@ -110,6 +110,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         persist_row_hash: String::new(),
         roles: Vec::new(),
         attestation_evidence: None,
+        consent_role: None,
     }
 }
 


### PR DESCRIPTION
**Major** — persist **v13.0.0** adoption (CC 1.0 RC1 cut) is a Rust-consumer break (wire/JSON stable). verify unchanged at v8.7.0 (persist v13 pins it; lockstep holds). Batches five closed items.

| Issue | What |
|---|---|
| **#278** | persist v12.6.0 → **v13.0.0** (×2 pins, `>=13,<14`); 27 `KeyRecord.consent_role: None` sites (persist#365) |
| **#267** | `holonomic/aggregation.rs` re-exports verify's §19.7.1.2 AggregationMetaV1 **v2** preimage + signed `n_eff` dominance surface (CIRISVerify#167); v2 golden byte-identical to verify |
| **#266** | pub **N→1 aggregation/resampling** operator in codec-fountain (unblocks aggregation-erasure conformance) |
| **#192/#193** | pyo3 conformance reach-through: **EmissionScheduler** (virtual-clock, seedable, drives production Poisson/budget/seal) + `scope_privacy` `derive_record_id`/`derive_symbol_key` |
| **#242** | cargo-deny **runner-native** (kills musl toolchain-override noise) |

### Deferred (not in this cut)
- **#277** `apply_key` upgrade-aware routing — **trait-blocked on CIRISPersist#375**: persist v13 shipped `apply_replicated_key_record` as an *inherent* method on the concrete backends, not on the `FederationDirectory` trait, so edge's `dyn`-holding bridge can't reach it. Unblocks when #375 lands.
- **#216** sccache remote backend — scheduled infra, separate.

### Tests
11/11 aggregation · 6/6 conformance_vectors_v19_7 · 20/20 fountain · 18/18 pyo3 tier-2 · 29/29 emission — all green. `clippy -D warnings` clean across core / reticulum / codec-fountain / pyo3 (incl `--tests`).

### Provenance
Assembled from five parallel agent branches, each cherry-picked and re-gated on the v13 integration base: #242 `d1b2d33`, #266 `d9d9768`, #267 `ee047d1`, #192/#193 `18d7eee`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)