### PR TITLE
chore(v9.6.1): re-pin persist v13.9.1 — advisory bindings now durably persist (completes #301)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.6.0"
+version = "9.6.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.9.0", version = "13", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.9.1", version = "13", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.9.0", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v13.9.1", version = "13", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3


### PR DESCRIPTION
Patch re-pin — **persist v13.9.0 → v13.9.1** (#416, **CRITICAL**). V078 declared `transport_destinations.occurrence_key_id NOT NULL REFERENCES federation_keys(key_id)`, but #413 (V100) made that table also record **advisory** bindings (CC 3.3.6.2) — a self-consistent announce whose signing key is *not-yet-rooted* and therefore *not in* `federation_keys`. The FK blocked exactly those advisory write-throughs. v13.9.1 drops the FK.

**Why it matters here:** this is the persist-side completion of **#301** (edge v9.6.0). Edge's advisory admit calls `persist_transport_binding(.., Advisory)`, which is **fail-soft** — so on v13.9.0 the durable write silently hit the FK and warned, while the in-memory admit + KEX still worked. v13.9.1 makes the durable write **succeed**, so advisory bindings survive restart + boot-load (the #299 resolver). No edge code change needed — the fix is entirely persist-side schema.

verify unchanged **v8.10.1** (no split). **Zero edge compile surface** (FK/migration).

### Verification
lib + tests + benches compile clean; `clippy -D warnings` clean across default / reticulum / pyo3. `>=13,<14` unchanged.

Refs CIRISPersist#416, CIRISEdge#301, CIRISServer#216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)