### PR TITLE
feat(v11.0.0)!: CC cut — AggregationMetaV1 v3 multiplicity (#323, #325) + persist v16 revocation container (#326)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "10.1.2"
+version = "11.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v15.1.2", version = "15", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v16.0.0", version = "16", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -221,8 +221,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v15.1.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v9.0.2", version = "9", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v9.0.2", version = "9", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.1.0", version = "10", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.1.0", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -231,7 +231,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v9.0.2"
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v9.0.2", version = "9" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.1.0", version = "10" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v15.1.2", version = "15", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v16.0.0", version = "16", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=15.1.2,<16",
+    "ciris-persist>=16.0.0,<17",
 ]
 dynamic = ["version"]
 

--- a/src/holonomic/aggregation.rs
+++ b/src/holonomic/aggregation.rs
@@ -61,9 +61,10 @@
 
 // ── the canonical §19.7 shapes + verify gates (verify-owned) ──────────
 pub use ciris_verify_core::holonomic::aggregation::{
-    descend_order, effective_source_count, member_commitment, passes_dominance_gate,
-    verify_aggregation_meta, verify_member_commitment, AggregationMetaV1,
-    AggregationMetaVerification,
+    descend_order, effective_source_count, mass_commitment, mass_to_fixed, member_commitment,
+    passes_dominance_gate, passes_multiplicity_gate, verify_aggregation_meta,
+    verify_member_commitment, AggregationMetaV1, AggregationMetaVerification,
+    MASS_FIXED_POINT_SCALE,
 };
 pub use ciris_verify_core::holonomic::preimage::DOMAIN_AGG_META as AGG_META_DOMAIN;
 
@@ -81,6 +82,13 @@ pub const AGG_META_VERSION: u32 = 1;
 /// trailing big-endian `u32(n_eff)` in the signed preimage. What
 /// [`assemble_tier_meta_v2`] emits.
 pub const AGG_META_VERSION_V2: u32 = 2;
+
+/// §19.7.1.3 schema version (CIRISVerify#191 / CC 6.1.2.1.2 R9): the v2 layout
+/// plus a trailing `u32(max_source_multiplicity) ‖ mass_commitment[32]` in the
+/// signed preimage. What [`assemble_tier_meta_v3`] emits — the **go-forward**
+/// version: persist ≥ 16 fail-closes any tier below v3 at `put_aggregated_tier`
+/// (the flag-day cut; no deprecation window).
+pub const AGG_META_VERSION_V3: u32 = 3;
 
 /// §19.7.1.2 producer side (CIRISEdge#267): assemble a **version-2** tier meta
 /// from the per-member source ids and content masses — computing
