### PR TITLE
feat(v13.1.0): reply rides the live inbound link — NAT'd/initiator-only peers reachable (#353) + persist v17.5.0 + leviculum v0.9.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.0.9"
+version = "13.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.3.0", version = "17", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.0", version = "17", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -566,8 +566,8 @@ tempfile       = { version = "3", optional = true }
 # new AnnounceError::Pack(PacketError) — a breaking enum change, but edge only
 # matches AnnounceError::ExplicitHashCannotAnnounce (untouched), so the bump is
 # pin currency + the budget-const rewire with no match-arm churn.
-reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.1+ciris.1", version = "0.9", optional = true }
-reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.1+ciris.1", version = "0.9", optional = true }
+reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.2+ciris.1", version = "0.9", optional = true }
+reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.2+ciris.1", version = "0.9", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in
@@ -1128,7 +1128,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.3.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=17.3.0,<18",
+    "ciris-persist>=17.5.0,<18",
 ]
 dynamic = ["version"]
 

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -203,6 +203,51 @@ fn route_supersession_log() -> &'static crate::log_throttle::LogThrottle {
         .get_or_init(|| crate::log_throttle::LogThrottle::new(8, Duration::from_secs(60), 4))
 }
 
+static REVERSE_PATH_FALLBACK_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+static NAT_TOPOLOGY_DIAGNOSIS_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+
+/// CIRISEdge#353 — a reverse-path (live inbound link) send failed and we fell
+/// back to an outbound dial. Keyed on the peer key_id (rooted peers only —
+/// bounded by the admit gate, capped map as backstop).
+fn reverse_path_fallback_log() -> &'static crate::log_throttle::LogThrottle {
+    REVERSE_PATH_FALLBACK_LOG
+        .get_or_init(|| crate::log_throttle::LogThrottle::new(5, Duration::from_secs(60), 256))
+}
+
+/// CIRISEdge#353 ask 2 — the NAT'd/initiator-only topology diagnosis. Before
+/// this, an outbound dial to an undialable phone was a bare 30 s `Timeout` per
+/// kind per round FOREVER (the field symptom: 3 WARNs every 30 s, no cause).
+/// One diagnosis per peer per window, then a suppressed-count.
+fn nat_topology_diagnosis_log() -> &'static crate::log_throttle::LogThrottle {
+    NAT_TOPOLOGY_DIAGNOSIS_LOG
+        .get_or_init(|| crate::log_throttle::LogThrottle::new(2, Duration::from_secs(300), 256))
+}
+
+/// CIRISEdge#353 ask 2 — emit the topology diagnosis (throttled). Fired when a
+/// dial HAD a path (the peer's announce taught us one) yet never established,
+/// and the reverse-path check found no live inbound link. The classic cause is
+/// a NAT'd / initiator-only peer (phone, emulator, CGNAT): its announce arrives
+/// over ITS outbound link, but nothing can dial it back. Name the hypothesis
+/// ONCE per window instead of an unexplained 30 s `Timeout` per kind per round
+/// forever.
+fn log_nat_topology_diagnosis(destination_key_id: &str, establish_timeout: Duration) {
+    if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+        nat_topology_diagnosis_log().check(destination_key_id)
+    {
+        tracing::warn!(
+            destination_key_id,
+            establish_timeout_secs = establish_timeout.as_secs(),
+            suppressed_prev,
+            "outbound dial had a path but never established, and the peer has NO \
+             live inbound link to ride — if this peer is NAT'd / initiator-only \
+             it is structurally unreachable outbound; delivery will succeed over \
+             the peer's NEXT inbound link (reverse path, CIRISEdge#353)"
+        );
+    }
+}
+
 // ─── Peer resolution ────────────────────────────────────────────────
 
 /// Out-of-band resolver from a federation `key_id` to a peer's
@@ -2779,6 +2824,111 @@ impl ReticulumTransport {
             signing_key: ed25519,
         })
     }
