### PR TITLE
feat(v9.4.0): auto-seed canonical TCP dial in init_edge_runtime (closes #296) + persist v13.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.3.0"
+version = "9.4.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.5.0", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.6.0", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.5.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.6.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4739,6 +4739,75 @@ pub fn init_edge_runtime(
     // `AgentMode` docblock.
     transport_config.listen_addr = listen_addr;
     transport_config.bootstrap_peers = bootstrap_peers;
+    // CIRISEdge#296 — auto-seed the canonical TCP dial from persist's baked
+    // `canonical_bootstrap_hints()` so a DIRECT `init_edge_runtime` consumer
+    // (the agent-embedded edge, which does NOT run ciris-server's
+    // `compose::serve`) dials the public canonical mesh and roots it. Without
+    // this the agent boots with an empty canonical dial → never receives
+    // Node A's announce → the (already-wired) rooting never fires →
+    // `knows_peer(canonical)=false` → zero delivery. `list_canonical_servers`
+    // is Engine-only (not on the `FederationDirectory` edge holds) and edge
+    // has no Rust `Engine` handle in this path, so we call the #402 pyfn
+    // wrapper on the engine PyObject cross-wheel: `canonical_bootstrap_hints()`
+    // → JSON `[{key_id, kind, destination}]`. Filter `kind == "ip"`, union the
+    // TCP dials in (dedup). Fail-soft: a missing method / parse error WARNs and
+    // continues (a caller can still pass the addr in `bootstrap_peers`) — it
+    // never breaks init.
+    {
+        #[derive(serde::Deserialize)]
+        struct CanonicalHint {
+            key_id: String,
+            kind: String,
+            destination: String,
+        }
+        match engine
+            .call_method0("canonical_bootstrap_hints")
+            .and_then(|obj| obj.extract::<String>())
+        {
+            Ok(json) => match serde_json::from_str::<Vec<CanonicalHint>>(&json) {
+                Ok(hints) => {
+                    let mut seeded = 0usize;
+                    for h in hints.iter().filter(|h| h.kind == "ip") {
+                        match h.destination.parse::<std::net::SocketAddr>() {
+                            Ok(addr) if !transport_config.bootstrap_peers.contains(&addr) => {
+                                transport_config.bootstrap_peers.push(addr);
+                                seeded += 1;
+                                tracing::info!(
+                                    canonical_key_id = %h.key_id,
+                                    dial = %addr,
+                                    "init_edge_runtime: seeded canonical TCP dial from baked \
+                                     canonical_bootstrap_hints (CIRISEdge#296)"
+                                );
+                            }
+                            Ok(_) => {} // already present — dedup
+                            Err(e) => tracing::warn!(
+                                canonical_key_id = %h.key_id,
+                                destination = %h.destination,
+                                "init_edge_runtime: canonical ip hint is not a valid SocketAddr, \
+                                 skipping: {e}"
+                            ),
+                        }
+                    }
+                    if seeded == 0 {
+                        tracing::warn!(
+                            "init_edge_runtime: canonical_bootstrap_hints yielded no NEW ip dial \
+                             (already in bootstrap_peers, or no canonical servers baked). If the \
+                             agent cannot reach the canonical mesh, check list_canonical_servers()."
+                        );
+                    }
+                }
+                Err(e) => tracing::warn!(
+                    "init_edge_runtime: canonical_bootstrap_hints JSON parse failed — canonical \
+                     dial NOT auto-seeded: {e}"
+                ),
+            },
+            Err(e) => tracing::warn!(
+                "init_edge_runtime: engine.canonical_bootstrap_hints() unavailable (persist < \
+                 v13.6.0 / #402?) — canonical dial NOT auto-seeded; a direct consumer must pass \
+                 the canonical addr in bootstrap_peers: {e}"
+            ),
+        }
+    }
     transport_config.announce_interval = Duration::from_secs(announce_interval_seconds);
     transport_config.local_epoch = local_epoch;
     // CIRISEdge#168 (v5.0) — Transport-node mode (§24 NAT-traversal).


### PR DESCRIPTION
The actual fix for the 3-day agent-embedded **zero-delivery** chase — neither a bake nor a rooting bug.

## Root cause (#296)
`init_edge_runtime` seeded the transport dial set **solely** from the caller-passed `bootstrap_peers`. The "read baked canonical hints → seed the dial" glue lived **only** in ciris-server's `compose::serve`. The agent calls `init_edge_runtime` **directly** (not `compose::serve`), so it booted with an empty canonical dial → behind NAT it never dialed the public canonical (Node A) → never received the announce → the already-wired rooting never fired → `knows_peer(canonical)=false` → zero delivery.

## Fix (pure-edge, automatic for every consumer)
After seeding `bootstrap_peers` from the param, read persist's baked `canonical_bootstrap_hints()`, filter `kind == "ip"`, and union the TCP dials into `transport_config.bootstrap_peers` (dedup). A bare agent now auto-dials + auto-roots the canonical mesh with **zero caller glue** — what `compose::serve` did, moved down into the substrate.

## Why the pyfn path (not the direct Rust Engine method)
`list_canonical_servers` is **Engine-only** (not on the `FederationDirectory` edge holds), and `init_edge_runtime` has **no Rust `Engine` handle** — it holds the persist Engine as a **PyObject**. So edge calls the #402 pyfn wrapper cross-wheel (`canonical_bootstrap_hints()` → JSON `[{key_id,kind,destination}]`) rather than `Engine::canonical_bootstrap_hints()`. **Fail-soft**: a missing method / parse error / bad addr WARNs and continues — never breaks init. Rich logging per the issue's "never a 3-day chase again" ask.

## Re-pin
persist v13.5.0 → **v13.6.0** (#402), verify unchanged **v8.10.1** (no split).

## Verification
Compiles + `clippy -D warnings` clean under 1.97 across default / reticulum / codec-fountain / full ffi-uniffi (`--all-targets`); fmt clean. `init_edge_runtime` is exercised end-to-end by the CIRISServer agent bring-up (needs a live Python engine; not Rust-unit-testable) — this is the change that flips `knows_peer(canonical)=true` and restores the trace flow.

Closes #296. Refs CIRISPersist#402/#381, CIRISServer#205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)