@@ -137,6 +145,85 @@ pub fn assemble_tier_meta_v2(
         member_commitment: member_commitment(source_member_ids),
         noise_floor_descriptor: noise_floor_descriptor.to_string(),
         n_eff: effective_source_count(member_masses),
+        // CIRISVerify#191 v3 fields — NEUTRAL and UNSIGNED at v2: the signing
+        // preimage appends them only iff `version >= 3`, so a v2 tier's bytes
+        // (and its golden vectors) are untouched. A v2 tier fails
+        // `passes_multiplicity_gate` closed by construction — that is the
+        // flag-day cut, not a regression. Use `assemble_tier_meta_v3` to
+        // produce a tier that persist >= 16 will admit.
+        max_source_multiplicity: 0,
+        mass_commitment: [0u8; 32],
+    }
+}
+
+/// §19.7.1.3 (CIRISVerify#191 / CC 6.1.2.1.2 R9) — assemble a **v3** tier meta:
+/// the v2 surface plus the *measured* content-similarity multiplicity and the
+/// auditable mass commitment. **This is the go-forward producer**: persist ≥ 16
+/// enforces `passes_dominance_gate` AND `passes_multiplicity_gate` at
+/// `put_aggregated_tier`, and a pre-v3 tier **fails closed** at every peer.
+///
+/// `member_masses` + `max_source_multiplicity` come from the fold —
+/// `realtime_av_codec::fountain::content_multiplicity` (behind the codec
+/// feature), the only point in the pipeline holding member payloads. Pass its
+/// `ContentMultiplicity` fields straight through. The masses are a *measured*
+/// output (each member's share of content energy), so `n_eff` and
+/// `mass_commitment` are both auditable: an auditor holding the members
+/// recomputes this root and can prove a lying `n_eff` or multiplicity.
+///
+/// The gate persist applies is `max_source_multiplicity · n_min <= source_count`
+/// (`n_min` corpus-pinned persist-side, default 2) — so a fold whose largest
+/// near-duplicate cluster exceeds half the members is rejected. The 900/1000
+/// near-duplicate fold that v2 admitted (`n_eff == 1000`, honestly) is rejected
+/// here.
+///
+/// # Panics
+///
+/// If `source_member_ids` and `member_masses` lengths differ, or the fan-in
+/// exceeds `u32::MAX`.
+#[must_use]
+// The §19.7.1.3 producer is a composition site for the full signed tier surface
+// (identity + fan-in + the two measured v3 fields); grouping them into a struct
+// would just move the arity, and every field is independently supplied by the
+// caller's fold. Mirrors `assemble_tier_meta_v2`.
+#[allow(clippy::too_many_arguments)]
+pub fn assemble_tier_meta_v3(
+    content_id: &str,
+    corpus_kind: &str,
+    tier: u32,
+    aggregation_algorithm_id: &str,
+    source_member_ids: &[String],
+    member_masses: &[f64],
+    max_source_multiplicity: u32,
+    noise_floor_descriptor: &str,
+) -> AggregationMetaV1 {
+    assert_eq!(
+        source_member_ids.len(),
+        member_masses.len(),
+        "source_member_ids and measured member_masses must be index-aligned"
+    );
+    let source_count =
+        u32::try_from(source_member_ids.len()).expect("tier fan-in exceeds u32 wire range");
+
+    // §19.7.1.3 mass commitment: Merkle root over (member_id, fixed-point mass),
+    // pinned at MASS_FIXED_POINT_SCALE = 1e6 verify-side.
+    let mass_leaves: Vec<(String, u64)> = source_member_ids
+        .iter()
+        .cloned()
+        .zip(member_masses.iter().map(|m| mass_to_fixed(*m)))
+        .collect();
+
+    AggregationMetaV1 {
+        version: AGG_META_VERSION_V3,
+        content_id: content_id.to_string(),
+        corpus_kind: corpus_kind.to_string(),
+        tier,
+        aggregation_algorithm_id: aggregation_algorithm_id.to_string(),
+        source_count,
+        member_commitment: member_commitment(source_member_ids),
+        noise_floor_descriptor: noise_floor_descriptor.to_string(),
+        n_eff: effective_source_count(member_masses),
+        max_source_multiplicity,
+        mass_commitment: mass_commitment(&mass_leaves),
     }
 }
 
@@ -169,6 +256,11 @@ mod tests {
             // Neutral placeholder on a v1 tier — NOT in the v1 preimage
             // (asserted below), NOT accepted by passes_dominance_gate.
             n_eff: 3,
+            // §19.7.1.3 (#191): likewise neutral + un-signed at v1 — appended to
+            // the preimage only iff version >= 3, so the v1 golden bytes below
+            // stay byte-identical.
+            max_source_multiplicity: 0,
+            mass_commitment: [0u8; 32],
         }
     }
 