+
+    /// CIRISEdge#353 — the newest LIVE link already attributed to this peer
+    /// (the reverse path). Scans `link_to_peer_key_id` — populated by
+    /// `LinkIdentified` (the peer dialed + identified to us) — and keeps only
+    /// links leviculum still holds `Active` (`link_is_established` resolves
+    /// the #66 re-key alias, so a re-keyed inbound link still matches).
+    /// Newest-established wins when a peer holds several.
+    async fn live_attributed_link_to(&self, destination_key_id: &str) -> Option<LinkId> {
+        let candidates: Vec<LinkId> = self
+            .link_to_peer_key_id
+            .lock()
+            .await
+            .iter()
+            .filter(|(_, peer)| peer.as_str() == destination_key_id)
+            .map(|(id, _)| *id)
+            .collect();
+        let established_at = self.link_established_at.lock().await;
+        candidates
+            .into_iter()
+            .filter(|id| self.node.link_is_established(id))
+            .max_by_key(|id| established_at.get(id).copied().unwrap_or(0))
+    }
+
+    /// CIRISEdge#353 — REVERSE PATH FIRST. If the peer holds a LIVE link to us
+    /// that it dialed + identified (a NAT'd / initiator-only peer's ONLY
+    /// connectivity), the reply rides THAT link — a fresh outbound dial to
+    /// such a peer is structurally impossible and burned 30 s per kind per
+    /// round forever in the field (Node A ↔ Android emulator, the first
+    /// mobile trace's last leg). Symmetric topologies also win: no dial
+    /// round-trip when a live link already exists. No `identify_link` here —
+    /// we are not this link's initiator (RNS permits only the initiator to
+    /// identify); the peer attributes our reply by the dest it dialed
+    /// (leviculum v0.9.2 `link_destination`, the other half of #353).
+    ///
+    /// Returns `true` iff the envelope was DELIVERED over the reverse path;
+    /// `false` means fall through to the outbound dial (no live inbound link,
+    /// or the ship failed — logged loud + throttled, since a reverse-path
+    /// failure for an initiator-only peer means the dial will likely fail too).
+    async fn send_via_reverse_path(&self, destination_key_id: &str, envelope_bytes: &[u8]) -> bool {
+        let Some(link_id) = self.live_attributed_link_to(destination_key_id).await else {
+            return false;
+        };
+        match self.ship_resource_on_link(&link_id, envelope_bytes).await {
+            Ok(()) => {
+                tracing::debug!(
+                    destination_key_id,
+                    link = ?link_id,
+                    "delivered over the peer's live inbound link (reverse path, CIRISEdge#353)"
+                );
+                true
+            }
+            Err(e) => {
+                if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                    reverse_path_fallback_log().check(destination_key_id)
+                {
+                    tracing::warn!(
+                        destination_key_id,
+                        link = ?link_id,
+                        error = %e,
+                        suppressed_prev,
+                        "reverse-path send over the peer's inbound link failed; \
+                         falling back to an outbound dial (CIRISEdge#353)"
+                    );
+                }
+                false
+            }
+        }
+    }
+
+    /// Ship one envelope as a resource over an ALREADY-ESTABLISHED link and
+    /// wait for the sender-side `ResourceCompleted`. The shared tail of both
+    /// send paths (fresh outbound dial AND the #353 reverse path) — one body so
+    /// the two can never diverge (the #348 two-loops lesson).
+    async fn ship_resource_on_link(
+        &self,
+        link_id: &LinkId,
+        envelope_bytes: &[u8],
+    ) -> Result<(), TransportError> {
+        // Auto-accept any resources the peer pushes back on this link
+        // (e.g. an ACK envelope), and ship our envelope as a resource.
+        let _ = self
+            .node
+            .set_resource_strategy(link_id, ResourceStrategy::AcceptAll);
+        let resource_hash = self
+            .node
+            .send_resource(link_id, envelope_bytes, None, true)
+            .await
+            .map_err(|e| TransportError::Io(format!("reticulum send_resource: {e}")))?;
+
+        // Wait for the sender-side `ResourceCompleted` — the driver
+        // paces + retransmits resource parts, and completion means
+        // every part was delivered + proven. If the transfer does not
+        // complete within the window, treat it as a timeout so edge's
+        // durable dispatcher retries.
+        let completed = wait_until_async(
+            RESOURCE_TRANSFER_TIMEOUT,
+            Duration::from_millis(100),
+            || async { self.sent_resources.lock().await.remove(&resource_hash) },
+        )
+        .await;
+        if !completed {
+            return Err(TransportError::Timeout(RESOURCE_TRANSFER_TIMEOUT));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -2854,6 +3004,15 @@ impl Transport for ReticulumTransport {
         // semantically inert at that point).
         let dest_hash_bytes = peer.dest_hash.into_bytes();
         self.check_blackhole(&dest_hash_bytes).await?;
+
+        // CIRISEdge#353 — REVERSE PATH FIRST (see `send_via_reverse_path`).
+        // Ordered AFTER the blackhole check so an operator ban still wins.
+        if self
+            .send_via_reverse_path(destination_key_id, envelope_bytes)
+            .await
+        {
+            return Ok(TransportSendOutcome::Delivered);
+        }
 
         // CIRISEdge#336 — the no-path GUARD. Decide the establishment window
         // from whether the node holds a path to this exact dest BEFORE dialing.
@@ -2931,6 +3090,7 @@ impl Transport for ReticulumTransport {
                     paths,
                 });
             }
+            log_nat_topology_diagnosis(destination_key_id, establish_timeout);
             return Err(TransportError::Timeout(establish_timeout));
         }
 
