### PR TITLE
feat(v9.9.0): adopt persist v15.0.0 + verify v9.0.0 (infra:attest trust root) + expose local_named_dest_hash (#309)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "9.8.0"
+version = "9.9.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v14.1.0", version = "14", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v15.0.0", version = "15", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -221,8 +221,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v14.1.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.12.0", version = "8", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.12.0", version = "8", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v9.0.0", version = "9", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v9.0.0", version = "9", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -231,7 +231,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.12.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v8.12.0", version = "8" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v9.0.0", version = "9" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v14.1.0", version = "14", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v15.0.0", version = "15", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=14.0.0,<15",
+    "ciris-persist>=15.0.0,<16",
 ]
 dynamic = ["version"]
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -3412,6 +3412,25 @@ impl Edge {
             .map(|t| t.local_dest_hash())
     }
 
+    /// CIRISEdge#309 — the **named** destination hash
+    /// (`sha256(name_hash("ciris",["edge"]) ‖ identity_hash)[..16]`) this
+    /// node announces + listens on for mesh-routed delivery. Distinct from
+    /// [`Self::local_dest_hash`] (the *explicit* `sha256(fed_pubkey)[..16]`).
+    /// This is the value `verify_transport_binding` recomputes for a signed
+    /// occurrence's `transport_destination`, so a consumer building that
+    /// binding must use THIS authoritative accessor rather than recomputing
+    /// `compute_destination_hash` itself (byte-identical today, but drifts if
+    /// edge ever changes the app/aspects or hash shape). Returns `None` for
+    /// HTTPS-only / transport-less builds — same posture as
+    /// [`Self::local_dest_hash`].
+    #[cfg(feature = "_reticulum-module")]
+    #[must_use]
+    pub fn local_named_dest_hash(&self) -> Option<[u8; 16]> {
+        self.reticulum_transport
+            .as_ref()
+            .map(|t| t.local_named_dest_hash())
+    }
+
     /// Test/diagnostics helper — `true` if `peer_key_id` would be
     /// admitted by the configured [`PeerSubscriptionFilter`] for
     /// `message_type`. When no filter is configured, returns `true`


### PR DESCRIPTION
Double-major dependency adoption — **zero edge code surface** + one small accessor.

## persist v14.1.0 → v15.0.0 (major, CIRISPersist#422!)
Confers **`infra:attest`** via the accord co-scrub: a build-signing pipeline key is blessed by the **same m-of-n accord co-scrub** as a canonical server, gated at every `federation_keys` write chokepoint (`check_infra_attest_role_admission`, strict majority of the LIVE accord roster). **This is the persist-side trust root the manifest-gated-KEX centipede needs** (#303 / CIRISVerify#181 / CIRISPersist#415 / CIRISServer#219) — a build attestation can now be verified as trust-root-blessed via the `infra:attest` role.

## verify v8.12.0 → v9.0.0 (major)
Its workspace crates bump to v9, so edge re-pins **`ciris-crypto` + `ciris-keyring` version 8 → 9** (same v9.0.0 tag). **No consumed-API break** — edge's `ciris_verify_core` surface (holonomic/aggregation, jcs, threshold, transport_binding) is unchanged. `>=15,<16` pyproject range.

#422's breaking change is internal to persist's write chokepoints — **edge compiles clean**; the only adaptation is the transitive crypto/keyring version bump.

## #309 — `Edge::local_named_dest_hash()`
Mirror `local_dest_hash`, delegating to `ReticulumTransport::local_named_dest_hash` (`#[cfg(_reticulum-module)]`, `None` when transport-less). It's the `sha256(name_hash("ciris",["edge"]) ‖ identity_hash)[..16]` named dest edge announces/listens on — the value `verify_transport_binding` recomputes for a signed occurrence's `transport_destination`. Consumers (CIRISServer's `publish_self_identity_occurrence`, driving the in-process `Arc<Edge>` via `current_edge()`) now use edge's **authoritative** value instead of recomputing `compute_destination_hash` — zero drift.

## Verification
lib + tests + benches compile clean; `clippy -D warnings` clean under 1.97 across default / reticulum / codec-fountain / full ffi-uniffi; fmt clean.

Closes #309. Refs CIRISPersist#422, CIRISVerify(v9.0.0), CIRISEdge#303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)