### PR TITLE
fix(v10.0.2): #317 admit disambiguator — announce-identity vs transport-identity split (CIRISServer#235)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "10.0.1"
+version = "10.0.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -73,7 +73,6 @@
 //! as a `NodeEvent::ResourceCompleted`, which the listener turns into
 //! an [`InboundFrame`].
 
-use sha2::{Digest as _, Sha256};
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -3511,16 +3510,39 @@ async fn resolve_announce_cold_start(
                 if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
                     peer_admitted_log().check(provenance_key)
                 {
+                    // CIRISEdge#317 disambiguator (CIRISServer#235) — is
+                    // `announce.public_key()` actually the TRANSPORT identity the
+                    // RNS link proves, or the FEDERATION announce identity? The
+                    // link-attribution match compares `transport_identity_hash`
+                    // (= truncated_hash(announce_pubkey64)) against the link's
+                    // proven `identity_hash`. If those bytes are a DIFFERENT
+                    // identity than the transport one, the match can never hold.
+                    // The conclusive test at admit: the ed25519 half of
+                    // `announce.public_key()` (what edge hashed) vs the
+                    // attestation's DECLARED transport ed25519. If they differ,
+                    // `announce.public_key()` is NOT the transport identity → an
+                    // identity-SOURCE split, and this line proves it without a
+                    // link miss (`announce_ed25519_half != attestation_transport_ed25519`).
+                    let announce_ed25519_half = hex::encode(&announce_pubkey64[32..]);
+                    let attestation_transport_ed25519 = attestation
+                        .transport_identity_pubkey_bytes()
+                        .map_or_else(|_| "decode_err".to_string(), hex::encode);
+                    let ed25519_halves_match =
+                        announce_ed25519_half == attestation_transport_ed25519;
                     tracing::info!(
                         key_id = %key_id,
                         provenance = ?provenance,
                         epoch = attestation.epoch,
                         dest_hash = %hex::encode(resolved.dest_hash.into_bytes()),
                         transport_identity_hash = %hex::encode(transport_identity_hash),
-                        announce_pubkey_sha256_prefix =
-                            %hex::encode(&Sha256::digest(announce_pubkey64)[..4]),
+                        announce_pubkey64_hex = %hex::encode(announce_pubkey64),
+                        announce_ed25519_half = %announce_ed25519_half,
+                        attestation_transport_ed25519 = %attestation_transport_ed25519,
+                        ed25519_halves_match,
                         suppressed_prev,
-                        "peer_admitted (attribution operands stored)"
+                        "peer_admitted — #317 disambiguator: ed25519_halves_match=false ⇒ \
+                         announce.public_key() is the FEDERATION identity, not the transport \
+                         one the link proves (identity-source split, CIRISServer#235)"
                     );
                 }
                 peers.insert(


### PR DESCRIPTION
The v10.0.1 self-diagnosing wheel did its job: the field RCA (CIRISServer#235) pinned the #314/#317 attribution miss to an **identity-source split** — admit-stored `transport_identity_hash` (= `truncated_hash(announce.public_key())`) ≠ the link-proven RNS `identity_hash`. leviculum (`ded96ee`) rules out a derivation gap (`compute_hash` already hashes the combined 64-byte `x25519 ‖ ed25519`, so #314's recompute *is* the same derivation the link proves). So `announce.public_key()` at the admit site is a **different identity** than the transport one the link proves — most likely the AV-42 **federation** announce identity.

## What this lands
The **conclusive disambiguator, at admit** (no link miss needed). The attestation already carries the *declared* transport ed25519 (`transport_identity_pubkey`), so the `peer_admitted` log now also emits:
- `announce_pubkey64_hex` — the full 64 bytes edge hashed (is it well-formed `x25519‖ed25519`, or a federation key / zeros?)
- `announce_ed25519_half` — the ed25519 half of `announce.public_key()`
- `attestation_transport_ed25519` — the attestation's declared transport ed25519
- **`ed25519_halves_match`** — the one-glance verdict

If `ed25519_halves_match=false`, `announce.public_key()` is **not** the transport identity → the source split is proven in one line, and the fix is scoped precisely: derive `transport_identity_hash` from the transport identity. Note the constraint this surfaces — the attestation carries only the transport **ed25519**; the transport **x25519** is not currently plumbed, so the aligned-admit fix likely needs that half threaded (a verify/attestation change up the centipede) or the identity captured from the link directly.

## Scope
Still the diagnostic half — the aligned-admit fix follows this confirmation (candidate 2a source-split vs 2b send-vs-announce). Throttle-preserving (rides the existing provenance-keyed admit throttle from v10.0.1). clippy `-D warnings` clean; 7 reticulum tests pass.

Companion: CIRISServer#235, #317 (fix), #318 (peers-map bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)