@@ -2951,31 +3111,7 @@ impl Transport for ReticulumTransport {
             .await
             .map_err(|e| TransportError::Io(format!("reticulum identify_link: {e}")))?;
 
-        // Auto-accept any resources the peer pushes back on this link
-        // (e.g. an ACK envelope), and ship our envelope as a resource.
-        let _ = self
-            .node
-            .set_resource_strategy(&link_id, ResourceStrategy::AcceptAll);
-        let resource_hash = self
-            .node
-            .send_resource(&link_id, envelope_bytes, None, true)
-            .await
-            .map_err(|e| TransportError::Io(format!("reticulum send_resource: {e}")))?;
-
-        // Wait for the sender-side `ResourceCompleted` — the driver
-        // paces + retransmits resource parts, and completion means
-        // every part was delivered + proven. If the transfer does not
-        // complete within the window, treat it as a timeout so edge's
-        // durable dispatcher retries.
-        let completed = wait_until_async(
-            RESOURCE_TRANSFER_TIMEOUT,
-            Duration::from_millis(100),
-            || async { self.sent_resources.lock().await.remove(&resource_hash) },
-        )
-        .await;
-        if !completed {
-            return Err(TransportError::Timeout(RESOURCE_TRANSFER_TIMEOUT));
-        }
+        self.ship_resource_on_link(&link_id, envelope_bytes).await?;
 
         Ok(TransportSendOutcome::Delivered)
     }
@@ -3384,7 +3520,39 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             // from the per-link rooted-peer attribution table when
             // available. `None` falls back to v3.5.0 behavior (no
             // routing fires inside `Edge::install_replication_routing`).
-            let source_key_id = ctx.link_to_peer_key_id.lock().await.get(&link_id).cloned();
+            let mut source_key_id = ctx.link_to_peer_key_id.lock().await.get(&link_id).cloned();
+            // CIRISEdge#353 — INITIATOR-side attribution. The table above is
+            // fed by `LinkIdentified`, which only fires on links a PEER dialed
+            // to us; a reply arriving on a link WE dialed (the reverse path a
+            // NAT'd peer's responder now uses) has no entry and would drop as
+            // `SkippedNoSourceKeyId`. The stateless, #66-re-key-proof basis is
+            // the link's DESTINATION (leviculum v0.9.2 `link_destination`,
+            // alias-resolving): we dialed a dest resolved from the VERIFIED
+            // route table, and RNS link establishment proves the remote
+            // controls that dest's identity keys — so mapping dest → rooted
+            // peer attributes the frame on the same trust the outbound send
+            // used. A mid-link route supersession can miss here; that falls
+            // through to the existing LOUD SkippedNoSourceKeyId path, never a
+            // silent drop.
+            if source_key_id.is_none() {
+                if let Some(dest) = ctx.node.link_destination(&link_id) {
+                    source_key_id = ctx
+                        .peers
+                        .lock()
+                        .await
+                        .iter()
+                        .find(|(_, rooted)| rooted.peer.dest_hash == dest)
+                        .map(|(key_id, _)| key_id.clone());
+                    if let Some(key_id) = &source_key_id {
+                        tracing::debug!(
+                            link = ?link_id,
+                            peer = %key_id,
+                            "inbound frame on a link WE dialed attributed via its \
+                             destination (initiator-side reverse path, CIRISEdge#353)"
+                        );
+                    }
+                }
+            }
             let frame = InboundFrame {
                 envelope_bytes: data,
                 transport: TransportId::RETICULUM_RS,

--- a/tests/route_table_e2e.rs
+++ b/tests/route_table_e2e.rs
@@ -272,3 +272,136 @@ async fn identified_link_lets_the_responder_attribute_the_inbound_frame() {
          identified link — source_key_id=None is the #340 SkippedNoSourceKeyId drop",
     );
 }
