### PR TITLE
feat(v13.0.0)!: authenticated superseding route table — end the #336/#337 rooting saga

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,6 +56,21 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+  # cargo <-> pyproject pin-skew — runs at commit time. Fast (<1s, pure
+  # python). Mirrors CI's `cargo <-> pyproject pin-skew check` lane so a
+  # persist/verify re-pin that forgets the pyproject runtime constraint fails
+  # at commit, not 6 minutes into CI (v13.0.0 hit exactly this). Scoped to the
+  # two manifests so it only fires when a pin could have moved.
+  - repo: local
+    hooks:
+      - id: cargo-pyproject-pin-skew
+        name: cargo <-> pyproject pin-skew check
+        entry: python3 .github/scripts/check_cargo_pyproject_skew.py
+        language: system
+        files: ^(Cargo\.toml|pyproject\.toml)$
+        pass_filenames: false
+        stages: [pre-commit]
+
   # cargo clippy — runs at push time. ~30s warm. Mirrors CI's
   # `clippy + fmt` lane feature set so failures here = failures in CI.
   - repo: local

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "12.0.0"
+version = "12.0.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -538,8 +538,20 @@ tempfile       = { version = "3", optional = true }
 # currency with zero source-side changes on edge's side. `.recv().await`
 # unchanged. Future leviculum upstream releases land via the one-command
 # `scripts/ciris-sync-upstream.sh` rebase upstream-side now.
-reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.8.1+ciris.1", version = "0.8", optional = true }
-reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.8.1+ciris.1", version = "0.8", optional = true }
+#
+# v0.9.0+ciris.1 (leviculum#22, CIRISEdge#333 follow-up) — bumped to
+# 793a31c which exports `announce_app_data_budget(with_ratchet)` and
+# `announce_payload_fixed_len(with_ratchet)` so edge stops hardcoding the
+# derived MTU app-data budget (it now pulls the ratcheted 300 B from the
+# source of truth in src/transport/attestation.rs — the same cross-boundary
+# duplication class as the #333 bug itself). Also carries the packed_size()
+# 3-byte over-count fix (3ebaf88) and turns AnnounceError::PacketTooLarge from
+# a unit variant into a struct carrying {packed, mtu, app_data, budget} plus a
+# new AnnounceError::Pack(PacketError) — a breaking enum change, but edge only
+# matches AnnounceError::ExplicitHashCannotAnnounce (untouched), so the bump is
+# pin currency + the budget-const rewire with no match-arm churn.
+reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.0+ciris.1", version = "0.9", optional = true }
+reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.0+ciris.1", version = "0.9", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "12.0.1"
+version = "13.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -197,7 +197,23 @@ publish = false
 # for the Windows sqlite-only wheel. v11.8.2 adds the directory_ops_capsule
 # ABI proxy `build_ops_directory` (#329) + the 6 peer-mutation ops (#333)
 # that CIRISEdge#245 / v8.1.0 consumes in `init_edge_runtime`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v16.1.1", version = "16", features = ["sqlite", "encrypted-kv"] }
+# v17.0.1 (CIRISPersist#443 + #446, CIRISEdge#336/#337/#338) — the route table
+# is now a well-formed, superseding, AUTHENTICATED CEG object. #443 (v17.0.0):
+# `transport_destinations` authoritative key is (occurrence_key_id,
+# transport_kind) with a durable monotonic `epoch`, `(epoch, asserted_at)`-guarded
+# supersession, a `retired_at` replicated tombstone, and a SIGNED replication
+# surface — `list_signed_records` emits `SignedTransportDestination` containers
+# and the apply (`put_signed_transport_destination`) verifies the hybrid sig +
+# `signer_acts_for(attesting, occurrence_key_id)`, closing the CIRISEdge#337
+# CRITICAL-2 confused-deputy (a bare/unsigned wire route for any key_id, with
+# attacker-set `Rooted`, is refused). #446 (v17.0.1): `put_identity_occurrence`
+# PROJECTS its embedded `transport_binding` into `transport_destinations` (a local
+# materialized read model, NULL-signature so it is excluded from the signed
+# replication plane — no double-carriage), and `put_identity_occurrence_revocation`
+# de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
+# the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
+# the write-through and adopts the signed apply in `src/replication/bridge.rs`.
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.0.1", version = "17", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1090,7 +1106,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v16.1.1", version = "16", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.0.1", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=16.1.1,<17",
+    "ciris-persist>=17.0.1,<18",
 ]
 dynamic = ["version"]
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -5879,6 +5879,11 @@ fn transport_error_class(e: &TransportError) -> &'static str {
         // unreachability. Surface it to the reachability tracker so
         // operators can disambiguate "peer down" from "peer banned".
         TransportError::PeerBlackholed { .. } => "peer_blackholed",
