### PR TITLE
feat(v9.3.0): persist v13.5.0 + verify v8.10.1 + toolchain pin 1.97.0 (#291) + CI concurrency (#293) + rooting observability (#292)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -49,7 +49,7 @@ jobs:
       - name: install libsqlite3-dev (sqlite build dep)
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: Swatinem/rust-cache@v2
         # CI hardening: cache restore is a speedup, not a correctness
         # gate. A flaky runner / Actions infra hiccup should downgrade

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ on:
     tags: ['v*']
   pull_request:
 
+concurrency:
+  # CIRISEdge#293 / CIRISPersist#397 — one full matrix per released commit.
+  # Push events key on the SHA so a merge (refs/heads/main) and its release
+  # tag (refs/tags/v*) — the SAME commit — share a group; cancel-in-progress
+  # lets the tag run (the superset that also publishes) cancel the redundant
+  # main run. PRs key on the ref so a new push cancels the stale PR run.
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
@@ -108,7 +117,7 @@ jobs:
       # cross-wheel SIGSEGV CIRISEdge#50 hit at v0.19.5).
       - name: install libsqlite3-dev (sqlite build dep)
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       # CIRISEdge#229 — canonical layered cache restore (verify →
       # persist → edge) via the local composite at
       # `.github/actions/ciriscache`. Emits the densest edge key as
@@ -185,7 +194,7 @@ jobs:
     # `packages: write` not needed here.
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: ./.github/actions/ciriscache
         id: cachekey
         with:
@@ -311,7 +320,7 @@ jobs:
       MOBILE_PYO3_FEATURES: "transport-reticulum pyo3-sqlite extension-module"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
       - uses: ./.github/actions/ciriscache
@@ -617,7 +626,7 @@ jobs:
           - { target: aarch64-apple-ios-sim, sdk: iphonesimulator,  plat: ios-aarch64-sim }
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
       - uses: ./.github/actions/ciriscache
@@ -840,7 +849,7 @@ jobs:
       IOS_PYO3_FEATURES: "transport-reticulum pyo3-sqlite extension-module"
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           targets: ${{ matrix.target }}
       - uses: ./.github/actions/ciriscache
@@ -1047,7 +1056,7 @@ jobs:
       # only libsqlite3-dev remains as a system build dep.
       - name: install libsqlite3-dev (sqlite build dep)
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: clippy, rustfmt
       # CIRISEdge#229 — restore only; the canonical linux-x86_64 save
@@ -1096,7 +1105,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: install libsqlite3-dev (sqlite build dep)
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: ./.github/actions/ciriscache
         with:
           plat: linux-x86_64
@@ -1141,7 +1150,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: taiki-e/install-action@cargo-deny
       - run: cargo deny --log-level warn --all-features check
 
@@ -1171,7 +1180,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: install libsqlite3-dev (sqlite build dep)
         run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       - uses: ./.github/actions/ciriscache
         with:
           plat: linux-x86_64
@@ -1308,7 +1317,7 @@ jobs:
       # rust-src branch is gone — the wheel now targets the standard
       # `x86_64-pc-windows-msvc` (Tier-1) so no `-Zbuild-std` is
       # needed.
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.97.0
       # CIRISEdge#229 — canonical CIRISCache layered restore on the
       # wheel matrix. PLAT maps wheel's `label` token to the canonical
       # platform token persist + verify save under:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.2.0"
+version = "9.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.2", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.5.0", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -221,8 +221,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.0", version = "8", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.1", version = "8", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.1", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -231,7 +231,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.0", version = "8" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.10.1", version = "8" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.4.2", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.5.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,13 @@
+[toolchain]
+# CIRISEdge#291 / CIRISPersist#396 / CIRISVerify#180 — EXACT pin, not a
+# floating `stable`. The CIRISCache substrate key embeds the rustc version
+# (`ciris-substrate-v1-<PLAT>-release-rustc<VER>-…`); all four repos
+# (verify/persist/edge/server) must carry the SAME exact channel or their
+# layer blobs key on whatever stable the runner's image happened to ship
+# (GitHub bumped windows-latest 1.96→1.97.0 on 2026-07-07), so CIRISServer's
+# centipede restore misses and windows recompiles the whole substrate cold.
+# Bump this in lockstep across all four repos; the workflow `dtolnay/
+# rust-toolchain@1.97.0` refs must match (a bare `@stable` there installs
+# stable and adds cross-compile targets to *stable*, not 1.97.0 → E0463).
+channel = "1.97.0"
+components = ["clippy", "rustfmt"]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -821,13 +821,34 @@ impl PyEdge {
                 )
             })?;
             let destination_key_id = destination_key_id.to_owned();
