### PR TITLE
fix(v13.0.2): identify the outbound replication link so the responder can attribute it (#340)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.0.1"
+version = "13.0.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1056,6 +1056,19 @@ pub struct ReticulumTransport {
     /// conformant source (edge owns the transport identity per
     /// `crate::identity` §"Reticulum-shape identity hash").
     local_transport_pubkey: [u8; 64],
+    /// CIRISEdge#340 — this node's full Reticulum transport identity (the
+    /// same one bound into `node`), kept so the send side can IDENTIFY an
+    /// outbound link after it establishes. A Reticulum link is anonymous by
+    /// default; only the initiator may identify it (RNS `Link.identify()`),
+    /// and identifying is what makes the responder emit `LinkIdentified` →
+    /// populate `link_to_peer_key_id` → attribute inbound replication frames.
+    /// Without this, every inbound CRPL frame dropped `SkippedNoSourceKeyId`
+    /// (#317) because the link carried no proven identity — the reason the
+    /// #314 attribution machinery, though correct, never fired in the field
+    /// (and why CIRISServer#235 was never verified end-to-end). Holds the
+    /// PRIVATE key (unlike `local_transport_pubkey`), so it can sign the
+    /// LINKIDENTIFY packet.
+    local_identity: Identity,
     /// Edge's own announce attestation app-data — built once in
     /// `new` (sign with the federation `LocalSigner`) and emitted
     /// verbatim on every announce. `None` when no signer was
@@ -1581,7 +1594,10 @@ impl ReticulumTransport {
         // one underlying identity → either inbound path reaches the
         // same handler set.
         let mut named_dest = Destination::new(
-            Some(identity),
+            // CIRISEdge#340 — clone (not move): `local_identity` on the struct
+            // keeps the full transport identity so the send side can identify
+            // outbound links after they establish.
+            Some(identity.clone()),
             Direction::In,
             DestinationType::Single,
             EDGE_APP_NAME,
@@ -1613,6 +1629,7 @@ impl ReticulumTransport {
             local_dest_hash,
             local_named_dest_hash,
             local_transport_pubkey,
+            local_identity: identity.clone(),
             local_attestation,
             events: Mutex::new(Some(events)),
             peers: Arc::new(Mutex::new(HashMap::new())),
@@ -1855,6 +1872,41 @@ impl ReticulumTransport {
         );
     }
 
+    /// CIRISEdge#340 test seam — inject a rooted peer with its FULL 64-byte
+    /// transport identity (`x25519 ‖ ed25519`), computing the real
+    /// `transport_identity_hash` the way the announce path does. Unlike
+    /// [`Self::inject_rooted_peer_for_test`] (which stores a `[0u8; 16]`
+    /// sentinel because it lacks the x25519 half), this reproduces the FIELD
+    /// shape: an announce-rooted peer whose stored identity hash matches the
+    /// hash a real identified link proves — the precondition #340 attribution
+    /// needs. `dest_hash` is the peer's ROUTABLE (named) dest.
+    #[doc(hidden)]
+    pub async fn inject_rooted_peer_with_transport_identity_for_test(
+        &self,
+        destination_key_id: &str,
+        dest_hash: [u8; 16],
+        transport_pubkey64: [u8; 64],
+    ) {
+        let x25519: [u8; 32] = transport_pubkey64[..32].try_into().unwrap_or([0u8; 32]);
+        let ed25519: [u8; 32] = transport_pubkey64[32..].try_into().unwrap_or([0u8; 32]);
+        let transport_identity_hash =
+            Identity::from_public_keys(&x25519, &ed25519).map_or([0u8; 16], |id| *id.hash());
+        let mut peers = self.peers.lock().await;
+        peers.insert(
+            destination_key_id.to_string(),
+            RootedPeer {
+                peer: ResolvedPeer {
+                    dest_hash: DestinationHash::new(dest_hash),
+                    signing_key: ed25519,
+                },
+                epoch: 0,
+                chain: None,
+                provenance: ciris_persist::federation::self_at_login::BindingProvenance::Rooted,
+                transport_identity_hash,
+            },
+        );
+    }
+
     // ─── CIRISEdge#32 (v0.14.0) Links FFI surface ───────────────────
     //
     // The Reticulum link lifecycle is normally an internal substrate
@@ -1995,6 +2047,14 @@ impl ReticulumTransport {
         if !established {
             return Err(TransportError::Timeout(timeout));
         }
+        // CIRISEdge#340 — identify the link so the responder can attribute what
+        // arrives on it (same rationale as `send`: an anonymous link yields
+        // `source_key_id=None` → dropped). The FFI Links surface establishes
+        // links the same way, so it needs the same identify precondition.
+        self.node
+            .identify_link(&link_id, &self.local_identity)
+            .await
+            .map_err(|e| TransportError::Io(format!("reticulum identify_link: {e}")))?;
         Ok(link_id.into_bytes())
     }
 
@@ -2846,6 +2906,23 @@ impl Transport for ReticulumTransport {
             }
             return Err(TransportError::Timeout(establish_timeout));
         }
+
+        // CIRISEdge#340 — IDENTIFY the link before sending. A Reticulum link is
+        // anonymous by default; only the initiator may identify it, and the
+        // responder emits `LinkIdentified` (→ populates its `link_to_peer_key_id`
+        // via the #314 identity-hash match → attributes our inbound frame) ONLY
+        // if we do. Without this, every replication frame we send lands on the
+        // responder as `source_key_id=None` and is dropped `SkippedNoSourceKeyId`
+        // (#317) — the field-confirmed reason attribution never fired and
+        // CIRISServer#235 was never verified end-to-end. Ordered before
+        // `send_resource` on the same link so the LINKIDENTIFY is processed
+        // first. A failure here means the responder cannot attribute the frame,
+        // so fail the send (the durable dispatcher retries) rather than ship an
+        // unattributable resource that will be silently dropped.
+        self.node
+            .identify_link(&link_id, &self.local_identity)
+            .await
+            .map_err(|e| TransportError::Io(format!("reticulum identify_link: {e}")))?;
 
         // Auto-accept any resources the peer pushes back on this link
         // (e.g. an ACK envelope), and ship our envelope as a resource.

--- a/tests/route_table_e2e.rs
+++ b/tests/route_table_e2e.rs
@@ -23,8 +23,9 @@ use std::time::{Duration, Instant};
 
 use ciris_edge::identity::LocalSigner;
 use ciris_edge::transport::reticulum::{ReticulumAuth, ReticulumTransportConfig};
-use ciris_edge::transport::{Transport, TransportError};
+use ciris_edge::transport::{InboundFrame, Transport, TransportError};
 use ciris_edge::verify::RootingDirectory;
+use tokio::sync::mpsc;
 
 use common::{build_reticulum_with_retry, directory_with, signed_record, TestFedKey};
 
@@ -163,4 +164,111 @@ async fn no_path_send_fails_fast_and_loud_not_a_silent_30s_timeout() {
              here is the silent-failure regression the #336 guard must prevent",
         ),
     }
+}
+
+/// CIRISEdge#340 — a replication link MUST be IDENTIFIED by the initiator so the
+/// responder can attribute the inbound frame to the sender's key_id. A Reticulum
+/// link is anonymous by default; before this fix `send` established the link and
+/// shipped the resource WITHOUT identifying, so every inbound frame landed on the
+/// responder as `source_key_id=None` and dropped `SkippedNoSourceKeyId` (#317) —
+/// the field-confirmed reason the #314 attribution machinery never fired and
+/// CIRISServer#235 was never verified end-to-end.
+///
+/// The test reproduces the FIELD shape (an announce-rooted peer whose stored
+/// `transport_identity_hash` is the REAL one, not the `[0;16]` sentinel that
+/// `prime_v7_peer_pair` injects): B sends to A; A must attribute the inbound
+/// frame to `edge-key-bbbb` via the link B identified. The assertion is on
+/// `InboundFrame::source_key_id` — the exact operand that was `None` in the
+/// field logs. Delivery alone (the existing loopback test) does not catch this;
+/// attribution does.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn identified_link_lets_the_responder_attribute_the_inbound_frame() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("warn,ciris_edge=debug")
+        .try_init();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let steward = TestFedKey::new("steward-340", 0x01);
+    let key_a = TestFedKey::new("edge-key-aaaa", 0x0a);
+    let key_b = TestFedKey::new("edge-key-bbbb", 0x0b);
+    let directory = directory_with(vec![
+        signed_record(&steward, &steward, "steward"),
+        signed_record(&key_a, &steward, "agent"),
+        signed_record(&key_b, &steward, "agent"),
+    ])
+    .await;
+
+    // Node A — the receiver.
+    let (transport_a, addr_a) = build_reticulum_with_retry(|| {
+        let key = &key_a;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c = ReticulumTransportConfig::new(base.join("a/transport.id"), "edge-key-aaaa");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.announce_interval = Duration::from_secs(30);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
+    let port_a = addr_a.port();
+
+    // Node B — the sender; dials A.
+    let (transport_b, _addr_b) = build_reticulum_with_retry(|| {
+        let key = &key_b;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c = ReticulumTransportConfig::new(base.join("b/transport.id"), "edge-key-bbbb");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.bootstrap_peers = vec![format!("127.0.0.1:{port_a}").parse().unwrap()];
+            c.announce_interval = Duration::from_secs(30);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
+
+    // A must know B by B's REAL transport identity (the field shape), so the
+    // identity B proves when it identifies the link matches A's stored hash and
+    // attribution fires. B must know A's dest so the link can establish.
+    transport_a
+        .inject_rooted_peer_with_transport_identity_for_test(
+            "edge-key-bbbb",
+            transport_b.local_dest_hash(),
+            transport_b.local_transport_pubkey(),
+        )
+        .await;
+    let mut a_ed = [0u8; 32];
+    a_ed.copy_from_slice(&transport_a.local_transport_pubkey()[32..64]);
+    transport_b
+        .inject_rooted_peer_for_test("edge-key-aaaa", transport_a.local_dest_hash(), a_ed)
+        .await;
+
+    let (tx_a, mut rx_a) = mpsc::channel::<InboundFrame>(16);
+    let (tx_b, _rx_b) = mpsc::channel::<InboundFrame>(16);
+    let la = transport_a.clone();
+    let lb = transport_b.clone();
+    let _listen_a = tokio::spawn(async move { la.listen(tx_a).await });
+    let _listen_b = tokio::spawn(async move { lb.listen(tx_b).await });
+
+    // B → A. The send identifies the link before shipping the resource.
+    transport_b
+        .send("edge-key-aaaa", b"attributed-inbound-frame")
+        .await
+        .expect("send B -> A");
+
+    let frame = tokio::time::timeout(Duration::from_secs(60), rx_a.recv())
+        .await
+        .expect("frame must arrive within 60s")
+        .expect("inbound channel open");
+
+    assert_eq!(
+        frame.source_key_id.as_deref(),
+        Some("edge-key-bbbb"),
+        "the responder must ATTRIBUTE the inbound frame to the sender via the \
+         identified link — source_key_id=None is the #340 SkippedNoSourceKeyId drop",
+    );
 }


### PR DESCRIPTION
Settled from **live canonical logs** (Node A, edge v13.0.1): with #336's routing fixed, links establish (42 links, 8–15ms RTT) and resources reassemble — but every inbound CRPL frame still dropped `SkippedNoSourceKeyId` (#317), `source_key_id=None`, **zero `LinkIdentified`**. The #314 attribution machinery was correct; its precondition — an **identified** link — was never met.

## Root cause

A Reticulum link is **anonymous by default**, and only the INITIATOR may identify it (RNS `Link.identify()`). `ReticulumTransport::send` did connect → wait-established → `send_resource`, **never identifying**. So the responder had no proven identity to key on, and #314/#317 could never fire in the field — which is also why **CIRISServer#235 was never verified end-to-end**.

## Fix (one call, send-side, agent-transparent)

After `LinkEstablished`, `node.identify_link(&link_id, &self.local_identity)` before `send_resource` (ordered on the same link so LINKIDENTIFY is processed first). Same call added to the `link_open` FFI path. A new `local_identity: Identity` field holds the full transport identity (private key) to sign the LINKIDENTIFY; identify failure fails the send (dispatcher retries) rather than shipping an unattributable resource.

## Regression test — the field shape, not the convenient one

`route_table_e2e::identified_link_lets_the_responder_attribute_the_inbound_frame` reproduces an **announce-rooted** peer whose stored `transport_identity_hash` is REAL (new full-identity test seam, not the `[0;16]` sentinel `prime_v7_peer_pair` injects), and asserts the responder resolves `source_key_id = Some("edge-key-bbbb")` — the exact operand that was `None` in the field logs. Delivery-only tests (loopback) never caught this; attribution does. (Applying the lesson from v13.0.1: test the path the field takes.)

## Acceptance (from #340)
- A replication link from a rooted peer emits `LinkIdentified` on the responder; `source_key_id` resolves (no `SkippedNoSourceKeyId`). ✓ (regression test)
- The IdentityOccurrence round completes end to end — first true frame — the first real exercise of CIRISServer#235, straight to KEX.
- An unidentified/anonymous link from an unknown origin still drops (guard's legitimate case).

Both CI clippy combos + guard/attestation/av42/route_supersession green.

Refs: #340, #317, #314, #336; CIRISServer#235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)