### PR TITLE
feat(v9.5.0): persist-backed rooting — write-through + boot-load KEX bindings (closes #299) + persist v13.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.4.1"
+version = "9.5.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.6.1", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.8.0", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.6.1", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.8.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4952,6 +4952,81 @@ pub fn init_edge_runtime(
             None
         };
 
+    // CIRISEdge#299 — boot-load the KEX resolver from persist. Persist is
+    // the source of truth for rooted transport identities; edge's in-memory
+    // rooted-peers map is a write-through cache. Load EVERY persisted binding
+    // (written by `RootingDirectory::persist_rooted_transport` on root) in
+    // full at startup, so a KNOWN peer is reachable-and-sealable the instant
+    // edge comes up — with zero announces (fixes CIRISServer#216: a months-old
+    // binding vanishing across a restart → 0 envelopes sealed). The persisted
+    // `TransportDestination` IS the resolver source. Fail-soft: a load error
+    // logs and leaves the resolver empty (peers re-root via announce).
+    let persisted_binding_resolver: Option<Arc<dyn crate::transport::reticulum::PeerResolver>> = {
+        let dir = Arc::clone(&federation_directory_for_edge);
+        match run_async(&executor, async move {
+            dir.list_all_transport_destinations().await
+        }) {
+            Ok(rows) => {
+                use base64::Engine as _;
+                let b64 = base64::engine::general_purpose::STANDARD;
+                let mut map: std::collections::HashMap<String, [u8; 64]> =
+                    std::collections::HashMap::new();
+                for row in rows {
+                    if row.transport_kind != "reticulum" {
+                        continue;
+                    }
+                    let (Some(x), Some(e)) = (
+                        row.transport_x25519_pubkey_base64.as_deref(),
+                        row.transport_ed25519_pubkey_base64.as_deref(),
+                    ) else {
+                        // Pre-#411 row with no KEX half — cannot seal; skip.
+                        continue;
+                    };
+                    match (b64.decode(x), b64.decode(e)) {
+                        (Ok(xb), Ok(eb)) if xb.len() == 32 && eb.len() == 32 => {
+                            let mut full = [0u8; 64];
+                            full[0..32].copy_from_slice(&xb);
+                            full[32..64].copy_from_slice(&eb);
+                            map.insert(row.occurrence_key_id, full);
+                        }
+                        _ => tracing::warn!(
+                            key_id = %row.occurrence_key_id,
+                            "CIRISEdge#299: persisted transport binding has malformed pubkey \
+                             base64 — skipping (peer must re-announce to root)"
+                        ),
+                    }
+                }
+                if map.is_empty() {
+                    tracing::info!(
+                        "CIRISEdge#299: boot-load found no persisted reticulum transport \
+                         bindings (fresh node, or none rooted yet)"
+                    );
+                    None
+                } else {
+                    tracing::info!(
+                        count = map.len(),
+                        "CIRISEdge#299: boot-loaded persisted transport bindings into the KEX \
+                         resolver — known peers reachable+sealable with zero announces"
+                    );
+                    Some(
+                        Arc::new(crate::transport::reticulum::PersistedBindingResolver::new(
+                            map,
+                        ))
+                            as Arc<dyn crate::transport::reticulum::PeerResolver>,
+                    )
+                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "CIRISEdge#299: boot-load of persisted transport bindings failed — peers \
+                     must re-announce to root this session"
+                );
+                None
+            }
+        }
+    };
+
     let auth = ReticulumAuth {
         // v0.16.1 cherry-pick (CIRISEdge#43): the Reticulum-identity
         // signer is split out from the hot-path keyring signer above.
@@ -4964,7 +5039,7 @@ pub fn init_edge_runtime(
         // for the fallback rationale.
         signer: Some(reticulum_identity_signer.clone()),
         rooting: Some(rooting_dir.clone()),
-        resolver: None,
+        resolver: persisted_binding_resolver,
         hybrid_policy,
         transport_binding_enforcement,
         event_bus: Some(Arc::clone(&event_bus)),
@@ -5080,10 +5155,17 @@ pub fn init_edge_runtime(
             // of the #292 rooting story). It is the Ed25519 (signing) half of
             // the 64-byte RNS transport identity (`[x25519||ed25519]`), NOT
             // the identity-tier key (§5.6.8.8.2 key-separation).
-            let transport_ed25519_pubkey_base64 = {
+            // v13.8.0 (CIRISPersist#411 / CIRISEdge#299) — also publish the
+            // transport-tier X25519 (KEX) half so a peer that boot-loads this
+            // binding from persist can SEAL to us without waiting for a fresh
+            // announce. Both halves come from the 64-byte RNS transport
+            // identity (`[x25519 ‖ ed25519]`): x25519 = [0..32], ed25519 =
+            // [32..64].
+            let (transport_x25519_pubkey_base64, transport_ed25519_pubkey_base64) = {
                 use base64::Engine as _;
                 let full = transport.local_transport_pubkey();
-                base64::engine::general_purpose::STANDARD.encode(&full[32..64])
+                let b64 = base64::engine::general_purpose::STANDARD;
+                (b64.encode(&full[0..32]), b64.encode(&full[32..64]))
             };
             let directory_for_register = Arc::clone(&federation_directory_for_edge);
             let row = ciris_persist::federation::self_at_login::TransportDestination {
@@ -5093,6 +5175,7 @@ pub fn init_edge_runtime(
                 asserted_at: chrono::Utc::now(),
                 last_seen_at: None,
                 transport_ed25519_pubkey_base64: Some(transport_ed25519_pubkey_base64),
+                transport_x25519_pubkey_base64: Some(transport_x25519_pubkey_base64),
             };
             let occurrence_for_log = occurrence_key_id.to_string();
             let register_result = run_async(&executor, async move {

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -446,6 +446,43 @@ struct ResolvedPeer {
     signing_key: [u8; 32],
 }
 
+/// CIRISEdge#299 — a boot-snapshot [`PeerResolver`] built from persist's
+/// `list_all_transport_destinations()` at startup. Restores the full
+/// `key_id → (x25519 ‖ ed25519)` transport identity for every
+/// previously-rooted peer, so `resolve_peer` (hence `knows_peer` +
+/// routing) succeeds and sealing has the KEX x25519 the instant edge
+/// comes up — zero announces. The write-through side is
+/// [`crate::verify::RootingDirectory::persist_rooted_transport`]; this is
+/// the reload side. Snapshot semantics: loaded in full once at boot; new
+/// roots after boot land in the live `peers` map (and are write-through
+/// persisted for the next boot).
+pub struct PersistedBindingResolver {
+    bindings: std::collections::HashMap<String, [u8; 64]>,
+}
+
+impl PersistedBindingResolver {
+    /// Build the resolver from a `key_id → 64-byte (x25519 ‖ ed25519)` map.
+    pub fn new(bindings: std::collections::HashMap<String, [u8; 64]>) -> Self {
+        Self { bindings }
+    }
+
+    /// Number of persisted bindings loaded.
+    pub fn len(&self) -> usize {
+        self.bindings.len()
+    }
+
+    /// Whether any bindings were loaded.
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+}
+
+impl PeerResolver for PersistedBindingResolver {
+    fn resolve(&self, destination_key_id: &str) -> Option<[u8; 64]> {
+        self.bindings.get(destination_key_id).copied()
+    }
+}
+
 /// A peer whose `key_id → transport-identity` binding has been
 /// **rooted** against the persist `federation_keys` directory and
 /// whose announce attestation signature verified — the authenticated
@@ -3247,63 +3284,87 @@ async fn resolve_announce_cold_start(
         dest_hash: *announce.destination_hash(),
         signing_key: transport_pubkey,
     };
-    let mut peers = ctx.peers.lock().await;
-    match peers.get(&key_id) {
-        Some(existing) if existing.epoch >= attestation.epoch => {
-            tracing::trace!(
-                key_id = %key_id,
-                cached_epoch = existing.epoch,
-                announce_epoch = attestation.epoch,
-                "stale re-announce ignored (epoch not newer)",
-            );
-        }
-        _ => {
-            tracing::info!(
-                key_id = %key_id,
-                dest = %resolved.dest_hash,
-                epoch = attestation.epoch,
-                "peer ROOTED via authenticated cold-start path",
-            );
-            // CIRISEdge#29 (v0.11.0) — record passive-evidence
-            // reachability against the (peer, RETICULUM_RS) tuple.
-            // Logged BEFORE the event emission and the peer-map
-            // insert so a tracker-only consumer observes liveness
-            // even if a later panic prevents the insert; the
-            // tracker / event / peer-map writes are logically
-            // independent (the tracker is observability, the peer
-            // map is routing).
-            if let Some(tracker) = ctx.reachability {
-                tracker.record_attempt(
-                    &key_id,
-                    TransportId::RETICULUM_RS,
-                    AttemptOutcome::AnnounceReceived,
+    // CIRISEdge#299 — the full 64-byte transport identity (`x25519 ‖
+    // ed25519`) + dest-hash for the write-through below. `resolved.signing_key`
+    // is only the ed25519 half; the KEX x25519 needed to seal after a restart
+    // lives on the announce identity (`announce.public_key()`), so we capture
+    // it here from the authenticated announce.
+    let announce_pubkey64: [u8; 64] = *announce.public_key();
+    let dest_hash16: [u8; 16] = (*announce.destination_hash()).into_bytes();
+    let newly_rooted_key = {
+        let mut peers = ctx.peers.lock().await;
+        match peers.get(&key_id) {
+            Some(existing) if existing.epoch >= attestation.epoch => {
+                tracing::trace!(
+                    key_id = %key_id,
+                    cached_epoch = existing.epoch,
+                    announce_epoch = attestation.epoch,
+                    "stale re-announce ignored (epoch not newer)",
                 );
+                None
             }
-            // CIRISEdge#34 — successful root → emit announce_received
-            // event with info severity. The peer key_id is now known
-            // to be authentic; surface it on the announce stream so
-            // the UI can render "peer X joined".
-            if let Some(bus) = ctx.event_bus {
-                bus.emit_announce(crate::events::NetworkEvent::announce(
-                    Some(key_id.clone()),
-                    announce.destination_hash().as_bytes().to_vec(),
-                    announce.app_data().to_vec(),
-                    crate::events::EventSeverity::Info,
-                    format!(
-                        "peer rooted via authenticated cold-start path (epoch {})",
-                        attestation.epoch
-                    ),
-                ));
+            _ => {
+                tracing::info!(
+                    key_id = %key_id,
+                    dest = %resolved.dest_hash,
+                    epoch = attestation.epoch,
+                    "peer ROOTED via authenticated cold-start path",
+                );
+                // CIRISEdge#29 (v0.11.0) — record passive-evidence
+                // reachability against the (peer, RETICULUM_RS) tuple.
+                // Logged BEFORE the event emission and the peer-map
+                // insert so a tracker-only consumer observes liveness
+                // even if a later panic prevents the insert; the
+                // tracker / event / peer-map writes are logically
+                // independent (the tracker is observability, the peer
+                // map is routing).
+                if let Some(tracker) = ctx.reachability {
+                    tracker.record_attempt(
+                        &key_id,
+                        TransportId::RETICULUM_RS,
+                        AttemptOutcome::AnnounceReceived,
+                    );
+                }
+                // CIRISEdge#34 — successful root → emit announce_received
+                // event with info severity. The peer key_id is now known
+                // to be authentic; surface it on the announce stream so
+                // the UI can render "peer X joined".
+                if let Some(bus) = ctx.event_bus {
+                    bus.emit_announce(crate::events::NetworkEvent::announce(
+                        Some(key_id.clone()),
+                        announce.destination_hash().as_bytes().to_vec(),
+                        announce.app_data().to_vec(),
+                        crate::events::EventSeverity::Info,
+                        format!(
+                            "peer rooted via authenticated cold-start path (epoch {})",
+                            attestation.epoch
+                        ),
+                    ));
+                }
+                let persisted_key = key_id.clone();
+                peers.insert(
+                    key_id,
+                    RootedPeer {
+                        peer: resolved,
+                        epoch: attestation.epoch,
+                        chain,
+                    },
+                );
+                Some(persisted_key)
             }
-            peers.insert(
-                key_id,
-                RootedPeer {
-                    peer: resolved,
-                    epoch: attestation.epoch,
-                    chain,
-                },
-            );
         }
+    };
+    // CIRISEdge#299 — write-through the rooted binding to persist AFTER
+    // releasing the peers-map lock (the upsert is DB I/O; don't hold the
+    // map mutex across it). Only on a genuinely-new / newer-epoch root.
+    // On restart this is reloaded by the boot-load resolver, so a KNOWN
+    // peer is reachable-and-sealable with zero announces. `rooting` is the
+    // FederationDirectory-backed `RootingDirectory`; the write is a no-op
+    // for non-directory impls (default trait method).
+    if let Some(persisted_key) = newly_rooted_key {
+        rooting
+            .persist_rooted_transport(&persisted_key, dest_hash16, announce_pubkey64)
+            .await;
     }
 }
 
@@ -3789,6 +3850,122 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// CIRISEdge#299 — the persisted-binding resolver returns the exact
+    /// 64-byte identity it was loaded with, and `None` for an unknown peer.
+    #[test]
+    fn persisted_binding_resolver_resolves_full_identity() {
+        let mut map = std::collections::HashMap::new();
+        let mut ident = [0u8; 64];
+        for (i, b) in ident.iter_mut().enumerate() {
+            *b = u8::try_from(i).unwrap();
+        }
+        map.insert("peer-abc".to_string(), ident);
+        let r = PersistedBindingResolver::new(map);
+        assert_eq!(r.len(), 1);
+        assert!(!r.is_empty());
+        assert_eq!(r.resolve("peer-abc"), Some(ident));
+        assert_eq!(r.resolve("peer-unknown"), None);
+    }
+
+    /// CIRISEdge#299 — the full write-through → persist → boot-load →
+    /// resolve round-trip through a real `FederationDirectory`
+    /// (`MemoryBackend`): a rooted transport identity persisted via
+    /// `RootingDirectory::persist_rooted_transport` is read back by
+    /// `list_all_transport_destinations` and reconstructed into the same
+    /// 64-byte `(x25519 ‖ ed25519)` a `PersistedBindingResolver` serves.
+    #[tokio::test]
+    async fn rooted_transport_write_through_boot_load_round_trip() {
+        use crate::verify::RootingDirectory;
+        use base64::Engine as _;
+        use ciris_persist::federation::FederationDirectory;
+        use ciris_persist::store::MemoryBackend;
+
+        let backend = MemoryBackend::new();
+        let key_id = "peer-roundtrip";
+        let dest_hash = [7u8; 16];
+        let mut pubkey = [0u8; 64];
+        for (i, b) in pubkey.iter_mut().enumerate() {
+            *b = u8::try_from(i).unwrap().wrapping_add(3);
+        }
+
+        // Seed the occurrence's federation_keys row — put_transport_destination
+        // is FK-gated on it (in production, rooting already confirmed this row
+        // exists before the write-through fires, so the FK always holds).
+        let record = ciris_persist::federation::KeyRecord {
+            key_id: key_id.to_string(),
+            pubkey_ed25519_base64: String::new(),
+            pubkey_ml_dsa_65_base64: None,
+            algorithm: "hybrid".to_string(),
+            identity_type: "agent".to_string(),
+            identity_ref: format!("ref-{key_id}"),
+            valid_from: chrono::Utc::now(),
+            valid_until: None,
+            registration_envelope: serde_json::json!({ "key_id": key_id }),
+            original_content_hash: "0".repeat(64),
+            scrub_signature_classical: "x".repeat(88),
+            scrub_signature_pqc: None,
+            scrub_key_id: key_id.to_string(),
+            scrub_timestamp: chrono::Utc::now(),
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            roles: Vec::new(),
+            attestation_evidence: None,
+            consent_role: None,
+            additional_scrubs: Vec::new(),
+        };
+        FederationDirectory::put_public_key(
+            &backend,
+            ciris_persist::federation::SignedKeyRecord { record },
+        )
+        .await
+        .expect("seed occurrence key");
+
+        // Write-through (the announce-handler path).
+        RootingDirectory::persist_rooted_transport(&backend, key_id, dest_hash, pubkey).await;
+
+        // Boot-load: read every persisted binding back.
+        let rows = FederationDirectory::list_all_transport_destinations(&backend)
+            .await
+            .expect("list_all_transport_destinations");
+        let row = rows
+            .iter()
+            .find(|r| r.occurrence_key_id == key_id)
+            .expect("the persisted binding is present");
+        assert_eq!(row.transport_kind, "reticulum");
+        assert_eq!(row.destination, hex::encode(dest_hash));
+
+        // Reconstruct the 64-byte identity the resolver would serve.
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let xb = b64
+            .decode(
+                row.transport_x25519_pubkey_base64
+                    .as_deref()
+                    .expect("x25519"),
+            )
+            .expect("x25519 b64");
+        let eb = b64
+            .decode(
+                row.transport_ed25519_pubkey_base64
+                    .as_deref()
+                    .expect("ed25519"),
+            )
+            .expect("ed25519 b64");
+        let mut full = [0u8; 64];
+        full[0..32].copy_from_slice(&xb);
+        full[32..64].copy_from_slice(&eb);
+        assert_eq!(
+            full, pubkey,
+            "boot-loaded identity matches the write-through"
+        );
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(row.occurrence_key_id.clone(), full);
+        assert_eq!(
+            PersistedBindingResolver::new(map).resolve(key_id),
+            Some(pubkey)
+        );
+    }
 
     #[test]
     fn identity_round_trips_through_file() {

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -220,6 +220,27 @@ pub trait RootingDirectory: Send + Sync + 'static {
     /// Assemble the recursive-provenance chain for `key_id` without
     /// the verifying verdict — the verify-consumable read.
     async fn provenance_chain(&self, key_id: &str) -> Result<ProvenanceChain, RootingRejection>;
+
+    /// CIRISEdge#299 — **write-through** a peer's rooted transport
+    /// identity so it survives a restart (reloaded via
+    /// `list_all_transport_destinations` on boot) and a KNOWN peer is
+    /// reachable-and-sealable with zero announces. Called by the
+    /// reticulum announce handler the moment an announce roots
+    /// (`RootingVerdict::Rooted`), with the full 64-byte transport
+    /// identity (`x25519 ‖ ed25519`) it holds. NOT TOFU — `root_binding`
+    /// already verified the peer against the anchor; this only persists
+    /// the already-verified binding. Idempotent upsert on `key_id`
+    /// (last-writer-wins → a transport-identity rotation re-roots and
+    /// overwrites). Default is a no-op so non-`FederationDirectory`
+    /// impls (test doubles) don't break; the blanket impl over
+    /// `FederationDirectory` does the real `put_transport_destination`.
+    async fn persist_rooted_transport(
+        &self,
+        _key_id: &str,
+        _dest_hash: [u8; 16],
+        _transport_pubkey: [u8; 64],
+    ) {
+    }
 }
 
 #[async_trait]
@@ -234,6 +255,39 @@ impl<F: FederationDirectory + Send + Sync + 'static> RootingDirectory for F {
 
     async fn provenance_chain(&self, key_id: &str) -> Result<ProvenanceChain, RootingRejection> {
         persist_provenance_chain(self, key_id).await
+    }
+
+    async fn persist_rooted_transport(
+        &self,
+        key_id: &str,
+        dest_hash: [u8; 16],
+        transport_pubkey: [u8; 64],
+    ) {
+        use base64::Engine as _;
+        let b64 = base64::engine::general_purpose::STANDARD;
+        // The 64-byte RNS transport identity is `[x25519 ‖ ed25519]`.
+        let row = ciris_persist::federation::self_at_login::TransportDestination {
+            occurrence_key_id: key_id.to_string(),
+            transport_kind: "reticulum".to_string(),
+            destination: hex::encode(dest_hash),
+            asserted_at: chrono::Utc::now(),
+            last_seen_at: None,
+            transport_ed25519_pubkey_base64: Some(b64.encode(&transport_pubkey[32..64])),
+            transport_x25519_pubkey_base64: Some(b64.encode(&transport_pubkey[0..32])),
+        };
+        match FederationDirectory::put_transport_destination(self, &row).await {
+            Ok(()) => tracing::info!(
+                key_id,
+                dest_hash = %row.destination,
+                "CIRISEdge#299: persisted rooted transport binding (write-through)"
+            ),
+            Err(e) => tracing::warn!(
+                key_id,
+                error = %e,
+                "CIRISEdge#299: write-through of rooted transport binding failed (peer still \
+                 rooted in-memory this session, but will not survive a restart)"
+            ),
+        }
     }
 }
 


### PR DESCRIPTION
The edge companion to **CIRISPersist#411** — completes the trace-flow substrate arc (rootable #397 → address-move #405/#410 → **survives-restart #411**).

## Principle
Edge holds no authoritative ephemeral rooting state — **persist is the source of truth**; edge's in-memory rooted-peers map is a write-through cache. Fixes **CIRISServer#216**: a months-old rooted binding vanished across a restart → `resolve_peer_kex_pubkeys=None` → 0 envelopes sealed.

## Write-through (ask 1)
`RootingDirectory` gains `persist_rooted_transport` (default no-op; the blanket impl over `FederationDirectory` does `put_transport_destination` with **both** pubkey halves). The reticulum announce handler calls it on every newer-epoch root, using the full 64-byte identity from **`announce.public_key()`** — the KEX **x25519 is not in the peers map** (`signing_key` is ed25519-only), so it's captured from the authenticated announce. Written **after releasing the peers lock** (DB I/O). NOT TOFU — `root_binding` already verified the peer against the anchor.

## Boot-load (ask 2)
New **`PersistedBindingResolver`** (a `PeerResolver`) is built at `init_edge_runtime` startup from `directory.list_all_transport_destinations()` — every persisted binding, in full, immediately — and wired as `ReticulumAuth.resolver` (was `None`). `resolve_peer` falls back to it on a peers-map miss, so a KNOWN peer is `knows_peer=true` and **sealable (KEX x25519) with zero announces** after a restart. Fail-soft: load error / malformed row logs and degrades to announce-rooting.

## Re-pin
persist v13.6.1 → **v13.8.0** (#405/#410/#407-408/#411), verify unchanged **v8.10.1**. `TransportDestination.transport_x25519_pubkey_base64` added — edge's self-at-login now publishes both halves.

## Tests
`PersistedBindingResolver` resolve + a full **write-through → persist → boot-load → resolve round-trip** through `MemoryBackend`. `clippy -D warnings` clean under 1.97 across default / reticulum / codec-fountain / full ffi-uniffi (`--all-targets`); fmt clean.

Closes #299. Refs CIRISPersist#411, CIRISServer#216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)