### PR TITLE
chore(v9.1.2): re-pin persist v13.2.0 + verify v8.9.0 (lockstep)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.1.1"
+version = "9.1.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.1.0", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.2.0", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -221,8 +221,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.1.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.8.0", version = "8", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.8.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.9.0", version = "8", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.9.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -231,7 +231,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.8.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.8.0", version = "8" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.9.0", version = "8" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.1.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.2.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/benches/common/mock_directory.rs
+++ b/benches/common/mock_directory.rs
@@ -143,6 +143,7 @@ pub fn signed_record(
         roles: Vec::new(),
         attestation_evidence,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -6807,6 +6807,7 @@ mod delegation_gate_tests {
             roles: Vec::new(),
             attestation_evidence: None,
             consent_role: None,
+            additional_scrubs: Vec::new(),
         }
     }
 

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -8000,6 +8000,7 @@ mod pyo3_tier2_tests {
                 // accord-holder so the V048 CHECK admits None.
                 attestation_evidence: None,
                 consent_role: None,
+                additional_scrubs: Vec::new(),
             };
             backend
                 .put_public_key(SignedKeyRecord { record })

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1098,6 +1098,7 @@ mod tests {
             roles: Vec::new(),
             attestation_evidence: None,
             consent_role: None,
+            additional_scrubs: Vec::new(),
         }
     }
 

--- a/tests/accord_carrier_verify.rs
+++ b/tests/accord_carrier_verify.rs
@@ -174,6 +174,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/blob_swarm_scheduler.rs
+++ b/tests/blob_swarm_scheduler.rs
@@ -113,6 +113,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/bridge_combinator_e2e.rs
+++ b/tests/bridge_combinator_e2e.rs
@@ -90,6 +90,7 @@ fn fixture_key_record(key_id: &str, identity_type_: &str) -> KeyRecord {
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/canonical_peer.rs
+++ b/tests/canonical_peer.rs
@@ -115,6 +115,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/ceg_content_discipline.rs
+++ b/tests/ceg_content_discipline.rs
@@ -127,6 +127,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/cohort_scope_persist_backed.rs
+++ b/tests/cohort_scope_persist_backed.rs
@@ -106,6 +106,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/cohort_scope_refusal.rs
+++ b/tests/cohort_scope_refusal.rs
@@ -113,6 +113,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -98,6 +98,7 @@ pub fn signed_record(subject: &TestFedKey, signer: &TestFedKey, identity_type: &
         // identity_type that isn't 'accord_holder'.
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/content_fetch.rs
+++ b/tests/content_fetch.rs
@@ -122,6 +122,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         // identity_type='accord_holder'.
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/federation_announcement.rs
+++ b/tests/federation_announcement.rs
@@ -124,6 +124,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         // is 'accord_holder'.
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/https_per_messagetype_roundtrip.rs
+++ b/tests/https_per_messagetype_roundtrip.rs
@@ -128,6 +128,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/https_pyedge_init.rs
+++ b/tests/https_pyedge_init.rs
@@ -112,6 +112,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/multimedia_tier.rs
+++ b/tests/multimedia_tier.rs
@@ -122,6 +122,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/observability_metrics.rs
+++ b/tests/observability_metrics.rs
@@ -108,6 +108,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/observability_tracing.rs
+++ b/tests/observability_tracing.rs
@@ -158,6 +158,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/peer_mutation_ffi.rs
+++ b/tests/peer_mutation_ffi.rs
@@ -109,6 +109,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/probe_pattern_observer_integration.rs
+++ b/tests/probe_pattern_observer_integration.rs
@@ -114,6 +114,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/reachability_integration.rs
+++ b/tests/reachability_integration.rs
@@ -110,6 +110,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/steward_topology.rs
+++ b/tests/steward_topology.rs
@@ -112,6 +112,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/subscribe_resource_events.rs
+++ b/tests/subscribe_resource_events.rs
@@ -93,6 +93,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/tier3_fetch_content_and_feed.rs
+++ b/tests/tier3_fetch_content_and_feed.rs
@@ -104,6 +104,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/transport_http_hardening.rs
+++ b/tests/transport_http_hardening.rs
@@ -113,6 +113,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/trust_recursion_depth_wired.rs
+++ b/tests/trust_recursion_depth_wired.rs
@@ -140,6 +140,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 

--- a/tests/trust_short_circuit.rs
+++ b/tests/trust_short_circuit.rs
@@ -111,6 +111,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
         roles: Vec::new(),
         attestation_evidence: None,
         consent_role: None,
+        additional_scrubs: Vec::new(),
     }
 }
 


### PR DESCRIPTION
Lockstep dependency bump — **persist v13.1.0 → v13.2.0** (#383 2-of-3 canonical add · #377 accord m-of-n hardening · #378 single-owner · #379 detection wildcard) and its verify re-pin **v8.8.0 → v8.9.0** (#174, multi-scrub / append-a-scrub producers).

### Why verify moves too
persist v13.2.0's Cargo.toml **requires verify v8.9.0** — staying on v8.8.0 splits `ciris_verify_core` into two graph versions (E0308 across `threshold`/`bridge`). The v13.2.0 release summary didn't call the verify bump out, but the pin did.

### Compile surface (additive, wire-safe)
- `KeyRecord` gained **`additional_scrubs: Vec<ScrubSig>`** (#377, `#[serde(default, skip_serializing_if)]`) — added `additional_scrubs: Vec::new()` to all **28** literals across `src/` + `tests/` + `benches/` (benches included up front this time).
- verify v8.9.0 unifies the version split.

### Patch, not minor
Checked the open backlog for unblocked conformance work: **none**. #276's conformance impact is a transport bug (not persist-gated); #114 gates on lens-core. Consuming #383's canonical 2-of-3 add belongs to the **#281** canonical-bootstrap cut, not this re-pin. So: dependency adaptation only, no new edge capability → patch.

### Verification
lib + tests + benches compile clean; 17/17 bridge + 11/11 aggregation green; `clippy -D warnings` clean across default / reticulum / codec-fountain / pyo3. `>=13,<14` pyproject range unchanged.

Adoption tracked persist-side in CIRISServer#173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)