### PR TITLE
fix(v12.0.0)!: the attested announce has never fit the MTU — binary-pack it, stop re-sending the 64 bytes the packet already carries (#333)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "11.1.2"
+version = "12.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/transport/attestation.rs
+++ b/src/transport/attestation.rs
@@ -42,7 +42,6 @@
 //! verification *inputs*, not signed content — they are checked
 //! against the directory, not trusted off the wire.
 
-use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
 /// Domain-separation tag prepended to the canonical signing bytes.
@@ -69,14 +68,14 @@ pub struct AttestationPayload<'a> {
     /// public key (the ed25519 half of the dual-key identity — the
     /// half `ReticulumNode::connect` needs as the `signing_key`).
     pub transport_identity_pubkey: &'a [u8; 32],
-    /// CIRISEdge#317 — the announcer's 32-byte Reticulum transport-identity
-    /// **x25519** (encryption) public key, the OTHER half of the dual-key RNS
-    /// identity. `None` for a v1 announce (the field this fix adds). When set,
-    /// the admit side reconstructs the full transport identity
-    /// (`x25519 ‖ ed25519`) and computes `Identity::hash()` = exactly what the
-    /// RNS link proves — the announce previously carried only the ed25519 half,
-    /// so admit fell back to `announce.public_key()` (the FEDERATION identity)
-    /// and never matched the transport-identity link.
+    /// CIRISEdge#333 — the announcer's 32-byte transport-identity **x25519**
+    /// (encryption) half. **SIGNED, never transmitted in `app_data`**: the
+    /// announce packet already carries the full transport identity as its
+    /// `public_key` (`x25519 ‖ ed25519`, binary — leviculum `announce.rs`
+    /// `build_announce_payload`). A verifier reads both halves from
+    /// `announce.public_key()` and re-derives this payload to check the
+    /// signature. Binding by SIGNING OVER them (not re-sending them) is what
+    /// keeps the app_data inside the MTU budget.
     pub transport_x25519_pubkey: Option<&'a [u8; 32]>,
     /// The announcer's federation `key_id` (`federation_keys.key_id`).
     pub federation_key_id: &'a str,
@@ -218,29 +217,101 @@ impl TransportBindingEnforcement {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+/// CIRISEdge#333 — the hard app_data budget an announce must fit inside.
+///
+/// From leviculum's own constants (`reticulum-core::constants`) and
+/// `build_announce_payload`'s layout
+/// (`public_key(64) ‖ name_hash(10) ‖ random_hash(10) ‖ [ratchet(32)] ‖
+/// signature(64) ‖ app_data`):
+///
+/// ```text
+/// MTU                                 500
+///   − HEADER_MINSIZE (2 + 1 + 16)     −19
+///   − IFAC_MIN_SIZE                    −1
+///   − public_key (x25519 ‖ ed25519)   −64
+///   − name_hash                       −10
+///   − random_hash                     −10
+///   − ratchet                         −32
+///   − signature                       −64
+/// ───────────────────────────────────────
+///   app_data budget                   300
+/// ```
+///
+/// `Node::announce_destination` packs into a fixed `[0u8; MTU]` buffer, so an
+/// oversized `app_data` makes `pack()` fail and the announce **never leaves the
+/// box** — the node becomes invisible to the mesh while looking healthy locally.
+/// The pre-#333 JSON attestation was 337 B (410 B once #317 added the x25519
+/// field): it had **never** fit, which is the root cause of the whole AV-42
+/// rooting saga (no attested announce ever propagated an RNS path).
+pub const ANNOUNCE_APP_DATA_BUDGET: usize = 300;
+
+/// The binary wire tag for [`AnnounceAttestation::to_app_data`]. A version byte
+/// so a future shape is distinguishable rather than mis-parsed.
+const ATTESTATION_WIRE_V1: u8 = 0x01;
+
+/// Fixed overhead of the packed attestation, excluding `federation_key_id`:
+/// `version(1) ‖ key_id_len(1) ‖ federation_pubkey(32) ‖ epoch(8) ‖ signature(64)`.
+const ATTESTATION_FIXED_OVERHEAD: usize = 1 + 1 + 32 + 8 + 64;
+
+/// CIRISEdge#333 — the longest `federation_key_id` that can appear in an
+/// announce. Derived, not chosen: it is whatever [`ANNOUNCE_APP_DATA_BUDGET`]
+/// leaves after the fixed overhead. A longer key_id cannot be announced at all
+/// (the packet would exceed the MTU and never transmit), so it is refused at
+/// compose time instead. Real key_ids are ~20–45 B; this is a wide margin.
+pub const MAX_FEDERATION_KEY_ID_LEN: usize = ANNOUNCE_APP_DATA_BUDGET - ATTESTATION_FIXED_OVERHEAD;
+
+// The load-bearing invariant, checked AT COMPILE TIME: the worst admissible
+// attestation fits the announce budget. Add a field to the wire shape without
+// shrinking the key_id bound and THIS fails the build — which is the whole point
+// of CIRISEdge#333 (the old shape failed silently, on the wire, at runtime).
+const _: () = assert!(
+    ATTESTATION_FIXED_OVERHEAD + MAX_FEDERATION_KEY_ID_LEN <= ANNOUNCE_APP_DATA_BUDGET,
+    "the worst-case announce attestation must fit ANNOUNCE_APP_DATA_BUDGET"
+);
+
+/// A federation-key-signed transport-identity binding, carried in the Reticulum
+/// announce app-data.
+///
+/// # Wire form: BINARY, and it does NOT carry the transport pubkeys
+///
+/// ```text
+/// u8(version=1) ‖ u8(len key_id) ‖ key_id ‖ federation_pubkey_ed25519(32)
+///               ‖ u64_be(epoch) ‖ signature(64)
+/// ```
+///
+/// Two deliberate choices, both forced by [`ANNOUNCE_APP_DATA_BUDGET`]:
+///
+/// 1. **The transport pubkeys are NOT in `app_data`.** The announce packet
+///    already transmits them, in binary, as its own `public_key` (64 B). The
+///    old JSON shape re-encoded those same bytes as base64 — ~140 B of pure
+///    duplication, *more* than the 104 B by which it overflowed. They are still
+///    **bound**: the signature covers them ([`AttestationPayload`]); a verifier
+///    supplies them from `announce.public_key()`.
+/// 2. **Binary, not JSON.** JSON key names alone cost ~110 B of a 300 B budget.
+///    A broadcast primitive under a hard MTU is the wrong place for a
+///    self-describing format. This shape is ~150 B, leaving real headroom.
+///
+/// # Authentication
+///
+/// `signature` is **not** trusted on its own — it proves only that whoever holds
+/// `federation_key_id`'s Ed25519 seed signed the
+/// `(transport identity, federation_key_id, epoch)` binding. The resolver still
+/// roots `federation_key_id` against the persist directory (`root_binding`) and
+/// verifies the signature against the **directory-confirmed** pubkey — never
+/// against the `federation_pubkey_ed25519` carried here, which is a claim.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AnnounceAttestation {
-    /// The announcer's 32-byte Reticulum transport-identity Ed25519
-    /// public key, base64 standard.
-    pub transport_identity_pubkey: String,
-    /// CIRISEdge#317 — the announcer's 32-byte transport-identity **x25519**
-    /// (encryption) public key, base64 standard. `None` on a v1 announce; when
-    /// present, it is covered by the signature (v2 canonical bytes) and lets the
-    /// admit side compute the transport-identity hash the RNS link proves.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transport_x25519_pubkey: Option<String>,
     /// The announcer's federation `key_id`.
     pub federation_key_id: String,
-    /// The announcer's *claimed* federation Ed25519 public key,
-    /// base64 standard. A verification input rooted against the
-    /// directory — `root_binding`'s `claimed_pubkey_ed25519_base64`.
-    pub federation_pubkey_ed25519_base64: String,
-    /// Transport-identity rotation epoch (see
-    /// [`AttestationPayload::epoch`]).
+    /// The announcer's *claimed* federation Ed25519 public key (32 B). A
+    /// verification input rooted against the directory — never trusted as-is.
+    pub federation_pubkey_ed25519: [u8; 32],
+    /// Transport-identity rotation epoch.
     pub epoch: u64,
     /// Ed25519 signature by the federation key over
-    /// [`AttestationPayload::canonical_bytes`], base64 standard.
-    pub signature: String,
+    /// [`AttestationPayload::canonical_bytes`] (which covers the transport
+    /// identity read from the announce's own `public_key`).
+    pub signature: [u8; 64],
 }
 
 /// Errors decoding / verifying an [`AnnounceAttestation`].
@@ -256,85 +327,138 @@ pub enum AttestationError {
     /// pubkey. AV-42 — a spoofed binding fails here.
     #[error("attestation signature verification failed")]
     SignatureMismatch,
+    /// CIRISEdge#333 — the packed attestation exceeds the announce app_data
+    /// budget. Refused at COMPOSE time: an oversized announce silently fails to
+    /// transmit (leviculum packs into a fixed `[0u8; MTU]`), leaving the node
+    /// invisible to the mesh while it looks healthy locally.
+    #[error("attestation is {actual} B; the announce app_data budget is {budget} B")]
+    TooLarge { actual: usize, budget: usize },
 }
 
 impl AnnounceAttestation {
-    /// Decode the 32-byte transport-identity pubkey.
+    /// Serialize to announce app-data bytes (BINARY — see the type docs).
     ///
     /// # Errors
-    /// [`AttestationError::FieldDecode`] when the field is not
-    /// base64 of exactly 32 bytes.
-    pub fn transport_identity_pubkey_bytes(&self) -> Result<[u8; 32], AttestationError> {
-        decode_fixed::<32>(&self.transport_identity_pubkey, "transport_identity_pubkey")
-    }
-
-    /// CIRISEdge#317 — decode the optional 32-byte transport-identity x25519
-    /// pubkey. `Ok(None)` for a v1 announce (field absent); `Ok(Some(_))` for v2.
-    ///
-    /// # Errors
-    /// [`AttestationError::FieldDecode`] when the field is present but not
-    /// base64 of exactly 32 bytes.
-    pub fn transport_x25519_pubkey_bytes(&self) -> Result<Option<[u8; 32]>, AttestationError> {
-        match &self.transport_x25519_pubkey {
-            Some(b64) => Ok(Some(decode_fixed::<32>(b64, "transport_x25519_pubkey")?)),
-            None => Ok(None),
-        }
-    }
-
-    /// Serialize to announce app-data bytes (JSON).
-    ///
-    /// # Errors
-    /// [`AttestationError::Parse`] if JSON serialization fails
-    /// (effectively unreachable for this fixed shape).
+    /// [`AttestationError::Parse`] if `federation_key_id` exceeds 255 bytes, or
+    /// if the packed form would exceed [`ANNOUNCE_APP_DATA_BUDGET`] — the latter
+    /// is the CIRISEdge#333 compose-time gate: an announce that cannot fit is
+    /// refused HERE, loudly, rather than silently failing to transmit and making
+    /// the node invisible to the mesh.
     pub fn to_app_data(&self) -> Result<Vec<u8>, AttestationError> {
-        serde_json::to_vec(self).map_err(|e| AttestationError::Parse(format!("serialize: {e}")))
+        let key_id = self.federation_key_id.as_bytes();
+        if key_id.len() > MAX_FEDERATION_KEY_ID_LEN {
+            return Err(AttestationError::TooLarge {
+                actual: ATTESTATION_FIXED_OVERHEAD + key_id.len(),
+                budget: ANNOUNCE_APP_DATA_BUDGET,
+            });
+        }
+        let key_id_len = u8::try_from(key_id.len())
+            .map_err(|_| AttestationError::Parse("federation_key_id too long".to_string()))?;
+        let mut out = Vec::with_capacity(1 + 1 + key_id.len() + 32 + 8 + 64);
+        out.push(ATTESTATION_WIRE_V1);
+        out.push(key_id_len);
+        out.extend_from_slice(key_id);
+        out.extend_from_slice(&self.federation_pubkey_ed25519);
+        out.extend_from_slice(&self.epoch.to_be_bytes());
+        out.extend_from_slice(&self.signature);
+
+        if out.len() > ANNOUNCE_APP_DATA_BUDGET {
+            return Err(AttestationError::TooLarge {
+                actual: out.len(),
+                budget: ANNOUNCE_APP_DATA_BUDGET,
+            });
+        }
+        Ok(out)
     }
 
     /// Parse an [`AnnounceAttestation`] from announce app-data bytes.
     ///
     /// # Errors
-    /// [`AttestationError::Parse`] when `app_data` is not valid
-    /// attestation JSON — e.g. a v0.3.1 bare-`key_id` announce, or a
-    /// non-attestation announce from an unrelated app.
+    /// [`AttestationError::Parse`] when `app_data` is not a well-formed
+    /// attestation — e.g. an empty (unattested) announce, a legacy JSON
+    /// attestation, or a non-CIRIS app's announce.
     pub fn from_app_data(app_data: &[u8]) -> Result<Self, AttestationError> {
-        serde_json::from_slice(app_data)
-            .map_err(|e| AttestationError::Parse(format!("deserialize: {e}")))
+        let bad = |m: &str| AttestationError::Parse(m.to_string());
+        if app_data.len() < 2 {
+            return Err(bad("attestation too short"));
+        }
+        if app_data[0] != ATTESTATION_WIRE_V1 {
+            return Err(AttestationError::Parse(format!(
+                "unknown attestation wire version {:#04x}",
+                app_data[0]
+            )));
+        }
+        let key_id_len = app_data[1] as usize;
+        let want = 2 + key_id_len + 32 + 8 + 64;
+        if app_data.len() != want {
+            return Err(AttestationError::Parse(format!(
+                "attestation length {} != expected {want}",
+                app_data.len()
+            )));
+        }
+        let mut off = 2;
+        let federation_key_id = std::str::from_utf8(&app_data[off..off + key_id_len])
+            .map_err(|e| AttestationError::Parse(format!("key_id not utf-8: {e}")))?
+            .to_string();
+        off += key_id_len;
+        let federation_pubkey_ed25519: [u8; 32] = app_data[off..off + 32]
+            .try_into()
+            .map_err(|_| bad("federation pubkey"))?;
+        off += 32;
+        let epoch = u64::from_be_bytes(
+            app_data[off..off + 8]
+                .try_into()
+                .map_err(|_| bad("epoch"))?,
+        );
+        off += 8;
+        let signature: [u8; 64] = app_data[off..off + 64]
+            .try_into()
+            .map_err(|_| bad("signature"))?;
+        Ok(Self {
+            federation_key_id,
+            federation_pubkey_ed25519,
+            epoch,
+            signature,
+        })
     }
 
-    /// Verify [`Self::signature`] over the canonical attestation
-    /// bytes against `federation_pubkey_ed25519` — the **32-byte
-    /// Ed25519 public key the persist directory confirmed for
-    /// `federation_key_id`**, never the claim carried on the wire.
+    /// Verify [`Self::signature`] over the canonical attestation bytes against
+    /// `federation_pubkey_ed25519` — the **32-byte Ed25519 public key the persist
+    /// directory confirmed** for `federation_key_id`, never the claim carried on
+    /// the wire.
     ///
-    /// On `Ok(())` the binding `federation_key_id → transport
-    /// identity` is cryptographically attested by the federation key.
+    /// CIRISEdge#333: `announce_public_key` is the announce's OWN
+    /// `public_key` — the transport identity, `x25519(32) ‖ ed25519(32)` (see
+    /// leviculum `build_announce_payload`). The attestation no longer transmits
+    /// those bytes; it BINDS them, and the verifier supplies them from the packet
+    /// it just received. A spoofer cannot pair someone else's `key_id` with its
+    /// own destination: the signature covers the transport identity the packet
+    /// arrived with (AV-42).
     ///
     /// # Errors
-    /// - [`AttestationError::FieldDecode`] — a malformed base64 field.
-    /// - [`AttestationError::SignatureMismatch`] — the signature did
-    ///   not verify (AV-42: a spoofed announce is rejected here).
+    /// - [`AttestationError::SignatureMismatch`] — the signature did not verify.
+    /// - [`AttestationError::FieldDecode`] — the Ed25519 verify call failed.
     pub fn verify_signature(
         &self,
         federation_pubkey_ed25519: &[u8; 32],
+        announce_public_key: &[u8; 64],
     ) -> Result<(), AttestationError> {
         use ciris_crypto::ClassicalVerifier;
 
-        let transport_pubkey = self.transport_identity_pubkey_bytes()?;
-        let transport_x25519 = self.transport_x25519_pubkey_bytes()?;
-        let signature = decode_fixed::<64>(&self.signature, "signature")?;
+        // leviculum `Identity::public_key_bytes()` = x25519 ‖ ed25519.
+        let x25519: [u8; 32] = announce_public_key[..32]
+            .try_into()
+            .map_err(|_| AttestationError::FieldDecode("announce x25519 half".into()))?;
+        let ed25519: [u8; 32] = announce_public_key[32..]
+            .try_into()
+            .map_err(|_| AttestationError::FieldDecode("announce ed25519 half".into()))?;
 
-        // CIRISEdge#317 — verify over the v2 payload (binding the x25519 half)
-        // when the announce carries it, else the v1 payload. The signature's
-        // domain is bound to the shape, so a v1 sig can't be accepted as v2.
-        let mut payload =
-            AttestationPayload::new(&transport_pubkey, &self.federation_key_id, self.epoch);
-        if let Some(x25519) = &transport_x25519 {
-            payload = payload.with_transport_x25519(x25519);
-        }
-        let canonical = payload.canonical_bytes();
+        let canonical = AttestationPayload::new(&ed25519, &self.federation_key_id, self.epoch)
+            .with_transport_x25519(&x25519)
+            .canonical_bytes();
 
         let verified = ciris_crypto::Ed25519Verifier::new()
-            .verify(federation_pubkey_ed25519, &canonical, &signature)
+            .verify(federation_pubkey_ed25519, &canonical, &self.signature)
             .map_err(|e| AttestationError::FieldDecode(format!("ed25519 verify: {e}")))?;
 
         if verified {
@@ -345,164 +469,137 @@ impl AnnounceAttestation {
     }
 }
 
-/// Decode a base64-standard field expected to be exactly `N` bytes.
-fn decode_fixed<const N: usize>(b64: &str, field: &str) -> Result<[u8; N], AttestationError> {
-    let raw = base64::engine::general_purpose::STANDARD
-        .decode(b64)
-        .map_err(|e| AttestationError::FieldDecode(format!("{field}: base64: {e}")))?;
-    let arr: [u8; N] = raw.as_slice().try_into().map_err(|_| {
-        AttestationError::FieldDecode(format!("{field}: expected {N} bytes, got {}", raw.len()))
-    })?;
-    Ok(arr)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use ciris_crypto::ClassicalSigner;
 
-    /// A canonical-bytes encoding must be injective: distinct
-    /// `(pubkey, key_id, epoch)` triples never collide.
+    /// The static worst-case gate: even a max-length (255 B) federation key_id
+    /// packs inside the announce app_data budget. This is the CIRISEdge#333
+    /// guarantee — *adding a field must fail the build/tests, not the mesh*.
     #[test]
-    fn canonical_bytes_are_injective() {
-        let pk_a = [0x11u8; 32];
-        let pk_b = [0x22u8; 32];
-        let a = AttestationPayload::new(&pk_a, "edge-key-a", 1).canonical_bytes();
-        let b = AttestationPayload::new(&pk_b, "edge-key-a", 1).canonical_bytes();
-        let c = AttestationPayload::new(&pk_a, "edge-key-b", 1).canonical_bytes();
-        let d = AttestationPayload::new(&pk_a, "edge-key-a", 2).canonical_bytes();
-        assert_ne!(a, b, "distinct pubkey must differ");
-        assert_ne!(a, c, "distinct key_id must differ");
-        assert_ne!(a, d, "distinct epoch must differ");
+    fn worst_case_attestation_fits_the_announce_budget() {
+        // The MAXIMUM admissible key_id must pack inside the budget — this is the
+        // compile-time invariant, re-asserted at runtime against the real packer.
+        let att = AnnounceAttestation {
+            federation_key_id: "k".repeat(MAX_FEDERATION_KEY_ID_LEN),
+            federation_pubkey_ed25519: [0; 32],
+            epoch: u64::MAX,
+            signature: [0; 64],
+        };
+        let packed = att.to_app_data().expect("worst case must fit");
+        assert_eq!(packed.len(), ANNOUNCE_APP_DATA_BUDGET);
     }
 
-    /// A length-prefixed encoding must not be confusable: the
-    /// boundary between pubkey and key_id is unambiguous, so a
-    /// `key_id` whose prefix matches another's cannot alias.
+    /// A realistic attestation is far inside budget (the old JSON shape was
+    /// 337 B — 410 B once #317 added the x25519 field — against a 300 B budget,
+    /// so it had NEVER fit).
     #[test]
-    fn canonical_bytes_resist_field_confusion() {
-        let pk = [0x33u8; 32];
-        // "ab" + "c"  vs  "a" + "bc" — without length prefixes a
-        // naive concat would collide; with prefixes it must not.
-        let x = AttestationPayload::new(&pk, "abc", 0).canonical_bytes();
-        let y = AttestationPayload::new(&pk, "ab", 0).canonical_bytes();
-        assert_ne!(x, y);
+    fn realistic_attestation_is_well_inside_budget() {
+        let att = AnnounceAttestation {
+            federation_key_id: "ciris-agent-bootstrap-vroaxowlhv-rktt5f5yyv".to_string(),
+            federation_pubkey_ed25519: [0x11; 32],
+            epoch: 7,
+            signature: [0x22; 64],
+        };
+        let packed = att.to_app_data().expect("must fit");
+        assert!(
+            packed.len() <= ANNOUNCE_APP_DATA_BUDGET,
+            "packed {} B > budget {ANNOUNCE_APP_DATA_BUDGET} B",
+            packed.len()
+        );
+        // Real headroom, not a squeaker.
+        assert!(packed.len() < 200, "expected ~150 B, got {}", packed.len());
     }
 
-    /// A legitimately signed attestation verifies; a tamper does not.
+    /// An over-budget attestation is refused at COMPOSE time — loudly — rather
+    /// than silently failing to transmit.
     #[test]
-    fn signed_attestation_round_trips_and_rejects_tamper() {
+    fn over_budget_attestation_is_refused_at_compose_time() {
+        // One byte past the bound: refused HERE, loudly — never silently
+        // transmitted-and-dropped (which is what made the node invisible).
+        let att = AnnounceAttestation {
+            federation_key_id: "k".repeat(MAX_FEDERATION_KEY_ID_LEN + 1),
+            federation_pubkey_ed25519: [0; 32],
+            epoch: 0,
+            signature: [0; 64],
+        };
+        assert!(matches!(
+            att.to_app_data(),
+            Err(AttestationError::TooLarge { .. })
+        ));
+    }
+
+    /// Round-trip + AV-42: the signature binds the transport identity the packet
+    /// ARRIVED with, even though the attestation never transmits it. A spoofer
+    /// pairing someone else's key_id with its own destination fails.
+    #[test]
+    fn binds_the_announce_transport_identity_without_transmitting_it() {
         let signer = ciris_crypto::Ed25519Signer::random().unwrap();
         let fed_pubkey: [u8; 32] = signer.public_key().unwrap().try_into().unwrap();
-        let transport_pubkey = [0x5au8; 32];
 
-        let payload = AttestationPayload::new(&transport_pubkey, "edge-key-honest", 7);
-        let sig = signer.sign(&payload.canonical_bytes()).unwrap();
+        // The announce's own public_key = transport identity (x25519 ‖ ed25519).
+        let mut announce_pk = [0u8; 64];
+        announce_pk[..32].copy_from_slice(&[0xAA; 32]); // x25519
+        announce_pk[32..].copy_from_slice(&[0xBB; 32]); // ed25519
+
+        let x: [u8; 32] = announce_pk[..32].try_into().unwrap();
+        let e: [u8; 32] = announce_pk[32..].try_into().unwrap();
+        let payload = AttestationPayload::new(&e, "edge-key-honest", 7).with_transport_x25519(&x);
+        let sig: [u8; 64] = signer
+            .sign(&payload.canonical_bytes())
+            .unwrap()
+            .try_into()
+            .unwrap();
 
         let att = AnnounceAttestation {
-            transport_identity_pubkey: base64::engine::general_purpose::STANDARD
-                .encode(transport_pubkey),
-            transport_x25519_pubkey: None,
             federation_key_id: "edge-key-honest".to_string(),
-            federation_pubkey_ed25519_base64: base64::engine::general_purpose::STANDARD
-                .encode(fed_pubkey),
+            federation_pubkey_ed25519: fed_pubkey,
             epoch: 7,
-            signature: base64::engine::general_purpose::STANDARD.encode(&sig),
+            signature: sig,
         };
 
-        // Round-trip through app-data bytes.
-        let bytes = att.to_app_data().unwrap();
-        let parsed = AnnounceAttestation::from_app_data(&bytes).unwrap();
+        // Binary round-trip.
+        let parsed = AnnounceAttestation::from_app_data(&att.to_app_data().unwrap()).unwrap();
         assert_eq!(parsed, att);
 
-        // Legitimate verify.
-        parsed.verify_signature(&fed_pubkey).unwrap();
+        // Verifies against the identity the packet carried.
+        parsed.verify_signature(&fed_pubkey, &announce_pk).unwrap();
 
-        // AV-42: a spoofed key_id (different signed content) fails.
+        // AV-42: a spoofer replays this attestation on ITS OWN destination — the
+        // announce's public_key differs, so the bound signature fails.
+        let mut spoof_pk = announce_pk;
+        spoof_pk[32..].copy_from_slice(&[0xCC; 32]); // attacker's transport ed25519
+        assert!(matches!(
+            parsed.verify_signature(&fed_pubkey, &spoof_pk),
+            Err(AttestationError::SignatureMismatch)
+        ));
+
+        // AV-42: a spoofed key_id fails (signed content differs).
         let mut spoofed = parsed.clone();
         spoofed.federation_key_id = "edge-key-victim".to_string();
         assert!(matches!(
-            spoofed.verify_signature(&fed_pubkey),
-            Err(AttestationError::SignatureMismatch)
-        ));
-
-        // AV-42: a flipped signature byte fails.
-        let mut bad_sig = parsed.clone();
-        let mut sig_bytes = sig.clone();
-        sig_bytes[0] ^= 0xff;
-        bad_sig.signature = base64::engine::general_purpose::STANDARD.encode(&sig_bytes);
-        assert!(matches!(
-            bad_sig.verify_signature(&fed_pubkey),
+            spoofed.verify_signature(&fed_pubkey, &announce_pk),
             Err(AttestationError::SignatureMismatch)
         ));
     }
 
-    /// CIRISEdge#317 — a v2 attestation binding the transport x25519 verifies,
-    /// its signature is domain-separated from v1, and swapping the x25519
-    /// (a spoofed transport identity) fails verification.
+    /// An unattested (empty app_data) or legacy-JSON announce parses to a typed
+    /// error, not a panic.
     #[test]
-    fn v2_attestation_binds_transport_x25519_and_rejects_swap() {
-        let signer = ciris_crypto::Ed25519Signer::random().unwrap();
-        let fed_pubkey: [u8; 32] = signer.public_key().unwrap().try_into().unwrap();
-        let transport_ed25519 = [0x5au8; 32];
-        let transport_x25519 = [0x77u8; 32];
-
-        let payload = AttestationPayload::new(&transport_ed25519, "edge-key-v2", 9)
-            .with_transport_x25519(&transport_x25519);
-        let sig = signer.sign(&payload.canonical_bytes()).unwrap();
-
-        let att = AnnounceAttestation {
-            transport_identity_pubkey: base64::engine::general_purpose::STANDARD
-                .encode(transport_ed25519),
-            transport_x25519_pubkey: Some(
-                base64::engine::general_purpose::STANDARD.encode(transport_x25519),
-            ),
-            federation_key_id: "edge-key-v2".to_string(),
-            federation_pubkey_ed25519_base64: base64::engine::general_purpose::STANDARD
-                .encode(fed_pubkey),
-            epoch: 9,
-            signature: base64::engine::general_purpose::STANDARD.encode(&sig),
-        };
-
-        // Round-trips through app-data + verifies.
-        let parsed = AnnounceAttestation::from_app_data(&att.to_app_data().unwrap()).unwrap();
-        assert_eq!(parsed, att);
-        assert_eq!(
-            parsed.transport_x25519_pubkey_bytes().unwrap(),
-            Some(transport_x25519)
-        );
-        parsed.verify_signature(&fed_pubkey).unwrap();
-
-        // A swapped x25519 (spoofed transport identity) fails — the x25519 is
-        // signed content in v2.
-        let mut swapped = parsed.clone();
-        swapped.transport_x25519_pubkey =
-            Some(base64::engine::general_purpose::STANDARD.encode([0x88u8; 32]));
+    fn empty_or_legacy_app_data_is_rejected_cleanly() {
         assert!(matches!(
-            swapped.verify_signature(&fed_pubkey),
-            Err(AttestationError::SignatureMismatch)
+            AnnounceAttestation::from_app_data(b""),
+            Err(AttestationError::Parse(_))
         ));
-
-        // v1 and v2 canonical bytes are domain-separated (no cross-replay).
-        let v1 = AttestationPayload::new(&transport_ed25519, "edge-key-v2", 9).canonical_bytes();
-        assert_ne!(v1, payload.canonical_bytes(), "v1/v2 domains disjoint");
-    }
-
-    /// A v0.3.1-style bare-`key_id` announce is not attestation JSON
-    /// and parses to a typed error rather than a panic.
-    #[test]
-    fn legacy_bare_key_id_announce_is_rejected_cleanly() {
-        let legacy = b"edge-key-legacy";
         assert!(matches!(
-            AnnounceAttestation::from_app_data(legacy),
+            AnnounceAttestation::from_app_data(br#"{"federation_key_id":"x"}"#),
             Err(AttestationError::Parse(_))
         ));
     }
 
     #[test]
     fn transport_binding_enforcement_default_is_advisory() {
-        // CIRISEdge#205 — the default MUST be Advisory (no silent flip);
-        // the fleet-floor cutover to RequireTransportBinding is opt-in.
         assert_eq!(
             TransportBindingEnforcement::default(),
             TransportBindingEnforcement::Advisory

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1358,25 +1358,31 @@ impl ReticulumTransport {
         // the transport identity the link proves.
         let mut transport_x25519 = [0u8; 32];
         transport_x25519.copy_from_slice(&local_transport_pubkey[..32]);
-        let local_attestation = if let Some(s) = &signer {
-            Some(
-                build_local_attestation(
-                    s,
-                    &transport_ed25519,
-                    &transport_x25519,
-                    &config.local_key_id,
-                    config.local_epoch,
-                )
-                .await?,
-            )
-        } else {
-            tracing::warn!(
-                "Reticulum transport built without a federation signer; \
-                 its announce carries no attestation and rooting peers \
-                 will drop it (AV-42 fail-honest)",
-            );
-            None
+        // CIRISEdge#333 — EVERY announce is self-attested. There is no
+        // unattested branch: a node with no federation signer that announced
+        // anyway produced a routable-but-unrootable peer — a trap that looks
+        // HEALTHY (paths resolve!) yet can never be rooted, and it silently
+        // masked the fact that the attested announce was failing to transmit at
+        // all. `signer: None` is now a hard configuration error, not a
+        // degradation.
+        let Some(signer_ref) = &signer else {
+            return Err(TransportError::Config(
+                "Reticulum transport requires a federation signer: every announce must be \
+                 self-attested (CIRISEdge#333). An unattested announce yields a peer that \
+                 routes but can never root — it looks healthy and is not."
+                    .to_string(),
+            ));
         };
+        let local_attestation = Some(
+            build_local_attestation(
+                signer_ref,
+                &transport_ed25519,
+                &transport_x25519,
+                &config.local_key_id,
+                config.local_epoch,
+            )
+            .await?,
+        );
 
         // Build the node. The transport identity is the node identity;
         // a per-process storage dir alongside the identity file holds
@@ -3341,7 +3347,11 @@ async fn resolve_announce_cold_start(
 
     // Step 2 — root the federation key against the persist directory.
     let verdict = rooting
-        .root_binding(&key_id, &attestation.federation_pubkey_ed25519_base64)
+        .root_binding(
+            &key_id,
+            &base64::engine::general_purpose::STANDARD
+                .encode(attestation.federation_pubkey_ed25519),
+        )
         .await;
     // CIRISEdge#301 (CC 3.3.6.2) — `root_binding` CLASSIFIES the binding, it
     // does NOT gate it. The AV-42 `dest_hash` crypto check already ran upstream
@@ -3359,7 +3369,12 @@ async fn resolve_announce_cold_start(
         RootingVerdict::Confirmed { chain } => {
             // ROOTED — verify the attestation against the directory-CONFIRMED
             // Ed25519 (never the wire claim), then apply the hybrid PQC policy.
-            if !attestation_verifies_against_chain(&attestation, &chain, &key_id) {
+            if !attestation_verifies_against_chain(
+                &attestation,
+                &chain,
+                &key_id,
+                announce.public_key(),
+            ) {
                 return;
             }
             if !hybrid_policy_accepts(ctx.hybrid_policy, &chain) {
@@ -3382,7 +3397,7 @@ async fn resolve_announce_cold_start(
             // crypto floor (proves the announcer controls the key it claims); a
             // forged self-claim is a crypto failure → dropped. On success, admit
             // as an advisory routing hint (authority NOT established) — never drop.
-            if !attestation_self_verifies(&attestation, &key_id) {
+            if !attestation_self_verifies(&attestation, &key_id, announce.public_key()) {
                 return;
             }
             tracing::info!(
@@ -3402,40 +3417,27 @@ async fn resolve_announce_cold_start(
     // Step 5 — record the rooted resolution. A strictly-newer epoch
     // supersedes a cached binding; an equal-or-older epoch is a stale
     // re-announce and is ignored (keeps the cached chain).
-    let transport_pubkey = match attestation.transport_identity_pubkey_bytes() {
-        Ok(pk) => pk,
-        Err(e) => {
-            tracing::warn!(av = "AV-42", key_id = %key_id, error = %e,
-                "announce rejected: transport-identity pubkey malformed");
-            return;
-        }
+    // CIRISEdge#333 — the transport identity comes from the ANNOUNCE ITSELF.
+    // `announce.public_key()` IS the transport identity (`x25519 ‖ ed25519`) —
+    // leviculum's `build_announce_payload` packs `identity.public_key_bytes()`
+    // of the announcing destination. The attestation no longer re-sends those
+    // 64 bytes (that duplication is what pushed app_data over the MTU budget and
+    // meant an attested announce NEVER transmitted); it BINDS them by signature,
+    // and we read them from the packet we just received.
+    //
+    // This also retires the #317 premise: `announce.public_key()` was never the
+    // federation identity. It is, and always was, the transport identity the RNS
+    // link authenticates under — so hashing it is exactly right for attribution.
+    let announce_pubkey64: [u8; 64] = *announce.public_key();
+    let binding_pubkey64: [u8; 64] = announce_pubkey64;
+    let Ok(transport_pubkey) = <[u8; 32]>::try_from(&announce_pubkey64[32..]) else {
+        tracing::warn!(av = "AV-42", key_id = %key_id,
+            "announce rejected: transport-identity pubkey malformed");
+        return;
     };
     let resolved = ResolvedPeer {
         dest_hash: *announce.destination_hash(),
         signing_key: transport_pubkey,
-    };
-    // CIRISEdge#317 — reconstruct the TRANSPORT identity (`x25519_enc ‖
-    // ed25519_sig`) the RNS link proves, from the attestation's two transport
-    // halves. The pre-#317 code hashed `announce.public_key()` — but that is the
-    // FEDERATION announce identity (same ed25519 signing half, DIFFERENT x25519),
-    // a different `Identity` than the link authenticates under, so the
-    // attribution could never match (CIRISServer#235). A v2 announce carries the
-    // transport x25519; for a v1 (legacy) announce that doesn't, we fall back to
-    // the announce identity — those peers stay unattributable until they upgrade,
-    // exactly as before, but new peers now match.
-    let announce_pubkey64: [u8; 64] = *announce.public_key();
-    let transport_x25519 = attestation.transport_x25519_pubkey_bytes().ok().flatten();
-    // The binding pubkey used BOTH for the attribution hash and the #299
-    // write-through (so the persisted transport binding + KEX x25519 are the
-    // transport identity, not the federation one).
-    let binding_pubkey64: [u8; 64] = match transport_x25519 {
-        Some(x25519) => {
-            let mut id = [0u8; 64];
-            id[..32].copy_from_slice(&x25519); // x25519 (encryption) half
-            id[32..].copy_from_slice(&transport_pubkey); // ed25519 (signing) half
-            id
-        }
-        None => announce_pubkey64, // v1 announce — no transport x25519 carried
     };
     // The identity hash the link's LINKIDENTIFY proves:
     // `truncated_hash(x25519 ‖ ed25519)`.
@@ -3533,37 +3535,23 @@ async fn resolve_announce_cold_start(
                 if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
                     peer_admitted_log().check(provenance_key)
                 {
-                    // CIRISEdge#317 — the stored `transport_identity_hash` is now
-                    // derived from the TRANSPORT identity (attestation x25519 ‖
-                    // ed25519) for a v2 announce (`transport_x25519_present=true`),
-                    // = exactly the identity the RNS link proves. `false` = a v1
-                    // (legacy) announce that carries no transport x25519, so admit
-                    // fell back to `announce.public_key()` (the federation
-                    // identity) and this peer stays unattributable until it
-                    // upgrades. `ed25519_halves_match` remains a diagnostic: it is
-                    // the announce identity's ed25519 half vs the attestation's
-                    // declared transport ed25519 — `false` confirms the federation-
-                    // vs-transport identity split the v2 binding fixes.
-                    let announce_ed25519_half = hex::encode(&announce_pubkey64[32..]);
-                    let attestation_transport_ed25519 = attestation
-                        .transport_identity_pubkey_bytes()
-                        .map_or_else(|_| "decode_err".to_string(), hex::encode);
-                    let ed25519_halves_match =
-                        announce_ed25519_half == attestation_transport_ed25519;
+                    // CIRISEdge#333 — the stored `transport_identity_hash` is derived
+                    // from the announce's OWN `public_key` (the transport identity
+                    // `x25519 ‖ ed25519`), which is exactly the identity the RNS
+                    // link proves at LINKIDENTIFY. The attestation no longer
+                    // carries those bytes — it binds them by signature — so there
+                    // is nothing left to disagree: the operands are the same 64
+                    // bytes the packet arrived with. If link attribution still
+                    // misses, `link_attribution_miss` (point 2) reports it.
                     tracing::info!(
                         key_id = %key_id,
                         provenance = ?provenance,
                         epoch = attestation.epoch,
                         dest_hash = %hex::encode(resolved.dest_hash.into_bytes()),
                         transport_identity_hash = %hex::encode(transport_identity_hash),
-                        transport_x25519_present = transport_x25519.is_some(),
-                        announce_ed25519_half = %announce_ed25519_half,
-                        attestation_transport_ed25519 = %attestation_transport_ed25519,
-                        ed25519_halves_match,
                         suppressed_prev,
-                        "peer_admitted — #317: transport_identity_hash from \
-                         transport identity when transport_x25519_present=true \
-                         (matches the link); v1 fallback when false"
+                        "peer_admitted — transport identity taken from the announce's own \
+                         public_key (CIRISEdge#333)"
                     );
                 }
                 // CIRISEdge#318 — bound the peers map against advisory-admit
@@ -3632,6 +3620,7 @@ fn attestation_verifies_against_chain(
     attestation: &AnnounceAttestation,
     chain: &ProvenanceChain,
     key_id: &str,
+    announce_public_key: &[u8; 64],
 ) -> bool {
     // The rooted chain's leaf (`chain[0]`) is the queried row; its
     // `pubkey_ed25519_base64` is the directory's confirmed pubkey.
@@ -3657,7 +3646,7 @@ fn attestation_verifies_against_chain(
         );
         return false;
     };
-    if let Err(e) = attestation.verify_signature(&confirmed_pubkey) {
+    if let Err(e) = attestation.verify_signature(&confirmed_pubkey, announce_public_key) {
         tracing::warn!(
             av = "AV-42",
             key_id,
@@ -3681,20 +3670,15 @@ fn attestation_verifies_against_chain(
 /// genuine crypto failure. Distinct from
 /// [`attestation_verifies_against_chain`], which verifies against the
 /// directory-CONFIRMED key for a `Rooted` admit.
-fn attestation_self_verifies(attestation: &AnnounceAttestation, key_id: &str) -> bool {
-    let claimed = base64::engine::general_purpose::STANDARD
-        .decode(&attestation.federation_pubkey_ed25519_base64)
-        .ok()
-        .and_then(|b| <[u8; 32]>::try_from(b).ok());
-    let Some(claimed) = claimed else {
-        tracing::warn!(
-            av = "AV-42",
-            key_id,
-            "announce dropped: claimed federation pubkey is not 32-byte base64",
-        );
-        return false;
-    };
-    if let Err(e) = attestation.verify_signature(&claimed) {
+fn attestation_self_verifies(
+    attestation: &AnnounceAttestation,
+    key_id: &str,
+    announce_public_key: &[u8; 64],
+) -> bool {
+    // CIRISEdge#333 — the transport identity is the announce's own public_key;
+    // the signature binds it without the attestation re-sending it.
+    let claimed = attestation.federation_pubkey_ed25519;
+    if let Err(e) = attestation.verify_signature(&claimed, announce_public_key) {
         tracing::warn!(
             av = "AV-42",
             key_id,
@@ -3768,17 +3752,17 @@ async fn build_local_attestation(
         .await
         .map_err(|e| TransportError::Config(format!("attestation sign: {e}")))?;
 
+    let fed_pubkey32: [u8; 32] = fed_pubkey.as_slice().try_into().map_err(|_| {
+        TransportError::Config("federation Ed25519 pubkey must be 32 bytes".to_string())
+    })?;
+    let signature64: [u8; 64] = signature.as_slice().try_into().map_err(|_| {
+        TransportError::Config("attestation signature must be 64 bytes".to_string())
+    })?;
     let attestation = AnnounceAttestation {
-        transport_identity_pubkey: base64::engine::general_purpose::STANDARD
-            .encode(transport_identity_pubkey),
-        transport_x25519_pubkey: Some(
-            base64::engine::general_purpose::STANDARD.encode(transport_x25519_pubkey),
-        ),
         federation_key_id: federation_key_id.to_string(),
-        federation_pubkey_ed25519_base64: base64::engine::general_purpose::STANDARD
-            .encode(&fed_pubkey),
+        federation_pubkey_ed25519: fed_pubkey32,
         epoch,
-        signature: base64::engine::general_purpose::STANDARD.encode(&signature),
+        signature: signature64,
     };
     attestation
         .to_app_data()

--- a/tests/reticulum_av42.rs
+++ b/tests/reticulum_av42.rs
@@ -33,8 +33,6 @@
 
 mod common;
 
-use base64::engine::general_purpose::STANDARD as B64;
-use base64::Engine as _;
 use ciris_crypto::ClassicalSigner;
 use ciris_edge::transport::attestation::{
     AnnounceAttestation, AttestationError, AttestationPayload,
@@ -133,47 +131,68 @@ async fn av42_tampered_attestation_signature_fails_verify() {
     let victim = TestFedKey::new("edge-key-victim2", 0x0d);
     let victim_signer = ciris_crypto::Ed25519Signer::from_seed(&[0x0d; 32]).unwrap();
     let victim_pubkey: [u8; 32] = victim_signer.public_key().unwrap().try_into().unwrap();
-    let transport_pubkey = [0x5a; 32];
 
-    // A genuine attestation the victim itself would publish.
-    let payload = AttestationPayload::new(&transport_pubkey, &victim.key_id, 3);
-    let genuine_sig = victim_signer.sign(&payload.canonical_bytes()).unwrap();
+    // CIRISEdge#333 — the transport identity is the ANNOUNCE's own public_key
+    // (x25519 ‖ ed25519). The attestation binds it by signature and no longer
+    // transmits it, so the adversary cannot simply edit a field: it must actually
+    // announce from a destination, and THAT is what verification checks against.
+    let mut victim_announce_pk = [0u8; 64];
+    victim_announce_pk[..32].copy_from_slice(&[0x5a; 32]); // victim x25519
+    victim_announce_pk[32..].copy_from_slice(&[0x5b; 32]); // victim ed25519
+
+    let x: [u8; 32] = victim_announce_pk[..32].try_into().unwrap();
+    let e: [u8; 32] = victim_announce_pk[32..].try_into().unwrap();
+    let payload = AttestationPayload::new(&e, &victim.key_id, 3).with_transport_x25519(&x);
+    let genuine_sig: [u8; 64] = victim_signer
+        .sign(&payload.canonical_bytes())
+        .unwrap()
+        .try_into()
+        .unwrap();
 
     let genuine = AnnounceAttestation {
-        transport_identity_pubkey: B64.encode(transport_pubkey),
-        transport_x25519_pubkey: None,
         federation_key_id: victim.key_id.clone(),
-        federation_pubkey_ed25519_base64: B64.encode(victim_pubkey),
+        federation_pubkey_ed25519: victim_pubkey,
         epoch: 3,
-        signature: B64.encode(&genuine_sig),
+        signature: genuine_sig,
     };
-    // Sanity: the genuine attestation verifies.
+    // Sanity: the genuine attestation verifies against the identity it announced with.
     genuine
-        .verify_signature(&victim_pubkey)
+        .verify_signature(&victim_pubkey, &victim_announce_pk)
         .expect("genuine attestation must verify");
 
-    // Spoof A — the adversary keeps the victim's key_id + pubkey but
-    // swaps in an adversary-controlled transport identity. The
-    // signature still covers the OLD transport pubkey, so it no
-    // longer matches the announced binding.
-    let mut swapped_transport = genuine.clone();
-    swapped_transport.transport_identity_pubkey = B64.encode([0xad; 32]);
+    // Spoof A — THE AV-42 attack, in its real shape: the adversary lifts the
+    // victim's attestation verbatim and re-announces it from ITS OWN destination.
+    // The signature is bound to the victim's transport identity, so verifying it
+    // against the adversary's announce public_key fails. It cannot capture
+    // `send(victim_key_id, ..)`.
+    let mut adversary_announce_pk = victim_announce_pk;
+    adversary_announce_pk[32..].copy_from_slice(&[0xad; 32]); // adversary's transport ed25519
     assert!(
         matches!(
-            swapped_transport.verify_signature(&victim_pubkey),
+            genuine.verify_signature(&victim_pubkey, &adversary_announce_pk),
             Err(AttestationError::SignatureMismatch)
         ),
-        "AV-42 regression: a swapped transport identity must fail attestation verify",
+        "AV-42 regression: a replayed attestation on the adversary's OWN destination must fail",
+    );
+    // ...including a swap of only the encryption half.
+    let mut adversary_x = victim_announce_pk;
+    adversary_x[..32].copy_from_slice(&[0xae; 32]);
+    assert!(
+        matches!(
+            genuine.verify_signature(&victim_pubkey, &adversary_x),
+            Err(AttestationError::SignatureMismatch)
+        ),
+        "AV-42 regression: a swapped transport x25519 must fail attestation verify",
     );
 
     // Spoof B — a single flipped signature byte.
     let mut flipped = genuine.clone();
-    let mut sig = genuine_sig.clone();
+    let mut sig = genuine_sig;
     sig[10] ^= 0xff;
-    flipped.signature = B64.encode(&sig);
+    flipped.signature = sig;
     assert!(
         matches!(
-            flipped.verify_signature(&victim_pubkey),
+            flipped.verify_signature(&victim_pubkey, &victim_announce_pk),
             Err(AttestationError::SignatureMismatch)
         ),
         "AV-42 regression: a tampered signature must fail attestation verify",
@@ -183,12 +202,16 @@ async fn av42_tampered_attestation_signature_fails_verify() {
     // Verified against the victim's directory-confirmed pubkey it
     // fails: the adversary's signature is not the victim's.
     let foe_key = ciris_crypto::Ed25519Signer::from_seed(&[0xee; 32]).unwrap();
-    let foe_signature = foe_key.sign(&payload.canonical_bytes()).unwrap();
+    let foe_signature: [u8; 64] = foe_key
+        .sign(&payload.canonical_bytes())
+        .unwrap()
+        .try_into()
+        .unwrap();
     let mut foe_attestation = genuine.clone();
-    foe_attestation.signature = B64.encode(&foe_signature);
+    foe_attestation.signature = foe_signature;
     assert!(
         matches!(
-            foe_attestation.verify_signature(&victim_pubkey),
+            foe_attestation.verify_signature(&victim_pubkey, &victim_announce_pk),
             Err(AttestationError::SignatureMismatch)
         ),
         "AV-42 regression: an adversary-key signature must fail against the victim's pubkey",


### PR DESCRIPTION
**BREAKING** — the announce `app_data` wire changes (JSON → binary; the two transport-pubkey fields are removed). Both peers must be on v12.

## The bug, confirmed by measurement

An attested announce **could not fit**, and never could. Measured (43-char key_id):

| Shape | Size | vs 300 B budget |
|---|---|---|
| JSON, 5 fields (pre-#317) | **337 B** | over by 37 |
| JSON, 6 fields (v10.1.0+) | **410 B** | over by 110 |
| binary, this PR | **~150 B** | fits, with real headroom |

`Node::announce_destination` packs into a fixed `[0u8; MTU]`, so `pack()` failed and **the announce never left the box**. Every attested node was invisible to the mesh *while looking healthy locally*. This is the root cause of the whole AV-42 rooting saga — no attested announce ever propagated an RNS path, so no peer could ever root another by announce. It only surfaced now because CIRISServer#238's boot-prime fixed *directory* rooting, unmasking the transport failure beneath.

## The overflow was pure self-inflicted duplication

leviculum's `build_announce_payload` does `let public_key = identity.public_key_bytes()` — the packet **already carries** the transport identity's 64 bytes (`x25519 ‖ ed25519`), in binary. The attestation then re-encoded *those exact bytes* as base64 JSON: **~140 B of duplication — more than the amount by which it overflowed.**

## The fix

- **Stop re-sending the transport pubkeys; keep binding them.** The signature still covers them; the verifier supplies them from `announce.public_key()` — the packet it just received. **AV-42 gets *stronger*:** an adversary can no longer edit a field, it must actually announce *from a destination*, and that destination is what verification checks against. The AV-42 test now exercises the attack in its real shape (replaying a victim's attestation from the adversary's own destination).
- **Binary wire, not JSON** — `u8(ver) ‖ u8(len) ‖ key_id ‖ fed_pubkey(32) ‖ u64(epoch) ‖ sig(64)`. JSON key names alone cost ~110 B of a 300 B budget; a broadcast primitive under a hard MTU is the wrong place for a self-describing format.
- **A compile-time size gate.** `MAX_FEDERATION_KEY_ID_LEN` (194 B) is *derived* from the budget, and `const _: () = assert!(…)` enforces the invariant **at compile time**. Add a field without shrinking the bound and **the build fails** — the point being that the old shape failed *silently, on the wire, at runtime*. `to_app_data` additionally refuses an over-budget attestation at **compose** time.
- **The unattested-announce branch is deleted.** `signer: None` is now a hard config error. That branch produced a routable-but-unrootable peer — a trap that looks healthy (paths resolve!) and can never root — and it is what masked this bug.

## This retires the #317 premise — my error, owned

#317 concluded `announce.public_key()` was the *federation* identity and added the transport x25519 to the attestation to compensate. leviculum says otherwise (`announce.rs:173`): it is, and always was, the **transport** identity. So hashing it is exactly right for link attribution, **#314's original approach was sound**, and my #317 change was solving a phantom — while adding **73 B to a payload that was already 37 B over budget**. Admit now reads the transport identity from the announce again.

## Verification
682 lib + 3 AV-42 integration tests pass; clippy `-D warnings` clean (default, reticulum, pyo3+reticulum+codec).

Closes #333. Refs CIRISServer#238 (the boot-prime that unmasked it), CIRISServer#235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)