### PR TITLE
feat(v13.0.6): edge-tier test-anchor e2e (admit→root proof) + re-pin persist v17.2.0 (#345 ask 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1089,6 +1089,30 @@ jobs:
           retry_wait_seconds: 60
           shell: bash
           command: cargo clippy --all-targets --features "transport-http transport-reticulum pyo3 ffi-uniffi" -- -D warnings
+      # CIRISEdge#345 (ask #3) — the test-anchor lane. The compile-fenced
+      # `test-anchor` feature is what the mesh-repro harness (CIRISServer#258)
+      # enables to boot an edge/agent node under CIRIS_TESTING_MODE. Clippy it
+      # (so the harness build stays warning-clean) and run the edge-tier e2e
+      # that proves a SW-test-root-scrubbed peer ROOTS through edge's
+      # root_binding. This test is feature-gated, so it runs ONLY here — the
+      # default combos never compile it. NOT in any release lane: the wheel
+      # feature set omits `test-anchor`, so the relaxation is compiled out.
+      - name: cargo clippy (test-anchor on)
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 60
+          shell: bash
+          command: cargo clippy --features "transport-http transport-reticulum pyo3 test-anchor" -- -D warnings
+      - name: cargo test --features test-anchor (edge-tier test-model e2e)
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 60
+          shell: bash
+          command: cargo test --features "transport-reticulum test-anchor" --test test_anchor_e2e
 
   # ─── uniffi-drift: regenerate bindings, assert no diff ──────────────
   #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.0.5"
+version = "13.0.6"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.1.0", version = "17", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.2.0", version = "17", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1128,7 +1128,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.1.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.2.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=17.1.0,<18",
+    "ciris-persist>=17.2.0,<18",
 ]
 dynamic = ["version"]
 