+        // CIRISEdge#336 — target dest has no route (un-routable dest, e.g. the
+        // explicit-hash while the peer is only reachable on its named dest). A
+        // distinct reachability class from a slow-link `timeout`: it is an
+        // addressing/rooting fault the belt heals on the next verified announce.
+        TransportError::NoRouteToPeer { .. } => "no_route_to_peer",
     }
 }
 

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -5199,6 +5199,13 @@ pub fn init_edge_runtime(
                 // authoritative (self-at-login, verified locally): Rooted.
                 binding_provenance:
                     ciris_persist::federation::self_at_login::BindingProvenance::Rooted,
+                // CIRISEdge#336 / CIRISPersist#443 (v17.0.0) — this is the node's
+                // own row, self-asserted once at login; epoch 0 is the correct
+                // floor (a genuine transport-identity rotation re-registers at a
+                // higher epoch). `retired_at` only ever set via the signed
+                // tombstone path, never a local self-register.
+                epoch: 0,
+                retired_at: None,
             };
             let occurrence_for_log = occurrence_key_id.to_string();
             let register_result = run_async(&executor, async move {

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -596,6 +596,11 @@ async fn dispatch_one(
                 // backoff budget on a peer that won't recover until the
                 // operator lifts the rule.
                 TransportError::PeerBlackholed { .. } => "peer_blackholed",
+                // CIRISEdge#336 — un-routable dest (no path); an addressing/
+                // rooting fault distinct from a slow-link timeout. The belt
+                // heals it on the next verified announce, so the dispatcher's
+                // retry will find the routable named dest.
+                TransportError::NoRouteToPeer { .. } => "no_route_to_peer",
             };
             if let Some(t) = reachability {
                 t.record_attempt(

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -82,7 +82,6 @@ use ciris_persist::federation::operational::{
     SignedOrgMembership, SignedOrganization, SignedPartnerRecord,
 };
 use ciris_persist::federation::register::ReplicatedKeyOutcome;
-use ciris_persist::federation::self_at_login::TransportDestination;
 use ciris_persist::federation::types::{
     SignedAttestation, SignedCommunity, SignedCommunityMembershipRevocation, SignedFamily,
     SignedFamilyMembershipRevocation, SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation,
@@ -541,8 +540,31 @@ impl FederationDirectoryReplicationBridge {
                 Some((serde_json::to_vec(canonical_json).ok()?, hash, seq))
             }
             ReplicatedKind::TransportDestination => {
+                // CIRISEdge#338 / CIRISPersist#443 (v17.0.0) — the route arm is now
+                // the SIGNED CONTAINER `{transport_destination, attesting_key_id,
+                // signed_envelope, signature}`, the same #418/#421 discipline as
+                // IdentityOccurrence(Revocation): edge holds the TRANSPORT signer,
+                // not the identity/federation key that signed the route, so it can
+                // only re-publish BYTE-EXACT what was signed-put — never re-sign or
+                // synthesize the signature. (Pre-v17 this arm treated
+                // `canonical_json` as a bare row; against v17 the receiver's
+                // `apply_transport_destination` deserializes the SIGNED container,
+                // so emitting a bare row here would fail to apply and silently drop
+                // every route from the wire.) The container carries no
+                // `persist_row_hash`; hash over its JCS bytes like the v2
+                // operational kinds. `seq` comes from the durable `epoch` — the
+                // monotonic supersession counter #443 gave the row — with the
+                // `asserted_at` fallback for a pre-#443 producer whose projection
+                // reads epoch 0.
+                let inner = canonical_json.get("transport_destination");
                 let hash = v2_envelope_hash(canonical_json)?;
-                let seq = Self::ms_seq_from(canonical_json.get("asserted_at"));
+                let seq = inner
+                    .and_then(|td| td.get("epoch"))
+                    .and_then(serde_json::Value::as_u64)
+                    .filter(|&e| e > 0)
+                    .unwrap_or_else(|| {
+                        Self::ms_seq_from(inner.and_then(|td| td.get("asserted_at")))
+                    });
                 Some((serde_json::to_vec(canonical_json).ok()?, hash, seq))
             }
             ReplicatedKind::Attestation => {
@@ -1121,17 +1143,62 @@ impl FederationDirectoryReplicationBridge {
         }
     }
 
-    /// #311 — admit a replicated `TransportDestination` (reachability row).
-    /// The wire bytes are the bare (unsigned) `TransportDestination` the engine
-    /// emitted; `put_transport_destination` is idempotent/last-writer per V078
-    /// (a stale address is dropped + re-registered, never signed or revoked).
+    /// CIRISEdge#338 / CIRISPersist#443 (v17.0.0) — admit a replicated route.
+    ///
+    /// The wire bytes are now the SIGNED CONTAINER `SignedTransportDestination`
+    /// (`{transport_destination, attesting_key_id, signed_envelope, signature}`),
+    /// NOT a bare row. This closes the CIRISEdge#337 CRITICAL-2 confused-deputy:
+    /// the old path deserialized a bare `TransportDestination` and wrote it with
+    /// an attacker-chosen `binding_provenance = Rooted` for ANY `occurrence_key_id`,
+    /// with no signature and no authority check. `put_signed_transport_destination`
+    /// authenticates the whole thing in persist — the hybrid signature over
+    /// `JCS(signed_envelope)` against the attesting key's PINNED federation
+    /// pubkeys, then `signer_acts_for(attesting_key_id, occurrence_key_id)` (a peer
+    /// cannot sign a victim's route with its own unrelated key), and
+    /// `binding_provenance` is read ONLY from inside the verified envelope, never
+    /// a wire field. Supersession is `(epoch, asserted_at)`-monotonic, so a
+    /// replayed older frame is `Refused`, not applied.
+    ///
+    /// `Refused { reason }` is fail-closed and re-offerable — it is NOT a
+    /// transport error (the record is simply inadmissible: older epoch, or a
+    /// same-`(epoch, asserted_at)` content conflict), so we return `true`
+    /// (the frame was handled; do not retry-storm the sender). A genuine gate
+    /// failure (bad signature / unknown attesting key / not-acts-for) surfaces
+    /// as `Err` from persist → `false` → the frame is rejected. A parse failure
+    /// (a pre-v17 bare row from an un-upgraded peer) is also `false` — such a
+    /// peer's routes simply do not replicate until it adopts v17, which is the
+    /// intended breaking behavior, not a silent bare-row admit.
     async fn apply_transport_destination(&self, bytes: &[u8]) -> bool {
-        match serde_json::from_slice::<TransportDestination>(bytes) {
-            Ok(dest) => self
+        use ciris_persist::federation::self_at_login::{
+            SignedTransportDestination, TransportDestinationApplyOutcome,
+        };
+        match serde_json::from_slice::<SignedTransportDestination>(bytes) {
+            Ok(signed) => match self
                 .directory
-                .put_transport_destination(&dest)
+                .put_signed_transport_destination(&signed)
                 .await
-                .is_ok(),
+            {
+                Ok(TransportDestinationApplyOutcome::Refused { reason }) => {
+                    // Bounded: keyed on the low-cardinality refusal reason, never
+                    // the attacker-influenced key_id / dest (CIRISEdge#337 §4).
+                    tracing::debug!(
+                        occurrence_key_id = %signed.transport_destination.occurrence_key_id,
+                        reason = %reason,
+                        "replicated route refused (fail-closed, re-offerable): stale epoch \
+                         or content conflict — not applied (CIRISEdge#338)"
+                    );
+                    true
+                }
+                Ok(_) => true,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "replicated route REJECTED by the authenticated apply gate — \
+                         signature / attesting-key / acts-for failure (CIRISEdge#337 CRITICAL-2)"
+                    );
+                    false
+                }
+            },
             Err(_) => false,
         }
     }
@@ -1510,6 +1577,62 @@ mod tests {
                 .await;
             assert!(!r, "expected garbage refused for {kind:?}");
         }
+    }
+
+    /// CIRISEdge#337 CRITICAL-2 — the confused-deputy closure. A WELL-FORMED
+    /// BARE `TransportDestination` (valid JSON of the bare route row — the exact
+    /// shape the pre-v17 apply path deserialized and wrote with an attacker-set
+    /// `binding_provenance = Rooted` for ANY key_id, with no signature and no
+    /// authority check) must now be REFUSED. Only a `SignedTransportDestination`
+    /// container that clears persist's hybrid-sig + `signer_acts_for` gate is
+    /// admitted. This is the route-table half of the AV-42 saga: a peer can no
+    /// longer inject a route for a victim's key_id over replication.
+    #[tokio::test]
+    async fn apply_transport_destination_refuses_a_bare_unsigned_route() {
+        use ciris_persist::federation::self_at_login::{BindingProvenance, TransportDestination};
+
+        let (backend, bridge) = make_bridge(&[]);
+
+        // A perfectly well-formed bare route claiming a Rooted binding for a
+        // victim key_id — no signature, no authority. The confused-deputy input.
+        let bare = TransportDestination {
+            occurrence_key_id: "victim-key".to_string(),
+            transport_kind: "reticulum".to_string(),
+            destination: hex::encode([0xaa; 16]),
+            asserted_at: chrono::Utc::now(),
+            last_seen_at: None,
+            transport_ed25519_pubkey_base64: Some(
+                base64::engine::general_purpose::STANDARD.encode([0xbb; 32]),
+            ),
+            transport_x25519_pubkey_base64: Some(
+                base64::engine::general_purpose::STANDARD.encode([0xcc; 32]),
+            ),
+            binding_provenance: BindingProvenance::Rooted, // attacker-chosen
+            epoch: u64::MAX,                               // attacker-chosen ceiling
+            retired_at: None,
+        };
+        let bytes = serde_json::to_vec(&bare).expect("serialize bare route");
+
+        let admitted = bridge
+            .apply_envelope_bytes(EnvelopeKind::TransportDestination, &bytes)
+            .await;
+
+        assert!(
+            !admitted,
+            "a bare unsigned TransportDestination must be REFUSED — admitting it is the \
+             CIRISEdge#337 CRITICAL-2 confused-deputy route-hijack",
+        );
+
+        // And nothing was written for the victim.
+        let rows = backend
+            .list_transport_destinations_for("victim-key")
+            .await
+            .expect("list");
+        assert!(
+            rows.is_empty(),
+            "a refused bare route must not touch persist; found {} row(s)",
+            rows.len(),
+        );
     }
 
     // ── FSD §7.1 federation-tier-only invariant fence ───────────────

--- a/src/transport/attestation.rs
+++ b/src/transport/attestation.rs
@@ -243,7 +243,15 @@ impl TransportBindingEnforcement {
 /// The pre-#333 JSON attestation was 337 B (410 B once #317 added the x25519
 /// field): it had **never** fit, which is the root cause of the whole AV-42
 /// rooting saga (no attested announce ever propagated an RNS path).
-pub const ANNOUNCE_APP_DATA_BUDGET: usize = 300;
+///
+/// The value is **not** hardcoded here — it is leviculum's own derived budget
+/// (`MTU − IFAC − header − fixed_payload`), pulled from the source of truth so
+/// it cannot silently rot if leviculum changes a header size or the ratchet
+/// default. `with_ratchet = true`: edge announces are ratcheted, whose fixed
+/// payload (180 B) is larger than the un-ratcheted case, so 300 B (not 332 B) is
+/// the value a smaller-fits-so-does-larger argument does NOT get to assume.
+/// (leviculum#22 / v0.9.0+ciris.1 exported this; before, edge duplicated `300`.)
+pub const ANNOUNCE_APP_DATA_BUDGET: usize = reticulum_core::announce_app_data_budget(true);
 
 /// The binary wire tag for [`AnnounceAttestation::to_app_data`]. A version byte
 /// so a future shape is distinguishable rather than mis-parsed.

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -210,6 +210,40 @@ pub enum TransportError {
         reason: Option<String>,
         until: Option<String>,
     },
+    /// CIRISEdge#336 — the LINK_REQUEST target has **no route**: the link
+    /// request was aimed at a destination the node has no path-table entry
+    /// for, and it did not establish within the no-path window (a no-path
+    /// dest is broadcast-only and answerable solely by a *directly-attached*
+    /// neighbor in a single round-trip — a relay-reachable peer would have a
+    /// path; see `NO_PATH_ESTABLISH_TIMEOUT`). This is the transport-routing
+    /// sibling of the federation-vs-transport identity split: it fires when a
+    /// peer is addressed on its **explicit-hash** dest (`sha256(fed_pubkey)`,
+    /// which is un-announceable and therefore un-routable) while it is only
+    /// reachable on its **named** dest. The message names every operand needed
+    /// to see the mismatch at a glance — the target dest, the peer key_id, and
+    /// the paths the node *does* hold — so this failure is never again a
+    /// multi-day forensic. Unlike [`Self::Timeout`], this is an
+    /// addressing/rooting fault, not a slow link.
+    #[error(
+        "no route to peer: key_id={key_id} target_dest={target_dest} \
+         has_path={has_path} known_paths=[{paths}] (CIRISEdge#336)"
+    )]
+    NoRouteToPeer {
+        /// The federation key_id the send was routed to.
+        key_id: String,
+        /// The 16-byte Reticulum destination hash the link request targeted,
+        /// lowercase hex — the un-routable dest.
+        target_dest: String,
+        /// Whether the node held a path-table entry for `target_dest` at send
+        /// time (always `false` when this error is raised — surfaced so the
+        /// log line is self-contained).
+        has_path: bool,
+        /// A compact snapshot of the node's path table at failure — each
+        /// `dest via next_hop hops=N`. The routable **named** dest for this
+        /// very peer typically appears here, making the explicit-vs-named
+        /// mismatch obvious.
+        paths: String,
+    },
 }
 
 /// One inbound frame from a transport — raw envelope bytes plus the

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -112,8 +112,27 @@ const EDGE_APP_NAME: &str = "ciris";
 const EDGE_APP_ASPECT: &str = "edge";
 
 /// How long [`Transport::send`] waits for a link to establish before
-/// giving up and surfacing [`TransportError::Timeout`].
+/// giving up and surfacing [`TransportError::Timeout`]. Applies when the
+/// node **holds a path** to the target — a relayed path can legitimately be
+/// slow (LoRa, multi-hop), so it gets the full patient window.
 const LINK_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// CIRISEdge#336 — the establishment window for a target the node has **no
+/// path** to. This is not a guess: leviculum's `connect` builds a
+/// no-path link request with `hops = 1` and *broadcasts* it, so the only
+/// thing that can answer is a **directly-attached** neighbor on a live
+/// interface — which replies in a single interface round-trip. A
+/// relay-reachable peer would have produced a path-table entry (from its
+/// announce) and taken the [`LINK_ESTABLISH_TIMEOUT`] branch instead.
+/// Therefore, if a no-path link request has not established within this
+/// window, no amount of further waiting helps: there is no route. We fail
+/// fast with the self-diagnosing [`TransportError::NoRouteToPeer`] rather
+/// than stalling the full 30 s and surfacing an opaque timeout. The window
+/// is sized with a wide margin over any real direct link (localhost is
+/// sub-millisecond; internet-RTT direct TCP is tens of ms) so a genuinely
+/// directly-reachable peer — e.g. a `prime_peer`'d bootstrap peer that
+/// never announced — is never regressed.
+const NO_PATH_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// How long [`Transport::send`] waits for a resource transfer to
 /// complete after the link is up.
@@ -138,6 +157,9 @@ static PEER_ADMITTED_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> 
     std::sync::OnceLock::new();
 static LINK_ATTRIBUTION_MISS_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
     std::sync::OnceLock::new();
+// CIRISEdge#337 — route supersession decisions (verified-only gate + belt heal).
+static ROUTE_SUPERSESSION_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
 
 /// Point 1 — peer-admitted (INFO). Keyed on `provenance` (2 values), so the
 /// rare `Rooted` admit logs freely while a flood of junk `Advisory` admits is
@@ -152,6 +174,17 @@ fn peer_admitted_log() -> &'static crate::log_throttle::LogThrottle {
 fn link_attribution_miss_log() -> &'static crate::log_throttle::LogThrottle {
     LINK_ATTRIBUTION_MISS_LOG
         .get_or_init(|| crate::log_throttle::LogThrottle::new(5, Duration::from_secs(60), 1024))
+}
+
+/// CIRISEdge#337 — route supersession decisions (verified-only refusal + belt
+/// reroute-heal). Keyed on a fixed low-cardinality reason ("hijack_refused" /
+/// "reroute_healed", ≤4 keys), NEVER on the attacker-chosen `key_id`, so a flood
+/// of forged supersession attempts collapses to a suppressed-count instead of a
+/// per-key log line. The refusal is a genuine attack signal, so it logs the
+/// first few per window loudly then summarizes.
+fn route_supersession_log() -> &'static crate::log_throttle::LogThrottle {
+    ROUTE_SUPERSESSION_LOG
+        .get_or_init(|| crate::log_throttle::LogThrottle::new(8, Duration::from_secs(60), 4))
 }
 
 // ─── Peer resolution ────────────────────────────────────────────────