+
+/// CIRISEdge#353 — the NAT'd / initiator-only reply leg, the asymmetric twin of
+/// the #340 attribution test and the field shape of the first mobile trace
+/// (Android emulator behind NAT ↔ Node A):
+///
+///   * B (the "phone") can dial A, but A CANNOT dial B — B is rooted at A on a
+///     fabricated, un-routable dest (the strongest possible "structurally
+///     unreachable outbound", the #336 guard's phantom shape) while carrying
+///     B's REAL transport identity so link attribution still fires.
+///   * B dials + identifies a link to A (its round-open).
+///   * A's reply to B MUST ride that live inbound link (reverse path) — before
+///     the fix this send fast-failed `NoRouteToPeer` (and in the field burned a
+///     silent 30 s `Timeout` per kind per round, forever).
+///   * The reply frame must arrive at B ATTRIBUTED to A — B never receives a
+///     `LinkIdentified` for a link it initiated, so this exercises the
+///     initiator-side `link_destination` attribution (leviculum v0.9.2), the
+///     other half of #353. Unattributed would be the #317
+///     `SkippedNoSourceKeyId` drop: delivered bytes, dead round.
+#[tokio::test]
+async fn reply_to_a_nat_d_initiator_rides_the_live_inbound_link() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("warn,ciris_edge=debug")
+        .try_init();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    let steward = TestFedKey::new("steward-353", 0x01);
+    let key_a = TestFedKey::new("edge-key-aaaa", 0x0a);
+    let key_b = TestFedKey::new("edge-key-bbbb", 0x0b);
+    let directory = directory_with(vec![
+        signed_record(&steward, &steward, "steward"),
+        signed_record(&key_a, &steward, "agent"),
+        signed_record(&key_b, &steward, "agent"),
+    ])
+    .await;
+
+    // Node A — the canonical: dialable.
+    let (transport_a, addr_a) = build_reticulum_with_retry(|| {
+        let key = &key_a;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c = ReticulumTransportConfig::new(base.join("a/transport.id"), "edge-key-aaaa");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.announce_interval = Duration::from_secs(30);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
+    let port_a = addr_a.port();
+
+    // Node B — the "phone": dials A. (Its listener exists but A is never
+    // taught a routable dest for it, so A-side it is initiator-only.)
+    let (transport_b, _addr_b) = build_reticulum_with_retry(|| {
+        let key = &key_b;
+        let dir = directory.clone();
+        let base = tmp.path().to_path_buf();
+        async move {
+            let mut c = ReticulumTransportConfig::new(base.join("b/transport.id"), "edge-key-bbbb");
+            c.listen_addr = format!("127.0.0.1:{}", free_port()).parse().unwrap();
+            c.bootstrap_peers = vec![format!("127.0.0.1:{port_a}").parse().unwrap()];
+            c.announce_interval = Duration::from_secs(30);
+            let auth = auth_for(key, dir, &base).await;
+            (c, auth)
+        }
+    })
+    .await;
+
+    // A roots B with B's REAL transport identity (so `LinkIdentified`
+    // attribution fires) but a PHANTOM dest reachable on no interface — the
+    // NAT model: A structurally cannot dial B.
+    transport_a
+        .inject_rooted_peer_with_transport_identity_for_test(
+            "edge-key-bbbb",
+            [0xab; 16],
+            transport_b.local_transport_pubkey(),
+        )
+        .await;
+    // B roots A on A's REAL dest — the phone can always dial out.
+    let mut a_ed = [0u8; 32];
+    a_ed.copy_from_slice(&transport_a.local_transport_pubkey()[32..64]);
+    transport_b
+        .inject_rooted_peer_for_test("edge-key-aaaa", transport_a.local_dest_hash(), a_ed)
+        .await;
+
+    let (tx_a, mut rx_a) = mpsc::channel::<InboundFrame>(16);
+    let (tx_b, mut rx_b) = mpsc::channel::<InboundFrame>(16);
+    let la = transport_a.clone();
+    let lb = transport_b.clone();
+    let _listen_a = tokio::spawn(async move { la.listen(tx_a).await });
+    let _listen_b = tokio::spawn(async move { lb.listen(tx_b).await });
+
+    // Leg 1 — the "round-open": B dials + identifies + ships to A.
+    transport_b
+        .send("edge-key-aaaa", b"round-open-from-the-phone")
+        .await
+        .expect("B -> A send (the phone's outbound leg) must deliver");
+    let inbound_at_a = tokio::time::timeout(Duration::from_secs(60), rx_a.recv())
+        .await
+        .expect("A must receive B's frame within 60s")
+        .expect("A inbound channel open");
+    assert_eq!(
+        inbound_at_a.source_key_id.as_deref(),
+        Some("edge-key-bbbb"),
+        "precondition (#340): A must attribute B's inbound link",
+    );
+
+    // Leg 2 — the REPLY: A -> B must ride B's live inbound link. Before the
+    // fix this fast-failed NoRouteToPeer (phantom dest, no path).
+    transport_a
+        .send("edge-key-bbbb", b"reply-over-the-reverse-path")
+        .await
+        .expect(
+            "A -> B reply MUST deliver over B's live inbound link (CIRISEdge#353) — \
+             an outbound dial to a NAT'd initiator is structurally impossible",
+        );
+
+    // Leg 3 — attribution at B (initiator side): the reply must carry
+    // source_key_id=A, else the replication registry drops it.
+    let reply_at_b = tokio::time::timeout(Duration::from_secs(60), rx_b.recv())
+        .await
+        .expect("B must receive A's reply within 60s")
+        .expect("B inbound channel open");
+    assert_eq!(reply_at_b.envelope_bytes, b"reply-over-the-reverse-path");
+    assert_eq!(
+        reply_at_b.source_key_id.as_deref(),
+        Some("edge-key-aaaa"),
+        "the reply on B's own dialed link must be ATTRIBUTED via link_destination \
+         (initiator-side half of CIRISEdge#353) — None is the #317 \
+         SkippedNoSourceKeyId drop and the round dies delivered-but-dead",
+    );
+}


### PR DESCRIPTION
The first mobile agent exposed the reply leg (#353): its round-opens arrived and were served, but the responder's reply dialed a **fresh outbound link to an undialable NAT'd phone** — structurally impossible, 30 s timeout per kind per round forever, invisible to every symmetric topology.

## Both halves of the reverse path
- **Reverse path first** (`send_via_reverse_path`): a send to a peer holding a live link it dialed + identified to us rides **that** link (RNS links are duplex). After the operator-blackhole check; newest established wins; #66 re-key alias-resolved; loud + throttled fallback to the dial.
- **Initiator-side attribution**: the reply arrives on a link the phone **dialed**, so no `LinkIdentified` fires (only initiators identify) — previously a `SkippedNoSourceKeyId` drop: delivered bytes, dead round. Now attributed statelessly via the link's **destination** (leviculum v0.9.2 `link_destination`, alias-resolving): the dest came from the verified route table and RNS establishment proves the remote controls its keys — same trust the outbound send used.
- **Topology diagnosis** (ask 2): had-a-path-but-never-established with no live inbound link now names the NAT'd/initiator-only hypothesis once per window instead of an unexplained `Timeout` forever.
- `ship_resource_on_link` extracted as the **shared tail** of both send paths (the #348 two-loops lesson).

## Guard (ask 3)
`reply_to_a_nat_d_initiator_rides_the_live_inbound_link` — the asymmetric twin of the #340 test: B dials + identifies to A; A roots B on a **phantom dest** (structurally undialable) with B's real transport identity. A's reply must deliver (pre-fix: `NoRouteToPeer`) and must arrive attributed to A (pre-fix: `None`).

## Pins (the minor's second half)
persist **v17.5.0** (carries v17.3.0 `ResolveEncryptionKeys` → CIRISServer#260; v17.4.0 scores reads; v17.5.0 #455 owner-scope replication log + #456 `resolve_scores` boundedness — the #352 design-sweep asks); leviculum **v0.9.2+ciris.1**; pyproject `>=17.5.0,<18`.

## Verification
fmt; all three CI clippy combos (`-D warnings`); transport 188 / replication 108 / av42 3 / route_table_e2e 3 (incl. new guard) / test_anchor_e2e 1 — green.

Unblocks the last leg of the first mobile trace (CIRISServer#264/#260): phone roots → rounds served → **reply now rides the phone's own link** → KEX/occurrence syncs device-side → sealed envelope ships.

Refs: #353, #352, #348, #340, #336; CIRISPersist#455/#456; leviculum#24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)