--- a/tests/test_anchor_e2e.rs
+++ b/tests/test_anchor_e2e.rs
@@ -1,0 +1,161 @@
+//! CIRISEdge#345 (ask #3) — edge-tier end-to-end proof of the test-anchor
+//! admit→root flow, the same one the mesh-repro harness (CIRISServer#258)
+//! exercises, at edge's tier, in CI.
+//!
+//! Gated on the compile-fenced `test-anchor` feature. Under a SW test trust
+//! root supplied via env (CIRISPersist#451: PQC-complete holder + verifiable
+//! self-scrub), persist's genesis seeds a fully scrub-VERIFYING
+//! `test-accord-holder-0`, and a peer **hybrid-scrubbed by that root** must ROOT
+//! (`Confirmed`) through edge's `RootingDirectory::root_binding` — proving the
+//! full test model: the SW anchor is a real rooting terminus at edge's tier, not
+//! just "the feature compiles and the engine boots."
+//!
+//! This test mutates process env, so it lives in its own test binary; the
+//! `test-anchor` CI lane runs it with `--features test-anchor`.
+//!
+//! `cargo test --features "transport-reticulum test-anchor" --test test_anchor_e2e`
+
+#![cfg(all(feature = "transport-reticulum", feature = "test-anchor"))]
+
+use std::sync::Arc;
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
+
+use ciris_crypto::{ClassicalSigner, Ed25519Signer, HybridSigner, MlDsa65Signer, PqcSigner};
+use ciris_edge::verify::{RootingDirectory, RootingVerdict};
+use ciris_persist::federation::genesis::test_anchor_genesis_records;
+use ciris_persist::federation::{FederationDirectory, KeyRecord, SignedKeyRecord};
+use ciris_persist::prelude::FederationDirectorySqlite;
+use ciris_persist::verify::canonical::ceg_produce_canonicalize;
+
+/// The CEG-canonical bytes of a registration envelope — the EXACT message a
+/// scrub-signature covers (`root_binding` verifies `verify_hybrid(canonical,
+/// …)`, empirically the canonical envelope, NOT the hash bytes — CIRISPersist
+/// #344). Computed via persist's OWN `ceg_produce_canonicalize`, so what this
+/// test signs matches byte-for-byte what rooting verifies.
+fn canonical_bytes(envelope: &serde_json::Value) -> Vec<u8> {
+    ceg_produce_canonicalize(envelope).expect("ceg canonicalize")
+}
+
+#[tokio::test]
+async fn test_anchor_peer_roots_through_edge_root_binding() {
+    // ── 1. The SW test trust root (hybrid: Ed25519 + ML-DSA-65). ──────────
+    let root_ed = Ed25519Signer::from_seed(&[0x11; 32]).expect("root ed25519");
+    let root_pqc = MlDsa65Signer::from_seed(&[0x22; 32]).expect("root ml-dsa");
+    let root_ed_pub = root_ed.public_key().expect("root ed pub");
+    let root_pqc_pub = PqcSigner::public_key(&root_pqc).expect("root pqc pub");
+    // The hybrid signer binds the pair exactly as `verify_hybrid` checks it:
+    // classical = Sign_ed(data); pqc = Sign_mldsa(data ‖ classical_sig).
+    let root_signer = HybridSigner::new(root_ed, root_pqc).expect("hybrid root signer");
+
+    // ── 2. The root's VERIFIABLE self-scrub over test-accord-holder-0's own
+    //       CANONICAL envelope (CIRISPersist#451 CIRIS_TEST_TRUST_ROOT_SCRUB*). ─
+    let holder_env = serde_json::json!({ "key_id": "test-accord-holder-0", "test_anchor": true });
+    let holder_canonical = canonical_bytes(&holder_env);
+    let holder_scrub = root_signer
+        .sign(&holder_canonical)
+        .expect("holder self-scrub");
+
+    // ── 3. Arm the test anchor: the exact runtime contract the harness sets. ─
+    std::env::set_var("CIRIS_TESTING_MODE", "true");
+    for prod in ["ENVIRONMENT", "CIRIS_ENV", "CIRIS_ENVIRONMENT"] {
+        std::env::remove_var(prod); // no production signal, or the tripwire refuses
+    }
+    std::env::set_var("CIRIS_TEST_TRUST_ROOT", B64.encode(&root_ed_pub));
+    std::env::set_var("CIRIS_TEST_TRUST_ROOT_PQC", B64.encode(&root_pqc_pub));
+    std::env::set_var(
+        "CIRIS_TEST_TRUST_ROOT_SCRUB",
+        B64.encode(&holder_scrub.classical.signature),
+    );
+    std::env::set_var(
+        "CIRIS_TEST_TRUST_ROOT_SCRUB_PQC",
+        B64.encode(&holder_scrub.pqc.signature),
+    );
+
+    // ── 4. persist synthesizes the fully scrub-verifying genesis holder. ─────
+    let genesis = test_anchor_genesis_records()
+        .expect("test-anchor override must be LIVE (feature on + CIRIS_TESTING_MODE + root)");
+    assert!(
+        genesis
+            .iter()
+            .any(|r| r.record.key_id == "test-accord-holder-0"
+                && r.record.pubkey_ml_dsa_65_base64.is_some()),
+        "genesis must seed a PQC-complete test-accord-holder-0 (CIRISPersist#451)",
+    );
+
+    // ── 5. A peer hybrid-scrubbed BY the SW root (= test-accord-holder-0). ────
+    let peer_ed = Ed25519Signer::from_seed(&[0x0a; 32]).expect("peer ed25519");
+    let peer_pqc = MlDsa65Signer::from_seed(&[0x0b; 32]).expect("peer ml-dsa");
+    let peer_ed_pub = peer_ed.public_key().expect("peer ed pub");
+    let peer_pqc_pub = PqcSigner::public_key(&peer_pqc).expect("peer pqc pub");
+    let peer_env = serde_json::json!({ "key_id": "edge-key-peer" });
+    let peer_canonical = canonical_bytes(&peer_env);
+    let peer_scrub = root_signer
+        .sign(&peer_canonical)
+        .expect("peer scrub by root");
+    let ts: chrono::DateTime<chrono::Utc> = "2026-05-01T00:00:00Z".parse().unwrap();
+    let peer = KeyRecord {
+        key_id: "edge-key-peer".to_string(),
+        pubkey_ed25519_base64: B64.encode(&peer_ed_pub),
+        pubkey_ml_dsa_65_base64: Some(B64.encode(&peer_pqc_pub)),
+        algorithm: "hybrid".to_string(),
+        identity_type: "agent".to_string(),
+        identity_ref: "edge-key-peer".to_string(),
+        valid_from: ts,
+        valid_until: None,
+        registration_envelope: peer_env,
+        original_content_hash: hex::encode(Sha256::digest(&peer_canonical)),
+        scrub_signature_classical: B64.encode(&peer_scrub.classical.signature),
+        scrub_signature_pqc: Some(B64.encode(&peer_scrub.pqc.signature)),
+        scrub_key_id: "test-accord-holder-0".to_string(),
+        scrub_timestamp: ts,
+        pqc_completed_at: Some(ts),
+        persist_row_hash: String::new(),
+        roles: Vec::new(),
+        attestation_evidence: None,
+        consent_role: None,
+        additional_scrubs: Vec::new(),
+    };
+
+    // ── 6. Seed a directory: the genesis holder(s) THEN the peer. ────────────
+    let backend = FederationDirectorySqlite::open(":memory:")
+        .await
+        .expect("open in-memory federation directory");
+    // Genesis holders go through the dedicated seed path (direct insert), NOT
+    // `put_public_key` — an accord_holder row seeded here is the trust ROOT, so
+    // it is exempt from the platform-attestation admission a normal put demands.
+    backend
+        .seed_genesis_accord_holders(&genesis)
+        .await
+        .expect("seed genesis accord holders");
+    backend
+        .put_public_key(SignedKeyRecord { record: peer })
+        .await
+        .expect("put peer");
+
+    // ── 7. Edge's rooting path CONFIRMS the peer through the SW test anchor. ─
+    let rooting: Arc<dyn RootingDirectory> = backend;
+    let verdict = rooting
+        .root_binding("edge-key-peer", &B64.encode(&peer_ed_pub))
+        .await;
+
+    match verdict {
+        RootingVerdict::Confirmed { chain } => {
+            assert!(
+                !chain.chain.is_empty(),
+                "a confirmed rooting must carry a non-empty provenance chain"
+            );
+            println!(
+                "[test-anchor] PASS — peer `edge-key-peer` ROOTED through the SW test \
+                 anchor via edge root_binding ({} link(s) to test-accord-holder-0)",
+                chain.chain.len(),
+            );
+        }
+        other => panic!(
+            "test-anchor peer MUST root through edge's root_binding — the whole admit→root \
+             test model rides on it (CIRISEdge#345 / CIRISPersist#451); got {other:?}",
+        ),
+    }
+}


