### PR TITLE
fix(v10.0.1): self-diagnosing + DoS-safe observability for the inbound attribution path (#317)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "10.0.0"
+version = "10.0.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -3613,40 +3613,71 @@ impl Edge {
                     //     source_key_id (None = transport hasn't been
                     //     wired for peer attribution; can't safely
                     //     route to a peer-keyed coordinator)
-                    if let (Some(registry), Some(source)) = (
-                        replication_registry.get(),
-                        frame.source_key_id.as_deref(),
-                    ) {
-                        match registry
-                            .route_inbound_bytes(source, &frame.envelope_bytes)
-                            .await
+                    if let Some(registry) = replication_registry.get() {
+                        if let Some(source) = frame.source_key_id.as_deref() {
+                            match registry
+                                .route_inbound_bytes(source, &frame.envelope_bytes)
+                                .await
+                            {
+                                Ok(crate::replication::registry::RouteOutcome::Routed) => {
+                                    // Replication frame delivered; do NOT
+                                    // fall through to envelope dispatch.
+                                    continue;
+                                }
+                                Ok(crate::replication::registry::RouteOutcome::NotAReplicationFrame) => {
+                                    // No CRPL magic — fall through to the
+                                    // existing envelope dispatch path.
+                                }
+                                Ok(crate::replication::registry::RouteOutcome::NoCoordinatorRegistered { kind }) => {
+                                    tracing::debug!(
+                                        peer = %source,
+                                        ?kind,
+                                        "CRPL frame received but no coordinator registered for (peer, kind); dropping"
+                                    );
+                                    continue;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        peer = %source,
+                                        error = %e,
+                                        "replication route_inbound_bytes failed; dropping frame"
+                                    );
+                                    continue;
+                                }
+                            }
+                        } else if frame
+                            .envelope_bytes
+                            .starts_with(&crate::replication::wire_frame::REPLICATION_FRAME_MAGIC)
                         {
-                            Ok(crate::replication::registry::RouteOutcome::Routed) => {
-                                // Replication frame delivered; do NOT
-                                // fall through to envelope dispatch.
-                                continue;
-                            }
-                            Ok(crate::replication::registry::RouteOutcome::NotAReplicationFrame) => {
-                                // No CRPL magic — fall through to the
-                                // existing envelope dispatch path.
-                            }
-                            Ok(crate::replication::registry::RouteOutcome::NoCoordinatorRegistered { kind }) => {
+                            // CIRISEdge#317 point 4 — a CRPL replication frame
+                            // arrived but the transport could NOT attribute it to
+                            // a peer key_id (`source_key_id=None`; see the
+                            // reticulum `link_attribution_miss` WARN upstream). It
+                            // cannot route. DROP it here rather than fall through
+                            // to the JSON verifier — feeding binary CRPL to
+                            // `verify.verify()` is what produced the misleading
+                            // `schema_invalid` in the field. This is the exact
+                            // state the whole bug lived in and it emitted nothing;
+                            // now it's a throttled WARN (attacker-triggerable, so
+                            // first-N-per-window keyed on transport).
+                            if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                                inbound_unroutable_crpl_log().check(frame.transport.0)
+                            {
                                 tracing::warn!(
-                                    peer = %source,
-                                    ?kind,
-                                    "CRPL frame received but no coordinator registered for (peer, kind); dropping"
+                                    transport_id = %frame.transport.0,
+                                    bytes = frame.envelope_bytes.len(),
+                                    first_bytes_hex = %first_bytes_hex(&frame.envelope_bytes),
+                                    route = "SkippedNoSourceKeyId",
+                                    suppressed_prev,
+                                    "inbound CRPL replication frame with source_key_id=None — \
+                                     transport could not attribute the sending link to a peer \
+                                     (link attribution miss upstream); dropping (CIRISEdge#317)"
                                 );
-                                continue;
                             }
-                            Err(e) => {
-                                tracing::warn!(
-                                    peer = %source,
-                                    error = %e,
-                                    "replication route_inbound_bytes failed; dropping frame"
-                                );
-                                continue;
-                            }
+                            continue;
                         }
+                        // else: no source + not a CRPL frame — a normal inbound
+                        // envelope that carries no peer attribution; fall through.
                     }
                     let verify_clone = verify.clone();
                     let handlers_clone = handlers.clone();
@@ -3903,6 +3934,38 @@ async fn key_is_own_node(
     }
 }
 
+// CIRISEdge#317 — throttles for the two attacker-triggerable, per-frame inbound
+// log sites (points 4 + 5). Both are keyed on a LOW-cardinality discriminant
+// (transport id / verify-error class), so a flood of junk frames collapses to a
+// bounded first-N-per-window + suppressed-count rather than a per-frame line.
+// The always-on rate lives in `EdgeMetrics` (`inc_verify_failure`).
+static INBOUND_UNROUTABLE_CRPL_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+static INBOUND_VERIFY_REJECT_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+
+/// Point 4 — a CRPL replication frame that couldn't be attributed (no
+/// `source_key_id`). Keyed on transport id (a handful of values).
+fn inbound_unroutable_crpl_log() -> &'static crate::log_throttle::LogThrottle {
+    INBOUND_UNROUTABLE_CRPL_LOG.get_or_init(|| {
+        crate::log_throttle::LogThrottle::new(5, std::time::Duration::from_secs(60), 16)
+    })
+}
+
+/// Point 5 — a verify-rejected inbound frame (attacker-expected junk). Keyed on
+/// the verify-error class (a small closed set).
+fn inbound_verify_reject_log() -> &'static crate::log_throttle::LogThrottle {
+    INBOUND_VERIFY_REJECT_LOG.get_or_init(|| {
+        crate::log_throttle::LogThrottle::new(5, std::time::Duration::from_secs(60), 32)
+    })
+}
+
+/// Hex of the first up-to-8 bytes of a frame — distinguishes a binary CRPL frame
+/// that was misrouted to the JSON verifier from a genuinely-malformed envelope.
+fn first_bytes_hex(bytes: &[u8]) -> String {
+    hex::encode(&bytes[..bytes.len().min(8)])
+}
+
 /// Inbound dispatch: verify → maybe-ACK-match → `ContentBody`
 /// AV-13/integrity gate (CIRISEdge#21 v0.8.0) → `FederationAnnouncement`
 /// `AccordCarrier` 2-of-3 multi-sig wire-layer gate (CIRISEdge#19,
