### PR TITLE
ci: save CIRISCache blobs on tag runs too (fix #293-dedup regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
           path: dist/${{ matrix.abi }}/
       # CIRISEdge#229 — save edge-self-warm on main, per-ABI.
       - uses: CIRISAI/CIRISCache/save@v1
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           key: ${{ steps.cachekey.outputs.key }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -976,7 +976,7 @@ jobs:
           if-no-files-found: error
       # CIRISEdge#229 — save edge-self-warm on main, per-target.
       - uses: CIRISAI/CIRISCache/save@v1
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           key: ${{ steps.cachekey.outputs.key }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -1572,7 +1572,7 @@ jobs:
       # feature combos + incremental → ~7.5 GB blob). Moved here so
       # consumers get a release blob like every other PLAT.
       - uses: CIRISAI/CIRISCache/save@v1
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         with:
           key: ${{ steps.cachekey.outputs.key }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The regression (found by CIRISPersist, same bug there → their PR #401)
My #293 concurrency block (SHA-keyed push) makes the release **tag** run cancel the redundant **main-push** run on the same commit — one matrix per release, as intended. **But all 3 `CIRISCache/save@v1` steps are gated `if: github.ref == 'refs/heads/main'`**, so the run that survives dedup (the tag run) **publishes but never saves**.

Net: since **v9.3.0** (the first cut carrying the concurrency block), edge's CIRISCache substrate blob is no longer republished — the main run that used to save it is now cancelled. That's precisely why the **edge layer stayed cold under rustc1.97.0** even after the #291 toolchain pin: the pin was correct, but the blob under the new key was never written.

Verified on the v9.3.0 commit (00d06de): `main` run `29041377864` = **cancelled**, tag run = published. Pre-#293 cuts (v9.2.0) had both main+tag succeed.

## Fix
Broaden all 3 save gates:
```yaml
if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
```
so the surviving (tag) run both publishes **and** caches the exact released build. PRs still never save; a tag-less merge still saves via its main run. No collateral — these were the only 3 `main`-only gates in the file; the publish-job tag-gates are untouched. YAML validated.

## Immediate republish
Re-ran v9.3.0's cancelled main run (`29041377864`, ref=main → saves fire) so the 1.97.0 edge blobs land now; this PR makes it structural for every future release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)