### PR TITLE
feat(v13.0.5): forward test-anchor feature to edge-embedded persist + re-pin persist v17.1.0 (#345)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.0.4"
+version = "13.0.5"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.0.2", version = "17", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.1.0", version = "17", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -631,6 +631,28 @@ uniffi = { version = "=0.31.1", optional = true, features = ["build", "cli", "bi
 
 [features]
 default = []
+
+# CIRISEdge#345 / CIRISPersist#449 / CIRISVerify#202 — test-anchor relaxation.
+#
+# persist v17.1.0's genesis-seed verifiers reject a SW single-key trust root
+# (a "test anchor"), so an edge-embedded Engine is unbootable under
+# `CIRIS_TESTING_MODE=true` + `CIRIS_TEST_TRUST_ROOT`. The relaxation is
+# COMPILE-FENCED behind `ciris-persist/test-anchor` (→ `ciris-verify-core/
+# test-anchor`); feature-unification only turns it on if the flag propagates
+# all the way to the ONE persist + ONE verify-core instance edge builds into
+# the wheel `.so`. Edge sits between the one-wheel consumer (ciris-server, which
+# enables `test-anchor`) and the embedded persist, so it must forward the flag
+# explicitly — otherwise the embedded persist compiles the relaxation OUT and
+# the agent node fails to boot in test mode exactly as before.
+#
+# Forwards to BOTH so the single verify-core instance edge links directly ALSO
+# has the fence open (persist already forwards to verify-core, but edge depends
+# on verify-core directly too — belt-and-suspenders for feature unification).
+#
+# DELIBERATELY out of `default` and every release/prod build: it relaxes a
+# trust-root check and must NEVER be present in a shipped wheel. The mesh-repro
+# QA harness (CIRISServer#258) is the only consumer that enables it.
+test-anchor = ["ciris-persist/test-anchor", "ciris-verify-core/test-anchor"]
 
 # v1.1.7 (CIRISEdge#58) — opt-in panic + hang diagnostic harness.
 #
@@ -1106,7 +1128,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.0.2", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.1.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=17.0.2,<18",
+    "ciris-persist>=17.1.0,<18",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Adopts **CIRISPersist#449** (persist v17.0.2 → **v17.1.0**). Closes **#345**.

## The problem
persist v17.1.0's genesis-seed verifiers reject a SW single-key trust root ("test anchor"), so an **edge-embedded** Engine is unbootable under `CIRIS_TESTING_MODE=true` + `CIRIS_TEST_TRUST_ROOT`. The relaxation is **compile-fenced** behind `ciris-persist/test-anchor` (→ `ciris-verify-core/test-anchor`).

## Why edge must act (not automatic)
Edge sits between the one-wheel consumer (ciris-server, which enables `test-anchor`) and the persist it embeds in the wheel `.so`. Feature-unification only opens the fence if the flag reaches edge's persist. If edge doesn't forward it, the embedded persist compiles the relaxation OUT and the agent node fails to boot in test mode.

## The fix
An edge `test-anchor` feature → `["ciris-persist/test-anchor", "ciris-verify-core/test-anchor"]` (both — edge links verify-core directly too). **Out of `default` and every prod/release build.**

## Feature-reach verified (`cargo tree`)
- test-anchor **ON** → **one** `ciris-persist` instance (no split) carrying `test-anchor`, and one `ciris-verify-core` with it on (via edge's direct forward *and* persist's forward).
- test-anchor **OFF** → persist's `test-anchor` count = **0** → relaxation compiled out of every shipped wheel.

#345 asks #1 (feature+forwards) + #2 (reach to one instance, off in prod) satisfied; #3 (boot smoke) is the CIRISServer#258 harness.

## Verification
pin-skew (pyproject floor → `>=17.1.0`); `cargo fmt`; both CI clippy combos **and** the `test-anchor` build (`-D warnings`); av42 + route_table_e2e green. No prod behavior change.

Refs: #345; CIRISPersist#449 (v17.1.0), CIRISVerify#202 (v10.2.0), CIRISServer#258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)