-            py.detach(|| {
+            // CIRISEdge#292 — log the prime attempt + outcome so a MISSING
+            // prime (the silent-zero-delivery cause on CIRISServer#205) and
+            // a successful rooting are both visible. Today a prime that
+            // never happened produces no signal at all.
+            let reticulum_dest_hash_hex = reticulum_dest_hash_hex.to_owned();
+            let rooted = py.detach(|| {
                 run_async(&self.executor, async move {
+                    let before = transport.knows_peer(&destination_key_id).await;
                     transport
                         .inject_rooted_peer_for_test(&destination_key_id, dest_hash, ed25519)
                         .await;
-                });
+                    let after = transport.knows_peer(&destination_key_id).await;
+                    tracing::info!(
+                        destination_key_id,
+                        dest_hash = %reticulum_dest_hash_hex,
+                        knows_peer_before = before,
+                        knows_peer_after = after,
+                        "prime_peer: rooted peer binding installed"
+                    );
+                    after
+                })
             });
+            if !rooted {
+                tracing::warn!(
+                    "prime_peer: installed binding but knows_peer is still false \
+                     — the peer remains unroutable (unexpected)"
+                );
+            }
             Ok(())
         }
         #[cfg(not(feature = "_reticulum-module"))]
@@ -874,6 +895,32 @@ impl PyEdge {
         {
             let _ = (destination_key_id, py);
             false
+        }
+    }
+
+    /// CIRISEdge#292 — the `key_id`s currently in the live rooted-peer
+    /// map (announce-rooted or `prime_peer`'d). Operator readback for
+    /// triaging a zero-delivery bring-up (CIRISServer#205): an admitted
+    /// replication target absent from this list is admitted-but-unrooted
+    /// and cannot be addressed. Returns `[]` for HTTPS-only /
+    /// transport-less builds.
+    fn rooted_peers(&self, py: Python<'_>) -> Vec<String> {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            let Some(transport) = self.inner.reticulum_transport() else {
+                return Vec::new();
+            };
+            py.detach(|| {
+                run_async(
+                    &self.executor,
+                    async move { transport.rooted_peers().await },
+                )
+            })
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            let _ = py;
+            Vec::new()
         }
     }
 
@@ -3085,10 +3132,7 @@ impl PyDurableHandle {
                     .map_err(|e| PyRuntimeError::new_err(format!("outbound_status: {e}")))?;
                 Ok(matches!(
                     row.map(|r| crate::edge::map_outbound_row_to_status(&r)),
-                    Some(DurableStatus::Terminal(DurableOutcome::Delivered {
-                        ack: _,
-                        ..
-                    })),
+                    Some(DurableStatus::Terminal(DurableOutcome::Delivered { .. })),
                 ))
             })
         })