@@ -400,6 +492,96 @@ mod tests {
             m.signing_preimage(),
             base,
             "n_eff must affect the v2 preimage (§19.7.1.2 signed dominance surface)"
+        );
+    }
+
+    // ── §19.7.1.3 v3 producer (CIRISEdge#325 / CIRISVerify#191) ──────────
+
+    /// The persist-side gate, mirrored: `max_source_multiplicity * n_min <=
+    /// source_count`, `n_min` default 2 (`multiplicity_n_min_for`).
+    const N_MIN: u32 = 2;
+
+    /// The dominance-gate floor: `n_eff / source_count >= min_ratio`. Both the
+    /// balanced fold AND the R9 near-duplicate fold score 1.0 here — which is
+    /// precisely why the mass gate alone cannot see R9.
+    const DOMINANCE_MIN_RATIO: f64 = 0.5;
+
+    /// A v3 tier from a BALANCED fold (mutually distinct members, multiplicity
+    /// 1) carries the signed v3 surface and is ADMITTED by both gates.
+    #[test]
+    fn v3_meta_from_balanced_fold_passes_both_gates() {
+        let ids: Vec<String> = (0..10).map(|i| format!("src-{i:03}")).collect();
+        let masses = vec![0.1_f64; 10]; // balanced
+        let meta = assemble_tier_meta_v3(
+            "content-v3",
+            "trace",
+            2,
+            "raptorq-pyramid-v1",
+            &ids,
+            &masses,
+            1, // measured multiplicity: distinct members
+            "mean+stddev",
+        );
+        assert_eq!(meta.version, AGG_META_VERSION_V3);
+        assert_eq!(meta.max_source_multiplicity, 1);
+        assert_ne!(meta.mass_commitment, [0u8; 32], "mass commitment is bound");
+        assert!(
+            passes_dominance_gate(&meta, DOMINANCE_MIN_RATIO),
+            "balanced fold: dominance ok"
+        );
+        assert!(
+            passes_multiplicity_gate(&meta, N_MIN),
+            "balanced fold: multiplicity ok (1*2 <= 10)"
+        );
+    }
+
+    /// THE R9 CASE end-to-end: 900 near-duplicates in a 1000-member fold. The
+    /// masses are HONEST (all equal ⇒ `n_eff == 1000`), so the v2 dominance gate
+    /// ADMITS — but the measured multiplicity (900) makes the v3 gate REJECT.
+    /// This is exactly the residual CIRISVerify#191 closes.
+    #[test]
+    fn v3_meta_rejects_the_900_near_duplicate_fold_the_mass_gate_admits() {
+        let ids: Vec<String> = (0..1000).map(|i| format!("src-{i:04}")).collect();
+        let masses = vec![0.001_f64; 1000]; // equal mass — honest n_eff == 1000
+        let meta = assemble_tier_meta_v3(
+            "content-r9",
+            "trace",
+            2,
+            "raptorq-pyramid-v1",
+            &ids,
+            &masses,
+            900, // measured at fold: the near-duplicate cluster
+            "mean+stddev",
+        );
+        assert_eq!(meta.n_eff, 1000, "the mass gate sees an honest n_eff");
+        assert!(
+            passes_dominance_gate(&meta, DOMINANCE_MIN_RATIO),
+            "the v2 mass gate ADMITS this fold — that is the R9 residual"
+        );
+        assert!(
+            !passes_multiplicity_gate(&meta, N_MIN),
+            "the v3 multiplicity gate REJECTS it (900*2 > 1000)"
+        );
+    }
+
+    /// A v2 tier lacks the v3 surface and FAILS CLOSED at the multiplicity gate
+    /// — the flag-day cut (persist >= 16 rejects it at every peer).
+    #[test]
+    fn v2_meta_fails_closed_at_the_multiplicity_gate() {
+        let ids = fixed_source_ids();
+        let meta = assemble_tier_meta_v2(
+            "content-v2",
+            "trace",
+            2,
+            "raptorq-pyramid-v1",
+            &ids,
+            &[0.33, 0.33, 0.34],
+            "mean+stddev",
+        );
+        assert_eq!(meta.version, AGG_META_VERSION_V2);
+        assert!(
+            !passes_multiplicity_gate(&meta, N_MIN),
+            "a pre-v3 tier must fail closed (no deprecation window)"
         );
     }
 }

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -552,10 +552,21 @@ impl FederationDirectoryReplicationBridge {
                 Some((serde_json::to_vec(&wire).ok()?, hash, seq))
             }
             ReplicatedKind::IdentityOccurrenceRevocation => {
-                let hash = Self::decode_hash(canonical_json.get("persist_row_hash")?.as_str()?)?;
-                let seq = Self::ms_seq_from(canonical_json.get("revoked_at"));
-                let wire = serde_json::json!({ "identity_occurrence_revocation": canonical_json });
-                Some((serde_json::to_vec(&wire).ok()?, hash, seq))
+                // CIRISEdge#326 / CIRISPersist#421 (persist v16) — the revocation
+                // kind is now the SIGNED CONTAINER (`{identity_occurrence_revocation,
+                // attesting_key_id, signed_envelope, signature}`), the same #418
+                // discipline as IdentityOccurrence — NOT a bare row. It is
+                // re-published BYTE-EXACT: edge holds the transport signer, not
+                // the identity key, so it can neither re-sign nor synthesize the
+                // signature — only re-wrap what was signed-put. (Pre-v16 this arm
+                // re-wrapped a bare row; against v16 that would double-wrap it,
+                // AND reading `persist_row_hash` at the top level now misses — it
+                // is nested — which would silently drop every revocation from the
+                // wire.)
+                let inner = canonical_json.get("identity_occurrence_revocation")?;
+                let hash = Self::decode_hash(inner.get("persist_row_hash")?.as_str()?)?;
+                let seq = Self::ms_seq_from(inner.get("revoked_at"));
+                Some((serde_json::to_vec(canonical_json).ok()?, hash, seq))
             }
             // `#[non_exhaustive]` — a kind edge doesn't yet adapt is skipped
             // (not advertised) rather than emitted in an unknown wire shape.
