### PR TITLE
feat(v9.7.0): IdentityOccurrence publish-own selector — KEX keys replicate (closes #305)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.6.1"
+version = "9.7.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2144,7 +2144,7 @@ impl PyEdge {
     ///   transport was registered at init.
     /// - `ValueError("unknown EnvelopeKind: {token}")` if a kind
     ///   string in `peers` doesn't match the 10 wire tokens.
-    #[pyo3(signature = (peers, cadence_seconds = None, key_publish_set = None))]
+    #[pyo3(signature = (peers, cadence_seconds = None, key_publish_set = None, occurrence_publish_set = None))]
     fn start_replication(
         &self,
         py: Python<'_>,
@@ -2161,6 +2161,13 @@ impl PyEdge {
         // into the bridge's Key-plane selector. `None` preserves the
         // pre-#257 cohort projection.
         key_publish_set: Option<Vec<String>>,
+        // CIRISEdge#305 — the IdentityOccurrence-plane publish set: the node's
+        // OWN key_id, so its own occurrence (carrying content-tier
+        // `encryption_pubkeys`) is advertised (KERI publish-own). Without it,
+        // peers resolve `None` KEX keys for this node → cannot seal content to
+        // it → 0 delivery even after transport rooting. `None` preserves the
+        // pre-fix cohort projection. The server supplies the set; edge wraps it.
+        occurrence_publish_set: Option<Vec<String>>,
     ) -> PyResult<PyReplicationHandle> {
         let directory = self
             .inner
@@ -2191,6 +2198,15 @@ impl PyEdge {
                     as crate::replication::bridge::CohortProvider
             });
 
+        // CIRISEdge#305 — wrap the server-supplied IdentityOccurrence-plane
+        // publish set into the bridge's occurrence selector (twin of the #257
+        // Key-plane selector above).
+        let occurrence_selector: Option<crate::replication::bridge::CohortProvider> =
+            occurrence_publish_set.map(|set| {
+                std::sync::Arc::new(move || set.clone())
+                    as crate::replication::bridge::CohortProvider
+            });
+
         let executor = self.executor.clone();
         let runtime = py.detach(|| {
             run_async(&executor, async move {
@@ -2200,6 +2216,7 @@ impl PyEdge {
                     typed_peers,
                     config,
                     key_selector,
+                    occurrence_selector,
                 )
                 .await
             })

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -201,6 +201,17 @@ pub struct FederationDirectoryReplicationBridge {
     /// replication logic lives in edge — the engine does not hard-code
     /// the Key-plane projection).
     key_selector: Option<CohortProvider>,
+    /// CIRISEdge#305 — the IdentityOccurrence-plane publish-set selector (KEX
+    /// analogue of `key_selector`). When set, [`Self::list_identity_occurrences`]
+    /// advertises the occurrences for the key_ids THIS callback yields (the
+    /// node's OWN occurrence — which carries the content-tier
+    /// `encryption_pubkeys`) rather than only cohort-members'-own. Without it,
+    /// a node never publishes its own occurrence → peers' `resolve_peer_kex_
+    /// pubkeys` stays `None` → 0 content delivery even after transport rooting.
+    /// `None` preserves the pre-fix cohort projection (back-compat, same posture
+    /// as #257). The server supplies the selector (own key_id); edge only
+    /// provides the hook.
+    occurrence_selector: Option<CohortProvider>,
     cache: Mutex<BridgeCache>,
     config: BridgeConfig,
     /// v2 operational-data admission providers. `None` = v2 admission
@@ -229,6 +240,7 @@ impl FederationDirectoryReplicationBridge {
             directory,
             cohort,
             key_selector: None,
+            occurrence_selector: None,
             cache,
             config,
             operational: None,
@@ -262,6 +274,7 @@ impl FederationDirectoryReplicationBridge {
             directory,
             cohort,
             key_selector: None,
+            occurrence_selector: None,
             cache,
             config,
             operational: Some(operational),
@@ -279,6 +292,21 @@ impl FederationDirectoryReplicationBridge {
     #[must_use]
     pub fn with_key_selector(mut self, selector: Option<CohortProvider>) -> Self {
         self.key_selector = selector;
+        self
+    }
+
+    /// CIRISEdge#305 — install the IdentityOccurrence-plane publish-set
+    /// selector (KEX analogue of [`Self::with_key_selector`]). When set,
+    /// [`Self::list_identity_occurrences`] advertises the occurrences for the
+    /// key_ids this callback yields (the node's OWN occurrence, which carries
+    /// the content-tier `encryption_pubkeys`) rather than the cohort's
+    /// members'-own. `None` restores the cohort projection. The server computes
+    /// its own key_id and hands it in; edge just projects it through
+    /// `list_identity_occurrences_for` — the KERI publish-own model, so a peer
+    /// can resolve this node's KEX keys and seal content to it.
+    #[must_use]
+    pub fn with_occurrence_selector(mut self, selector: Option<CohortProvider>) -> Self {
+        self.occurrence_selector = selector;
         self
     }
 
@@ -549,21 +577,46 @@ impl FederationDirectoryReplicationBridge {
     }
 
     async fn list_identity_occurrences(&self) -> Vec<EnvelopeRef> {
-        self.fan_out_for_member(
-            EnvelopeKind::IdentityOccurrence,
-            |key_id| async move {
-                self.directory
-                    .list_identity_occurrences_for(&key_id)
-                    .await
-                    .unwrap_or_default()
-            },
-            |row| SignedIdentityOccurrence {
-                identity_occurrence: row.clone(),
-            },
-            |row| row.asserted_at,
-            |row| row.persist_row_hash.as_str(),
-        )
-        .await
+        // CIRISEdge#305 — publish-OWN occurrence (KERI publish-own; the KEX
+        // analogue of #257's Key-plane fix). The identity occurrence carries
+        // the content-tier `encryption_pubkeys` (x25519 + ML-KEM-768); if the
+        // node never advertises its OWN occurrence, no peer can resolve its KEX
+        // keys → `resolve_peer_kex_pubkeys` stays `None` → 0 content delivery
+        // even after the peer is transport-rooted. Resolve the publish set via
+        // `occurrence_selector` (own key_id, server-supplied) exactly as
+        // `list_keys` uses `key_selector`; `None` preserves the pre-fix cohort
+        // projection. Hand-rolled rather than `fan_out_for_member` because that
+        // combinator hardcodes the cohort (and mirrors `list_keys`, which is
+        // hand-rolled for the same reason).
+        let mut refs = Vec::new();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        let publish_set = self.occurrence_selector.as_ref().unwrap_or(&self.cohort);
+        for key_id in publish_set() {
+            let rows = self
+                .directory
+                .list_identity_occurrences_for(&key_id)
+                .await
+                .unwrap_or_default();
+            for row in rows {
+                let Some(envelope_hash) = Self::decode_hash(&row.persist_row_hash) else {
+                    continue;
+                };
+                if !seen.insert(envelope_hash) {
+                    continue;
+                }
+                let bytes = serde_json::to_vec(&SignedIdentityOccurrence {
+                    identity_occurrence: row.clone(),
+                })
+                .unwrap_or_default();
+                self.cache_insert(EnvelopeKind::IdentityOccurrence, envelope_hash, bytes)
+                    .await;
+                refs.push(EnvelopeRef {
+                    envelope_hash,
+                    seq: Self::ms_seq(row.asserted_at),
+                });
+            }
+        }
+        refs
     }
 
     async fn list_families(&self) -> Vec<EnvelopeRef> {
@@ -1216,6 +1269,75 @@ mod tests {
             refs.len(),
             2,
             "selector advertises the node's own + the anchored record, not the cohort"
+        );
+    }
+
+    /// CIRISEdge#305 — a minimal self-occurrence (identity == occurrence key),
+    /// software-only (no enc pubkeys needed to exercise the publish selector).
+    fn fixture_identity_occurrence(key_id: &str) -> ciris_persist::federation::IdentityOccurrence {
+        ciris_persist::federation::IdentityOccurrence {
+            identity_key_id: key_id.to_string(),
+            occurrence_key_id: key_id.to_string(),
+            device_class: "server".to_string(),
+            hardware_attestation: None,
+            asserted_at: Utc::now(),
+            valid_until: None,
+            encryption_pubkeys: None,
+            persist_row_hash: String::new(),
+        }
+    }
+
+    /// CIRISEdge#305 — the IdentityOccurrence-plane selector publishes the
+    /// node's OWN occurrence (which carries the content-tier
+    /// `encryption_pubkeys`) even though it is not in the node's consent cohort
+    /// (KERI publish-own, the KEX analogue of #257). Without it,
+    /// `list_identity_occurrences` projects the cohort and never carries own →
+    /// peers resolve `None` KEX keys → 0 content delivery.
+    #[tokio::test]
+    async fn occurrence_selector_publishes_own_not_cohort() {
+        let cohort_member = "occ-peer-in-cohort";
+        let own_key = "occ-this-node-own";
+        let (backend, bridge) = make_bridge(&[cohort_member.to_string()]);
+        for k in [cohort_member, own_key] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+            backend
+                .put_identity_occurrence(SignedIdentityOccurrence {
+                    identity_occurrence: fixture_identity_occurrence(k),
+                })
+                .await
+                .expect("seed occurrence");
+        }
+
+        // Pre-#305 projection: the cohort → only the cohort member's occurrence.
+        let cohort_refs = bridge
+            .list_envelope_refs(EnvelopeKind::IdentityOccurrence)
+            .await;
+        assert_eq!(
+            cohort_refs.len(),
+            1,
+            "cohort projection advertises only cohort members' occurrence"
+        );
+
+        // Install the occurrence publish set {own}: publish-own.
+        let publish_set = vec![own_key.to_string()];
+        let selector: CohortProvider = Arc::new(move || publish_set.clone());
+        let bridge = bridge.with_occurrence_selector(Some(selector));
+        let refs = bridge
+            .list_envelope_refs(EnvelopeKind::IdentityOccurrence)
+            .await;
+        assert_eq!(
+            refs.len(),
+            1,
+            "selector advertises the node's OWN occurrence, not the cohort's"
+        );
+        assert_ne!(
+            refs[0].envelope_hash, cohort_refs[0].envelope_hash,
+            "the node's own occurrence is a different envelope than the cohort member's"
         );
     }
 

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -151,6 +151,13 @@ impl ReplicationRuntime {
         // knowledge) and hands it to edge alongside the consent-derived
         // cohort — edge only provides the hook.
         key_selector: Option<CohortProvider>,
+        // CIRISEdge#305 — the IdentityOccurrence-plane publish-set selector
+        // (KEX analogue of `key_selector`). `Some` yields the node's OWN key_id
+        // so `list_identity_occurrences` advertises its own occurrence (which
+        // carries the content-tier `encryption_pubkeys`) — without which peers
+        // resolve `None` KEX keys and cannot seal content to it. `None`
+        // preserves the pre-fix cohort projection. Server-supplied hook.
+        occurrence_selector: Option<CohortProvider>,
     ) -> Self {
         // Cohort callback: yields the set of peer_key_ids we
         // anti-entropy with, snapshotted at construction. Hot-adds
@@ -170,7 +177,8 @@ impl ReplicationRuntime {
                 cohort,
                 config.bridge,
             )
-            .with_key_selector(key_selector),
+            .with_key_selector(key_selector)
+            .with_occurrence_selector(occurrence_selector),
         );
 
         let registry = Arc::new(ReplicationRegistry::new());
@@ -455,6 +463,7 @@ mod tests {
             Vec::new(),
             ReplicationRuntimeConfig::default(),
             None,
+            None,
         )
         .await;
         assert!(rt.registry().is_empty().await);
@@ -478,6 +487,7 @@ mod tests {
             peers,
             ReplicationRuntimeConfig::default(),
             None,
+            None,
         )
         .await;
         let registry = rt.registry();
@@ -500,6 +510,7 @@ mod tests {
             Vec::new(),
             ReplicationRuntimeConfig::default(),
             None,
+            None,
         )
         .await;
         rt.register_peer("agent-bob", EnvelopeKind::Attestation)
@@ -521,6 +532,7 @@ mod tests {
             transport,
             Vec::new(),
             ReplicationRuntimeConfig::default(),
+            None,
             None,
         )
         .await;
@@ -552,6 +564,7 @@ mod tests {
             transport,
             Vec::new(),
             ReplicationRuntimeConfig::default(),
+            None,
             None,
         )
         .await;
@@ -594,6 +607,7 @@ mod tests {
             transport,
             initial,
             ReplicationRuntimeConfig::default(),
+            None,
             None,
         )
         .await;
@@ -641,6 +655,7 @@ mod tests {
             transport,
             Vec::new(),
             ReplicationRuntimeConfig::default(),
+            None,
             None,
         )
         .await;


### PR DESCRIPTION
The **last gap in the trace-flow arc** (#296 → #299 → #301 → CIRISPersist#416). The `IdentityOccurrence` replication plane had **no publish-own selector**: `list_identity_occurrences` fanned out over the cohort (peer set) only and **never advertised the node's OWN occurrence**. Since the occurrence carries the content-tier `encryption_pubkeys` (x25519 + ML-KEM-768), a node's KEX keys never replicated → every peer's `resolve_peer_kex_pubkeys(node)` stayed `None` → **no peer could seal to it → 0 content delivery even after the peer was fully transport-rooted** (CIRISServer#216: `ROOTED … resolve_peer_kex_pubkeys=None … [no seal]`).

The **KEX analogue of #257** (which fixed exactly this asymmetry for the Key plane). Receive/apply + seal-time resolution were already correct — only *publish* was missing.

## Change
- `FederationDirectoryReplicationBridge` gains an `occurrence_selector` field + `with_occurrence_selector()` (twin of `with_key_selector`).
- `list_identity_occurrences` resolves its publish set via the selector (`unwrap_or(&self.cohort)`) exactly like `list_keys` — hand-rolled (the `fan_out_for_member` combinator hardcodes the cohort; same reason `list_keys` is hand-rolled). `None` preserves the cohort projection (back-compat).
- `ReplicationRuntime::start` + pyo3 `start_replication` gain an `occurrence_publish_set` param (twin of #257's `key_publish_set`). **Edge only provides the hook; the server computes its own key_id.**
- **Not** solved by injecting self into the cohort — `runtime.rs` derives both the cohort snapshot AND the per-peer coordinator set from `peers`, so self-in-cohort would spawn a coordinator that anti-entropies with itself. The selector is the sound seam (same reason #257 added `key_selector`).

## Test
`occurrence_selector_publishes_own_not_cohort` — the selector advertises the node's own occurrence (a distinct envelope from the cohort member's) where the cohort projection would not. `clippy -D warnings` clean under 1.97 (`--all-targets`); fmt clean; 96 replication + 5 e2e green.

Server companion (own-occurrence registration + `occurrence_selector` wiring) is CIRISServer-side — inert without this hook, ready to adopt the moment it lands.

Closes #305. Refs CIRISEdge#257, CIRISServer#216, CIRISPersist#416, CC 5.3.3.5 E1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)