### PR TITLE
chore(v13.0.9): re-pin persist v17.3.0 — ResolveEncryptionKeys composite (CIRISServer#260 KEX unblock)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.0.8"
+version = "13.0.9"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.2.0", version = "17", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.3.0", version = "17", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1128,7 +1128,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.2.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.3.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=17.2.0,<18",
+    "ciris-persist>=17.3.0,<18",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
persist v17.2.0 → **v17.3.0** (CIRISPersist#329/#453). No edge source change.

The ops-proxy now ships a `ResolveEncryptionKeys` composite op — the whole revocation-aware KEX-pubkey fold executes **inside persist's `.so`**, so there's no consumer-side comparator skew — plus the raw `ListIdentityOccurrenceRevocationsFor`. Edge's `resolve_peer_kex_pubkeys` resolves correctly with **zero edge code change** once pinned `>=17.3.0` (the proxy override supplies the composite the trait default lacked). Unblocks **CIRISServer#260** end-to-end sealed-envelope trace delivery — the KEX gate returns `Some` post-adoption.

pyproject floor → `>=17.3.0,<18`.

Verified: cargo↔pyproject pin-skew; `cargo fmt`; both CI clippy combos (`-D warnings`); av42, route_table_e2e, replication suite (108) green.

Refs: CIRISPersist#329/#453, CIRISServer#260.

🤖 Generated with [Claude Code](https://claude.com/claude-code)