@@ -1847,6 +1858,45 @@ mod tests {
         assert_eq!(v["record"]["key_id"], "k1", "re-wrapped to SignedKeyRecord");
         // Wire identity == decoded persist_row_hash (stable across versions).
         assert_eq!(hex::encode(hash), prh, "hash stays persist_row_hash");
+    }
+
+    /// CIRISEdge#326 / CIRISPersist#421 (persist v16) — the revocation kind is a
+    /// SIGNED CONTAINER, re-published byte-exact (edge can't re-sign). Fences the
+    /// SILENT break: pre-v16 this arm read `persist_row_hash` at the top level
+    /// and re-wrapped a bare row; against v16's container that lookup misses, so
+    /// `adapt_record` would return `None` and every revocation would vanish from
+    /// the wire with no compile error (the engine speaks `serde_json::Value`).
+    #[test]
+    fn adapt_record_revocation_is_the_signed_container_republished_byte_exact() {
+        let prh = "cd".repeat(32); // 64 hex chars → 32 bytes
+        let container = serde_json::json!({
+            "identity_occurrence_revocation": {
+                "occurrence_key_id": "occ-1",
+                "persist_row_hash": prh,
+                "revoked_at": "2026-07-12T00:00:00Z",
+            },
+            "attesting_key_id": "signer-1",
+            "signed_envelope": { "kind": "identity_occurrence_revocation" },
+            "signature": "sig-b64",
+        });
+        let (bytes, hash, _seq) = FederationDirectoryReplicationBridge::adapt_record(
+            ReplicatedKind::IdentityOccurrenceRevocation,
+            &container,
+        )
+        .expect("adapt signed revocation container");
+
+        // Emitted BYTE-EXACT — the signature container survives (not double-wrapped).
+        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("wire json");
+        assert_eq!(v["signature"], "sig-b64", "signature preserved");
+        assert_eq!(v["attesting_key_id"], "signer-1");
+        assert!(
+            v.get("identity_occurrence_revocation")
+                .and_then(|r| r.get("identity_occurrence_revocation"))
+                .is_none(),
+            "must NOT be double-wrapped"
+        );
+        // Hash read from the NESTED row, not the top level.
+        assert_eq!(hex::encode(hash), prh);
     }
 
     // ── v10 — per-record dynamic policy for the scores/Attestation plane ──

--- a/src/transport/realtime_av_codec/fountain.rs
+++ b/src/transport/realtime_av_codec/fountain.rs
@@ -57,6 +57,8 @@
 //! - `< min_viable_symbols` → hard refusal via
 //!   [`FountainError::InsufficientSymbols`].
 
+use std::collections::HashMap;
+
 use sha2::{Digest, Sha256};
 
 #[cfg(feature = "codec-fountain")]
@@ -639,6 +641,182 @@ pub fn aggregate_symbols(members: &[&[u8]], op: AggregateOp) -> Result<Composite
     })
 }
 
