### PR TITLE
chore(v13.1.1): re-pin persist v17.5.2 + verify v10.3.0 — mobile fold-boot panic fix + dimension_exact parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.1.0"
+version = "13.1.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.0", version = "17", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.2", version = "17", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.2.0", version = "10", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.2.0", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.3.0", version = "10", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.3.0", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.2.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.2.0", version = "10" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.3.0", version = "10" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1128,7 +1128,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.2", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=17.5.0,<18",
+    "ciris-persist>=17.5.2,<18",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Pin-currency patch cut, no edge source change.

- persist **v17.5.2** (#464): `list_attestations` dimension_exact fix (#461, both backends) + wheel disk-reclaim on the tagged commit (the v17.5.0/v17.5.1 runner-loss prevention).
- CIRISVerify **v10.3.0** across ALL of edge's verify-repo pins (verify-core, keyring, crypto) — the mobile fold-boot `block_on` panic fix, moved in lockstep with persist's re-pin so the graph holds one CIRISVerify checkout (dual-checkout = the cross-cdylib duplication class; lockfile verified single-tag).
- pyproject floor `>=17.5.2,<18`.

Gates: pin-skew, fmt, all three CI clippy combos, replication 108 / route_table_e2e 3 / av42 3 / test_anchor_e2e 1 — green on the new pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)