### PR TITLE
feat(v10.1.0): announce carries transport x25519 — fix federation-vs-transport identity split (#317) + bound peers map (#318)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "10.0.2"
+version = "10.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/transport/attestation.rs
+++ b/src/transport/attestation.rs
@@ -51,6 +51,12 @@ use serde::{Deserialize, Serialize};
 /// be replayed into the other.
 const ATTESTATION_DOMAIN: &[u8] = b"ciris-edge/announce-attestation/v1";
 
+/// Domain for the **v2** payload that also binds the transport **x25519**
+/// (encryption) half — CIRISEdge#317. Distinct from the v1 domain so a v1
+/// signature can never be replayed as v2 (or vice versa): the two payload
+/// shapes live in disjoint signature spaces.
+const ATTESTATION_DOMAIN_V2: &[u8] = b"ciris-edge/announce-attestation/v2";
+
 /// The three signed fields of an [`AnnounceAttestation`], in the
 /// canonical order the signature covers.
 ///
@@ -63,6 +69,15 @@ pub struct AttestationPayload<'a> {
     /// public key (the ed25519 half of the dual-key identity — the
     /// half `ReticulumNode::connect` needs as the `signing_key`).
     pub transport_identity_pubkey: &'a [u8; 32],
+    /// CIRISEdge#317 — the announcer's 32-byte Reticulum transport-identity
+    /// **x25519** (encryption) public key, the OTHER half of the dual-key RNS
+    /// identity. `None` for a v1 announce (the field this fix adds). When set,
+    /// the admit side reconstructs the full transport identity
+    /// (`x25519 ‖ ed25519`) and computes `Identity::hash()` = exactly what the
+    /// RNS link proves — the announce previously carried only the ed25519 half,
+    /// so admit fell back to `announce.public_key()` (the FEDERATION identity)
+    /// and never matched the transport-identity link.
+    pub transport_x25519_pubkey: Option<&'a [u8; 32]>,
     /// The announcer's federation `key_id` (`federation_keys.key_id`).
     pub federation_key_id: &'a str,
     /// The transport-identity rotation epoch. Monotonic per
@@ -72,7 +87,8 @@ pub struct AttestationPayload<'a> {
 }
 
 impl<'a> AttestationPayload<'a> {
-    /// Construct a payload from its three signed fields.
+    /// Construct a v1 payload from its three signed fields (no transport
+    /// x25519). Use [`Self::with_transport_x25519`] to bind the x25519 half.
     #[must_use]
     pub fn new(
         transport_identity_pubkey: &'a [u8; 32],
@@ -81,34 +97,64 @@ impl<'a> AttestationPayload<'a> {
     ) -> Self {
         Self {
             transport_identity_pubkey,
+            transport_x25519_pubkey: None,
             federation_key_id,
             epoch,
         }
     }
 
+    /// CIRISEdge#317 — bind the transport **x25519** half, upgrading the payload
+    /// to the v2 canonical shape (distinct signature domain).
+    #[must_use]
+    pub fn with_transport_x25519(mut self, transport_x25519_pubkey: &'a [u8; 32]) -> Self {
+        self.transport_x25519_pubkey = Some(transport_x25519_pubkey);
+        self
+    }
+
     /// The exact bytes the federation key signs / a verifier checks.
     ///
-    /// Layout (all integers big-endian):
-    /// `DOMAIN ‖ len(pubkey):u64 ‖ pubkey ‖ len(key_id):u64 ‖ key_id ‖ epoch:u64`.
-    /// Length prefixes make the encoding injective — distinct field
-    /// triples never collide on a byte string, so a signature is
-    /// bound to exactly one `(pubkey, key_id, epoch)`.
+    /// v1 layout (all integers big-endian):
+    /// `DOMAIN ‖ len(ed25519) ‖ ed25519 ‖ len(key_id) ‖ key_id ‖ epoch`.
+    ///
+    /// v2 layout (when [`Self::transport_x25519_pubkey`] is set):
+    /// `DOMAIN_V2 ‖ len(ed25519) ‖ ed25519 ‖ len(x25519) ‖ x25519 ‖ len(key_id) ‖ key_id ‖ epoch`.
+    ///
+    /// Length prefixes make each encoding injective; the distinct domain keeps
+    /// v1 and v2 signatures in disjoint spaces.
     #[must_use]
     pub fn canonical_bytes(&self) -> Vec<u8> {
         let key_id = self.federation_key_id.as_bytes();
         // Length prefixes are `u64` big-endian — wide enough that the
-        // `usize → u64` widening is lossless on every supported
-        // target (no truncation risk).
-        let pubkey_len = self.transport_identity_pubkey.len() as u64;
+        // `usize → u64` widening is lossless on every supported target.
+        let ed_len = self.transport_identity_pubkey.len() as u64;
         let key_id_len = key_id.len() as u64;
-        let mut out = Vec::with_capacity(ATTESTATION_DOMAIN.len() + 8 + 32 + 8 + key_id.len() + 8);
-        out.extend_from_slice(ATTESTATION_DOMAIN);
-        out.extend_from_slice(&pubkey_len.to_be_bytes());
-        out.extend_from_slice(self.transport_identity_pubkey);
-        out.extend_from_slice(&key_id_len.to_be_bytes());
-        out.extend_from_slice(key_id);
-        out.extend_from_slice(&self.epoch.to_be_bytes());
-        out
+        if let Some(x25519) = self.transport_x25519_pubkey {
+            // v2 — binds the FULL transport identity (ed25519 + x25519).
+            let x_len = x25519.len() as u64;
+            let mut out = Vec::with_capacity(
+                ATTESTATION_DOMAIN_V2.len() + 8 + 32 + 8 + 32 + 8 + key_id.len() + 8,
+            );
+            out.extend_from_slice(ATTESTATION_DOMAIN_V2);
+            out.extend_from_slice(&ed_len.to_be_bytes());
+            out.extend_from_slice(self.transport_identity_pubkey);
+            out.extend_from_slice(&x_len.to_be_bytes());
+            out.extend_from_slice(x25519);
+            out.extend_from_slice(&key_id_len.to_be_bytes());
+            out.extend_from_slice(key_id);
+            out.extend_from_slice(&self.epoch.to_be_bytes());
+            out
+        } else {
+            // v1 — transport ed25519 only (unchanged).
+            let mut out =
+                Vec::with_capacity(ATTESTATION_DOMAIN.len() + 8 + 32 + 8 + key_id.len() + 8);
+            out.extend_from_slice(ATTESTATION_DOMAIN);
+            out.extend_from_slice(&ed_len.to_be_bytes());
+            out.extend_from_slice(self.transport_identity_pubkey);
+            out.extend_from_slice(&key_id_len.to_be_bytes());
+            out.extend_from_slice(key_id);
+            out.extend_from_slice(&self.epoch.to_be_bytes());
+            out
+        }
     }
 }
 
@@ -177,6 +223,12 @@ pub struct AnnounceAttestation {
     /// The announcer's 32-byte Reticulum transport-identity Ed25519
     /// public key, base64 standard.
     pub transport_identity_pubkey: String,
+    /// CIRISEdge#317 — the announcer's 32-byte transport-identity **x25519**
+    /// (encryption) public key, base64 standard. `None` on a v1 announce; when
+    /// present, it is covered by the signature (v2 canonical bytes) and lets the
+    /// admit side compute the transport-identity hash the RNS link proves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport_x25519_pubkey: Option<String>,
     /// The announcer's federation `key_id`.
     pub federation_key_id: String,
     /// The announcer's *claimed* federation Ed25519 public key,
@@ -214,6 +266,19 @@ impl AnnounceAttestation {
     /// base64 of exactly 32 bytes.
     pub fn transport_identity_pubkey_bytes(&self) -> Result<[u8; 32], AttestationError> {
         decode_fixed::<32>(&self.transport_identity_pubkey, "transport_identity_pubkey")
+    }
+
+    /// CIRISEdge#317 — decode the optional 32-byte transport-identity x25519
+    /// pubkey. `Ok(None)` for a v1 announce (field absent); `Ok(Some(_))` for v2.
+    ///
+    /// # Errors
+    /// [`AttestationError::FieldDecode`] when the field is present but not
+    /// base64 of exactly 32 bytes.
+    pub fn transport_x25519_pubkey_bytes(&self) -> Result<Option<[u8; 32]>, AttestationError> {
+        match &self.transport_x25519_pubkey {
+            Some(b64) => Ok(Some(decode_fixed::<32>(b64, "transport_x25519_pubkey")?)),
+            None => Ok(None),
+        }
     }
 
     /// Serialize to announce app-data bytes (JSON).
@@ -255,10 +320,17 @@ impl AnnounceAttestation {
         use ciris_crypto::ClassicalVerifier;
 
         let transport_pubkey = self.transport_identity_pubkey_bytes()?;
+        let transport_x25519 = self.transport_x25519_pubkey_bytes()?;
         let signature = decode_fixed::<64>(&self.signature, "signature")?;
 
-        let payload =
+        // CIRISEdge#317 — verify over the v2 payload (binding the x25519 half)
+        // when the announce carries it, else the v1 payload. The signature's
+        // domain is bound to the shape, so a v1 sig can't be accepted as v2.
+        let mut payload =
             AttestationPayload::new(&transport_pubkey, &self.federation_key_id, self.epoch);
+        if let Some(x25519) = &transport_x25519 {
+            payload = payload.with_transport_x25519(x25519);
+        }
         let canonical = payload.canonical_bytes();
 
         let verified = ciris_crypto::Ed25519Verifier::new()
@@ -330,6 +402,7 @@ mod tests {
         let att = AnnounceAttestation {
             transport_identity_pubkey: base64::engine::general_purpose::STANDARD
                 .encode(transport_pubkey),
+            transport_x25519_pubkey: None,
             federation_key_id: "edge-key-honest".to_string(),
             federation_pubkey_ed25519_base64: base64::engine::general_purpose::STANDARD
                 .encode(fed_pubkey),
@@ -362,6 +435,57 @@ mod tests {
             bad_sig.verify_signature(&fed_pubkey),
             Err(AttestationError::SignatureMismatch)
         ));
+    }
+
+    /// CIRISEdge#317 — a v2 attestation binding the transport x25519 verifies,
+    /// its signature is domain-separated from v1, and swapping the x25519
+    /// (a spoofed transport identity) fails verification.
+    #[test]
+    fn v2_attestation_binds_transport_x25519_and_rejects_swap() {
+        let signer = ciris_crypto::Ed25519Signer::random().unwrap();
+        let fed_pubkey: [u8; 32] = signer.public_key().unwrap().try_into().unwrap();
+        let transport_ed25519 = [0x5au8; 32];
+        let transport_x25519 = [0x77u8; 32];
+
+        let payload = AttestationPayload::new(&transport_ed25519, "edge-key-v2", 9)
+            .with_transport_x25519(&transport_x25519);
+        let sig = signer.sign(&payload.canonical_bytes()).unwrap();
+
+        let att = AnnounceAttestation {
+            transport_identity_pubkey: base64::engine::general_purpose::STANDARD
+                .encode(transport_ed25519),
+            transport_x25519_pubkey: Some(
+                base64::engine::general_purpose::STANDARD.encode(transport_x25519),
+            ),
+            federation_key_id: "edge-key-v2".to_string(),
+            federation_pubkey_ed25519_base64: base64::engine::general_purpose::STANDARD
+                .encode(fed_pubkey),
+            epoch: 9,
+            signature: base64::engine::general_purpose::STANDARD.encode(&sig),
+        };
+
+        // Round-trips through app-data + verifies.
+        let parsed = AnnounceAttestation::from_app_data(&att.to_app_data().unwrap()).unwrap();
+        assert_eq!(parsed, att);
+        assert_eq!(
+            parsed.transport_x25519_pubkey_bytes().unwrap(),
+            Some(transport_x25519)
+        );
+        parsed.verify_signature(&fed_pubkey).unwrap();
+
+        // A swapped x25519 (spoofed transport identity) fails — the x25519 is
+        // signed content in v2.
+        let mut swapped = parsed.clone();
+        swapped.transport_x25519_pubkey =
+            Some(base64::engine::general_purpose::STANDARD.encode([0x88u8; 32]));
+        assert!(matches!(
+            swapped.verify_signature(&fed_pubkey),
+            Err(AttestationError::SignatureMismatch)
+        ));
+
+        // v1 and v2 canonical bytes are domain-separated (no cross-replay).
+        let v1 = AttestationPayload::new(&transport_ed25519, "edge-key-v2", 9).canonical_bytes();
+        assert_ne!(v1, payload.canonical_bytes(), "v1/v2 domains disjoint");
     }
 
     /// A v0.3.1-style bare-`key_id` announce is not attestation JSON

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -119,6 +119,12 @@ const LINK_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(30);
 /// complete after the link is up.
 const RESOURCE_TRANSFER_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// CIRISEdge#318 — cap on the in-memory `peers` (rooted + advisory bindings)
+/// map. Bounds advisory-admit pollution: at cap, an Advisory binding is evicted
+/// before a new key is inserted (Rooted bindings are never evicted for advisory
+/// churn). Far above any real cohort; the target is unbounded attacker growth.
+const MAX_PEERS: usize = 4096;
+
 // ─── CIRISEdge#317 — throttles for attacker-triggerable log sites ────
 //
 // Announces + link establishment are unauthenticated / advisory-admitted, so a
@@ -1347,11 +1353,17 @@ impl ReticulumTransport {
         // 32..64) of the dual-key identity.
         let mut transport_ed25519 = [0u8; 32];
         transport_ed25519.copy_from_slice(&local_transport_pubkey[32..64]);
+        // CIRISEdge#317 — the x25519 (encryption) half is bytes 0..32 of the
+        // dual-key identity; bind it into the announce so receivers can match
+        // the transport identity the link proves.
+        let mut transport_x25519 = [0u8; 32];
+        transport_x25519.copy_from_slice(&local_transport_pubkey[..32]);
         let local_attestation = if let Some(s) = &signer {
             Some(
                 build_local_attestation(
                     s,
                     &transport_ed25519,
+                    &transport_x25519,
                     &config.local_key_id,
                     config.local_epoch,
                 )
@@ -3402,23 +3414,34 @@ async fn resolve_announce_cold_start(
         dest_hash: *announce.destination_hash(),
         signing_key: transport_pubkey,
     };
-    // CIRISEdge#299 — the full 64-byte transport identity (`x25519 ‖
-    // ed25519`) + dest-hash for the write-through below. `resolved.signing_key`
-    // is only the ed25519 half; the KEX x25519 needed to seal after a restart
-    // lives on the announce identity (`announce.public_key()`), so we capture
-    // it here from the authenticated announce.
+    // CIRISEdge#317 — reconstruct the TRANSPORT identity (`x25519_enc ‖
+    // ed25519_sig`) the RNS link proves, from the attestation's two transport
+    // halves. The pre-#317 code hashed `announce.public_key()` — but that is the
+    // FEDERATION announce identity (same ed25519 signing half, DIFFERENT x25519),
+    // a different `Identity` than the link authenticates under, so the
+    // attribution could never match (CIRISServer#235). A v2 announce carries the
+    // transport x25519; for a v1 (legacy) announce that doesn't, we fall back to
+    // the announce identity — those peers stay unattributable until they upgrade,
+    // exactly as before, but new peers now match.
     let announce_pubkey64: [u8; 64] = *announce.public_key();
-    // CIRISEdge#314 — the peer's transport identity hash (x25519 ‖ ed25519 →
-    // truncated identity hash), captured so the inbound-link→key_id attribution
-    // (`NodeEvent::LinkIdentified`) can match the link's PROVEN identity form-
-    // agnostically, rather than via the fragile named-dest recompute that missed
-    // on the named-vs-explicit split. Equals the link's `identity_hash` because
-    // both derive `Identity::from_public_keys(x25519, ed25519).hash()` from the
-    // same authenticated transport pubkeys. `[0u8; 16]` if the pubkey is
-    // malformed (that record was already crypto-verified upstream).
+    let transport_x25519 = attestation.transport_x25519_pubkey_bytes().ok().flatten();
+    // The binding pubkey used BOTH for the attribution hash and the #299
+    // write-through (so the persisted transport binding + KEX x25519 are the
+    // transport identity, not the federation one).
+    let binding_pubkey64: [u8; 64] = match transport_x25519 {
+        Some(x25519) => {
+            let mut id = [0u8; 64];
+            id[..32].copy_from_slice(&x25519); // x25519 (encryption) half
+            id[32..].copy_from_slice(&transport_pubkey); // ed25519 (signing) half
+            id
+        }
+        None => announce_pubkey64, // v1 announce — no transport x25519 carried
+    };
+    // The identity hash the link's LINKIDENTIFY proves:
+    // `truncated_hash(x25519 ‖ ed25519)`.
     let transport_identity_hash: [u8; 16] = {
-        let x25519: [u8; 32] = announce_pubkey64[..32].try_into().unwrap_or([0u8; 32]);
-        let ed25519: [u8; 32] = announce_pubkey64[32..].try_into().unwrap_or([0u8; 32]);
+        let x25519: [u8; 32] = binding_pubkey64[..32].try_into().unwrap_or([0u8; 32]);
+        let ed25519: [u8; 32] = binding_pubkey64[32..].try_into().unwrap_or([0u8; 32]);
         Identity::from_public_keys(&x25519, &ed25519).map_or([0u8; 16], |id| *id.hash())
     };
     let dest_hash16: [u8; 16] = (*announce.destination_hash()).into_bytes();
@@ -3510,19 +3533,17 @@ async fn resolve_announce_cold_start(
                 if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
                     peer_admitted_log().check(provenance_key)
                 {
-                    // CIRISEdge#317 disambiguator (CIRISServer#235) — is
-                    // `announce.public_key()` actually the TRANSPORT identity the
-                    // RNS link proves, or the FEDERATION announce identity? The
-                    // link-attribution match compares `transport_identity_hash`
-                    // (= truncated_hash(announce_pubkey64)) against the link's
-                    // proven `identity_hash`. If those bytes are a DIFFERENT
-                    // identity than the transport one, the match can never hold.
-                    // The conclusive test at admit: the ed25519 half of
-                    // `announce.public_key()` (what edge hashed) vs the
-                    // attestation's DECLARED transport ed25519. If they differ,
-                    // `announce.public_key()` is NOT the transport identity → an
-                    // identity-SOURCE split, and this line proves it without a
-                    // link miss (`announce_ed25519_half != attestation_transport_ed25519`).
+                    // CIRISEdge#317 — the stored `transport_identity_hash` is now
+                    // derived from the TRANSPORT identity (attestation x25519 ‖
+                    // ed25519) for a v2 announce (`transport_x25519_present=true`),
+                    // = exactly the identity the RNS link proves. `false` = a v1
+                    // (legacy) announce that carries no transport x25519, so admit
+                    // fell back to `announce.public_key()` (the federation
+                    // identity) and this peer stays unattributable until it
+                    // upgrades. `ed25519_halves_match` remains a diagnostic: it is
+                    // the announce identity's ed25519 half vs the attestation's
+                    // declared transport ed25519 — `false` confirms the federation-
+                    // vs-transport identity split the v2 binding fixes.
                     let announce_ed25519_half = hex::encode(&announce_pubkey64[32..]);
                     let attestation_transport_ed25519 = attestation
                         .transport_identity_pubkey_bytes()
@@ -3535,15 +3556,41 @@ async fn resolve_announce_cold_start(
                         epoch = attestation.epoch,
                         dest_hash = %hex::encode(resolved.dest_hash.into_bytes()),
                         transport_identity_hash = %hex::encode(transport_identity_hash),
-                        announce_pubkey64_hex = %hex::encode(announce_pubkey64),
+                        transport_x25519_present = transport_x25519.is_some(),
                         announce_ed25519_half = %announce_ed25519_half,
                         attestation_transport_ed25519 = %attestation_transport_ed25519,
                         ed25519_halves_match,
                         suppressed_prev,
-                        "peer_admitted — #317 disambiguator: ed25519_halves_match=false ⇒ \
-                         announce.public_key() is the FEDERATION identity, not the transport \
-                         one the link proves (identity-source split, CIRISServer#235)"
+                        "peer_admitted — #317: transport_identity_hash from \
+                         transport identity when transport_x25519_present=true \
+                         (matches the link); v1 fallback when false"
                     );
+                }
+                // CIRISEdge#318 — bound the peers map against advisory-admit
+                // pollution (an attacker minting unlimited self-signed keypairs,
+                // each admitting as a distinct `Advisory` entry). At cap, evict an
+                // Advisory binding before inserting a new key — NEVER a `Rooted`
+                // (accord-blessed, finite) binding for advisory churn. If the map
+                // is full of rooted peers (unrealistic — accord-bounded), the new
+                // entry is still admitted; the cap targets advisory growth only.
+                if !peers.contains_key(&key_id) && peers.len() >= MAX_PEERS {
+                    let evict = peers
+                        .iter()
+                        .find(|(_, rp)| {
+                            matches!(
+                                rp.provenance,
+                                ciris_persist::federation::self_at_login::BindingProvenance::Advisory
+                            )
+                        })
+                        .map(|(k, _)| k.clone());
+                    if let Some(evict) = evict {
+                        peers.remove(&evict);
+                        tracing::debug!(
+                            evicted = %evict,
+                            cap = MAX_PEERS,
+                            "peers map at cap — evicted an advisory binding (CIRISEdge#318)"
+                        );
+                    }
                 }
                 peers.insert(
                     key_id,
@@ -3567,8 +3614,11 @@ async fn resolve_announce_cold_start(
     // FederationDirectory-backed `RootingDirectory`; the write is a no-op
     // for non-directory impls (default trait method).
     if let Some(persisted_key) = newly_rooted_key {
+        // CIRISEdge#317 — persist the TRANSPORT identity (binding_pubkey64), not
+        // `announce.public_key()` (the federation identity), so the boot-reloaded
+        // binding resolves + seals to the identity the link proves.
         rooting
-            .persist_transport_binding(&persisted_key, dest_hash16, announce_pubkey64, provenance)
+            .persist_transport_binding(&persisted_key, dest_hash16, binding_pubkey64, provenance)
             .await;
     }
 }
@@ -3691,6 +3741,7 @@ fn hybrid_policy_accepts(policy: HybridPolicy, chain: &ProvenanceChain) -> bool 
 async fn build_local_attestation(
     signer: &LocalSigner,
     transport_identity_pubkey: &[u8; 32],
+    transport_x25519_pubkey: &[u8; 32],
     federation_key_id: &str,
     epoch: u64,
 ) -> Result<Vec<u8>, TransportError> {
@@ -3706,7 +3757,11 @@ async fn build_local_attestation(
         )));
     }
 
-    let payload = AttestationPayload::new(transport_identity_pubkey, federation_key_id, epoch);
+    // CIRISEdge#317 — bind the FULL transport identity (ed25519 ‖ x25519) so the
+    // receiver's admit computes `Identity::hash()` = exactly what the RNS link
+    // proves. v2 payload (distinct signature domain).
+    let payload = AttestationPayload::new(transport_identity_pubkey, federation_key_id, epoch)
+        .with_transport_x25519(transport_x25519_pubkey);
     let signature = signer
         .classical
         .sign(&payload.canonical_bytes())
@@ -3716,6 +3771,9 @@ async fn build_local_attestation(
     let attestation = AnnounceAttestation {
         transport_identity_pubkey: base64::engine::general_purpose::STANDARD
             .encode(transport_identity_pubkey),
+        transport_x25519_pubkey: Some(
+            base64::engine::general_purpose::STANDARD.encode(transport_x25519_pubkey),
+        ),
         federation_key_id: federation_key_id.to_string(),
         federation_pubkey_ed25519_base64: base64::engine::general_purpose::STANDARD
             .encode(&fed_pubkey),

--- a/tests/reticulum_av42.rs
+++ b/tests/reticulum_av42.rs
@@ -141,6 +141,7 @@ async fn av42_tampered_attestation_signature_fails_verify() {
 
     let genuine = AnnounceAttestation {
         transport_identity_pubkey: B64.encode(transport_pubkey),
+        transport_x25519_pubkey: None,
         federation_key_id: victim.key_id.clone(),
         federation_pubkey_ed25519_base64: B64.encode(victim_pubkey),
         epoch: 3,


### PR DESCRIPTION
**The delivery fix.** The v10.0.2 admit disambiguator + field RCA (CIRISServer#235) confirmed the #314/#317 attribution miss as a **federation-vs-transport identity split**: the announce advertised the node's **federation** identity, but the RNS link authenticates under the **transport** identity — same Ed25519 signing half, **different x25519** encryption half. So admit's `transport_identity_hash` could never match the link → `source_key_id=None` → CRPL dropped → 0 envelopes. leviculum ruled out a derivation gap (`compute_hash` already hashes the combined 64-byte), so the fix is to **carry the missing half**.

## #317 — announce binds the transport x25519
- **attestation.rs**: `AnnounceAttestation.transport_x25519_pubkey` (`Option`, v1 back-compat) + a **v2 signed payload** (distinct signature domain so v1/v2 can't cross-replay); `verify_signature` covers it (a swapped x25519 fails).
- **emit**: populate the x25519 from `local_transport_pubkey[..32]`.
- **admit**: reconstruct the transport identity `(x25519 ‖ ed25519)` → `Identity::hash()` = exactly what the link proves. The #299 write-through now persists the transport identity. v1 announces fall back to the old path (legacy peers unchanged; new peers match).
- Corrected the v10.0.2 disambiguator log (dropped the message-says-false contradiction).

## #318 — advisory-pollution memory-DoS bound
Cap the `peers` map (`MAX_PEERS=4096`); at cap, evict an **Advisory** binding before a new key — never a `Rooted` one.

## End-to-end
New peers: `source_key_id=Some` → CRPL routes → #312 responder answers → agent `resolve_peer_kex_pubkeys` → `Some` → **KEX PRESENT** → 2.9.7.

## Verification
New v2 attestation tests (round-trip + swap-rejection + v1/v2 domain-separation); 19 attestation + 7 reticulum tests pass; clippy `-D warnings` clean (default, reticulum, pyo3+reticulum).

Closes #317, #318. The delivery wheel — adopt into ciris-server, bundle #232, one floor bump → `safety_battery --federation-delivery`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)