@@ -2131,6 +2164,42 @@ impl ReticulumTransport {
     /// precision contract. `last_seen_at` is the call-time wall
     /// clock (path entries don't carry an insertion timestamp in
     /// leviculum's storage shape).
+    /// CIRISEdge#336 — a compact, single-line snapshot of the node's path
+    /// table for the [`TransportError::NoRouteToPeer`] diagnostic. Each entry
+    /// renders as `dest via next_hop hops=N` (or `dest direct hops=N` for a
+    /// directly-attached neighbor). Synchronous and lock-free —
+    /// `path_table_entries()` clones leviculum's rows — so it is safe to call
+    /// on the send failure path. Bounded to a handful of rows so an enormous
+    /// fabric can't turn one failure into a megabyte log line.
+    fn path_table_snapshot(&self) -> String {
+        use std::fmt::Write as _;
+        const MAX_ROWS: usize = 16;
+        let rows = self.node.path_table_entries();
+        let total = rows.len();
+        let mut out = String::new();
+        for (i, entry) in rows.iter().take(MAX_ROWS).enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            let dest = hex::encode(entry.hash);
+            match entry.next_hop {
+                Some(nh) if entry.hops > 1 => {
+                    let _ = write!(out, "{dest} via {} hops={}", hex::encode(nh), entry.hops);
+                }
+                _ => {
+                    let _ = write!(out, "{dest} direct hops={}", entry.hops);
+                }
+            }
+        }
+        if total > MAX_ROWS {
+            let _ = write!(out, ", …(+{} more)", total - MAX_ROWS);
+        }
+        if total == 0 {
+            out.push_str("<empty>");
+        }
+        out
+    }
+
     #[cfg(feature = "ffi-uniffi")]
     pub async fn routing_path_table(
         &self,
@@ -2707,6 +2776,23 @@ impl Transport for ReticulumTransport {
         let dest_hash_bytes = peer.dest_hash.into_bytes();
         self.check_blackhole(&dest_hash_bytes).await?;
 
+        // CIRISEdge#336 — the no-path GUARD. Decide the establishment window
+        // from whether the node holds a path to this exact dest BEFORE dialing.
+        // A no-path dest is broadcast-only (leviculum sends the link request
+        // with hops=1) and can be answered only by a directly-attached
+        // neighbor in one round-trip — so it establishes fast or never. A
+        // relay-reachable peer has a path and gets the patient window. This is
+        // the tripwire that ends the rooting saga's whack-a-mole: a send aimed
+        // at an un-routable dest (e.g. the un-announceable explicit-hash while
+        // the peer is only reachable on its named dest) fails FAST and LOUD
+        // with every operand named, instead of a silent 30 s opaque timeout.
+        let has_path = self.node.has_path(&peer.dest_hash);
+        let establish_timeout = if has_path {
+            LINK_ESTABLISH_TIMEOUT
+        } else {
+            NO_PATH_ESTABLISH_TIMEOUT
+        };
+
         // Establish a link to the peer's destination. `connect`
         // returns immediately; the link is usable once
         // `LinkEstablished` arrives on the event channel. The event
@@ -2724,14 +2810,39 @@ impl Transport for ReticulumTransport {
         // the peer must have accepted the LINK_REQUEST or a resource
         // transfer cannot start. The event loop records established
         // link IDs in `established_links`; poll it.
-        let established = wait_until_async(
-            LINK_ESTABLISH_TIMEOUT,
-            Duration::from_millis(50),
-            || async { self.established_links.lock().await.contains(&link_id) },
-        )
-        .await;
+        let established =
+            wait_until_async(establish_timeout, Duration::from_millis(50), || async {
+                self.established_links.lock().await.contains(&link_id)
+            })
+            .await;
         if !established {
-            return Err(TransportError::Timeout(LINK_ESTABLISH_TIMEOUT));
+            // CIRISEdge#336 — a no-path target that never established is
+            // un-routable, not slow: fail fast with the self-diagnosing error
+            // (naming target dest, key_id, and the paths we DO hold — the
+            // routable named dest for this peer usually appears there, making
+            // the explicit-vs-named mismatch obvious). A had-a-path target that
+            // stalled is a genuine slow/dead link → the opaque timeout stands.
+            if !has_path {
+                let target_dest = hex::encode(peer.dest_hash.into_bytes());
+                let paths = self.path_table_snapshot();
+                tracing::error!(
+                    key_id = %destination_key_id,
+                    target_dest = %target_dest,
+                    has_path,
+                    known_paths = %paths,
+                    "link_request target has no route — un-routable dest (CIRISEdge#336). \
+                     A no-path dest is broadcast-only and no directly-attached neighbor \
+                     answered; if the peer is relay-reachable it must be addressed on its \
+                     announced (named) dest, which appears in known_paths."
+                );
+                return Err(TransportError::NoRouteToPeer {
+                    key_id: destination_key_id.to_string(),
+                    target_dest,
+                    has_path,
+                    paths,
+                });
+            }
+            return Err(TransportError::Timeout(establish_timeout));
         }
 
         // Auto-accept any resources the peer pushes back on this link
@@ -3261,11 +3372,79 @@ fn link_event(
 // fragment the cold-start verdict logic without adding clarity, so
 // the gate is allowed locally rather than refactored across the
 // merge boundary.
+/// The route-table supersession verdict for an admitted announce (CIRISEdge#336
+/// belt + CIRISEdge#337 CRITICAL-1 verified-only invariant), factored out as a
+/// PURE function so the security-critical decision is exhaustively unit-testable
+/// without the event-loop `EventCtx` scaffolding. No I/O, no logging, no clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RouteSupersession {
+    /// No prior entry, or a legitimate supersession / first-root upgrade /
+    /// verified reroute-heal — write the incoming route.
+    Admit,
+    /// A same-or-lower-epoch re-announce with no upgrade and no heal — ignore
+    /// (stale); the cached route stands.
+    IgnoreStale,
+    /// CIRISEdge#337 CRITICAL-1 — an Advisory announce attempting to override a
+    /// Rooted route. NEVER written: a self-signed announce (mintable for any
+    /// key_id) must not repoint a directory-rooted peer at an attacker dest.
+    HijackRefused,
+}
+
+/// Decide whether an incoming announce supersedes the cached route for its
+/// key_id. `existing` is `(provenance, epoch, dest16)` of the cached entry (if
+/// any). Order is load-bearing: the Rooted-not-overridden-by-Advisory hijack
+/// gate is checked FIRST, before any epoch comparison, so a `u64::MAX`-epoch
+/// advisory cannot poison a rooted route.
+fn route_supersession_decision(
+    existing: Option<(
+        ciris_persist::federation::self_at_login::BindingProvenance,
+        u64,
+        [u8; 16],
+    )>,
+    incoming_provenance: ciris_persist::federation::self_at_login::BindingProvenance,
+    incoming_epoch: u64,
+    incoming_dest16: [u8; 16],
+) -> RouteSupersession {
+    use ciris_persist::federation::self_at_login::BindingProvenance::{Advisory, Rooted};
+    let Some((ex_prov, ex_epoch, ex_dest16)) = existing else {
+        // Fresh peer — nothing to supersede.
+        return RouteSupersession::Admit;
+    };
+    // CRITICAL-1, FIRST and epoch-independent: rooted is never overridden by
+    // advisory. This is the route-hijack gate.
+    if matches!(ex_prov, Rooted) && matches!(incoming_provenance, Advisory) {
+        return RouteSupersession::HijackRefused;
+    }
+    // A strictly-newer epoch always supersedes (a genuine transport-identity
+    // rotation, or a rooted upgrade at a higher epoch).
+    if incoming_epoch > ex_epoch {
+        return RouteSupersession::Admit;
+    }
+    if incoming_epoch == ex_epoch {
+        // CIRISEdge#301 — advisory→rooted first-root upgrade at equal epoch.
+        let advisory_to_rooted_upgrade =
+            matches!(ex_prov, Advisory) && matches!(incoming_provenance, Rooted);
+        // CIRISEdge#336 BELT — a VERIFIED (rooted) announce at the same epoch
+        // carrying a DIFFERENT dest heals the route (the explicit→named boot-
+        // prime trap). Advisory can never reroute (it would be caught above only
+        // if existing were rooted; an advisory-over-advisory reroute at equal
+        // epoch is NOT honored — epoch must advance for a non-verified change).
+        let verified_reroute =
+            matches!(incoming_provenance, Rooted) && incoming_dest16 != ex_dest16;
+        if advisory_to_rooted_upgrade || verified_reroute {
+            return RouteSupersession::Admit;
+        }
+    }
+    // Lower epoch, or equal epoch with no upgrade/heal → stale.
+    RouteSupersession::IgnoreStale
+}
+
 #[allow(clippy::too_many_lines)]
 async fn resolve_announce_cold_start(
     announce: &reticulum_core::ReceivedAnnounce,
     ctx: &EventCtx<'_>,
 ) {
+    use ciris_persist::federation::self_at_login::BindingProvenance;
     // Step 0 — the cold-start path needs the persist directory. With
     // no rooting backend the announce cannot be authenticated; drop
     // it (fail-honest — never fall back to TOFU).
@@ -3400,7 +3579,11 @@ async fn resolve_announce_cold_start(
             if !attestation_self_verifies(&attestation, &key_id, announce.public_key()) {
                 return;
             }
-            tracing::info!(
+            // CIRISEdge#337 §4 — advisory admits are attacker-floodable (mint
+            // unlimited self-signed keypairs). DEBUG, not INFO: the always-on
+            // admit signal is the THROTTLED `peer_admitted_log` point-1 line
+            // below; this per-admit detail must not flood the default stream.
+            tracing::debug!(
                 av = "AV-42",
                 key_id = %key_id,
                 reason = rejection.kind(),
@@ -3447,37 +3630,78 @@ async fn resolve_announce_cold_start(
         Identity::from_public_keys(&x25519, &ed25519).map_or([0u8; 16], |id| *id.hash())
     };
     let dest_hash16: [u8; 16] = (*announce.destination_hash()).into_bytes();
-    // CIRISEdge#301 — a same-epoch re-announce that finally ROOTS a peer
-    // previously admitted as ADVISORY must UPGRADE the binding, not be ignored
-    // as stale (the advisory→rooted promotion is the whole point of first-root).
-    let is_advisory_to_rooted_upgrade = |existing: &RootedPeer| {
-        existing.epoch == attestation.epoch
-            && matches!(
-                existing.provenance,
-                ciris_persist::federation::self_at_login::BindingProvenance::Advisory
-            )
-            && matches!(
-                provenance,
-                ciris_persist::federation::self_at_login::BindingProvenance::Rooted
-            )
-    };
+    let announced_dest = *announce.destination_hash();
+    let announced_dest16 = announced_dest.into_bytes();
     let newly_rooted_key = {
         let mut peers = ctx.peers.lock().await;
-        match peers.get(&key_id) {
-            Some(existing)
-                if existing.epoch >= attestation.epoch
-                    && !is_advisory_to_rooted_upgrade(existing) =>
-            {
+        // Snapshot the existing entry's decision-relevant fields (all Copy), so
+        // the pure supersession decision runs without holding a borrow across
+        // the admit side effects (which re-borrow `peers` mutably to insert).
+        let existing_snapshot = peers
+            .get(&key_id)
+            .map(|e| (e.provenance, e.epoch, e.peer.dest_hash.into_bytes()));
+        match route_supersession_decision(
+            existing_snapshot,
+            provenance,
+            attestation.epoch,
+            announced_dest16,
+        ) {
+            // CIRISEdge#337 CRITICAL-1 — an Advisory announce cannot override a
+            // Rooted route (route-hijack refused). Attacker-floodable, so the
+            // WARN is throttled on the fixed "hijack_refused" key, never key_id.
+            RouteSupersession::HijackRefused => {
+                if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                    route_supersession_log().check("hijack_refused")
+                {
+                    let (_, ex_epoch, _) = existing_snapshot.unwrap_or_default();
+                    tracing::warn!(
+                        av = "AV-42",
+                        key_id = %key_id,
+                        existing_epoch = ex_epoch,
+                        announce_epoch = attestation.epoch,
+                        suppressed_prev,
+                        "route supersession REFUSED — an advisory (self-signed, not \
+                         directory-rooted) announce cannot override a rooted route \
+                         (CIRISEdge#337 verified-only supersession)"
+                    );
+                }
+                None
+            }
+            RouteSupersession::IgnoreStale => {
                 tracing::trace!(
                     key_id = %key_id,
-                    cached_epoch = existing.epoch,
                     announce_epoch = attestation.epoch,
-                    "stale re-announce ignored (epoch not newer, no provenance upgrade)",
+                    "stale re-announce ignored (epoch not newer, no provenance upgrade, \
+                     no verified reroute)",
                 );
                 None
             }
-            _ => {
-                tracing::info!(
+            RouteSupersession::Admit => {
+                // CIRISEdge#336 — surface a reroute-heal distinctly from a fresh
+                // admit so the explicit→named transition is visible in the log.
+                if let Some((_, _, ex_dest16)) = existing_snapshot {
+                    if ex_dest16 != announced_dest16
+                        && matches!(provenance, BindingProvenance::Rooted)
+                    {
+                        if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                            route_supersession_log().check("reroute_healed")
+                        {
+                            tracing::info!(
+                                key_id = %key_id,
+                                old_dest = %hex::encode(ex_dest16),
+                                new_dest = %hex::encode(announced_dest16),
+                                epoch = attestation.epoch,
+                                suppressed_prev,
+                                "route HEALED from a verified announce — repointed to the \
+                                 announced (routable) destination (CIRISEdge#336)"
+                            );
+                        }
+                    }
+                }
+                // CIRISEdge#337 §4 — DEBUG (was INFO): attacker-floodable per
+                // admit. The throttled `peer_admitted_log` point-1 line is the
+                // always-on admit signal; this is the verbose companion.
+                tracing::debug!(
                     key_id = %key_id,
                     dest = %resolved.dest_hash,
                     epoch = attestation.epoch,
@@ -3606,7 +3830,13 @@ async fn resolve_announce_cold_start(
         // `announce.public_key()` (the federation identity), so the boot-reloaded
         // binding resolves + seals to the identity the link proves.
         rooting
-            .persist_transport_binding(&persisted_key, dest_hash16, binding_pubkey64, provenance)
+            .persist_transport_binding(
+                &persisted_key,
+                dest_hash16,
+                binding_pubkey64,
+                provenance,
+                attestation.epoch,
+            )
             .await;
     }
 }
@@ -4135,6 +4365,121 @@ where
 mod tests {
     use super::*;
 
+    // ── CIRISEdge#336/#337 route-supersession decision — the saga's tombstone ──
+    //
+    // One test per prior footgun path, over the PURE `route_supersession_decision`
+    // so a regression is a compile-fast unit failure, never a field incident.
+    mod route_supersession {
+        use super::*;
+        use ciris_persist::federation::self_at_login::BindingProvenance::{Advisory, Rooted};
+
+        const EXPLICIT: [u8; 16] = [0x1f; 16]; // stand-in for the un-routable explicit-hash
+        const NAMED: [u8; 16] = [0x81; 16]; // stand-in for the routable named dest
+
+        /// A fresh peer (no cached route) is always admitted.
+        #[test]
+        fn fresh_peer_is_admitted() {
+            assert_eq!(
+                route_supersession_decision(None, Rooted, 0, NAMED),
+                RouteSupersession::Admit
+            );
+            assert_eq!(
+                route_supersession_decision(None, Advisory, 7, NAMED),
+                RouteSupersession::Admit
+            );
+        }
+
+        /// CIRISEdge#337 CRITICAL-1 — the route-hijack gate. An Advisory announce
+        /// can NEVER override a Rooted route, even at a wildly higher epoch. This
+        /// is the test that must never regress: it is the whole verified-only
+        /// invariant.
+        #[test]
+        fn higher_epoch_advisory_cannot_override_rooted() {
+            assert_eq!(
+                route_supersession_decision(Some((Rooted, 5, NAMED)), Advisory, u64::MAX, EXPLICIT),
+                RouteSupersession::HijackRefused,
+            );
+            // …and at equal epoch, and with the SAME dest — still refused.
+            assert_eq!(
+                route_supersession_decision(Some((Rooted, 5, NAMED)), Advisory, 5, NAMED),
+                RouteSupersession::HijackRefused,
+            );
+        }
+
+        /// CIRISEdge#336 BELT — a VERIFIED (rooted) announce at the SAME epoch
+        /// carrying a DIFFERENT dest heals the route. This is the boot-prime
+        /// trap: an epoch-0 prime on the explicit-hash, healed by the peer's
+        /// genuine epoch-0 announce on its named dest. Without this the peer is
+        /// pinned to a dest no path can reach — the #336 root cause.
+        #[test]
+        fn equal_epoch_verified_reroute_heals_explicit_to_named() {
+            assert_eq!(
+                route_supersession_decision(Some((Rooted, 0, EXPLICIT)), Rooted, 0, NAMED),
+                RouteSupersession::Admit,
+            );
+        }
+
+        /// CIRISEdge#301 — an advisory entry is upgraded to rooted at equal epoch
+        /// (first-root promotion), even with the same dest.
+        #[test]
+        fn equal_epoch_advisory_to_rooted_upgrades() {
+            assert_eq!(
+                route_supersession_decision(Some((Advisory, 3, NAMED)), Rooted, 3, NAMED),
+                RouteSupersession::Admit,
+            );
+        }
+
+        /// A strictly-newer epoch supersedes (genuine transport-identity
+        /// rotation) for both provenance-preserving cases.
+        #[test]
+        fn higher_epoch_supersedes() {
+            assert_eq!(
+                route_supersession_decision(Some((Rooted, 2, NAMED)), Rooted, 3, EXPLICIT),
+                RouteSupersession::Admit,
+            );
+            assert_eq!(
+                route_supersession_decision(Some((Advisory, 2, NAMED)), Advisory, 3, EXPLICIT),
+                RouteSupersession::Admit,
+            );
+        }
+
+        /// A same-epoch re-announce with the same provenance and same dest is
+        /// stale — no needless churn / persist write / replication gossip.
+        #[test]
+        fn equal_epoch_same_provenance_same_dest_is_stale() {
+            assert_eq!(
+                route_supersession_decision(Some((Rooted, 4, NAMED)), Rooted, 4, NAMED),
+                RouteSupersession::IgnoreStale,
+            );
+            assert_eq!(
+                route_supersession_decision(Some((Advisory, 4, NAMED)), Advisory, 4, NAMED),
+                RouteSupersession::IgnoreStale,
+            );
+        }
+
+        /// A lower-epoch announce is stale even if it carries a different dest —
+        /// a replayed/older frame can never rewrite a newer binding (the durable
+        /// half of this is persist's `(epoch, asserted_at)` guard, #443).
+        #[test]
+        fn lower_epoch_is_stale_even_with_new_dest() {
+            assert_eq!(
+                route_supersession_decision(Some((Rooted, 9, NAMED)), Rooted, 2, EXPLICIT),
+                RouteSupersession::IgnoreStale,
+            );
+        }
+
+        /// An advisory-over-advisory reroute at EQUAL epoch is NOT honored — a
+        /// non-verified route change must advance the epoch. (Only a VERIFIED
+        /// announce reroutes at equal epoch; the belt is rooted-gated.)
+        #[test]
+        fn equal_epoch_advisory_reroute_is_not_honored() {
+            assert_eq!(
+                route_supersession_decision(Some((Advisory, 1, NAMED)), Advisory, 1, EXPLICIT),
+                RouteSupersession::IgnoreStale,
+            );
+        }
+    }
+
     /// CIRISEdge#299 — the persisted-binding resolver returns the exact
     /// 64-byte identity it was loaded with, and `None` for an unknown peer.
     #[test]
@@ -4212,6 +4557,7 @@ mod tests {
             dest_hash,
             pubkey,
             ciris_persist::federation::self_at_login::BindingProvenance::Rooted,
+            0, // epoch (CIRISEdge#336 / CIRISPersist#443)
         )
         .await;
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -246,6 +246,7 @@ pub trait RootingDirectory: Send + Sync + 'static {
         _dest_hash: [u8; 16],
         _transport_pubkey: [u8; 64],
         _provenance: ciris_persist::federation::self_at_login::BindingProvenance,
+        _epoch: u64,
     ) {
     }
 }
@@ -270,6 +271,7 @@ impl<F: FederationDirectory + Send + Sync + 'static> RootingDirectory for F {
         dest_hash: [u8; 16],
         transport_pubkey: [u8; 64],
         provenance: ciris_persist::federation::self_at_login::BindingProvenance,
+        epoch: u64,
     ) {
         use base64::Engine as _;
         let b64 = base64::engine::general_purpose::STANDARD;
@@ -285,18 +287,33 @@ impl<F: FederationDirectory + Send + Sync + 'static> RootingDirectory for F {
             // CIRISEdge#301 — Rooted (Confirmed verdict) or Advisory (CC 3.3.6.2
             // admit-as-routing-hint); the caller decides from the verdict.
             binding_provenance: provenance,
+            // CIRISEdge#336 / CIRISPersist#443 (v17.0.0) — the durable monotonic
+            // supersession counter (the announce attestation's epoch, which is
+            // `RootedPeer.epoch`). Persist's put is `(epoch, asserted_at)`-guarded,
+            // so a replayed older frame can never clobber a newer binding — the
+            // durable half of the verified-only supersession invariant. Route
+            // retirement (`retired_at`) goes through the signed tombstone path,
+            // never a plain local write-through, so it is `None` here.
+            epoch,
+            retired_at: None,
         };
         match FederationDirectory::put_transport_destination(self, &row).await {
-            Ok(()) => tracing::info!(
+            // CIRISEdge#337 §4 — DEBUG (was INFO): one per persist write, i.e. per
+            // admit, so attacker-floodable. The failure branch stays WARN (a
+            // durable-write failure is a real incident, and it is not
+            // attacker-amplifiable beyond the admit rate the peers-map cap bounds).
+            Ok(()) => tracing::debug!(
                 key_id,
                 dest_hash = %row.destination,
                 provenance = ?provenance,
+                epoch,
                 "CIRISEdge#299/#301: persisted transport binding (write-through)"
             ),
             Err(e) => tracing::warn!(
                 key_id,
                 error = %e,
                 provenance = ?provenance,
+                epoch,
                 "CIRISEdge#299/#301: write-through of transport binding failed (peer still \
                  admitted in-memory this session, but will not survive a restart)"
             ),

--- a/tests/route_table_e2e.rs
+++ b/tests/route_table_e2e.rs
@@ -1,0 +1,166 @@
+//! Route-table end-to-end regression gate — the CIRISEdge#336/#337 saga's
+//! tombstone. Every prior footgun of the rooting saga gets a named test here so
+//! it can never silently bleed back.
+//!
+//! The route-table DECISION logic (verified-only supersession, the belt
+//! reroute-heal, epoch monotonicity) is unit-tested exhaustively over the pure
+//! `route_supersession_decision` in `src/transport/reticulum.rs`. This file
+//! holds the LIVE-TRANSPORT regressions that need a real Leviculum node:
+//!
+//!   * the no-path GUARD — a send to an un-routable dest must fail FAST and
+//!     LOUD (`NoRouteToPeer`, the self-diagnosing error naming the mismatch),
+//!     never the silent 30-second `Timeout` that cost this saga days per round.
+//!
+//! Requires the `transport-reticulum` feature:
+//! `cargo test --features transport-reticulum --test route_table_e2e`
+
+#![cfg(feature = "transport-reticulum")]
+
+mod common;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use ciris_edge::identity::LocalSigner;
+use ciris_edge::transport::reticulum::{ReticulumAuth, ReticulumTransportConfig};
+use ciris_edge::transport::{Transport, TransportError};
+use ciris_edge::verify::RootingDirectory;
+
+use common::{build_reticulum_with_retry, directory_with, signed_record, TestFedKey};
+
+fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+async fn signer_for(key: &TestFedKey, base: &std::path::Path) -> Arc<LocalSigner> {
+    let seed_dir = key.write_seed_dir(base);
+    let (classical, _pqc) = ciris_keyring::load_local_seed(ciris_keyring::LocalSeedConfig {
+        key_id: key.key_id.clone(),
+        key_path: seed_dir.join("ed25519.seed"),
+        pqc_key_id: None,
+        pqc_key_path: None,
+    })
+    .await
+    .expect("load_local_seed");
+    Arc::new(LocalSigner::new(key.key_id.clone(), classical, None))
+}
+
+async fn auth_for(
+    key: &TestFedKey,
+    directory: Arc<ciris_persist::store::sqlite::SqliteBackend>,
+    base: &std::path::Path,
+) -> ReticulumAuth {
+    ReticulumAuth {
+        signer: Some(signer_for(key, base).await),
+        rooting: Some(directory as Arc<dyn RootingDirectory>),
+        resolver: None,
+        hybrid_policy: ciris_edge::HybridPolicy::Ed25519Fallback,
+        ..ReticulumAuth::default()
+    }
+}
+
+/// CIRISEdge#336 GUARD — a send to a rooted peer whose destination has NO route
+/// must fail FAST with the self-diagnosing `NoRouteToPeer`, not stall the full
+/// `LINK_ESTABLISH_TIMEOUT` (30 s) and surface an opaque `Timeout`.
+///
+/// This is the anti-whack-a-mole tripwire. Every round of the rooting saga cost
+/// days because "send to a dest with no route" failed *silently* after 30 s and
+/// shape-shifted into a dozen plausible-but-wrong causes. A no-path dest is
+/// broadcast-only and answerable solely by a directly-attached neighbor in one
+/// round-trip; if none answers within the short no-path window, no amount of
+/// waiting helps — so we fail loud and immediately, naming the target dest, the
+/// key_id, and the paths we DO hold.
+///
+/// The test injects a rooted peer on a fabricated dest that is reachable on no
+/// interface (the sender has no bootstrap peer and no path to it), sends, and
+/// asserts: (1) the error is `NoRouteToPeer` with the operands populated, and
+/// (2) it returned in well under the 30 s establish timeout.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_path_send_fails_fast_and_loud_not_a_silent_30s_timeout() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("warn,ciris_edge=debug")
+        .try_init();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let steward = TestFedKey::new("steward-guard", 0x01);
+    let sender = TestFedKey::new("edge-key-sender", 0x0a);
+    let directory = directory_with(vec![
+        signed_record(&steward, &steward, "steward"),
+        signed_record(&sender, &steward, "agent"),
+    ])
+    .await;
+
+    // A lone sender node — listens on loopback, has NO bootstrap peer, so it
+    // holds a path to nothing.
+    let (sender_transport, _addr) = build_reticulum_with_retry(|| {
+        let key = &sender;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c =
+                ReticulumTransportConfig::new(base.join("s/transport.id"), "edge-key-sender");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.announce_interval = Duration::from_secs(30);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
+
+    // Drive the event loop so `connect` can progress (and, crucially, so a
+    // never-establishing link is observed as such rather than hanging).
+    let (tx, _rx) = tokio::sync::mpsc::channel(16);
+    let listener = sender_transport.clone();
+    let _listen = tokio::spawn(async move { listener.listen(tx).await });
+
+    // Inject a rooted peer on a FABRICATED dest reachable on no interface — the
+    // exact shape of the #336 bug (a peer primed on an un-routable dest).
+    let phantom_dest = [0xab; 16];
+    let phantom_ed25519 = [0xcd; 32];
+    sender_transport
+        .inject_rooted_peer_for_test("edge-key-phantom", phantom_dest, phantom_ed25519)
+        .await;
+    assert!(
+        sender_transport.knows_peer("edge-key-phantom").await,
+        "peer must be rooted so the send reaches the connect/guard path",
+    );
+
+    // Send to the un-routable peer and time it.
+    let started = Instant::now();
+    let result = sender_transport
+        .send("edge-key-phantom", b"payload that can never be routed")
+        .await;
+    let elapsed = started.elapsed();
+
+    // (1) FAST — well under the 30 s LINK_ESTABLISH_TIMEOUT. The no-path window
+    // is 5 s; allow generous CI slack but stay far below the patient timeout.
+    assert!(
+        elapsed < Duration::from_secs(20),
+        "no-path send must fail fast (< 20 s), took {elapsed:?} — the silent 30 s \
+         timeout is exactly the #336 footgun this guard exists to kill",
+    );
+
+    // (2) LOUD + self-diagnosing — `NoRouteToPeer`, not an opaque `Timeout`,
+    // carrying the operands that name the mismatch at a glance.
+    match result {
+        Err(TransportError::NoRouteToPeer {
+            key_id,
+            target_dest,
+            has_path,
+            ..
+        }) => {
+            assert_eq!(key_id, "edge-key-phantom");
+            assert_eq!(target_dest, hex::encode(phantom_dest));
+            assert!(!has_path, "the whole point: the target had no path");
+        }
+        other => panic!(
+            "expected NoRouteToPeer (fast, self-diagnosing); got {other:?} — a bare Timeout \
+             here is the silent-failure regression the #336 guard must prevent",
+        ),
+    }
+}


### PR DESCRIPTION
Supersedes the v12.0.1 leviculum re-pin (folded in as the first commit). This branch is now the **v13.0.0** cut that ends the AV-42/#336 rooting saga.

**BREAKING**: route replication is signed-only (persist v17). Bare/unsigned routes no longer replicate or apply — both peers must be on v13.

### #336 — the fix
- **BELT**: a VERIFIED announce at equal epoch with a different dest heals the route (explicit → named). Extracted into a **pure `route_supersession_decision`** — 8 exhaustive unit tests.
- **GUARD**: a no-path send fails **fast** (5 s; no-path ⇒ direct-or-never) with self-diagnosing `NoRouteToPeer{key_id,target_dest,has_path,paths}`, not a silent 30 s `Timeout`. E2E test proves it fails in ~5 s.

### #337 — security
- **CRITICAL-1** verified-only supersession: an Advisory announce can **never** override a Rooted route, regardless of epoch (hijack gate checked before any epoch compare — a `u64::MAX` advisory can't poison a rooted route).
- **CRITICAL-2**: replication apply authenticates (`SignedTransportDestination` → `put_signed_transport_destination`: hybrid sig + `signer_acts_for`). A bare route with attacker-set `Rooted` for any key_id is **refused** — confused-deputy closed. Regression-tested.

### #338 — adoption
- persist **v16.1.1 → v17.0.1** (#443 authenticated superseding route table + **#446** occurrence→route projection: `put_identity_occurrence` materializes its embedded `transport_binding` into `transport_destinations`, de-projected on revocation — the offline/pre-announce last mile).
- leviculum **→ v0.9.0+ciris.1** (folds in the v12.0.1 budget-source re-pin).
- Edge threads the announce `epoch` into the write-through; persist's `(epoch, asserted_at)` guard rejects replayed frames.

### Footgun observability (DoS/disk-aware)
Route-supersession decisions log through a throttled, low-cardinality-keyed tripwire; attacker-floodable admit INFO demoted to DEBUG.

## The saga's tombstone — one test per prior footgun
`route_supersession` (8: hijack-refused, belt heal, epoch monotonicity, upgrade, stale) · guard e2e (no-path fast-fail) · crit-2 (bare-route refused) · attestation MTU fit #333 (7) · av42 spoof (3) · loopback (2).

Verified: `cargo fmt`; both CI clippy combos (`-D warnings`); all suites green.

Refs: #336, #337, #338; CIRISPersist#443, #446; CIRISServer#227; leviculum#22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
