### PR TITLE
chore(v9.1.6): re-pin persist v13.4.1 (verify unchanged v8.9.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.1.5"
+version = "9.1.6"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.0", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.1", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.1", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
Patch re-pin — **persist v13.4.0 → v13.4.1** (#392: fix `PyEngine::new`, the pyo3/wheel ctor, which hand-rolled its genesis seed and missed the #386 entrenched-family + #390 canonical bakes — so wheel consumers got A1/B1/C1 but no `HUMANITY_ACCORD` family row and `list_canonical_servers() == []`). **verify unchanged at v8.9.0** (confirmed, no split).

**Zero edge compile surface** — persist-internal fix to the wheel ctor's seed path.

**Relevant to edge as a wheel consumer & to #281:** the baked family + 2-of-3 canonical (`ciris-canonical-1`) genesis now actually reaches the pyo3/wheel path, so `canonical_genesis_records()`/`list_canonical_servers()` return the real seed instead of empty — the exact surface #281's canonical-bootstrap adoption consumes. (Worth a quick edge-side sanity check that edge's wheel init now sees a populated `list_canonical_servers()` if/when #281 lands.)

### Verification
lib + tests + benches compile clean; `clippy -D warnings` clean across default / reticulum / pyo3. `>=13,<14` pyproject range unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)