@@ -4029,16 +4092,32 @@ async fn dispatch_inbound(
     let verified = match verify.verify(&frame.envelope_bytes, transport).await {
         Ok(v) => v,
         Err(e) => {
+            // CIRISEdge#317 point 5 — a verify-rejected frame is attacker-EXPECTED
+            // traffic, not an operational error, so the always-on signal is the
+            // `verify_failures_total[class]` counter (below), and the per-event
+            // line is a THROTTLED WARN (was ERROR — always shipped). It carries
+            // `source_key_id` explicitly (log `None`, don't omit) + `first_bytes_hex`
+            // so a binary CRPL frame misrouted here vs a genuinely-malformed
+            // signed envelope is one glance. Keyed on the verify class (small
+            // closed set) so a flood of one class collapses to a suppressed-count.
             let class = crate::observability::VerifyErrorClass::from_verify_error(&e);
             metrics.inc_verify_failure(class);
             tracing::Span::current().record("verify_outcome", class.as_str());
-            tracing::error!(
-                event = "edge.dispatch_inbound.verify_rejected",
-                transport_id = %transport.0,
-                verify_error_class = class.as_str(),
-                error = %e,
-                "verify rejected",
-            );
+            if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                inbound_verify_reject_log().check(class.as_str())
+            {
+                tracing::warn!(
+                    event = "edge.dispatch_inbound.verify_rejected",
+                    transport_id = %transport.0,
+                    verify_error_class = class.as_str(),
+                    source_key_id = ?frame.source_key_id,
+                    bytes = frame.envelope_bytes.len(),
+                    first_bytes_hex = %first_bytes_hex(&frame.envelope_bytes),
+                    suppressed_prev,
+                    error = %e,
+                    "verify rejected (CIRISEdge#317)",
+                );
+            }
             return;
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,7 @@ pub mod handler;
 pub mod holonomic;
 pub mod identity;
 pub mod key_boundary;
+pub mod log_throttle;
 pub mod manifest;
 pub mod messages;
 // v6.0.0 (CIRISEdge#175, FSD §3.3 / §3.5 / §6) — substrate-tier MLS

--- a/src/log_throttle.rs
+++ b/src/log_throttle.rs
@@ -1,0 +1,210 @@
+//! `LogThrottle` — a bounded "first-N-per-window, then a suppressed-count
+//! summary" gate for **attacker-triggerable** log sites (CIRISEdge#317).
+//!
+//! ## Why this exists
+//!
+//! Announces and link establishment are unauthenticated / advisory-admitted
+//! (CC 3.3.6.2 — an unauthenticated announce is a routing hint, never dropped),
+//! so a peer can flood a node with them. The library installs **no** tracing
+//! subscriber (the embedding binary does — see [`crate::observability`]), and
+//! the common `fmt::init()` default ships INFO-and-above to storage. So any
+//! per-announce / per-link / per-frame INFO or WARN line is an attacker-driven
+//! **storage-write amplification** and a log-flood DoS.
+//!
+//! The two anti-DoS levers this codebase already uses are (1) demote high-volume
+//! detail to `DEBUG` (suppressed under the default INFO filter) and (2) count,
+//! don't log-per-event ([`crate::observability::EdgeMetrics`]). `LogThrottle` is
+//! the third: for the RCA-critical signals that MUST stay loggable at WARN/INFO
+//! (so a single genuinely-broken run still self-diagnoses, the #317 acceptance
+//! bar), emit the first `max_per_window` occurrences per key — which carry the
+//! full operand payload — then collapse the rest to one `suppressed=<n>` summary
+//! when the window rolls.
+//!
+//! ## Bounded so it can't become the DoS
+//!
+//! The per-key bucket map is itself cardinality-capped with front-drop eviction
+//! (mirroring [`crate::transport::reachability`]'s ring buffer), because the
+//! throttle keys are attacker-controlled (`link_id`, `verify_class`, …). An
+//! unbounded key map would just relocate the memory-exhaustion vector into the
+//! mitigation. Keying on a **low-cardinality** discriminant (e.g. the
+//! `provenance` enum, the `RouteOutcome` variant) is preferred where possible;
+//! where the key is attacker-chosen (`link_id`) the cap is the backstop.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+/// The caller's decision after consulting the throttle.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ThrottleDecision {
+    /// Within budget — emit the full log line. `suppressed_prev` is the number
+    /// of occurrences dropped in the *previous* window for this key (non-zero
+    /// only on the call that rolled the window); log it as a `suppressed=<n>`
+    /// field/summary so the flood is visible without per-event lines.
+    Emit { suppressed_prev: u64 },
+    /// Over budget this window — do not emit. The drop is counted internally and
+    /// surfaced as `suppressed_prev` when the window next rolls.
+    Suppress,
+}
+
+struct Bucket {
+    window_start: Instant,
+    emitted: u32,
+    suppressed: u64,
+}
+
+struct State {
+    buckets: HashMap<String, Bucket>,
+    /// Eviction order; front is oldest. Capped at `max_keys`.
+    order: VecDeque<String>,
+}
+
+/// A bounded first-N-per-window log gate. Cheap to hold as a process-global
+/// `static OnceLock<LogThrottle>` per log site (MSRV 1.75 — `OnceLock`, not
+/// `LazyLock`) — the throttle is about total log rate, so shared state across
+/// instances is correct, and it never affects program behavior (only whether a
+/// line is written).
+pub struct LogThrottle {
+    state: Mutex<State>,
+    max_per_window: u32,
+    window: Duration,
+    max_keys: usize,
+}
+
+impl LogThrottle {
+    /// `max_per_window` full lines per key per `window`; the per-key map is
+    /// capped at `max_keys` (front-drop) so an attacker cycling keys can't grow
+    /// it unbounded.
+    pub fn new(max_per_window: u32, window: Duration, max_keys: usize) -> Self {
+        Self {
+            state: Mutex::new(State {
+                buckets: HashMap::new(),
+                order: VecDeque::new(),
+            }),
+            max_per_window,
+            window,
+            max_keys,
+        }
+    }
+
+    /// Consult the throttle for `key` at `now`. Pure w.r.t. wall-clock: the
+    /// caller passes `Instant::now()` so this is testable without a clock.
+    pub fn check_at(&self, key: &str, now: Instant) -> ThrottleDecision {
+        let mut st = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        // Fast path: existing bucket.
+        if let Some(b) = st.buckets.get_mut(key) {
+            if now.duration_since(b.window_start) >= self.window {
+                // Window rolled — surface the suppressed count, reset.
+                let suppressed_prev = b.suppressed;
+                b.window_start = now;
+                b.emitted = 1;
+                b.suppressed = 0;
+                return ThrottleDecision::Emit { suppressed_prev };
+            }
+            if b.emitted < self.max_per_window {
+                b.emitted += 1;
+                return ThrottleDecision::Emit { suppressed_prev: 0 };
+            }
+            b.suppressed += 1;
+            return ThrottleDecision::Suppress;
+        }
+
+        // New key — evict oldest if at capacity (front-drop, like the
+        // reachability ring buffer) so the map stays bounded under key churn.
+        if st.order.len() >= self.max_keys {
+            if let Some(evict) = st.order.pop_front() {
+                st.buckets.remove(&evict);
+            }
+        }
+        st.order.push_back(key.to_string());
+        st.buckets.insert(
+            key.to_string(),
+            Bucket {
+                window_start: now,
+                emitted: 1,
+                suppressed: 0,
+            },
+        );
+        ThrottleDecision::Emit { suppressed_prev: 0 }
+    }
+
+    /// Convenience wrapper using the real clock.
+    pub fn check(&self, key: &str) -> ThrottleDecision {
+        self.check_at(key, Instant::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_n_emit_then_suppress_within_window() {
+        let t = LogThrottle::new(3, Duration::from_secs(60), 16);
+        let t0 = Instant::now();
+        // First 3 within budget.
+        for _ in 0..3 {
+            assert_eq!(
+                t.check_at("k", t0),
+                ThrottleDecision::Emit { suppressed_prev: 0 }
+            );
+        }
+        // Next 5 suppressed.
+        for _ in 0..5 {
+            assert_eq!(t.check_at("k", t0), ThrottleDecision::Suppress);
+        }
+    }
+
+    #[test]
+    fn window_roll_surfaces_suppressed_count() {
+        let t = LogThrottle::new(1, Duration::from_secs(60), 16);
+        let t0 = Instant::now();
+        assert_eq!(
+            t.check_at("k", t0),
+            ThrottleDecision::Emit { suppressed_prev: 0 }
+        );
+        // 4 suppressed in this window.
+        for _ in 0..4 {
+            assert_eq!(t.check_at("k", t0), ThrottleDecision::Suppress);
+        }
+        // Next window: first call surfaces the 4 dropped.
+        let t1 = t0 + Duration::from_secs(61);
+        assert_eq!(
+            t.check_at("k", t1),
+            ThrottleDecision::Emit { suppressed_prev: 4 }
+        );
+    }
+
+    #[test]
+    fn key_map_is_bounded_under_churn() {
+        // max_keys = 4; cycle 1000 distinct keys → map never exceeds the cap.
+        let t = LogThrottle::new(1, Duration::from_secs(60), 4);
+        let t0 = Instant::now();
+        for i in 0..1000 {
+            let _ = t.check_at(&format!("attacker-key-{i}"), t0);
+        }
+        let st = t.state.lock().unwrap();
+        assert!(st.buckets.len() <= 4, "bucket map bounded at max_keys");
+        assert!(st.order.len() <= 4, "eviction order bounded at max_keys");
+    }
+
+    #[test]
+    fn independent_keys_have_independent_budgets() {
+        let t = LogThrottle::new(1, Duration::from_secs(60), 16);
+        let t0 = Instant::now();
+        assert_eq!(
+            t.check_at("a", t0),
+            ThrottleDecision::Emit { suppressed_prev: 0 }
+        );
+        // Different key still has its own budget.
+        assert_eq!(
+            t.check_at("b", t0),
+            ThrottleDecision::Emit { suppressed_prev: 0 }
+        );
+        assert_eq!(t.check_at("a", t0), ThrottleDecision::Suppress);
+    }
+}

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -73,6 +73,7 @@
 //! as a `NodeEvent::ResourceCompleted`, which the listener turns into
 //! an [`InboundFrame`].
 
+use sha2::{Digest as _, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -118,6 +119,35 @@ const LINK_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(30);
 /// How long [`Transport::send`] waits for a resource transfer to
 /// complete after the link is up.
 const RESOURCE_TRANSFER_TIMEOUT: Duration = Duration::from_secs(120);
+
+// ─── CIRISEdge#317 — throttles for attacker-triggerable log sites ────
+//
+// Announces + link establishment are unauthenticated / advisory-admitted, so a
+// peer can flood them. These bound the RCA-critical WARN/INFO lines to
+// first-N-per-window (bounded key map, front-drop) so a single broken run still
+// self-diagnoses but a flood collapses to a suppressed-count. High-volume detail
+// is demoted to DEBUG instead (out of the default INFO stream).
+
+// `OnceLock` (not `LazyLock`) per the crate MSRV 1.75 + the codebase convention.
+static PEER_ADMITTED_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+static LINK_ATTRIBUTION_MISS_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+
+/// Point 1 — peer-admitted (INFO). Keyed on `provenance` (2 values), so the
+/// rare `Rooted` admit logs freely while a flood of junk `Advisory` admits is
+/// capped. A tiny key map suffices.
+fn peer_admitted_log() -> &'static crate::log_throttle::LogThrottle {
+    PEER_ADMITTED_LOG
+        .get_or_init(|| crate::log_throttle::LogThrottle::new(8, Duration::from_secs(60), 8))
+}
+
+/// Point 2 — link-attribution miss (WARN). Keyed on the link-proven identity
+/// hash (attacker-chosen), so the key map is capped as the DoS backstop.
+fn link_attribution_miss_log() -> &'static crate::log_throttle::LogThrottle {
+    LINK_ATTRIBUTION_MISS_LOG
+        .get_or_init(|| crate::log_throttle::LogThrottle::new(5, Duration::from_secs(60), 1024))
+}
 
 // ─── Peer resolution ────────────────────────────────────────────────
 
@@ -2947,30 +2977,95 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
                     "link identified",
                 ));
             }