### PR DESCRIPTION
Completes **#345 ask #3** and re-pins persist **v17.1.0 → v17.2.0** (CIRISPersist#451).

## v17.2.0 (CIRISPersist#451)
The seeded `test-accord-holder` now carries an ML-DSA pubkey + a real self-scrub (env-supplied), so a SW-root **hybrid** scrub verifies under registration's always-on Strict policy — the next blocker after v13.0.5 (which got the Engine booting) is cleared.

## The edge-tier e2e (`tests/test_anchor_e2e.rs`, feature-gated)
Under a SW test trust root via env (`CIRIS_TEST_TRUST_ROOT[_PQC][_SCRUB][_SCRUB_PQC]`), persist's genesis seeds a fully scrub-verifying `test-accord-holder-0`, and a peer **hybrid-scrubbed by that root** ROOTs (`Confirmed`) through edge's `RootingDirectory::root_binding`. That's the full **admit→root** the mesh-repro harness (CIRISServer#258) exercises — at edge's tier, in CI. Closes the gap between "feature compiles + engine boots" (v13.0.5) and "a test-blessed peer actually roots."

Two correctness details the test pins down (each a would-be silent *green-test-wrong-path*):
- Genesis holders seed via `seed_genesis_accord_holders` (direct insert — the trust root is exempt from the platform-attestation put admission).
- The scrub is the **bound hybrid over the CEG-canonical registration envelope** (ed over `canonical`; ml-dsa over `canonical ‖ ed_sig`, via `ciris_crypto::HybridSigner`) — **not** over the digest — matching `root_binding`'s `verify_hybrid` (the stale doc said "hash"; the code, per CIRISPersist#344, verifies the canonical envelope).

## CI
A new **`test-anchor` lane** in the clippy+fmt job clippies the harness feature set and runs the e2e with `--features test-anchor`. The feature is out of every default combo, so the test compiles **only** there — and the relaxation is absent from every release wheel.

## Verification
pin-skew (pyproject → `>=17.2.0`); `cargo fmt`; both CI clippy combos + the test-anchor build (`-D warnings`); the e2e passes; av42 + route_table_e2e green.

Refs: #345; CIRISPersist#451 (v17.2.0), CIRISVerify#202, CIRISServer#258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)