### PR TITLE
chore(v11.1.2): re-pin persist v16.1.1 + correct the similarity-pin doc (CIRISConstitution#35)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "11.1.1"
+version = "11.1.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,7 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v16.1.0", version = "16", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v16.1.1", version = "16", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1078,7 +1078,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v16.1.0", version = "16", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v16.1.1", version = "16", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=16.1.0,<17",
+    "ciris-persist>=16.1.1,<17",
 ]
 dynamic = ["version"]
 

--- a/src/holonomic/multiplicity.rs
+++ b/src/holonomic/multiplicity.rs
@@ -84,10 +84,23 @@ pub fn resample_nearest(src: &[u8], dst_len: usize) -> Vec<u8> {
 /// would be wrong here: byte vectors are all-positive, so even independent
 /// members score ≈ 0.75.)
 ///
-/// **This pin is wire-affecting** — it determines a signed field, so a producer
-/// that changes it forks the multiplicity any verifier recomputes from held
-/// evidence. Keep it in lockstep with the CC 6.1.2 conformance fixture; add
-/// per-`corpus_kind` arms HERE (one place) rather than at call sites.
+/// # ⚠️ This pin is wire-affecting AND currently UNGOVERNED
+///
+/// It determines a **signed** field (`max_source_multiplicity`), and persist
+/// gates admissibility on it — so a divergence here is not a cosmetic mismatch,
+/// it is a **fork in admissibility**: one substrate admits a fold another
+/// rejects, both with valid signatures.
+///
+/// CC pins **nothing** for this metric or threshold today (CIRISConstitution#35
+/// asks it to). Note it is a *distinct axis* from CC 6.1.2's `(R, ε)`, which is
+/// the **reconstruction** predicate ("can this item be individually recovered")
+/// — NOT similarity between members. The `(R, ε)` fixture
+/// (`test_540_noise_floor.py`) does not measure this and cannot confirm it.
+///
+/// So do **not** treat this const as free to tune: until CC pins it, cross-impl
+/// agreement is coincidence rather than conformance. Change it only in lockstep
+/// with CIRISConstitution#35, and add per-`corpus_kind` arms HERE (one place)
+/// rather than at call sites.
 #[must_use]
 pub fn multiplicity_similarity_threshold_milli(corpus_kind: &str) -> u64 {
     // Per-`corpus_kind` arms belong HERE (the single source of truth), e.g.


### PR DESCRIPTION
## Pin — pure currency
**CIRISPersist v16.1.1** (#389 / CIRISServer#243): blanket-revoke semantics for `resolve_scoped_consent` — a scope-less `consent:state:revoked` is BLANKET (the CC 4.5.13 fail-closed reading), so persist's fold is now a strict superset of the server's and the server deletes its copy. Same-major, additive; edge doesn't consume it. No API change.

## Correcting a doc we now know is wrong

CIRISConformance#76's pin reconciliation (from someone who can actually see the fixture) established two things edge's doc had backwards:

1. **`(R, ε)` is a different axis.** CC 6.1.2's `(R, ε)` is the **reconstruction** predicate — "can this item be individually recovered above fidelity ε" (default: the fountain symbol-count classifier). It is *not* similarity between members. The `(R, ε)` fixture (`test_540_noise_floor.py`) has **zero** occurrences of similarity/L1/cosine/threshold/cluster — it cannot confirm this pin, because it doesn't measure it. Edge's doc told maintainers to "keep it in lockstep with the CC 6.1.2 conformance fixture" — pointing them at a fixture that says nothing about it.

2. **The pin is ungoverned.** The similarity metric + threshold are an edge-chosen const with no normative backing, deciding a **signed** field (`max_source_multiplicity`) that persist gates admissibility on. That is exactly what CC forbids of `min_ratio`: *"not an implementation-tunable knob (two conformant substrates MUST NOT disagree on which folds are admissible)"*. A divergence isn't cosmetic — it's a **fork in admissibility**, one substrate admitting a fold another rejects, both with valid signatures. Until CC pins it, cross-impl agreement is **coincidence, not conformance**.

The doc now says exactly that and points at **CIRISConstitution#35**, which asks CC to pin the metric / threshold / clustering / resample basis / `n_min` / mass scale as CEG-pinned constants — **edge's values verbatim** (they're calibrated and reproduce verify's authored v3 vector byte-for-byte; they need to become *normative* rather than *emergent*).

## Verification
682 lib + 9 conformance-vector tests pass; clippy `-D warnings` clean (default, reticulum, pyo3+reticulum+codec).

Refs CIRISConstitution#35, CIRISConformance#76/#74/#71, CIRISPersist#389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)