+            // CIRISEdge#317 observability point 3 — LINKIDENTIFY fired for this
+            // link, so attribution can attempt. A frame that later arrives on a
+            // link for which get_remote_identity is None is candidate-1
+            // (LINKIDENTIFY never completed). DEBUG: this is per-link-establish
+            // and attacker-triggerable, so it stays out of the default INFO
+            // stream (available under RUST_LOG=debug) — the always-on signal is
+            // the point-2 miss WARN + point-1 admit line.
+            let remote_identity_present = ctx.node.get_remote_identity(&link_id).is_some();
+            tracing::debug!(
+                link = ?link_id,
+                remote_identity = remote_identity_present,
+                link_proven_identity_hash = %hex::encode(identity_hash),
+                "link_identified"
+            );
+
             // CIRISEdge#314 — attribute the link to a peer key_id by the link's
-            // PROVEN transport identity hash (form-agnostic), falling back to the
-            // legacy named-dest recompute for back-compat. The pre-#314 code
-            // matched ONLY `compute_destination_hash(name_hash, identity_hash)`
-            // (the named-dest form) against the stored announced dest, which
-            // missed whenever the peer announced on an explicit-hash dest
-            // (`sha256(fed_pubkey)[..16]`) — the same named-vs-explicit split
-            // that bit 0.5.100→0.5.101. On a miss, `source_key_id` stayed `None`,
-            // `route_inbound_bytes` was skipped, and the binary CRPL frame fell
-            // through to the JSON dispatcher (the "expected value at line 1" symptom)
-            // — leaving #312's responder unreachable. Matching the identity hash
-            // (which the advisory entry captured from the authenticated announce)
-            // is robust to whatever dest form the peer announced on.
+            // PROVEN transport identity hash (Branch A, form-agnostic), falling
+            // back to the legacy named-dest recompute (Branch B, fast-path). On a
+            // miss, `source_key_id` stays `None`, `route_inbound_bytes` is
+            // skipped, and the binary CRPL frame falls through to the JSON
+            // dispatcher — leaving #312's responder unreachable (CIRISEdge#317).
             let name_hash = Destination::compute_name_hash(EDGE_APP_NAME, &[EDGE_APP_ASPECT]);
             let expected_dest_hash =
                 Destination::compute_destination_hash(&name_hash, &identity_hash);
             let peers_guard = ctx.peers.lock().await;
