### PR TITLE
chore(v9.1.7): re-pin persist v13.4.2 + verify v8.10.0 (lockstep)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.1.6"
+version = "9.1.7"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.1", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.2", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -221,8 +221,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.9.0", version = "8", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.9.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.0", version = "8", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -231,7 +231,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.9.0"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.9.0", version = "8" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.0", version = "8" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.1", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.2", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
Lockstep re-pin — **persist v13.4.1 → v13.4.2** (#394: fix canonical seed to **upgrade** the canonical node's own self-signed row instead of boot-panicking — `ciris-canonical-1` already exists as the node's own `node` row from first registration, so #390's `put_public_key` of the baked 2-of-3 hit same-key/different-content → `EngineError::GenesisSeed` → boot abort) and its verify re-pin **v8.9.0 → v8.10.0** (#176, `manifest sign` CLI — no `ciris_verify_core` lib change).

### Why verify moves too
persist v13.4.2's Cargo.toml **requires verify v8.10.0** — staying on v8.9.0 splits `ciris_verify_core` into two graph versions (the E0308s across `threshold`/aggregation). The release summary didn't flag it; caught via the split. verify v8.10.0 itself is CLI-only, so no edge code adaptation — the bump just unifies the version.

**Zero edge compile surface** beyond the version unification.

### Verification
lib + tests + benches compile clean; `clippy -D warnings` clean across default / reticulum / codec-fountain / pyo3. `>=13,<14` pyproject range unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)