@@ -4961,6 +5005,17 @@ pub fn init_edge_runtime(
         let dest_hash = transport.local_dest_hash();
         {
             let destination_hex = hex::encode(dest_hash);
+            // v13.5.0 (CIRISPersist#397 / CIRISEdge#99, #214) — publish this
+            // node's transport-tier Ed25519 pubkey alongside the dest-hash so
+            // a peer can `prime_peer` this explicit-hash node (the data half
+            // of the #292 rooting story). It is the Ed25519 (signing) half of
+            // the 64-byte RNS transport identity (`[x25519||ed25519]`), NOT
+            // the identity-tier key (§5.6.8.8.2 key-separation).
+            let transport_ed25519_pubkey_base64 = {
+                use base64::Engine as _;
+                let full = transport.local_transport_pubkey();
+                base64::engine::general_purpose::STANDARD.encode(&full[32..64])
+            };
             let directory_for_register = Arc::clone(&federation_directory_for_edge);
             let row = ciris_persist::federation::self_at_login::TransportDestination {
                 occurrence_key_id: occurrence_key_id.to_string(),
@@ -4968,6 +5023,7 @@ pub fn init_edge_runtime(
                 destination: destination_hex.clone(),
                 asserted_at: chrono::Utc::now(),
                 last_seen_at: None,
+                transport_ed25519_pubkey_base64: Some(transport_ed25519_pubkey_base64),
             };
             let occurrence_for_log = occurrence_key_id.to_string();
             let register_result = run_async(&executor, async move {

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1643,6 +1643,17 @@ impl ReticulumTransport {
         self.resolve_peer(destination_key_id).await.is_some()
     }
 
+    /// CIRISEdge#292 — the `key_id`s currently in the live rooted-peer
+    /// map (announce-rooted or `prime_peer`'d). The operator readback for
+    /// "who can this node actually address right now": diagnosing a
+    /// zero-delivery bring-up (CIRISServer#205) previously required an
+    /// in-process snapshot of this map. Does NOT include directory-only
+    /// (`PeerResolver`) peers that `knows_peer` would resolve on demand —
+    /// this is the set that has a live `RootedPeer` entry.
+    pub async fn rooted_peers(&self) -> Vec<String> {
+        self.peers.lock().await.keys().cloned().collect()
+    }
+
     /// v0.14.0 (CIRISEdge#32) — return the 16-byte Reticulum
     /// destination hash for a rooted peer. Test seam: the Links FFI
     /// tests need `dest_hash` to drive `link_open(dest_hash)` after
@@ -2533,6 +2544,24 @@ impl Transport for ReticulumTransport {
         }
 
         let Some(peer) = self.resolve_peer(destination_key_id).await else {
+            // CIRISEdge#292 (CIRISServer#205) — an admitted replication
+            // target whose Reticulum destination we can't resolve is the
+            // silent-zero-delivery class: the round fires, this send
+            // fails, and without this line nothing in the log says why.
+            // WARN naming the actionable causes (explicit-hash peers must
+            // be `prime_peer`'d; announce-rooted peers need a received
+            // announce) so an unrooted-but-admitted peer is a log line,
+            // not a live-map interrogation. `knows_peer(key_id)` is the
+            // readback for the same condition.
+            tracing::warn!(
+                destination_key_id,
+                "replication/send: target is admitted but NOT rooted \
+                 (knows_peer=false) — no Reticulum destination resolved. \
+                 Cause: a v7 explicit-hash peer (e.g. ciris-canonical-1) that \
+                 was never prime_peer'd, or an announce-rooted peer whose \
+                 announce has not been received. This send cannot address the \
+                 peer; anti-entropy will not converge until it roots."
+            );
             // §24 NAT-traversal (CIRISEdge#169): an unreachable
             // destination under `PendingOrLive` with a wired queue is
             // stored for the destination's wake-up fetch rather than
@@ -2543,6 +2572,11 @@ impl Transport for ReticulumTransport {
                 if let Some(saf) = &self.store_and_forward {
                     saf.queue(destination_key_id, envelope_bytes)
                         .map_err(|e| TransportError::Io(format!("store-and-forward queue: {e}")))?;
+                    tracing::info!(
+                        destination_key_id,
+                        "replication/send: unrooted target queued for \
+                         store-and-forward wake-up fetch (§24)"
+                    );
                     return Ok(TransportSendOutcome::Queued);
                 }
             }


### PR DESCRIPTION
Bundle: re-pin + three issue fixes + the persist v13.5.0 API adaptation.

## Re-pin (not zero-surface)
persist **v13.4.2 → v13.5.0**, verify **v8.10.0 → v8.10.1** (lockstep — v13.5.0 requires v8.10.1). persist **#397 added `TransportDestination.transport_ed25519_pubkey_base64: Option<String>`** — edge's self-at-login registration now publishes its transport-tier Ed25519 (`local_transport_pubkey()[32..64]` b64), the **data-half complement to #292** (lets a peer `prime_peer` this explicit-hash node, CIRISEdge#214). Only surfaced under the pyo3/reticulum combo.

## #291 — exact-pin toolchain 1.97.0
Edge had **no `rust-toolchain.toml`** — floated `stable`, so its CIRISCache substrate blobs keyed on whatever rustc the runner shipped (windows-latest 1.96→1.97.0 on 2026-07-07) → CIRISServer's windows restore missed, recompiling the whole substrate cold. New `rust-toolchain.toml` `channel="1.97.0"` + all **11** `dtolnay/rust-toolchain@stable` → `@1.97.0` (bare `@stable` adds cross-compile targets to *stable*, not 1.97.0 → E0463). Lockstep w/ CIRISPersist#396 / CIRISVerify#180. New 1.97 lint fixed (redundant `ack: _` under `..`).

## #293 — CI concurrency block
ci.yml had none → same-SHA main+tag double-run (full matrix twice, CIRISCache restore/save race) + no stale-PR cancel. Added SHA-keyed-push / ref-keyed-PR block (same as CIRISPersist#397): one full matrix per release, stale PR runs cancelled.

## #292 — rooting/prime/anti-entropy observability (CIRISServer#205)
- `ReticulumTransport::send` WARNs when an admitted target can't be resolved, naming the cause (explicit-hash not `prime_peer`'d / announce not received) — silent zero-delivery → log line; + info on store-and-forward queue.
- `prime_peer` logs attempt + `knows_peer` before→after (a missing prime was no signal at all).
- new `PyEdge.rooted_peers()` + `ReticulumTransport::rooted_peers()` readback; `knows_peer` already exposed.

## Verification
clippy `-D warnings` clean under **1.97** across default / reticulum / codec-fountain / pyo3 / full ffi-uniffi (`--all-targets`); fmt clean; 5 reticulum + 95 replication tests green.

Closes #291, #292, #293. Refs CIRISServer#205, CIRISPersist#396/#397, CIRISVerify#180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)