-            let matched_key = peers_guard
-                .iter()
-                .find(|(_, rp)| {
-                    rp.transport_identity_hash == identity_hash
-                        || rp.peer.dest_hash == expected_dest_hash
-                })
-                .map(|(k, _)| k.clone());
+            let matched = peers_guard.iter().find_map(|(k, rp)| {
+                if rp.transport_identity_hash == identity_hash {
+                    Some((k.clone(), "identity"))
+                } else if rp.peer.dest_hash == expected_dest_hash {
+                    Some((k.clone(), "dest"))
+                } else {
+                    None
+                }
+            });
+            // CIRISEdge#317 observability point 2 — the line that localizes the
+            // bug in one run. A MATCH is DEBUG (success is not an incident). A
+            // MISS is the RCA-critical signal, kept at WARN but THROTTLED
+            // (first-N-per-window keyed on link_id, bounded map) so an attacker
+            // flooding links can't flood logs. The four operands (link identity,
+            // expected dest, remote_identity_present, peers_len) localize the
+            // announce-vs-send identity split; the per-peer stored operands ride
+            // DEBUG + a cap so the line stays O(1), not O(peers) — closing the
+            // prior O(N·M) quadratic-log blowup. The stored side of the compare
+            // is separately visible at admit (point 1).
+            if let Some((key_id, branch)) = &matched {
+                tracing::debug!(
+                    link = ?link_id,
+                    key_id = %key_id,
+                    branch,
+                    "link_attribution matched"
+                );
+            } else {
+                let link_key = hex::encode(identity_hash);
+                if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                    link_attribution_miss_log().check(&link_key)
+                {
+                    // First few candidate peers' stored side, capped — only
+                    // materialized under DEBUG and never the whole map.
+                    let peer_sample: Vec<String> = if tracing::enabled!(tracing::Level::DEBUG) {
+                        peers_guard
+                            .iter()
+                            .take(8)
+                            .map(|(k, rp)| {
+                                format!(
+                                    "{{key_id={k} tid={} dest={}}}",
+                                    hex::encode(rp.transport_identity_hash),
+                                    hex::encode(rp.peer.dest_hash.into_bytes()),
+                                )
+                            })
+                            .collect()
+                    } else {
+                        Vec::new()
+                    };
+                    tracing::warn!(
+                        link = ?link_id,
+                        link_identity = %link_key,
+                        expected_dest = %hex::encode(expected_dest_hash.into_bytes()),
+                        remote_identity_present,
+                        peers_len = peers_guard.len(),
+                        peer_sample = %peer_sample.join(", "),
+                        suppressed_prev,
+                        "link_attribution_miss — inbound frames from this link cannot be \
+                         attributed to a peer key_id (source_key_id will be None); rounds \
+                         dropped. Both Branch A (identity) and Branch B (dest) missed \
+                         (CIRISEdge#317)"
+                    );
+                }
+            }
+            let matched_key = matched.map(|(k, _)| k);
             drop(peers_guard);
             if let Some(key_id) = matched_key {
                 ctx.link_to_peer_key_id.lock().await.insert(link_id, key_id);
@@ -3398,6 +3493,36 @@ async fn resolve_announce_cold_start(
                     ));
                 }
                 let persisted_key = key_id.clone();