+// ─── §19.7.1.3 content-similarity multiplicity (CIRISEdge#323 / CIRISVerify#191)
+//
+// The CC 6.1.2.1.2 R9 residual: 900 near-duplicate contents folded as 900
+// *distinct members at equal mass* honestly compute `n_eff == 1000` and pass the
+// v2 mass-dominance gate — yet the composite blur IS the data subject (a false
+// erasure certificate). The mass gate cannot see this: `member_commitment` is a
+// Merkle root over member *ids* and is blind to content by construction.
+//
+// The fold is the ONLY point in the pipeline holding member payloads, so edge
+// measures the multiplicity here and signs it into `AggregationMetaV1` v3.
+
+/// The fixed-point scale for the pinned similarity threshold (milli-units).
+/// Integer/fixed-point throughout: the clustering feeds a SIGNED wire field, so
+/// it must be bit-deterministic across platforms — no `f64` in the decision path.
+const SIMILARITY_SCALE_MILLI: u64 = 1000;
+
+/// **Normative producer pin** (CIRISVerify#191 / CC 6.1.2 `(R, ε)`): the
+/// per-`corpus_kind` content-similarity threshold above which two members count
+/// as near-duplicates, in milli-units (`950` = 0.950).
+///
+/// The metric is `1 − normalized L1 distance` over the resampled payloads (see
+/// [`members_are_similar`]). Calibration: byte-identical members score `1.000`;
+/// near-duplicates (small perturbations) score `≥ 0.99`; independent
+/// high-entropy members score `≈ 0.667` (mean |Δ| of uniform bytes ≈ 85/255).
+/// `0.950` separates those populations with wide margin.
+///
+/// **This pin is wire-affecting** — it determines a signed field, so a producer
+/// that changes it forks the multiplicity any verifier recomputes from held
+/// evidence. Keep it in lockstep with the CC 6.1.2 conformance fixture; add
+/// per-`corpus_kind` arms here (one place) rather than at call sites.
+#[must_use]
+pub fn multiplicity_similarity_threshold_milli(corpus_kind: &str) -> u64 {
+    // Per-`corpus_kind` arms belong HERE (the single source of truth), e.g.
+    //   "audio/pcm16" => 970,
+    // Until a kind pins its own (R, ε), every corpus takes the default.
+    let _ = corpus_kind;
+    950
+}
+
+/// The §19.7.1.3 surface measured at fold time — what a producer needs to
+/// populate `AggregationMetaV1` v3 (CIRISEdge#325).
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContentMultiplicity {
+    /// Per-member content mass, index-aligned with the input members and
+    /// summing to `1.0`: each member's share of total content energy, measured
+    /// as its normalized L1 norm over the resample basis. This makes the masses
+    /// a **measured output of the fold**, not the aggregator's own accounting —
+    /// so `n_eff` (inverse-Simpson over these) and `mass_commitment` are both
+    /// auditable from held evidence.
+    pub member_masses: Vec<f64>,
+    /// The size of the largest cluster of members whose pairwise content
+    /// similarity exceeds the `corpus_kind`-pinned threshold. `1` for a fold of
+    /// mutually-distinct members; `≈ N_dup` when `N_dup` near-duplicates are
+    /// folded under distinct ids.
+    pub max_source_multiplicity: u32,
+}
+
+/// Are two equal-length resampled members near-duplicates under the pinned
+/// threshold? `similarity = 1 − (Σ|a_i − b_i|) / (255 · len)`, evaluated
+/// entirely in integer space:
+///
+/// `similarity > threshold  ⟺  SCALE · Σ|Δ|  <  (SCALE − threshold_milli) · 255 · len`
+#[must_use]
+fn members_are_similar(a: &[u8], b: &[u8], threshold_milli: u64) -> bool {
+    debug_assert_eq!(a.len(), b.len(), "similarity compares resampled members");
+    if a.is_empty() {
+        return true;
+    }
+    let l1: u64 = a
+        .iter()
+        .zip(b.iter())
+        .map(|(x, y)| u64::from(x.abs_diff(*y)))
+        .sum();
+    let slack = SIMILARITY_SCALE_MILLI.saturating_sub(threshold_milli);
+    let bound = slack * 255 * a.len() as u64;
+    SIMILARITY_SCALE_MILLI * l1 < bound
+}
+
+/// Measure the §19.7.1.3 content multiplicity + per-member masses from the
+/// member payloads (CIRISEdge#323). Members are nearest-neighbor resampled to
+/// the max member length — the SAME normalization [`aggregate_symbols`] applies
+/// — so similarity is measured on exactly the content the fold collapsed.
+///
+/// **Clustering**: the largest **connected component** of the similarity graph
+/// (union-find, `O(N²)` pairwise — acceptable at the fan-ins §19.7 folds carry;
+/// an LSH/simhash prefilter is the escape hatch if it ever isn't). This is a
+/// deliberate *conservative superset* of the max-clique reading: a component's
+/// members are transitively similar, so this can only ever **over**-estimate the
+/// multiplicity — which only ever **tightens** `passes_multiplicity_gate`. The
+/// fail-safe direction for a privacy gate (and max-clique is NP-hard).
+///
+/// Deterministic: byte-equal inputs yield an identical result on every platform
+/// (integer-only decision path), as required of a signed wire field.
+///
+/// # Errors
+/// Same preconditions as [`aggregate_symbols`]: [`AggregateError::NoMembers`],
+/// [`AggregateError::EmptyMember`], [`AggregateError::TooManyMembers`].
+pub fn content_multiplicity(
+    members: &[&[u8]],
+    corpus_kind: &str,
+) -> Result<ContentMultiplicity, AggregateError> {
+    if members.is_empty() {
+        return Err(AggregateError::NoMembers);
+    }
+    if let Some(idx) = members.iter().position(|m| m.is_empty()) {
+        return Err(AggregateError::EmptyMember(idx));
+    }
+    let n = members.len();
+    u32::try_from(n).map_err(|_| AggregateError::TooManyMembers(n))?;
+
+    // Same resample basis as the fold — similarity must be measured on the
+    // content that was actually collapsed.
+    let max_len = members.iter().map(|m| m.len()).max().unwrap_or(1);
+    let resampled: Vec<Vec<u8>> = members
+        .iter()
+        .map(|m| resample_nearest(m, max_len))
+        .collect();
+
+    // Per-member masses: normalized L1 norm (content energy share). The sums are
+    // exact u64; the f64 conversion produces a VALUE (a mass fraction), never a
+    // decision — the clustering that feeds the signed multiplicity is
+    // integer-only (see `members_are_similar`). Masses are in turn committed via
+    // the fixed-point `mass_to_fixed` (1e6) before signing, so the wire is not
+    // f64-sensitive either.
+    #[allow(clippy::cast_precision_loss)]
+    let member_masses: Vec<f64> = {
+        let norms: Vec<u64> = resampled
+            .iter()
+            .map(|m| m.iter().map(|b| u64::from(*b)).sum())
+            .collect();
+        let total: u64 = norms.iter().sum();
+        if total == 0 {
+            // All-zero payloads: fall back to a uniform (balanced) mass split so
+            // n_eff reflects the honest fan-in rather than dividing by zero.
+            vec![1.0 / n as f64; n]
+        } else {
+            norms.iter().map(|w| *w as f64 / total as f64).collect()
+        }
+    };
+
+    // Similarity graph → largest connected component (union-find).
+    let threshold_milli = multiplicity_similarity_threshold_milli(corpus_kind);
+    let mut parent: Vec<usize> = (0..n).collect();
+    for i in 0..n {
+        for j in (i + 1)..n {
+            if members_are_similar(&resampled[i], &resampled[j], threshold_milli) {
+                let (ri, rj) = (uf_find(&mut parent, i), uf_find(&mut parent, j));
+                if ri != rj {
+                    parent[ri] = rj;
+                }
+            }
+        }
+    }
+    let mut sizes: HashMap<usize, u32> = HashMap::new();
+    for i in 0..n {
+        let root = uf_find(&mut parent, i);
+        *sizes.entry(root).or_insert(0) += 1;
+    }
+    let max_source_multiplicity = sizes.values().copied().max().unwrap_or(1);
+
+    Ok(ContentMultiplicity {
+        member_masses,
+        max_source_multiplicity,
+    })
+}
+
+/// Union-find root with path-halving — the clustering primitive for
+/// [`content_multiplicity`]'s connected-component pass.
+fn uf_find(parent: &mut [usize], mut x: usize) -> usize {
+    while parent[x] != x {
+        parent[x] = parent[parent[x]];
+        x = parent[x];
+    }
+    x
+}
+
 /// Canonical per-member residual-fidelity measure for the §19.7
 /// aggregation-erasure gate (CIRISEdge#266): the fraction of
 /// byte-exact matches between the member (nearest-neighbor resampled
