### PR TITLE
chore(v9.4.1): re-pin persist v13.6.1 — canonical seed :4242 (RNS), completes #296 end-to-end

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.4.0"
+version = "9.4.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.6.0", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.6.1", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.6.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.6.1", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
Patch re-pin — **persist v13.6.0 → v13.6.1** (#404, **CRITICAL mesh-wide**). The v13.6.0 baked `canonical_seed.json` carried the canonical server's transport hint with the **HTTP read-API port** `108.61.242.236:4243` instead of the **Reticulum TCP wire port** `:4242`.

That `ip` hint is exactly what edge's **#296 auto-seed** dials — so on v13.6.0 the agent dialed `:4243`, the RNS handshake hit HTTP, and rooting failed. **v13.6.1 re-bakes the seed to `:4242`**, so #296's `canonical_bootstrap_hints()` → auto-dial now reaches the RNS transport and `knows_peer(canonical)=true`. (v9.4.0's #296 wiring was correct; the data it consumed had the wrong port — this completes the zero-delivery fix end-to-end.)

**verify unchanged v8.10.1** (no split). **Zero edge compile surface** — baked data in persist; edge just consumes the corrected hint.

### Verification
lib + tests + benches compile clean; `clippy -D warnings` clean across default / reticulum / pyo3. `>=13,<14` pyproject range unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)