+                // CIRISEdge#317 observability point 1 — surface the STORED
+                // attribution operands at admit, so the later
+                // `link_attribution_miss` comparison's stored side is visible
+                // without reading the diff. `transport_identity_hash` is what
+                // Branch A matches; `dest_hash` is Branch B's stored side.
+                // THROTTLED by provenance: a rare `Rooted` admit logs, a flood of
+                // junk `Advisory` admits (attacker minting keypairs) is capped to
+                // first-N-per-window + a suppressed-count — closing the log-flood
+                // that would otherwise track advisory-pollution 1:1.
+                let provenance_key = match provenance {
+                    ciris_persist::federation::self_at_login::BindingProvenance::Rooted => "rooted",
+                    ciris_persist::federation::self_at_login::BindingProvenance::Advisory => {
+                        "advisory"
+                    }
+                };
+                if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                    peer_admitted_log().check(provenance_key)
+                {
+                    tracing::info!(
+                        key_id = %key_id,
+                        provenance = ?provenance,
+                        epoch = attestation.epoch,
+                        dest_hash = %hex::encode(resolved.dest_hash.into_bytes()),
+                        transport_identity_hash = %hex::encode(transport_identity_hash),
+                        announce_pubkey_sha256_prefix =
+                            %hex::encode(&Sha256::digest(announce_pubkey64)[..4]),
+                        suppressed_prev,
+                        "peer_admitted (attribution operands stored)"
+                    );
+                }
                 peers.insert(
                     key_id,
                     RootedPeer {


### PR DESCRIPTION
Makes the inbound replication path **self-diagnosing** so the next occurrence of the #314/#317 attribution miss RCAs from **one run's logs** — without becoming a log-flood/storage DoS, since announces + link establishment are attacker-controllable (unauthenticated / advisory-admitted per CC 3.3.6.2). Ships the observability half of #317; the underlying announce-vs-send identity fix is candidate-dependent and *these logs are what confirm the candidate*.

## Threat-model-driven (a subagent audited the announce path)
Key findings that shaped this: the **lib installs no tracing subscriber** (the embedding binary does; default `fmt::init()` ships INFO+ to storage), so every attacker-triggerable INFO/WARN is a storage write; the `peers` map is **unbounded**; and my first-draft point-2 WARN formatted the **entire peers map per miss** → O(N·M) log blowup. All fixed here.

## The 5 silent-drop points, now loud (and safe)
1. **Announce admit** → INFO with the *stored* attribution operands (`transport_identity_hash` + `dest`), **throttled by provenance** (rare `Rooted` logs; junk `Advisory` flood capped).
2. **Link attribution** → DEBUG on match; on **MISS** a **throttled WARN** with all four operands (link identity, expected dest, `remote_identity_present`, `peers_len`). Removed the whole-peers-map format → closes the O(N·M) blowup; per-peer sample is DEBUG-only + capped at 8.
3. **LINKIDENTIFY fired** → DEBUG (`remote_identity` Some|None) — distinguishes "never identified" (candidate 1) from "match-miss".
4. **Inbound dispatch gate** → the `source_key_id=None` skip is now explicit: a CRPL frame that can't be attributed is **dropped at the gate** with a throttled WARN (`route=SkippedNoSourceKeyId` + `first_bytes_hex`) instead of falling through to the JSON verifier (the misleading `schema_invalid`).
5. **dispatch_inbound reject** → **ERROR demoted to a throttled WARN** carrying `source_key_id` + `first_bytes_hex`; the always-on rate stays on the existing `verify_failures_total` counter.

## DoS-safety primitive
New `log_throttle::LogThrottle` — bounded **first-N-per-window + suppressed-count**, with a **cardinality-capped key map** (front-drop, modeled on the reachability ring buffer) so an attacker cycling `link_id`s/keys can't grow it into the DoS it prevents. Strategy: demote high-volume attacker-triggerable detail to DEBUG (out of the default INFO stream); keep RCA-critical signals at WARN but throttled; key on low-cardinality discriminants (provenance / transport / verify-class) where possible, cap otherwise.

## Acceptance (#317 observability bar) preserved
A single genuinely-broken run still logs, on the **first** occurrence per window, the four operands that localize the announce-vs-send identity split — while a flood collapses to a bounded suppressed-count.

## Verification
- New `log_throttle` unit tests (first-N, window-roll suppressed-count, bounded-under-churn, independent budgets).
- 4 throttle + 98 replication + 7 reticulum tests pass; clippy `-D warnings` clean (default, reticulum, reticulum+pyo3).

Companion: **#318** (bound the `peers` map — advisory-pollution memory DoS, the orthogonal hardening the audit surfaced). Follows #314; the attribution fix itself lands once these logs confirm the candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)