### PR TITLE
feat(v9.1.0): re-pin persist v13.0.1 + route Key plane through upgrade-aware apply (closes #277)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.0.0"
+version = "9.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.0.0", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.0.1", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.0.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.0.1", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -80,6 +80,7 @@ use tokio::sync::Mutex;
 use ciris_persist::federation::operational::{
     SignedOrgMembership, SignedOrganization, SignedPartnerRecord,
 };
+use ciris_persist::federation::register::ReplicatedKeyOutcome;
 use ciris_persist::federation::types::{
     SignedAttestation, SignedCommunity, SignedCommunityMembershipRevocation, SignedFamily,
     SignedFamilyMembershipRevocation, SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation,
@@ -793,8 +794,28 @@ impl FederationDirectoryReplicationBridge {
 
 impl FederationDirectoryReplicationBridge {
     async fn apply_key(&self, bytes: &[u8]) -> bool {
+        // #277 — route the replicated Key plane through persist's
+        // upgrade-aware `apply_replicated_key_record` (CIRISPersist#375,
+        // dyn-reachable on `FederationDirectory` since v13.0.1) instead of
+        // the `ON CONFLICT DO NOTHING` `put_public_key`. An anchor-scrubbed
+        // record now *upgrades* a stale self-signed row over anti-entropy
+        // (owner_of-gated, monotonic, fail-closed) rather than being
+        // silently dropped — so the KERI publish-own Key plane rides
+        // replication end-to-end (retires CIRISServer#150's adopt-scrubbed
+        // endpoint once the owner-cohort Key plane lands).
+        //
+        // `apply_envelope_bytes`'s bool means "admitted a NEW envelope that
+        // changed local state" (see `ReplicationDirectory::apply_envelope_bytes`),
+        // so only `Inserted`/`Upgraded` count as progress. `Unchanged`
+        // (byte-identical duplicate) and `Refused` (not admitted: pubkey
+        // swap, downgrade, re-scrub, ambiguous owner, unverifiable sig) are
+        // deterministic non-progress ⇒ `false`, matching the duplicate/
+        // refused contract and keeping anti-entropy convergence honest.
         match serde_json::from_slice::<SignedKeyRecord>(bytes) {
-            Ok(record) => self.directory.put_public_key(record).await.is_ok(),
+            Ok(record) => matches!(
+                self.directory.apply_replicated_key_record(record).await,
+                Ok(ReplicatedKeyOutcome::Inserted | ReplicatedKeyOutcome::Upgraded)
+            ),
             Err(_) => false,
         }
     }
@@ -1144,10 +1165,14 @@ mod tests {
             serde_json::from_slice(&bytes).expect("canonical bytes decode");
         assert_eq!(decoded.record.key_id, key_id);
 
-        // apply_envelope_bytes routes to put_public_key — idempotent
-        // on matching content (persist returns Ok on dedup).
+        // apply_envelope_bytes routes the Key plane through
+        // apply_replicated_key_record (#277). On MemoryBackend (the trait
+        // default) a matching-content apply is a first-seen Ok ⇒ Inserted
+        // ⇒ admitted; the Unchanged/Refused ⇒ false distinction only
+        // surfaces on the scrub-upgrade-aware SqliteBackend (persist owns
+        // that classification test).
         let admitted = bridge.apply_envelope_bytes(EnvelopeKind::Key, &bytes).await;
-        assert!(admitted, "idempotent re-apply succeeds");
+        assert!(admitted, "matching-content apply admits on MemoryBackend");
     }
 
     /// CIRISEdge#257 — the Key-plane selector publishes the node's OWN


### PR DESCRIPTION
Re-pins **persist v13.0.0 → v13.0.1** (single-purpose patch: lifts `apply_replicated_key_record` onto the `FederationDirectory` trait, CIRISPersist#375) and consumes it to close **#277**. verify unchanged at v8.7.0; `>=13,<14` range unchanged.

## #277 — Key plane now upgrades over anti-entropy
`FederationDirectoryReplicationBridge::apply_key` (`bridge.rs:795`) routed the replicated Key envelope through `put_public_key` (`ON CONFLICT DO NOTHING`), so an anchor-scrubbed record for a key the receiver already held **self-signed** was silently dropped — the Key plane could deliver a rooting record but never *upgrade* an existing row. Now routes through the trait's `apply_replicated_key_record` (owner_of-gated, monotonic, fail-closed). The KERI publish-own Key plane (#257) rides replication end-to-end; retires the out-of-band adopt-scrubbed endpoint (CIRISServer#150).

### Bool mapping (deliberately not `.is_ok()`)
`apply_envelope_bytes`'s contract: `true` = **admitted a NEW envelope that changed local state**. So `Inserted`/`Upgraded` → `true`; `Unchanged` (duplicate) and `Refused` (not admitted) → `false`. The issue's original `.is_ok()` sketch would count `Ok(Refused)` as admitted — false anti-entropy progress that breaks convergence detection. The verify layer in persist is the canonical anti-rollback authority; edge just maps outcomes to the state-changed bool.

### Test coverage
The real `Upgraded` (self-signed → anchor-scrubbed) path is `SqliteBackend`-only and covered by persist's `apply_replicated_key_record_dyn_dispatch_upgrades_sqlite`. Edge's `MemoryBackend` bridge tests exercise the routing + `Inserted` arm. 17/17 bridge lib · 5/5 `bridge_combinator_e2e` · 5/5 `replication_wire_proptest` green; `clippy -D warnings` clean (default + reticulum).

Closes #277. Refs CIRISPersist#375/#376 · CIRISEdge#257 · CIRISServer#150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)