### PR TITLE
fix(v13.0.3): heal in seconds (event-driven announce) + send over re-keyed links (#336 fast-heal, #342)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.0.2"
+version = "13.0.3"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -566,8 +566,8 @@ tempfile       = { version = "3", optional = true }
 # new AnnounceError::Pack(PacketError) — a breaking enum change, but edge only
 # matches AnnounceError::ExplicitHashCannotAnnounce (untouched), so the bump is
 # pin currency + the budget-const rewire with no match-arm churn.
-reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.0+ciris.1", version = "0.9", optional = true }
-reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.0+ciris.1", version = "0.9", optional = true }
+reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.1+ciris.1", version = "0.9", optional = true }
+reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.1+ciris.1", version = "0.9", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -140,6 +140,20 @@ const NO_PATH_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(5);
 /// complete after the link is up.
 const RESOURCE_TRANSFER_TIMEOUT: Duration = Duration::from_secs(120);
 
+/// CIRISEdge#336 (fast heal) — minimum interval between EVENT-DRIVEN announces.
+///
+/// RNS reachability is on-demand, not periodic: markqvist's reference stack
+/// announces immediately on startup + on interface/link change, and treats the
+/// periodic timer as a coarse fallback (Sideband re-announces every 90–300
+/// *minutes*). Edge's 300 s [`ReticulumTransportConfig::announce_interval`] as
+/// the ONLY heal trigger is the anti-pattern: a peer that connects just after a
+/// tick waits ~5 min for the next announce before the #336 belt can heal its
+/// route. So we ALSO announce when a link establishes (a peer just connected) —
+/// which propagates our routable named dest in seconds. This gate bounds a burst
+/// of link-ups to one announce per window (RNS `ANNOUNCE_CAP` spirit), so an
+/// announce storm can't be driven by rapid link churn.
+const EVENT_ANNOUNCE_MIN_INTERVAL: Duration = Duration::from_secs(10);
+
 /// CIRISEdge#318 — cap on the in-memory `peers` (rooted + advisory bindings)
 /// map. Bounds advisory-admit pollution: at cap, an Advisory binding is evicted
 /// before a new key is inserted (Rooted bindings are never evicted for advisory
@@ -2040,8 +2054,11 @@ impl ReticulumTransport {
             .map_err(|e| TransportError::Io(format!("reticulum connect: {e}")))?;
         let link_id = *link.link_id();
 
+        // CIRISEdge#342 — alias-resolving establishment poll (see `send`): a
+        // #66 re-key on a lossy path re-keys the link under a fresh id, so a raw
+        // `established_links.contains(&original_id)` misses.
         let established = wait_until_async(timeout, Duration::from_millis(50), || async {
-            self.established_links.lock().await.contains(&link_id)
+            self.node.link_is_established(&link_id)
         })
         .await;
         if !established {
@@ -2872,9 +2889,19 @@ impl Transport for ReticulumTransport {
         // the peer must have accepted the LINK_REQUEST or a resource
         // transfer cannot start. The event loop records established
         // link IDs in `established_links`; poll it.
+        // CIRISEdge#342 — poll leviculum's ALIAS-RESOLVING establishment query,
+        // not edge's own `established_links` set. On a lossy path the #66
+        // establishment retry re-keys the link under a fresh wire id; the
+        // `LinkEstablished` event (hence `established_links`) then carries the
+        // RE-KEYED id, while we hold connect's ORIGINAL id. A raw
+        // `established_links.contains(&original)` never matches → we time out →
+        // never reach `send_resource` → 0 Data frames → the link idles to a
+        // keepalive death (the field symptom on the remote/canonical path).
+        // `link_is_established` resolves the origin id through leviculum's #66
+        // alias table and gates on `LinkState::Active`.
         let established =
             wait_until_async(establish_timeout, Duration::from_millis(50), || async {
-                self.established_links.lock().await.contains(&link_id)
+                self.node.link_is_established(&link_id)
             })
             .await;
         if !established {
@@ -3010,6 +3037,11 @@ impl Transport for ReticulumTransport {
         let mut announce_tick = tokio::time::interval(self.config.announce_interval);
         announce_tick.tick().await; // consume the immediate first tick
 
+        // CIRISEdge#336 (fast heal) — rate-limit gate for event-driven announces.
+        // `None` until the first link-up, so the first connecting peer triggers an
+        // announce immediately.
+        let mut last_event_announce: Option<std::time::Instant> = None;
+
         loop {
             tokio::select! {
                 _ = announce_tick.tick() => {
@@ -3026,6 +3058,13 @@ impl Transport for ReticulumTransport {
                         tracing::info!("Reticulum event channel closed; listener exiting");
                         break;
                     };
+                    // CIRISEdge#336 (fast heal) — RNS-aligned event-driven announce.
+                    // A `LinkEstablished` means a peer just connected; re-announce so
+                    // it learns our routable NAMED dest in seconds (→ the #336 belt
+                    // heals its route now, not after the next ~5 min periodic tick).
+                    // Rate-limited so rapid link churn can't storm announces.
+                    let link_just_established =
+                        matches!(event, NodeEvent::LinkEstablished { .. });
                     let ctx = EventCtx {
                         node: &self.node,
                         peers: &self.peers,
@@ -3043,6 +3082,28 @@ impl Transport for ReticulumTransport {
                         link_to_peer_key_id: &self.link_to_peer_key_id,
                     };
                     handle_event(event, &ctx).await;
+
+                    // `map_or(true, …)` not `is_none_or` — MSRV 1.75 (is_none_or is 1.82).
+                    if link_just_established
+                        && last_event_announce
+                            .map_or(true, |t| t.elapsed() >= EVENT_ANNOUNCE_MIN_INTERVAL)
+                    {
+                        last_event_announce = Some(std::time::Instant::now());
+                        match self
+                            .node
+                            .announce_destination(&self.local_named_dest_hash, Some(app_data))
+                            .await
+                        {
+                            Ok(()) => tracing::debug!(
+                                "event-driven announce on link-up — RNS-aligned fast \
+                                 convergence (CIRISEdge#336)"
+                            ),
+                            Err(e) => tracing::warn!(
+                                error = %e,
+                                "event-driven announce (link up) failed"
+                            ),
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
Field: with #336's belt healing and links establishing, the round still didn't land — two remaining gaps, both fixed here so the next run completes end to end.

## #336 fast heal — stop waiting ~5 minutes (RNS-aligned)

The belt heals a peer's route the moment it *receives* that peer's named-dest announce, but edge only announced on a **300 s** periodic timer — so a peer that connected just after a tick waited up to ~5 min for the next announce before its route could heal.

That's the RNS anti-pattern. I read markqvist's reference stack (RNS/Sideband/LXMF): reachability is **on-demand** — announce immediately on startup + interface/link change, solicit paths with `request_path` (answered in ~**0.4 s** via `PATH_REQUEST_GRACE`), and keep the periodic timer *coarse* (Sideband re-announces every **90–300 minutes**). A node that only re-announces on a long timer and passively waits is explicitly *not* correct RNS usage.

**Fix:** also announce when a `LinkEstablished` fires (a peer just connected), rate-limited to one per `EVENT_ANNOUNCE_MIN_INTERVAL` (10 s) so link churn can't storm announces (RNS `ANNOUNCE_CAP` spirit). First-contact heal drops from ~5 min to **seconds**.

## #342 — send over a re-keyed link (0 Data → keepalive death)

On a lossy path the leviculum #66 establishment retry re-keys the link under a fresh wire id; the `LinkEstablished` event (hence edge's `established_links` set) then carries the **re-keyed** id, while `send`/`link_open` hold `connect`'s **original** id. The raw `established_links.contains(&original_id)` never matched → the establish-wait timed out → `send_resource` was never reached → **0 Data frames** over the canonical link → it idled to a `keepalive_timeout` death (byte-identical across v13.0.0–.2 because none touched this wait).

**Fix:** poll leviculum v0.9.1's new alias-resolving `link_is_established` (resolves the origin id through the #66 alias table, gates on `LinkState::Active`) instead of edge's raw set, in both `send` and `link_open`. leviculum re-pinned v0.9.0 → **v0.9.1+ciris.1**.

## Verification
`cargo fmt`; both CI clippy combos (`-D warnings`); guard + #340 attribution e2e, loopback byte-exact, av42, attestation, route_supersession all green. Re-key resolution itself is covered by leviculum's `mvr_link_rekey_alias` test (a loopback can't reproduce packet loss); the heal-latency drop is field-validated on the canonical.

Refs: #336, #342, #340; leviculum#66, leviculum v0.9.1+ciris.1; CIRISServer#235.

🤖 Generated with [Claude Code](https://claude.com/claude-code)