@@ -1214,5 +1392,114 @@ mod tests {
         assert_eq!(AggregateOp::Mean.algorithm_id(), "fountain-mean-v1");
         assert_eq!(AggregateOp::Decimate.algorithm_id(), "fountain-decimate-v1");
         assert_eq!(AggregateOp::Mipmap.algorithm_id(), "fountain-mipmap-v1");
+    }
+
+    // ── §19.7.1.3 content multiplicity (CIRISEdge#323 / CIRISVerify#191) ──
+
+    /// Deterministic LCG — distinct high-entropy members without a rand dep.
+    fn pseudo_member(seed: u64, len: usize) -> Vec<u8> {
+        let mut s = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        (0..len)
+            .map(|_| {
+                s = s
+                    .wrapping_mul(6_364_136_223_846_793_005)
+                    .wrapping_add(1_442_695_040_888_963_407);
+                (s >> 33) as u8
+            })
+            .collect()
+    }
+
+    /// THE R9 CASE: 900 near-duplicates under distinct ids + 100 genuinely
+    /// distinct members. The v2 mass gate sees `n_eff == 1000` (honest — all
+    /// equal mass) and admits; the content-similarity multiplicity sees the
+    /// blur. `max_source_multiplicity >= 900` ⇒ `900 * n_min(2) > 1000` ⇒
+    /// `passes_multiplicity_gate` REJECTS.
+    #[test]
+    fn content_multiplicity_detects_the_900_near_duplicate_fold() {
+        let base = pseudo_member(7, 64);
+        // 900 near-duplicates: the same content, one byte nudged by ±1 — far
+        // inside the 0.95 threshold (similarity ≈ 0.9999).
+        let mut owned: Vec<Vec<u8>> = (0..900)
+            .map(|i| {
+                let mut m = base.clone();
+                m[i % 64] = m[i % 64].wrapping_add(1);
+                m
+            })
+            .collect();
+        // 100 genuinely distinct members.
+        owned.extend((0..100).map(|i| pseudo_member(1000 + i, 64)));
+        let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+
+        let m = content_multiplicity(&refs, "test/corpus").expect("multiplicity");
+        assert!(
+            m.max_source_multiplicity >= 900,
+            "the 900-near-duplicate cluster must surface (got {})",
+            m.max_source_multiplicity
+        );
+        // And that value fails the persist gate (n_min = 2): 900*2 > 1000.
+        assert!(
+            u64::from(m.max_source_multiplicity) * 2 > refs.len() as u64,
+            "the R9 fold must fail passes_multiplicity_gate"
+        );
+    }
+
+    /// A balanced fold of mutually-distinct members collapses to multiplicity 1
+    /// — and passes the gate (1 * 2 <= N).
+    #[test]
+    fn content_multiplicity_balanced_distinct_members_is_one() {
+        let owned: Vec<Vec<u8>> = (0..64).map(|i| pseudo_member(i, 64)).collect();
+        let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+
+        let m = content_multiplicity(&refs, "test/corpus").expect("multiplicity");
+        assert_eq!(
+            m.max_source_multiplicity, 1,
+            "distinct members must not cluster"
+        );
+        assert!(u64::from(m.max_source_multiplicity) * 2 <= refs.len() as u64);
+        // Masses are measured, index-aligned, and sum to 1.
+        assert_eq!(m.member_masses.len(), refs.len());
+        let total: f64 = m.member_masses.iter().sum();
+        assert!(
+            (total - 1.0).abs() < 1e-9,
+            "masses must sum to 1 (got {total})"
+        );
+    }
+
+    /// The multiplicity feeds a SIGNED wire field — byte-equal inputs must
+    /// produce a byte-equal result (integer-only decision path).
+    #[test]
+    fn content_multiplicity_is_deterministic() {
+        let owned: Vec<Vec<u8>> = (0..32)
+            .map(|i| {
+                if i < 20 {
+                    pseudo_member(3, 48)
+                } else {
+                    pseudo_member(100 + i, 48)
+                }
+            })
+            .collect();
+        let refs: Vec<&[u8]> = owned.iter().map(Vec::as_slice).collect();
+
+        let a = content_multiplicity(&refs, "test/corpus").expect("a");
+        let b = content_multiplicity(&refs, "test/corpus").expect("b");
+        assert_eq!(a, b, "identical inputs must yield an identical surface");
+        // 20 byte-identical members cluster.
+        assert!(a.max_source_multiplicity >= 20);
+    }
+
+    /// Identical members are maximally similar; independent high-entropy
+    /// members fall well below the pinned threshold — the separation the
+    /// 0.95 pin relies on.
+    #[test]
+    fn similarity_separates_duplicates_from_distinct_members() {
+        let a = pseudo_member(11, 128);
+        let b = a.clone();
+        let c = pseudo_member(12, 128);
+        let t = multiplicity_similarity_threshold_milli("test/corpus");
+        assert!(members_are_similar(&a, &b, t), "identical → similar");
+        assert!(
+            !members_are_similar(&a, &c, t),
+            "independent high-entropy members must NOT cluster"
+        );
     }
 }

--- a/tests/conformance_vectors_v19_7.rs
+++ b/tests/conformance_vectors_v19_7.rs
@@ -89,6 +89,10 @@ fn vector_aggregation_meta_canonical_bytes_three_source_pyramid() {
         // placeholder — the v1 preimage below MUST be byte-identical to the
         // pre-#167 layout regardless of this value.
         n_eff: 3,
+        // §19.7.1.3 (#191): same discipline — appended to the preimage only iff
+        // version >= 3, so the v1 golden vector stays byte-identical.
+        max_source_multiplicity: 0,
+        mass_commitment: [0u8; 32],
     };
     let vector = AggregationMetaCanonicalVector {
         vector_id: "aggregation_meta/canonical_bytes".to_string(),


### PR DESCRIPTION
**BREAKING** — adopts CIRISPersist **v16.0.0** + CIRISVerify **v10.1.0** (both majors). Closes the CC 6.1.2.1.2 **R9** residual.

## #323 — content-similarity multiplicity, measured at fold time
900 near-duplicate contents folded as 900 *distinct* members at equal mass **honestly** compute `n_eff == 1000` and **pass** the v2 mass-dominance gate — yet the composite blur IS the data subject (a false erasure certificate). `member_commitment` is a Merkle over member *ids*, blind to content by construction; the fold is the only point holding member payloads.

New `fountain::content_multiplicity(members, corpus_kind)`:
- **Metric**: `1 − normalized L1 distance` on the resampled payloads, evaluated **entirely in integer/fixed-point** — this feeds a **signed** wire field, so the decision path must be bit-deterministic across platforms (no `f64`). Identical → `1.000`; near-duplicates → `≥0.99`; independent high-entropy → `≈0.667`. The `0.950` pin separates them with wide margin. (Cosine would be wrong: byte vectors are all-positive, so even distinct members score ~0.75.)
- **Clustering**: largest **connected component** (union-find, O(N²)) — a deliberate *conservative superset* of max-clique (NP-hard). It can only **over**-estimate multiplicity, which only ever **tightens** the privacy gate. Fail-safe direction.
- **Masses** are now a *measured* output of the fold (content-energy share), not the aggregator's own accounting — so `n_eff` and `mass_commitment` are auditable from held evidence.
- `multiplicity_similarity_threshold_milli(corpus_kind)` is the single **normative, wire-affecting** producer pin — keep it in lockstep with the CC 6.1.2 conformance fixture.

## #325 — AggregationMetaV1 v3
- `assemble_tier_meta_v3` (`version = 3`) binds `max_source_multiplicity` + `mass_commitment` (Merkle over `(member_id, mass_to_fixed(mass))`, 1e6 scale).
- `assemble_tier_meta_v2` keeps the v3 fields **neutral + unsigned** — the preimage appends them only iff `version >= 3`, so **v1/v2 goldens stay byte-identical** (proven: `conformance_vectors_v19_7` green, untouched).
- A pre-v3 tier **fails closed** at `passes_multiplicity_gate` — the flag-day cut.

## #326 — persist v16 revocation container (a SILENT break, now fenced)
`SignedIdentityOccurrenceRevocation` is now the #418 signed container, and `list_signed_records` returns it. The #311 engine speaks `serde_json::Value`, so the old bare-row arm **compiled fine** but would read `persist_row_hash` at the top level (now nested) → `adapt_record` returns `None` → **every revocation silently vanishes from the wire**. Now re-published **byte-exact** (edge holds the transport signer, not the identity key — it can only re-wrap what was signed-put). Regression-tested.

## Verification
- **623 lib tests** — incl. the R9 case end-to-end (mass gate **admits**, multiplicity gate **rejects**), balanced fold passes both, v2 fails closed, determinism, and the revocation byte-exact republish.
- **6 conformance vectors** — v1 goldens byte-untouched.
- clippy `-D warnings` clean: default, codec-fountain+reticulum, pyo3+reticulum.

Closes #323, #325, #326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)