### PR TITLE
feat(v13.2.0): adopt CIRISVerify v10.5.0 crypto-DRY (all of #359) + persist v17.6.0 + announce-flood hygiene (#357)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -102,6 +102,16 @@ jobs:
           cargo bench --features "pyo3" \
             --bench subscription_throughput 2>&1 | tee -a bench-results.txt
 
+      # CIRISEdge#359 — the accord multi-sig bench measures the post-quantum
+      # (ML-DSA-65) hybrid verify cost and needs the `test-anchor` feature to
+      # seat its synthetic holders (verify's `accord_holder_bootstrap_anchor`
+      # override). Without the feature the default `cargo bench --benches` run
+      # above hits its inert `main` and skips it; this runs the real curve.
+      - name: Run test-anchor accord_threshold_verify bench (hybrid/PQ)
+        run: |
+          cargo bench --features "test-anchor" \
+            --bench accord_threshold_verify 2>&1 | tee -a bench-results.txt
+
       - name: Upload criterion report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1144,7 +1144,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 60
           shell: bash
-          command: cargo test --features "transport-reticulum test-anchor" --test test_anchor_e2e
+          command: cargo test --features "transport-reticulum test-anchor" --test test_anchor_e2e --test accord_carrier_verify
 
   # ─── uniffi-drift: regenerate bindings, assert no diff ──────────────
   #
@@ -1254,9 +1254,12 @@ jobs:
           plat: linux-x86_64
       - uses: Swatinem/rust-cache@v2
       - name: cargo bench --no-run (all features)
-        # All three feature-gates so EVERY bench file compiles in
-        # this gate — the feature-gated benches (transport-reticulum,
-        # transport-http, pyo3) cannot bit-rot silently.
+        # All feature-gates so EVERY bench file compiles in this gate —
+        # the feature-gated benches (transport-reticulum, transport-http,
+        # pyo3) cannot bit-rot silently. `test-anchor` is included so the
+        # real body of `accord_threshold_verify` (CIRISEdge#359 — seated
+        # roster injection is compile-fenced behind it) is compile-checked
+        # here, not just its inert no-feature `main`.
         #
         # Cross-process retry — same rationale as the iOS/Android
         # cross-compile lanes. PR #76 observed the `heck` index flake
@@ -1268,7 +1271,7 @@ jobs:
         with:
           timeout_minutes: 15
           max_attempts: 3
-          command: cargo bench --no-run --features "transport-http transport-reticulum pyo3"
+          command: cargo bench --no-run --features "transport-http transport-reticulum pyo3 test-anchor"
       - name: sccache stats
         if: always()
         run: sccache --show-stats

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.1.2"
+version = "13.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.2", version = "17", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.6.0", version = "17", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.3.0", version = "10", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.3.0", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.5.0", version = "10", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.5.0", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.3.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.3.0", version = "10" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.5.0", version = "10" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1128,7 +1128,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.5.2", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.6.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/benches/accord_threshold_verify.rs
+++ b/benches/accord_threshold_verify.rs
@@ -1,23 +1,47 @@
-//! `accord_threshold_verify` — CIRISEdge#19 wire-layer 2-of-3
-//! multi-sig check. Exercises the `dispatch_inbound` `AccordCarrier`
-//! gate (the only edge-public path that reaches `verify_accord_carrier`).
+//! `accord_threshold_verify` — CIRISEdge#19 / #359 wire-layer 2-of-3
+//! HYBRID (Ed25519 + ML-DSA-65) multi-sig check. Exercises the
+//! `dispatch_inbound` `AccordCarrier` gate (the only edge-public path that
+//! reaches `verify_accord_carrier`).
+//!
+//! # Post-quantum accuracy (CIRISEdge#359)
+//!
+//! The accord carrier is constitutional kill-switch-class traffic, so
+//! `verify_accord_carrier` verifies every signature as a HYBRID pair under
+//! `HybridPolicy::Strict` (finding 2) and counts it only if the holder occupies
+//! a pinned SEAT in verify's `accord_holder_bootstrap_anchor()` (finding 3).
+//! This bench therefore measures the REAL post-quantum cost: ML-DSA-65 verify
+//! dominates each holder's per-signature work.
+//!
+//! ## Why this bench requires `--features test-anchor`
+//!
+//! The seat set is pinned to verify's baked humanity-accord roster — the
+//! synthetic bench holders are only "seated" via the test-anchor
+//! `CIRIS_TEST_TRUST_ROOT` override, which is compile-fenced behind
+//! `test-anchor`. Without the feature the file compiles to an inert `main` and
+//! the default `cargo bench --benches` run skips it. Run the real measurement:
+//!
+//! ```text
+//! cargo bench --features test-anchor --bench accord_threshold_verify
+//! ```
 //!
 //! # Expected curve (per BENCHMARKS.md "Reading the curves")
 //!
-//! Flat across signature-count permutations — every holder's signature
-//! is verified once. Early-reject (≥ M valid sigs short-circuits) ⇒
-//! the wire-layer 2-of-3 gate is exiting before checking all holders.
-//! That is a fail-loud violation per the docs: every holder's sig must
-//! be checked so a tampered-holder is named in the reject.
+//! The gate checks EVERY seated holder's signature (no early-exit after the
+//! threshold is met — that's the fail-loud "name the tampered holder" contract).
+//! Cost scales with the number of VALID signatures: a valid signature pays the
+//! full Ed25519 + ML-DSA-65 verify (~150 µs, ML-DSA-dominated), while an invalid
+//! one fails on the cheap Ed25519 half before the ML-DSA verify. So `3of3 >
+//! 2of3 > 1of3` is EXPECTED (more valid sigs = more ML-DSA work). A DROP once
+//! ≥ M valid sigs are present (e.g. `2of3` ≈ `3of3`) would signal an illegal
+//! short-circuit after the threshold — the fail-loud violation to watch for.
 //!
 //! # Scenarios
 //!
-//! - `3of3_valid` — three valid sigs.
-//! - `2of3_valid_1of3_invalid` — two valid + one bad-bytes sig.
-//! - `1of3_valid` — one valid sig only (below threshold).
-//! - `no_holders_configured` — persist directory holds zero
-//!   `accord_holder` rows; refusal short-circuits to
-//!   `NoAccordHoldersConfigured`.
+//! - `3of3_valid` — three valid hybrid sigs (accept; 3 full ML-DSA verifies).
+//! - `2of3_valid_1of3_invalid` — two valid + one bad-bytes hybrid sig (accept).
+//! - `1of3_valid` — one valid hybrid sig + two invalid (below threshold → refuse).
+//! - `no_holders_configured` — zero `accord_holder` rows →
+//!   `NoAccordHoldersConfigured` (the cheap pre-verify reject).
 
 #![allow(
     clippy::pedantic,
@@ -34,244 +58,222 @@
     clippy::needless_raw_string_hashes
 )]
 
+// CIRISEdge#359 — the real bench lives behind `test-anchor` (seated-roster
+// injection). Everything is module-scoped under the feature so the default
+// (no-test-anchor) build has no unused imports and just an inert `main`.
+#[cfg(feature = "test-anchor")]
 #[path = "common/mod.rs"]
 mod common;
 
-use std::sync::Arc;
-use std::time::Duration;
+#[cfg(feature = "test-anchor")]
+mod imp {
+    use std::sync::{Arc, Once};
+    use std::time::Duration;
 
-use base64::engine::general_purpose::STANDARD as B64;
-use base64::Engine as _;
-use chrono::Utc;
-use ciris_edge::identity::{build_envelope, sign_envelope, LocalSigner};
-use ciris_edge::messages::{
-    AccordSignature, AnnouncementKind, AnnouncementPriority, AuthorityClass,
-    FederationAnnouncement, MessageType,
-};
-use ciris_edge::transport::{InboundFrame, Transport};
-use ciris_edge::verify::HybridPolicy;
-use ciris_edge::{Edge, EdgeConfig, OutboundHandle, TransportId};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-
-use common::{
-    bench_local_signer, build_in_memory_backend, signed_record, BenchFedKey, NullTransport,
-};
-
-struct Fixture {
-    edge: Arc<Edge>,
-    sender_signer: Arc<LocalSigner>,
-    holders: Vec<BenchFedKey>,
-    _tmp: tempfile::TempDir,
-}
-
-/// Build fixture. If `seed_holders` is true, persist directory is
-/// seeded with 3 `accord_holder` rows. Otherwise the directory has
-/// only the steward + agent rows (`NoAccordHoldersConfigured` path).
-async fn build_fixture(seed_holders: bool) -> Fixture {
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let bootstrap = BenchFedKey::new("bootstrap", 0x01);
-    let me = BenchFedKey::new("edge-self", 0xAA);
-    let sender = BenchFedKey::new("steward-sender", 0xBB);
-
-    let h1 = BenchFedKey::new("accord-holder-1", 0x11);
-    let h2 = BenchFedKey::new("accord-holder-2", 0x22);
-    let h3 = BenchFedKey::new("accord-holder-3", 0x33);
-
-    let mut rows = vec![
-        signed_record(&bootstrap, &bootstrap, "steward"),
-        signed_record(&me, &bootstrap, "agent"),
-        signed_record(&sender, &bootstrap, "steward"),
-    ];
-    if seed_holders {
-        rows.push(signed_record(&h1, &bootstrap, "accord_holder"));
-        rows.push(signed_record(&h2, &bootstrap, "accord_holder"));
-        rows.push(signed_record(&h3, &bootstrap, "accord_holder"));
-    }
-    let directory = build_in_memory_backend(rows).await;
-    let edge_signer = bench_local_signer(&me, &tmp).await;
-    let sender_signer = bench_local_signer(&sender, &tmp).await;
-    let config = EdgeConfig {
-        hybrid_policy: HybridPolicy::Ed25519Fallback,
-        ..EdgeConfig::default()
+    use chrono::Utc;
+    use ciris_edge::messages::{
+        AccordSignature, AnnouncementKind, AnnouncementPriority, AuthorityClass,
+        FederationAnnouncement,
     };
-    let edge = Edge::builder()
-        .directory(directory.clone() as Arc<dyn ciris_edge::verify::VerifyDirectory>)
-        .queue(directory as Arc<dyn OutboundHandle>)
-        .signer(edge_signer)
-        .transport(Arc::new(NullTransport) as Arc<dyn Transport>)
-        .config(config)
-        .build()
-        .expect("build edge");
-    Fixture {
-        edge: Arc::new(edge),
-        sender_signer,
-        holders: vec![h1, h2, h3],
-        _tmp: tmp,
-    }
-}
+    use ciris_edge::transport::Transport;
+    use ciris_edge::verify::HybridPolicy;
+    use ciris_edge::{Edge, EdgeConfig, OutboundHandle};
+    use criterion::{black_box, Criterion};
 
-fn announcement_with_sigs(
-    holders: &[(&BenchFedKey, bool)], // (holder, valid?)
-) -> FederationAnnouncement {
-    let mut ann = FederationAnnouncement {
-        priority: AnnouncementPriority::AccordCarrier,
-        kind: AnnouncementKind::AccordCarrier,
-        title: "bench accord".into(),
-        body: "bench body".into(),
-        authority_class: AuthorityClass::HumanityAccord,
-        accord_payload: None,
-        supersedes: None,
-        expires_at: chrono::DateTime::parse_from_rfc3339("2027-01-01T00:00:00Z")
-            .unwrap()
-            .with_timezone(&Utc),
-        evidence_refs: vec![],
-        accord_signatures: vec![],
+    use super::common::{
+        bench_local_signer, build_in_memory_backend, signed_record, BenchFedKey, NullTransport,
     };
-    let canonical = ann
-        .canonical_bytes_for_accord_signatures()
-        .expect("canonical bytes");
-    for (h, valid) in holders {
-        let sig = if *valid {
-            h.sign(&canonical)
-        } else {
-            // Sign a different message — the sig will be 64 bytes but
-            // won't verify.
-            h.sign(b"bench-invalid")
-        };
-        ann.accord_signatures.push(AccordSignature {
-            key_id: h.key_id.clone(),
-            signature_ed25519_base64: B64.encode(sig),
+
+    /// Arm the test-anchor ONCE (env is process-global; each `[[bench]]` is its
+    /// own process). Makes the synthetic accord holders "seated" by publishing
+    /// their Ed25519 pubkeys as `CIRIS_TEST_TRUST_ROOT` — the exact override
+    /// verify's `accord_holder_bootstrap_anchor()` reads under
+    /// `CIRIS_TESTING_MODE` + the `test-anchor` feature.
+    fn arm_test_anchor(seated: &[BenchFedKey]) {
+        static ARM: Once = Once::new();
+        ARM.call_once(|| {
+            std::env::set_var("CIRIS_TESTING_MODE", "true");
+            for prod in ["ENVIRONMENT", "CIRIS_ENV", "CIRIS_ENVIRONMENT"] {
+                std::env::remove_var(prod);
+            }
+            let roots: Vec<String> = seated.iter().map(BenchFedKey::pubkey_b64).collect();
+            std::env::set_var("CIRIS_TEST_TRUST_ROOT", roots.join(","));
         });
     }
-    ann
-}
 
-async fn make_envelope_bytes(
-    sender: &Arc<LocalSigner>,
-    dest_key_id: &str,
-    ann: &FederationAnnouncement,
-) -> Vec<u8> {
-    let mut env = build_envelope(
-        MessageType::FederationAnnouncement,
-        &sender.key_id,
-        dest_key_id,
-        ann,
-        None,
-    )
-    .expect("build envelope");
-    sign_envelope(sender, &mut env)
-        .await
-        .expect("sign envelope");
-    serde_json::to_vec(&env).expect("envelope to bytes")
-}
+    struct Fixture {
+        edge: Arc<Edge>,
+        holders: Vec<BenchFedKey>,
+        _tmp: tempfile::TempDir,
+    }
 
-fn bench_accord_threshold(c: &mut Criterion) {
-    let setup_rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("setup tokio runtime");
-    let bench_rt = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .expect("bench tokio runtime");
-    let fx_with = setup_rt.block_on(build_fixture(true));
-    let fx_without = setup_rt.block_on(build_fixture(false));
+    /// Build fixture. If `seed_holders`, the directory gets 3 `accord_holder`
+    /// rows (registered HYBRID — ed + ml-dsa pubkeys); otherwise only steward +
+    /// agent rows (`NoAccordHoldersConfigured` path).
+    async fn build_fixture(seed_holders: bool) -> Fixture {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let bootstrap = BenchFedKey::new("bootstrap", 0x01);
+        let me = BenchFedKey::new("edge-self", 0xAA);
+        let sender = BenchFedKey::new("steward-sender", 0xBB);
 
-    let mut group = c.benchmark_group("accord_threshold_verify");
-    group
-        .sample_size(30)
-        .measurement_time(Duration::from_secs(8));
+        let h1 = BenchFedKey::new("accord-holder-1", 0x11);
+        let h2 = BenchFedKey::new("accord-holder-2", 0x22);
+        let h3 = BenchFedKey::new("accord-holder-3", 0x33);
 
-    // Pre-build a pool of envelopes per scenario — the verify pipeline's
-    // replay window admits each `(signing_key_id, nonce)` once, so the
-    // bench replays from a pre-signed pool (within one criterion sample
-    // set the replay-reject path IS the dominant cost; the multi-sig
-    // gate runs BEFORE the replay window in dispatch_inbound, so the
-    // shape question is answered regardless).
-    //
-    // ALSO: re-derived per iteration is the per-scenario distinct cost
-    // (different signature mask), so we keep the bench's slope answer
-    // about the gate, not about envelope-build.
-    const POOL: usize = 64;
-    let scenarios: &[(&str, &[bool])] = &[
-        ("3of3_valid", &[true, true, true]),
-        ("2of3_valid_1of3_invalid", &[true, true, false]),
-        ("1of3_valid", &[true, false, false]),
-    ];
-    let scenario_pools: Vec<(&str, Vec<Vec<u8>>)> = setup_rt.block_on(async {
-        let mut out = Vec::with_capacity(scenarios.len());
-        let dest = fx_with.edge.signer_key_id().to_string();
+        let mut rows = vec![
+            signed_record(&bootstrap, &bootstrap, "steward"),
+            signed_record(&me, &bootstrap, "agent"),
+            signed_record(&sender, &bootstrap, "steward"),
+        ];
+        if seed_holders {
+            rows.push(signed_record(&h1, &bootstrap, "accord_holder"));
+            rows.push(signed_record(&h2, &bootstrap, "accord_holder"));
+            rows.push(signed_record(&h3, &bootstrap, "accord_holder"));
+        }
+        let directory = build_in_memory_backend(rows).await;
+        let edge_signer = bench_local_signer(&me, &tmp).await;
+        let config = EdgeConfig {
+            hybrid_policy: HybridPolicy::Ed25519Fallback,
+            ..EdgeConfig::default()
+        };
+        let edge = Edge::builder()
+            .directory(directory.clone() as Arc<dyn ciris_edge::verify::VerifyDirectory>)
+            .queue(directory as Arc<dyn OutboundHandle>)
+            .signer(edge_signer)
+            .transport(Arc::new(NullTransport) as Arc<dyn Transport>)
+            .config(config)
+            .build()
+            .expect("build edge");
+        Fixture {
+            edge: Arc::new(edge),
+            holders: vec![h1, h2, h3],
+            _tmp: tmp,
+        }
+    }
+
+    fn announcement_with_sigs(
+        holders: &[(&BenchFedKey, bool)], // (holder, valid?)
+    ) -> FederationAnnouncement {
+        let mut ann = FederationAnnouncement {
+            priority: AnnouncementPriority::AccordCarrier,
+            kind: AnnouncementKind::AccordCarrier,
+            title: "bench accord".into(),
+            body: "bench body".into(),
+            authority_class: AuthorityClass::HumanityAccord,
+            accord_payload: None,
+            supersedes: None,
+            expires_at: chrono::DateTime::parse_from_rfc3339("2027-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            evidence_refs: vec![],
+            accord_signatures: vec![],
+        };
+        let canonical = ann
+            .canonical_bytes_for_accord_signatures()
+            .expect("canonical bytes");
+        for (h, valid) in holders {
+            // CIRISEdge#359 finding 2 — HYBRID signature. A valid sig is the
+            // hybrid pair over the real canonical bytes; an "invalid" sig is a
+            // well-formed hybrid pair over DIFFERENT bytes, so both halves fail
+            // to verify against the announcement (the realistic tampered-holder
+            // cost — the ML-DSA verify still runs).
+            let (ed_b64, ml_dsa_b64) = if *valid {
+                h.hybrid_sign(&canonical)
+            } else {
+                h.hybrid_sign(b"bench-invalid-canonical-bytes")
+            };
+            ann.accord_signatures.push(AccordSignature {
+                key_id: h.key_id.clone(),
+                signature_ed25519_base64: ed_b64,
+                signature_ml_dsa_65_base64: Some(ml_dsa_b64),
+            });
+        }
+        ann
+    }
+
+    pub fn bench_accord_threshold(c: &mut Criterion) {
+        let setup_rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("setup tokio runtime");
+        let bench_rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("bench tokio runtime");
+        let fx_with = setup_rt.block_on(build_fixture(true));
+        let fx_without = setup_rt.block_on(build_fixture(false));
+        // Seat the bench holders (finding 3) BEFORE any verify runs.
+        arm_test_anchor(&fx_with.holders);
+
+        let mut group = c.benchmark_group("accord_threshold_verify");
+        group
+            .sample_size(30)
+            .measurement_time(Duration::from_secs(8));
+
+        // CIRISEdge#359 — measure the accord gate DIRECTLY (not through
+        // dispatch_inbound, whose replay window would reject a pooled envelope
+        // before the accord verify and hide the ML-DSA-65 cost). Each scenario
+        // is a fixed pre-built hybrid-signed announcement; every iteration runs
+        // the full per-signature hybrid verify, so the curve reflects the real
+        // post-quantum cost.
+        let scenarios: &[(&str, &[bool])] = &[
+            ("3of3_valid", &[true, true, true]),
+            ("2of3_valid_1of3_invalid", &[true, true, false]),
+            ("1of3_valid", &[true, false, false]),
+        ];
         for (label, valid_mask) in scenarios {
             let holders: Vec<(&BenchFedKey, bool)> = fx_with
                 .holders
                 .iter()
                 .zip(valid_mask.iter().copied())
                 .collect();
-            let mut envs = Vec::with_capacity(POOL);
-            for _ in 0..POOL {
-                let ann = announcement_with_sigs(&holders);
-                envs.push(make_envelope_bytes(&fx_with.sender_signer, &dest, &ann).await);
-            }
-            out.push((*label, envs));
+            let ann = announcement_with_sigs(&holders);
+            let edge = fx_with.edge.clone();
+            group.bench_function(*label, |b| {
+                let edge = edge.clone();
+                let ann = &ann;
+                b.to_async(&bench_rt).iter(|| {
+                    let edge = edge.clone();
+                    async move {
+                        black_box(edge.verify_accord_carrier_for_bench(ann).await).ok();
+                    }
+                });
+            });
         }
-        out
-    });
 
-    for (label, pool) in &scenario_pools {
-        let mut idx = 0usize;
-        let edge = fx_with.edge.clone();
-        group.bench_function(*label, |b| {
-            let edge = edge.clone();
+        // ── no_holders_configured: directory has zero accord_holder rows →
+        //    refusal short-circuits to NoAccordHoldersConfigured (the cheap
+        //    pre-verify reject). ──
+        let ann_no_holders = announcement_with_sigs(&[]);
+        let edge_without = fx_without.edge.clone();
+        group.bench_function("no_holders_configured", |b| {
+            let edge = edge_without.clone();
+            let ann = &ann_no_holders;
             b.to_async(&bench_rt).iter(|| {
-                let envelope_bytes = pool[idx % pool.len()].clone();
-                idx = idx.wrapping_add(1);
                 let edge = edge.clone();
                 async move {
-                    let frame = InboundFrame {
-                        envelope_bytes,
-                        transport: TransportId::HTTP,
-                        received_at: Utc::now(),
-                        source_key_id: None,
-                    };
-                    edge.dispatch_inbound_for_test(black_box(frame)).await;
+                    black_box(edge.verify_accord_carrier_for_bench(ann).await).ok();
                 }
             });
         });
+
+        group.finish();
     }
-
-    // ── no_holders_configured: directory has zero accord_holder rows
-    //    → refusal short-circuits to NoAccordHoldersConfigured. ──
-    let pool_no_holders: Vec<Vec<u8>> = setup_rt.block_on(async {
-        let dest = fx_without.edge.signer_key_id().to_string();
-        let mut envs = Vec::with_capacity(POOL);
-        for _ in 0..POOL {
-            let ann = announcement_with_sigs(&[]);
-            envs.push(make_envelope_bytes(&fx_without.sender_signer, &dest, &ann).await);
-        }
-        envs
-    });
-    let mut idx = 0usize;
-    let edge_without = fx_without.edge.clone();
-    group.bench_function("no_holders_configured", |b| {
-        let edge = edge_without.clone();
-        b.to_async(&bench_rt).iter(|| {
-            let envelope_bytes = pool_no_holders[idx % pool_no_holders.len()].clone();
-            idx = idx.wrapping_add(1);
-            let edge = edge.clone();
-            async move {
-                let frame = InboundFrame {
-                    envelope_bytes,
-                    transport: TransportId::HTTP,
-                    received_at: Utc::now(),
-                    source_key_id: None,
-                };
-                edge.dispatch_inbound_for_test(black_box(frame)).await;
-            }
-        });
-    });
-
-    group.finish();
 }
 
-criterion_group!(benches, bench_accord_threshold);
-criterion_main!(benches);
+#[cfg(feature = "test-anchor")]
+criterion::criterion_group!(benches, imp::bench_accord_threshold);
+#[cfg(feature = "test-anchor")]
+criterion::criterion_main!(benches);
+
+// Inert entry point when the `test-anchor` feature is off — the seated-roster
+// injection this bench needs is compile-fenced behind it. Keeps the default
+// `cargo bench --benches` run (and the `--no-run` compile gate without the
+// feature) green while measuring nothing.
+#[cfg(not(feature = "test-anchor"))]
+fn main() {
+    eprintln!(
+        "accord_threshold_verify requires `--features test-anchor` (seated-roster \
+         injection). Run: cargo bench --features test-anchor --bench accord_threshold_verify"
+    );
+}

--- a/benches/common/mock_directory.rs
+++ b/benches/common/mock_directory.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine as _;
 use chrono::Utc;
-use ciris_crypto::{ClassicalSigner, Ed25519Signer};
+use ciris_crypto::{ClassicalSigner, Ed25519Signer, HybridSigner, MlDsa65Signer, PqcSigner};
 use ciris_persist::federation::FederationDirectory;
 use ciris_persist::prelude::{FederationDirectorySqlite, KeyRecord, SignedKeyRecord};
 use ciris_persist::store::backend::Backend;
@@ -69,6 +69,30 @@ impl BenchFedKey {
     /// Sign canonical bytes with this identity's seed.
     pub fn sign(&self, canonical: &[u8]) -> Vec<u8> {
         self.signer().sign(canonical).expect("sign")
+    }
+
+    /// The ML-DSA-65 signer over this identity's seed (CIRISEdge#359 — accord
+    /// signatures are hybrid). Same seed as the ed25519 key.
+    pub fn ml_dsa_signer(&self) -> MlDsa65Signer {
+        MlDsa65Signer::from_seed(&self.seed).expect("ml-dsa from seed")
+    }
+
+    /// Base64-standard ML-DSA-65 public key.
+    #[must_use]
+    pub fn ml_dsa_pubkey_b64(&self) -> String {
+        B64.encode(PqcSigner::public_key(&self.ml_dsa_signer()).expect("ml-dsa pubkey"))
+    }
+
+    /// Hybrid-sign canonical bytes → `(ed25519_b64, ml_dsa_65_b64)`, bound
+    /// exactly as `verify_hybrid` re-checks it (ml-dsa over `canonical ‖
+    /// ed_sig`). This is the accord-carrier signature shape post-#359.
+    pub fn hybrid_sign(&self, canonical: &[u8]) -> (String, String) {
+        let hy = HybridSigner::new(self.signer(), self.ml_dsa_signer()).expect("hybrid signer");
+        let sig = hy.sign(canonical).expect("hybrid sign");
+        (
+            B64.encode(sig.classical.signature),
+            B64.encode(sig.pqc.signature),
+        )
     }
 
     /// Write the 32-byte raw seed file edge's keyring loader reads.
@@ -123,10 +147,20 @@ pub fn signed_record(
         None
     };
 
+    // CIRISEdge#359 — accord_holder rows carry the ML-DSA-65 pubkey so the
+    // hybrid accord-carrier verify (`verify_hybrid_via_directory`,
+    // RequireHybrid) can gate both signatures. Other identity_types stay
+    // ed25519-only (unchanged).
+    let pubkey_ml_dsa_65_base64 = if identity_type == "accord_holder" {
+        Some(subject.ml_dsa_pubkey_b64())
+    } else {
+        None
+    };
+
     KeyRecord {
         key_id: subject.key_id.clone(),
         pubkey_ed25519_base64: subject.pubkey_b64(),
-        pubkey_ml_dsa_65_base64: None,
+        pubkey_ml_dsa_65_base64,
         algorithm: "hybrid".to_string(),
         identity_type: identity_type.to_string(),
         identity_ref: subject.key_id.clone(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=17.5.2,<18",
+    "ciris-persist>=17.6.0,<18",
 ]
 dynamic = ["version"]
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -34,7 +34,8 @@ use crate::outbound::{
 use crate::reachability::{record_if_tracking, AttemptOutcome, ReachabilityTracker};
 use crate::transport::{InboundFrame, Transport, TransportError, TransportSendOutcome};
 use crate::verify::{
-    AccordHolderKey, HybridPolicy, VerifiedEnvelope, VerifyDirectory, VerifyError, VerifyPipeline,
+    AccordHolderKey, HybridPolicy, VerifiedEnvelope, VerifyDirectory, VerifyError, VerifyOutcome,
+    VerifyPipeline,
 };
 
 // ─── Public configuration ───────────────────────────────────────────
@@ -3315,6 +3316,23 @@ impl Edge {
         self.verify.directory()
     }
 
+    /// CIRISEdge#359 bench seam — run the `AccordCarrier` wire-layer multi-sig
+    /// gate ([`verify_accord_carrier`]) DIRECTLY on a pre-built announcement,
+    /// bypassing envelope dispatch + the replay window. The dispatch path runs
+    /// the verify pipeline (incl. the replay gate) BEFORE the accord gate, so a
+    /// benchmark that replays a pooled envelope measures replay-reject, not the
+    /// (now post-quantum, ML-DSA-65-dominated) multi-sig cost. This seam lets
+    /// the `accord_threshold_verify` bench measure the real per-signature hybrid
+    /// verify. Compile-fenced behind `test-anchor` so it never exists in a
+    /// production build.
+    #[cfg(feature = "test-anchor")]
+    pub async fn verify_accord_carrier_for_bench(
+        &self,
+        ann: &crate::messages::FederationAnnouncement,
+    ) -> Result<(), crate::messages::RefusalReason> {
+        verify_accord_carrier(ann, &self.verify_directory()).await
+    }
+
     /// CIRISEdge#26 mutation surface (v0.15.1) — concrete-typed
     /// `Arc<dyn FederationDirectory>` if the host wired one via
     /// [`EdgeBuilder::federation_directory`] (or one of the
@@ -6450,31 +6468,64 @@ async fn verify_accord_carrier(
         .canonical_bytes_for_accord_signatures()
         .map_err(|_e| RefusalReason::InvalidAccordSignature)?;
 
-    // Build a key_id → pubkey map for O(1) per-sig lookup. The holder
-    // set is small (3 by FSD spec), so a Vec scan is fine; map is
-    // future-proofing if 3-of-5 ships.
+    // Build a key_id → ed25519-pubkey map for O(1) per-sig lookup. The holder
+    // set is small (3 by FSD spec), so a Vec scan is fine.
     let by_id: std::collections::HashMap<&str, &[u8; 32]> = holders
         .iter()
         .map(|h| (h.key_id.as_str(), &h.pubkey_ed25519))
         .collect();
 
-    let mut verified_holders = std::collections::HashSet::<String>::new();
+    // CIRISEdge#359 finding 3 — the SEATED roster (one seat per human), pinned
+    // by verify. `list_accord_holders` returns EVERY `accord_holder` row incl. a
+    // human's spare (A2) as a distinct key_id, so counting distinct key_ids let
+    // one human's primary+spare meet a 2-of-N alone. Count against the pinned
+    // SEAT pubkeys instead, deduped by seat — a spare's key is not a seat, so it
+    // contributes nothing, and one seat is counted once regardless of how many
+    // of its keys sign.
+    let seated: std::collections::HashSet<[u8; 32]> =
+        ciris_verify_core::accord_genesis::accord_holder_bootstrap_anchor()
+            .into_iter()
+            .collect();
+
+    let mut verified_seats = std::collections::HashSet::<[u8; 32]>::new();
     let mut any_attempted = false;
     for sig in &ann.accord_signatures {
         any_attempted = true;
-        // The presented key_id MUST appear in the accord-holder set;
-        // a sig from a non-accord-holder counts as zero verifications
-        // toward the threshold. We don't even attempt verification
-        // against a non-accord-holder pubkey.
+        // The presented key_id MUST be a known accord holder …
         let Some(pubkey_bytes) = by_id.get(sig.key_id.as_str()) else {
             continue;
         };
-        if verify_ed25519_signature(pubkey_bytes, &canonical, &sig.signature_ed25519_base64) {
-            verified_holders.insert(sig.key_id.clone());
+        // … AND its key must occupy a pinned SEAT (finding 3 — excludes spares).
+        if !seated.contains(*pubkey_bytes) {
+            continue;
+        }
+        // CIRISEdge#359 finding 2 — verify the HYBRID (Ed25519 + ML-DSA-65)
+        // signature under the require-hybrid policy (`HybridPolicy::Strict`
+        // rejects a classical-only row: ml_dsa `None` ⇒ `HybridPendingRejected`).
+        // The accord carrier is constitutional kill-switch-class traffic; a
+        // classical-only signature must NOT count toward the quorum. The
+        // directory holds both pubkeys, so `verify_hybrid_via_directory` gates
+        // both signatures for us.
+        let outcome = directory
+            .verify_hybrid_via_directory(
+                &canonical,
+                &sig.key_id,
+                &sig.signature_ed25519_base64,
+                sig.signature_ml_dsa_65_base64.as_deref(),
+                HybridPolicy::Strict,
+                None,
+            )
+            .await;
+        // Under RequireHybrid, `HybridVerified` is the ONLY success — the
+        // Ed25519-only outcomes (`Ed25519VerifiedHybridPending` /
+        // `…Fallback`) are unreachable under this policy, so this match is the
+        // exact "both signatures verified" gate finding 2 requires.
+        if matches!(outcome, Ok(VerifyOutcome::HybridVerified)) {
+            verified_seats.insert(**pubkey_bytes);
         }
     }
 
-    let found = u32::try_from(verified_holders.len()).unwrap_or(u32::MAX);
+    let found = u32::try_from(verified_seats.len()).unwrap_or(u32::MAX);
     if found >= required {
         return Ok(());
     }
@@ -6693,29 +6744,6 @@ pub(crate) fn delegation_scope_for_message_type(mt: &MessageType) -> Option<&'st
         //   ContentMiss / ContentBody   → un-gated (content-routing)
         _ => None,
     }
-}
-
-/// Verify one Ed25519 signature against a 32-byte pubkey and the
-/// canonical bytes. Returns `false` on base64-decode failure, wrong
-/// signature length, or signature-verification failure (any error is
-/// "this signature does not pass"; the gate's job is to count
-/// confirming verifications, not surface error taxonomy).
-fn verify_ed25519_signature(pubkey: &[u8; 32], canonical: &[u8], sig_b64: &str) -> bool {
-    use ciris_crypto::ClassicalVerifier as _;
-
-    let Ok(sig_bytes) = base64::engine::general_purpose::STANDARD.decode(sig_b64.as_bytes()) else {
-        return false;
-    };
-    if sig_bytes.len() != 64 {
-        return false;
-    }
-    // Use ciris-crypto's verifier — the same primitive persist's
-    // verify_hybrid_via_directory composes (single-source-of-truth
-    // for Ed25519 verify across the federation).
-    matches!(
-        ciris_crypto::Ed25519Verifier::new().verify(pubkey, canonical, &sig_bytes),
-        Ok(true)
-    )
 }
 
 /// CIRISEdge#19 — build, sign, and enqueue a [`crate::DeliveryRefusalAttestation`]

--- a/src/holonomic/swarm_rarity.rs
+++ b/src/holonomic/swarm_rarity.rs
@@ -263,31 +263,27 @@ impl FountainHoldingClaim {
     /// `symbol_ids` is SORTED ASCENDING before encoding so two peers
     /// holding the same set in different orders produce identical
     /// signature targets. `DOMAIN` is [`HOLDING_CLAIM_DOMAIN`].
+    ///
+    /// §19 re-export debt (CIRISEdge#359 F-4): the §19.3 signed preimage
+    /// is owned by
+    /// [`ciris_verify_core::holonomic::fountain::FountainHoldingClaim::signing_preimage`]
+    /// (byte-frozen there by the §19.6 vectors). Edge's shape carries
+    /// edge-only fields (the hybrid-signature trio, serde derives, the
+    /// `Message` impl) so it cannot re-export verify's type wholesale;
+    /// instead it delegates the shared preimage byte-for-byte. `DOMAIN`
+    /// is edge-authored ([`HOLDING_CLAIM_DOMAIN`]) and verify reproduces
+    /// it, so the emitted bytes are unchanged.
     #[must_use]
+    #[allow(clippy::cast_sign_loss)] // observed_at_unix_ms is a unix-ms timestamp; i64→u64 is bit-preserving and byte-identical.
     pub fn canonical_bytes(&self) -> Vec<u8> {
-        let mut sorted = self.symbol_ids.clone();
-        sorted.sort_unstable();
-        let mut out = Vec::with_capacity(
-            HOLDING_CLAIM_DOMAIN.len()
-                + 8
-                + self.peer_id.len()
-                + 8
-                + self.content_id.len()
-                + 8
-                + sorted.len() * 4
-                + 8
-                + 4,
-        );
-        out.extend_from_slice(HOLDING_CLAIM_DOMAIN);
-        write_len_prefixed(&mut out, self.peer_id.as_bytes());
-        write_len_prefixed(&mut out, self.content_id.as_bytes());
-        out.extend_from_slice(&(sorted.len() as u64).to_be_bytes());
-        for sym in &sorted {
-            out.extend_from_slice(&sym.to_be_bytes());
+        ciris_verify_core::holonomic::fountain::FountainHoldingClaim {
+            peer_id: self.peer_id.clone(),
+            content_id: self.content_id.clone(),
+            symbol_ids: self.symbol_ids.clone(),
+            observed_at_unix_ms: self.observed_at_unix_ms as u64,
+            claim_version: self.claim_version,
         }
-        out.extend_from_slice(&self.observed_at_unix_ms.to_be_bytes());
-        out.extend_from_slice(&self.claim_version.to_be_bytes());
-        out
+        .signing_preimage()
     }
 }
 
@@ -342,27 +338,25 @@ impl FountainCompressRequest {
     ///        ‖ u32_be(request_version)`.
     ///
     /// `DOMAIN` is [`COMPRESS_REQUEST_DOMAIN`].
+    ///
+    /// §19 re-export debt (CIRISEdge#359 F-4): delegates the shared
+    /// §19.3 preimage to
+    /// [`ciris_verify_core::holonomic::fountain::FountainCompressRequest::signing_preimage`]
+    /// byte-for-byte (same rationale as
+    /// [`FountainHoldingClaim::canonical_bytes`] — edge-only signature
+    /// fields prevent a wholesale re-export).
     #[must_use]
+    #[allow(clippy::cast_sign_loss)] // deadline_unix_ms is a unix-ms timestamp; i64→u64 is bit-preserving and byte-identical.
     pub fn canonical_bytes(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(
-            COMPRESS_REQUEST_DOMAIN.len()
-                + 8
-                + self.peer_id.len()
-                + 8
-                + self.content_id.len()
-                + 4
-                + 4
-                + 8
-                + 4,
-        );
-        out.extend_from_slice(COMPRESS_REQUEST_DOMAIN);
-        write_len_prefixed(&mut out, self.peer_id.as_bytes());
-        write_len_prefixed(&mut out, self.content_id.as_bytes());
-        out.extend_from_slice(&self.evicting_range_low.to_be_bytes());
-        out.extend_from_slice(&self.evicting_range_high.to_be_bytes());
-        out.extend_from_slice(&self.deadline_unix_ms.to_be_bytes());
-        out.extend_from_slice(&self.request_version.to_be_bytes());
-        out
+        ciris_verify_core::holonomic::fountain::FountainCompressRequest {
+            peer_id: self.peer_id.clone(),
+            content_id: self.content_id.clone(),
+            evicting_range_low: self.evicting_range_low,
+            evicting_range_high: self.evicting_range_high,
+            deadline_unix_ms: self.deadline_unix_ms as u64,
+            request_version: self.request_version,
+        }
+        .signing_preimage()
     }
 }
 
@@ -927,11 +921,6 @@ pub trait FountainEvictHardDelete {
         content_id: &str,
         corpus_kind: &str,
     ) -> Result<(), FountainEvictError>;
-}
-
-fn write_len_prefixed(out: &mut Vec<u8>, bytes: &[u8]) {
-    out.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
-    out.extend_from_slice(bytes);
 }
 
 #[cfg(test)]

--- a/src/holonomic/wholeness_witness.rs
+++ b/src/holonomic/wholeness_witness.rs
@@ -40,9 +40,10 @@
 //!   live on the envelope wrapper, signing the canonical bytes from
 //!   outside.
 //!
-//! ## Merkle construction (CT-style, last-node duplication)
+//! ## Merkle construction (last-node duplication — NOT RFC 6962)
 //!
-//! The algorithm is byte-exact:
+//! [`compute_merkle_root`] is re-exported from the shared §19.1 owner
+//! (`ciris-verify-core`); the algorithm is byte-exact:
 //!
 //! 1. **Lex-sort the leaves** by their canonical bytes (§19.1 RC11).
 //!    The leaf order is NOT caller-controlled — the function sorts
@@ -56,15 +57,25 @@
 //!    the claim layer — we apply ONE additional SHA-256 here so the
 //!    leaf-hash domain is distinct from the inner-node domain).
 //! 4. While `layer.len() > 1`:
-//!    - If `layer.len()` is odd, push `layer.last().clone()`
-//!      (Bitcoin / RFC 6962 Certificate Transparency convention).
+//!    - If `layer.len()` is odd, duplicate the last node
+//!      (`node = SHA-256(last ‖ last)`).
 //!    - `new = layer.chunks(2).map(|p| SHA-256(p[0] || p[1])).collect()`
 //!    - `layer = new`
 //! 5. Return `layer[0]`.
 //!
+//! This deliberately does **NOT** use the RFC 6962 Certificate
+//! Transparency construction: RFC 6962 does not duplicate the odd node
+//! (it splits at the largest power of two below the leaf count) and uses
+//! `0x00`/`0x01` domain prefixes. The odd-node duplication here is the
+//! Bitcoin-merkle rule, whose CVE-2012-2459 malleability is not
+//! exploitable in this setting — every witness root is mandatorily
+//! hybrid-signed (no consumer trusts an unsigned root) and is verified
+//! by full recomputation, never partial inclusion proofs. See the
+//! `ciris-verify-core` `wholeness_witness` doc for the frozen rationale.
+//!
 //! §19.1 RC11 — leaves MUST be lex-sorted before Merkle construction,
 //! and the sort is done INSIDE [`compute_merkle_root`] (not by the
-//! caller). CIRISVerify v5.8.0's `holonomic::compute_merkle_root` sorts
+//! caller). CIRISVerify's `holonomic::compute_merkle_root` sorts
 //! and recomputes; an unsorted producer root would mismatch on the
 //! wire. The previous v1 contract ("caller controls order") is
 //! superseded — there is no legal alternative ordering. The contract
@@ -84,11 +95,16 @@
 
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
-/// Sentinel hashed when the leaf set is empty. Documented sentinel —
-/// changing this byte sequence breaks the v1 wire-format contract.
-const EMPTY_LEAF_SENTINEL: &[u8] = b"WW-v1-empty";
+/// §19.1 WW Merkle root — CIRISEdge#359 F-4 re-export debt.
+///
+/// The construction (lexicographic leaves, `leaf = SHA-256(bytes)`,
+/// `node = SHA-256(left ‖ right)`, odd-node duplication, `WW-v1-empty`
+/// empty-tree sentinel) is genuinely identical to the shared §19.1
+/// owner and is KAT-locked there, so edge re-exports it rather than
+/// maintaining a byte-for-byte twin. See
+/// [`ciris_verify_core::holonomic::wholeness_witness::compute_merkle_root`].
+pub use ciris_verify_core::holonomic::wholeness_witness::compute_merkle_root;
 
 /// Locked v1 domain-separation tag for [`EquivocationProof`] signed
 /// bytes. This is a NEW CEG-shape claim (the `hard_case:*` namespace)
@@ -268,37 +284,27 @@ impl WholenessWitness {
     /// order does not perturb the preimage. Length prefixes make the
     /// encoding injective: no two distinct witnesses share a preimage.
     /// The signature fields are EXCLUDED (they sign this, from outside).
+    ///
+    /// §19 re-export debt (CIRISEdge#359 F-4): the §19.1 signed preimage
+    /// framing is owned by
+    /// [`ciris_verify_core::holonomic::wholeness_witness::WholenessWitness::canonical_preimage`]
+    /// (byte-frozen there by the §19.6 vectors). Edge's shape carries
+    /// edge-only fields (the hybrid-signature trio, serde derives) so it
+    /// cannot re-export verify's type wholesale; it delegates the shared
+    /// preimage byte-for-byte. [`WITNESS_PREIMAGE_DOMAIN`] is
+    /// edge-authored and verify reproduces it, so the bytes are unchanged.
     #[must_use]
-    // §19 mandates u32-BE length prefixes. The cast matches the
-    // claim-layer length-prefix convention; a witness field longer than
-    // 4 GiB is not a real input, and the encoding is injective within
-    // that bound.
-    #[allow(clippy::cast_possible_truncation)]
     pub fn canonical_preimage_bytes(&self) -> Vec<u8> {
-        let mut namespaces = self.claim_namespaces.clone();
-        namespaces.sort();
-
-        let mut out = Vec::with_capacity(16 + 4 + self.peer_id.len() + 8 + 32 + 4 + 4 + 8 + 2);
-        out.extend_from_slice(WITNESS_PREIMAGE_DOMAIN);
-
-        let peer = self.peer_id.as_bytes();
-        out.extend_from_slice(&(peer.len() as u32).to_be_bytes());
-        out.extend_from_slice(peer);
-
-        out.extend_from_slice(&self.epoch_id.to_be_bytes());
-        out.extend_from_slice(&self.merkle_root);
-        out.extend_from_slice(&self.leaf_count.to_be_bytes());
-
-        out.extend_from_slice(&(namespaces.len() as u32).to_be_bytes());
-        for ns in &namespaces {
-            let b = ns.as_bytes();
-            out.extend_from_slice(&(b.len() as u32).to_be_bytes());
-            out.extend_from_slice(b);
+        ciris_verify_core::holonomic::wholeness_witness::WholenessWitness {
+            peer_id: self.peer_id.clone(),
+            epoch_id: self.epoch_id,
+            claim_namespaces: self.claim_namespaces.clone(),
+            merkle_root: self.merkle_root,
+            leaf_count: self.leaf_count,
+            observed_at_unix_ms: self.observed_at_unix_ms,
+            witness_version: self.witness_version,
         }
-
-        out.extend_from_slice(&self.observed_at_unix_ms.to_be_bytes());
-        out.extend_from_slice(&self.witness_version.to_be_bytes());
-        out
+        .canonical_preimage()
     }
 
     /// Build the private serialize-only canonical view. Shared by
@@ -344,68 +350,6 @@ struct CanonicalRepr<'a> {
     claim_namespaces: Vec<String>,
     observed_at_unix_ms: u64,
     witness_version: u16,
-}
-
-/// Compute the v1-locked Merkle root over the leaf set.
-///
-/// See module-level docs for the byte-exact algorithm. The function is
-/// pure: given the same leaf MULTISET, it returns the same 32-byte root
-/// on every implementation (Rust / Python / Swift / Kotlin),
-/// independent of the order the leaves are passed in.
-///
-/// # Leaf ordering (§19.1 RC11)
-///
-/// Leaves are lex-sorted by their bytes INSIDE this function — the
-/// order is NOT caller-controlled. CIRISVerify v5.8.0 sorts and
-/// recomputes, so an unsorted producer root would mismatch on the
-/// wire. The earlier "caller controls order" contract is superseded.
-///
-/// # Empty input
-///
-/// Returns `SHA-256(b"WW-v1-empty")` — the documented sentinel.
-#[must_use]
-pub fn compute_merkle_root(leaves: &[Vec<u8>]) -> [u8; 32] {
-    if leaves.is_empty() {
-        return sha256(EMPTY_LEAF_SENTINEL);
-    }
-
-    // §19.1: lex-sort the leaf bytes before hashing. Two peers with
-    // the same leaf multiset MUST land on the same root regardless of
-    // the order the leaves arrived in. The sort is total over byte
-    // slices (Vec<u8>: Ord is lexicographic), so it is deterministic
-    // and cross-impl-stable.
-    let mut sorted: Vec<&Vec<u8>> = leaves.iter().collect();
-    sorted.sort_unstable();
-
-    // Layer 0: hash each leaf. This step makes the leaf-hash domain
-    // distinct from the inner-node domain (defense against length-
-    // extension / second-preimage attacks where a forged inner node
-    // looks like a leaf and vice-versa).
-    let mut layer: Vec<[u8; 32]> = sorted.iter().map(|l| sha256(l)).collect();
-
-    // Reduce upward.
-    while layer.len() > 1 {
-        // CT / Bitcoin convention: duplicate the last node on
-        // odd-count layers so every internal node has two children.
-        if layer.len() % 2 == 1 {
-            let last = *layer.last().expect("layer non-empty");
-            layer.push(last);
-        }
-
-        // Pair-hash. `chunks(2)` is safe here — we just made the
-        // count even.
-        let mut next: Vec<[u8; 32]> = Vec::with_capacity(layer.len() / 2);
-        for pair in layer.chunks(2) {
-            let mut hasher = Sha256::new();
-            hasher.update(pair[0]);
-            hasher.update(pair[1]);
-            let out: [u8; 32] = hasher.finalize().into();
-            next.push(out);
-        }
-        layer = next;
-    }
-
-    layer[0]
 }
 
 /// §19.1 WW-2 — filter deniable / self-private leaves BEFORE Merkle
@@ -785,28 +729,9 @@ pub fn detect_equivocation(
     })
 }
 
-/// Compute a single-shot SHA-256 over a byte slice and return the
-/// 32-byte digest as a fixed-size array.
-fn sha256(bytes: &[u8]) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    hasher.finalize().into()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Helper: lowercase-hex 64-char string for asserting raw roots
-    /// in tests without pulling `hex` at runtime.
-    fn hex(bytes: &[u8; 32]) -> String {
-        let mut s = String::with_capacity(64);
-        for b in bytes {
-            use std::fmt::Write as _;
-            let _ = write!(s, "{b:02x}");
-        }
-        s
-    }
 
     /// Construct a minimally-populated witness for comparison tests.
     fn witness(epoch_id: u64, root: [u8; 32]) -> WholenessWitness {
@@ -825,116 +750,22 @@ mod tests {
     }
 
     #[test]
-    fn merkle_empty_leaves_returns_sentinel() {
+    fn merkle_empty_leaves_wire_locked_via_shared_owner() {
+        // CIRISEdge#359 F-4: the algorithmic KATs (single/two/odd/order-
+        // independence) are OWNED by ciris-verify-core, whose
+        // wholeness_witness tests pin them; edge no longer duplicates
+        // them. This one cross-crate anchor guards the §19.1 re-export
+        // against a verify-side regression: the shared owner MUST still
+        // produce edge's wire-locked empty-sentinel root
+        // (`sha256("WW-v1-empty")`; recompute with
+        // `printf 'WW-v1-empty' | sha256sum`).
         let got = compute_merkle_root(&[]);
-        let want = sha256(b"WW-v1-empty");
-        assert_eq!(got, want, "empty-input root must hash the v1 sentinel");
-        // Byte-exact assertion against the known SHA-256 of the
-        // sentinel string — this anchors the wire format. The hex
-        // below is `sha256("WW-v1-empty")`; recompute with
-        // `printf 'WW-v1-empty' | sha256sum`.
-        assert_eq!(
-            hex(&got),
-            "2280d27f232100367e86211b5349fe0d6fbaee98e4c2b489a86008049563464f",
-            "empty sentinel root is wire-locked at v1"
-        );
-    }
-
-    #[test]
-    fn merkle_single_leaf() {
-        let leaf = b"alpha".to_vec();
-        let got = compute_merkle_root(std::slice::from_ref(&leaf));
-        // Single leaf: ONE hash of the leaf (no inner-node hashing
-        // because the layer is already length 1). This is the
-        // documented `layer[0]` exit.
-        let want = sha256(&leaf);
-        assert_eq!(
-            got, want,
-            "single-leaf root must be SHA-256(leaf) per the documented contract"
-        );
-    }
-
-    #[test]
-    fn merkle_two_leaves() {
-        let l0 = b"alpha".to_vec();
-        let l1 = b"beta".to_vec();
-        let got = compute_merkle_root(&[l0.clone(), l1.clone()]);
-
-        let h0 = sha256(&l0);
-        let h1 = sha256(&l1);
-        let mut hasher = Sha256::new();
-        hasher.update(h0);
-        hasher.update(h1);
-        let want: [u8; 32] = hasher.finalize().into();
-        assert_eq!(got, want, "two-leaf root must be SHA-256(H(l0) || H(l1))");
-    }
-
-    #[test]
-    fn merkle_odd_count_duplicates_last() {
-        // 3 leaves — layer 0 becomes [H(l0), H(l1), H(l2)]; odd
-        // count → duplicate last → [H(l0), H(l1), H(l2), H(l2)];
-        // pair-hash → [H(H(l0)||H(l1)), H(H(l2)||H(l2))]; pair-hash
-        // → root.
-        let l0 = b"alpha".to_vec();
-        let l1 = b"beta".to_vec();
-        let l2 = b"gamma".to_vec();
-        let got = compute_merkle_root(&[l0.clone(), l1.clone(), l2.clone()]);
-
-        let h0 = sha256(&l0);
-        let h1 = sha256(&l1);
-        let h2 = sha256(&l2);
-
-        let pair01 = {
-            let mut h = Sha256::new();
-            h.update(h0);
-            h.update(h1);
-            let o: [u8; 32] = h.finalize().into();
-            o
-        };
-        // CT-style duplicate-last: pair[H(l2), H(l2)].
-        let pair22 = {
-            let mut h = Sha256::new();
-            h.update(h2);
-            h.update(h2);
-            let o: [u8; 32] = h.finalize().into();
-            o
-        };
-        let root = {
-            let mut h = Sha256::new();
-            h.update(pair01);
-            h.update(pair22);
-            let o: [u8; 32] = h.finalize().into();
-            o
-        };
-        assert_eq!(
-            got, root,
-            "odd-count layer must duplicate the last node (CT/Bitcoin convention)"
-        );
-    }
-
-    #[test]
-    fn merkle_order_independent_after_internal_lex_sort() {
-        // §19.1 RC11: the leaf order is NOT caller-controlled — the
-        // function lex-sorts internally, so the same multiset of leaves
-        // produces the SAME root regardless of the order passed in.
-        // CIRISVerify v5.8.0 sorts and recomputes; this is the producer
-        // side of that contract.
-        let l0 = b"alpha".to_vec();
-        let l1 = b"beta".to_vec();
-
-        let ordered = compute_merkle_root(&[l0.clone(), l1.clone()]);
-        let swapped = compute_merkle_root(&[l1.clone(), l0.clone()]);
-
-        assert_eq!(
-            ordered, swapped,
-            "§19.1: Merkle root MUST be independent of input leaf order \
-             (leaves are lex-sorted internally before construction)"
-        );
-
-        // And the sorted root equals the explicit pre-sorted call.
-        let mut presorted = vec![l0, l1];
-        presorted.sort();
-        assert_eq!(ordered, compute_merkle_root(&presorted));
+        let want: [u8; 32] = [
+            0x22, 0x80, 0xd2, 0x7f, 0x23, 0x21, 0x00, 0x36, 0x7e, 0x86, 0x21, 0x1b, 0x53, 0x49,
+            0xfe, 0x0d, 0x6f, 0xba, 0xee, 0x98, 0xe4, 0xc2, 0xb4, 0x89, 0xa8, 0x60, 0x08, 0x04,
+            0x95, 0x63, 0x46, 0x4f,
+        ];
+        assert_eq!(got, want, "empty sentinel root is wire-locked at v1");
     }
 
     #[test]

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -833,6 +833,18 @@ pub struct AccordSignature {
     /// Base64-standard Ed25519 signature (64 bytes raw, 88 chars b64)
     /// over [`FederationAnnouncement::canonical_bytes_for_accord_signatures`].
     pub signature_ed25519_base64: String,
+    /// CIRISEdge#359 finding 2 — the ML-DSA-65 half of the hybrid accord
+    /// signature (base64-standard), over the SAME
+    /// [`FederationAnnouncement::canonical_bytes_for_accord_signatures`].
+    /// The accord carrier is constitutional kill-switch-class traffic, which
+    /// verify gates at `HybridPolicy::RequireHybrid` (v5.7.0 #75) — a
+    /// classical-only signature must NOT satisfy the quorum. `None` is a
+    /// classical-only (pre-#359) signature and is REFUSED by
+    /// `verify_accord_carrier` under RequireHybrid. Additive to the wire: the
+    /// signed canonical bytes exclude `accord_signatures`, so adding this
+    /// field does not change what any holder signs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature_ml_dsa_65_base64: Option<String>,
 }
 
 impl FederationAnnouncement {

--- a/src/sas.rs
+++ b/src/sas.rs
@@ -13,14 +13,37 @@
 //! - **Hash**: SHA-256 (already in deps via `sha2`). No BLAKE3.
 //! - **Wordlist**: BIP39 English (2048 words = 11 bits each;
 //!   5 words ≈ 55 bits, matching CIRISEdge#47's stated entropy bar).
-//! - **Order independence**: concatenate `local_pub || peer_pub` then
-//!   `sort` before hashing so `peer_sas(A, B) == peer_sas(B, A)` —
-//!   neither operator has to know who is "local".
-//! - **Protocol constant**: [`CIRIS_SAS_PROTOCOL_CONSTANT`] — a
-//!   versioned ASCII tag. Locks the wire-spec; bump `v1 → v2` to
-//!   roll if the algorithm ever changes (algorithm + constant is the
-//!   wire shape; both must stay stable across edge versions to
-//!   preserve the verbal-comparison contract).
+//! - **Order independence**: the derivation is symmetric so
+//!   `peer_sas(A, B) == peer_sas(B, A)` — neither operator has to know
+//!   who is "local". Two constructions exist (see [`SasVersion`]):
+//!     - **v1** ([`SasVersion::V1`]) sorts the 64 individual bytes of
+//!       `local_pub || peer_pub`. This commits to the byte-*multiset*,
+//!       not the ordered key pair — a subtle weakness (CIRISEdge#359
+//!       finding 5): two different key pairs sharing the same 64-byte
+//!       multiset collide. Practically unexploitable (pubkey bytes are
+//!       not attacker-choosable) but not the construction we'd pick
+//!       fresh. Retained as the wire default for interop.
+//!     - **v2** ([`SasVersion::V2`]) orders the two keys as 32-byte
+//!       UNITS — `min(A, B) || max(A, B)` — committing to the
+//!       unordered key *pair*. Preferred construction.
+//! - **Protocol constant**: [`CIRIS_SAS_PROTOCOL_CONSTANT`] (v1) /
+//!   [`CIRIS_SAS_PROTOCOL_CONSTANT_V2`] (v2) — a versioned ASCII tag.
+//!   Locks the wire-spec; the version tag rolls with the algorithm
+//!   (algorithm + constant is the wire shape; both must stay stable
+//!   across edge versions to preserve the verbal-comparison contract).
+//!
+//! # SAS versions and coordinated rollout
+//!
+//! The SAS is compared out-of-band **by humans** and the version is
+//! NOT negotiated on the wire — each side computes independently, so
+//! **both operators must be on the same [`SasVersion`] for their
+//! strings to match**. Flipping the fleet from v1 to v2 is therefore a
+//! coordinated event (both peers simultaneously), NOT a silent
+//! per-node upgrade. v1 stays the operative default of the
+//! zero-version convenience functions ([`peer_sas_digest`],
+//! [`peer_sas_words`], [`peer_sas_digits`]); callers opt into v2
+//! explicitly via the `_versioned` entry points until the fleet-floor
+//! flip is dated.
 //!
 //! # Determinism
 //!
@@ -42,6 +65,31 @@ use sha2::{Digest, Sha256};
 /// Locked at v0.17.0; DO NOT change without bumping the version tag.
 pub const CIRIS_SAS_PROTOCOL_CONSTANT: &[u8] = b"ciris-edge::peer-sas::v1\0";
 
+/// v2 protocol-version-tagged constant (CIRISEdge#359 finding 5). Paired
+/// with the v2 key-ordering rule (32-byte units, `min || max`). Distinct
+/// from the v1 tag so a v1 digest and a v2 digest never collide even on
+/// the same key pair.
+///
+/// DO NOT change without bumping to `::v3`.
+pub const CIRIS_SAS_PROTOCOL_CONSTANT_V2: &[u8] = b"ciris-edge::peer-sas::v2\0";
+
+/// Which SAS construction to use. The version is baked into the
+/// key-ordering rule and the protocol constant; it is **not** negotiated
+/// on the wire — each side computes independently, so both operators must
+/// select the same version for their strings to match (see module docs on
+/// coordinated rollout).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SasVersion {
+    /// v1 (v0.17.0): sorts the 64 individual bytes of `local || peer`
+    /// before hashing. Commits to the byte-multiset, not the ordered key
+    /// pair. Operative wire default for interop with un-upgraded peers.
+    V1,
+    /// v2 (CIRISEdge#359 finding 5): orders the two keys as 32-byte UNITS
+    /// — `min(A, B) || max(A, B)` — committing to the unordered key pair.
+    /// Preferred construction; adopt fleet-wide via a coordinated flip.
+    V2,
+}
+
 /// Default word count for [`peer_sas`]. Five BIP39 words × 11 bits each
 /// = 55 bits of entropy, the bar called out in CIRISEdge#47.
 pub const DEFAULT_SAS_WORDS: usize = 5;
@@ -51,26 +99,70 @@ pub const DEFAULT_SAS_WORDS: usize = 5;
 /// authentication code (TOTP / SAS over Signal).
 pub const DEFAULT_SAS_DIGITS: usize = 6;
 
-/// Compute the 32-byte SAS digest for a `(local_pub, peer_pub)` pair.
+/// Compute the 32-byte SAS digest for a `(local_pub, peer_pub)` pair
+/// using the **v1** construction (the operative wire default).
 ///
-/// Pure function — order-independent, deterministic.
-///
-/// 1. Concatenate the two pubkeys.
-/// 2. Sort the concatenation (so swapping the two inputs yields the
-///    same digest — neither operator has to know who is "local").
-/// 3. Append [`CIRIS_SAS_PROTOCOL_CONSTANT`].
-/// 4. SHA-256 the whole thing.
+/// Pure function — order-independent, deterministic. Delegates to
+/// [`peer_sas_digest_versioned`] with [`SasVersion::V1`]; see that
+/// function for the v1/v2 recipes.
 #[must_use]
 pub fn peer_sas_digest(local_pub: &[u8; 32], peer_pub: &[u8; 32]) -> [u8; 32] {
-    let mut buf: Vec<u8> = Vec::with_capacity(64 + CIRIS_SAS_PROTOCOL_CONSTANT.len());
-    buf.extend_from_slice(local_pub);
-    buf.extend_from_slice(peer_pub);
-    buf.sort_unstable();
-    buf.extend_from_slice(CIRIS_SAS_PROTOCOL_CONSTANT);
-    let digest = Sha256::digest(&buf);
-    let mut out = [0u8; 32];
-    out.copy_from_slice(&digest);
-    out
+    peer_sas_digest_versioned(local_pub, peer_pub, SasVersion::V1)
+}
+
+/// Compute the 32-byte SAS digest for a `(local_pub, peer_pub)` pair at
+/// the requested [`SasVersion`].
+///
+/// Pure function — symmetric (`digest(A, B) == digest(B, A)`) and
+/// deterministic in both versions.
+///
+/// **v1** ([`SasVersion::V1`]):
+/// 1. Concatenate the two pubkeys.
+/// 2. Sort the 64-byte concatenation (byte-wise) so swapping the inputs
+///    yields the same digest. NB: this commits to the byte-multiset, not
+///    the ordered key pair — the weakness fixed by v2.
+/// 3. Append [`CIRIS_SAS_PROTOCOL_CONSTANT`].
+/// 4. SHA-256 the whole thing.
+///
+/// **v2** ([`SasVersion::V2`]):
+/// 1. Order the two 32-byte keys as UNITS — `min(A, B) || max(A, B)`
+///    (lexicographic compare of the full 32-byte keys). Symmetric by
+///    construction, and commits to the unordered key *pair*.
+/// 2. Append [`CIRIS_SAS_PROTOCOL_CONSTANT_V2`].
+/// 3. SHA-256 the whole thing.
+///
+/// See the module docs: v1 and v2 are NOT interchangeable across peers —
+/// both operators must select the same version.
+#[must_use]
+pub fn peer_sas_digest_versioned(
+    local_pub: &[u8; 32],
+    peer_pub: &[u8; 32],
+    version: SasVersion,
+) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    match version {
+        SasVersion::V1 => {
+            // v1: sort the 64 individual bytes of local || peer.
+            let mut buf: Vec<u8> = Vec::with_capacity(64);
+            buf.extend_from_slice(local_pub);
+            buf.extend_from_slice(peer_pub);
+            buf.sort_unstable();
+            hasher.update(&buf);
+            hasher.update(CIRIS_SAS_PROTOCOL_CONSTANT);
+        }
+        SasVersion::V2 => {
+            // v2: order the two keys as 32-byte units — min || max.
+            let (lo, hi) = if local_pub <= peer_pub {
+                (local_pub, peer_pub)
+            } else {
+                (peer_pub, local_pub)
+            };
+            hasher.update(lo);
+            hasher.update(hi);
+            hasher.update(CIRIS_SAS_PROTOCOL_CONSTANT_V2);
+        }
+    }
+    hasher.finalize().into()
 }
 
 /// Render the SAS digest as `words` BIP39-English words. The default
@@ -90,10 +182,26 @@ pub fn peer_sas_words(
     peer_pub: &[u8; 32],
     words: usize,
 ) -> Result<Vec<String>, SasError> {
+    peer_sas_words_versioned(local_pub, peer_pub, words, SasVersion::V1)
+}
+
+/// [`peer_sas_words`] at an explicit [`SasVersion`]. See the module docs
+/// on coordinated rollout before selecting [`SasVersion::V2`].
+///
+/// # Errors
+///
+/// Returns `Err(SasError::WordsOutOfRange)` if `words == 0` or
+/// `words > 23`.
+pub fn peer_sas_words_versioned(
+    local_pub: &[u8; 32],
+    peer_pub: &[u8; 32],
+    words: usize,
+    version: SasVersion,
+) -> Result<Vec<String>, SasError> {
     if words == 0 || words > 23 {
         return Err(SasError::WordsOutOfRange(words));
     }
-    let digest = peer_sas_digest(local_pub, peer_pub);
+    let digest = peer_sas_digest_versioned(local_pub, peer_pub, version);
     // CIRISEdge#264 — vendored BIP-39 English wordlist (see `sas_wordlist`);
     // dropped the `bip39` crate + its bitcoin-adjacent transitives.
     let wordlist = &crate::sas_wordlist::ENGLISH;
@@ -135,10 +243,26 @@ pub fn peer_sas_digits(
     peer_pub: &[u8; 32],
     digits: usize,
 ) -> Result<String, SasError> {
+    peer_sas_digits_versioned(local_pub, peer_pub, digits, SasVersion::V1)
+}
+
+/// [`peer_sas_digits`] at an explicit [`SasVersion`]. See the module docs
+/// on coordinated rollout before selecting [`SasVersion::V2`].
+///
+/// # Errors
+///
+/// Returns `Err(SasError::DigitsOutOfRange)` if `digits == 0` or
+/// `digits > 19`.
+pub fn peer_sas_digits_versioned(
+    local_pub: &[u8; 32],
+    peer_pub: &[u8; 32],
+    digits: usize,
+    version: SasVersion,
+) -> Result<String, SasError> {
     if digits == 0 || digits > 19 {
         return Err(SasError::DigitsOutOfRange(digits));
     }
-    let digest = peer_sas_digest(local_pub, peer_pub);
+    let digest = peer_sas_digest_versioned(local_pub, peer_pub, version);
     // First 8 bytes → u64; mod 10^digits → decimal string.
     let mut raw = [0u8; 8];
     raw.copy_from_slice(&digest[..8]);
@@ -320,6 +444,105 @@ mod tests {
         let expected: [u8; 32] = Sha256::digest(&buf).into();
         let actual = peer_sas_digest(&a, &b);
         assert_eq!(actual, expected);
+    }
+
+    /// v2 protocol constant lock — regression guard for the v2 tag.
+    #[test]
+    fn peer_sas_protocol_constant_v2_locked() {
+        assert_eq!(
+            CIRIS_SAS_PROTOCOL_CONSTANT_V2, b"ciris-edge::peer-sas::v2\0",
+            "DO NOT change CIRIS_SAS_PROTOCOL_CONSTANT_V2 — bump v2->v3 instead",
+        );
+        assert_eq!(CIRIS_SAS_PROTOCOL_CONSTANT_V2.len(), 25);
+    }
+
+    /// v2 symmetry — the load-bearing property: swapping local↔peer
+    /// yields the same digest at v2 (the whole point of the unit
+    /// ordering). Holds at the digest, words, and digits layers.
+    #[test]
+    fn peer_sas_v2_symmetric() {
+        let a = pub_a();
+        let b = pub_b();
+        assert_eq!(
+            peer_sas_digest_versioned(&a, &b, SasVersion::V2),
+            peer_sas_digest_versioned(&b, &a, SasVersion::V2),
+            "v2 digest MUST be symmetric (min||max ordering)"
+        );
+        assert_eq!(
+            peer_sas_words_versioned(&a, &b, 5, SasVersion::V2).expect("fwd"),
+            peer_sas_words_versioned(&b, &a, 5, SasVersion::V2).expect("rev"),
+            "v2 words MUST be symmetric"
+        );
+        assert_eq!(
+            peer_sas_digits_versioned(&a, &b, 6, SasVersion::V2).expect("fwd"),
+            peer_sas_digits_versioned(&b, &a, 6, SasVersion::V2).expect("rev"),
+            "v2 digits MUST be symmetric"
+        );
+    }
+
+    /// The v1→v2 bump actually changes the bytes — a v1 digest and a v2
+    /// digest of the same pair must differ (distinct ordering rule AND
+    /// distinct protocol constant).
+    #[test]
+    fn peer_sas_v1_and_v2_differ() {
+        let a = pub_a();
+        let b = pub_b();
+        assert_ne!(
+            peer_sas_digest_versioned(&a, &b, SasVersion::V1),
+            peer_sas_digest_versioned(&a, &b, SasVersion::V2),
+            "v1 and v2 constructions MUST produce different digests"
+        );
+        // And the zero-version convenience default is still v1.
+        assert_eq!(
+            peer_sas_digest(&a, &b),
+            peer_sas_digest_versioned(&a, &b, SasVersion::V1),
+            "peer_sas_digest default MUST remain v1 (operative wire default)"
+        );
+    }
+
+    /// v2 unit-ordering canonical recipe — pins `min||max ||
+    /// v2-constant`, so a refactor that reverts to byte-sort or the v1
+    /// constant trips immediately.
+    #[test]
+    fn peer_sas_v2_matches_canonical_recipe() {
+        let a = pub_a();
+        let b = pub_b();
+        let (lo, hi) = if a <= b { (a, b) } else { (b, a) };
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(&lo);
+        buf.extend_from_slice(&hi);
+        buf.extend_from_slice(CIRIS_SAS_PROTOCOL_CONSTANT_V2);
+        let expected: [u8; 32] = Sha256::digest(&buf).into();
+        assert_eq!(peer_sas_digest_versioned(&a, &b, SasVersion::V2), expected);
+    }
+
+    /// The concrete weakness v2 fixes: two DIFFERENT key pairs that share
+    /// the same 64-byte multiset collide under v1's byte-sort but are
+    /// distinguished by v2's unit ordering.
+    #[test]
+    fn peer_sas_v2_distinguishes_byte_multiset_collision() {
+        // Pair 1: all-zero local, all-0xff peer.
+        let a1 = [0x00u8; 32];
+        let b1 = [0xffu8; 32];
+        // Pair 2: same 64-byte multiset (32 zeros + 32 0xff) but a
+        // different pair — one byte migrated across the key boundary.
+        let mut a2 = [0x00u8; 32];
+        a2[31] = 0xff;
+        let mut b2 = [0xffu8; 32];
+        b2[31] = 0x00;
+
+        // v1 collides — byte-sort erases the pair distinction.
+        assert_eq!(
+            peer_sas_digest_versioned(&a1, &b1, SasVersion::V1),
+            peer_sas_digest_versioned(&a2, &b2, SasVersion::V1),
+            "v1 byte-sort collides on equal byte-multisets (the weakness)"
+        );
+        // v2 distinguishes them — unit ordering commits to the pair.
+        assert_ne!(
+            peer_sas_digest_versioned(&a1, &b1, SasVersion::V2),
+            peer_sas_digest_versioned(&a2, &b2, SasVersion::V2),
+            "v2 unit ordering MUST distinguish distinct key pairs"
+        );
     }
 
     /// Out-of-range word counts surface a typed error.

--- a/src/transport/realtime_av.rs
+++ b/src/transport/realtime_av.rs
@@ -92,7 +92,6 @@
 //!   drive the rotation.
 
 use ciris_crypto::aes_gcm;
-use sha2::{Digest, Sha256};
 use zeroize::Zeroize;
 
 use crate::reachability::ReachabilityTracker;
@@ -422,31 +421,27 @@ pub enum RealtimeAvError {
 /// where `label = b"CIRIS-AV-INNER-V1"`. The label binds the nonce
 /// to this module's purpose so a future inner-nonce derivation for a
 /// different surface cannot collide.
+///
+/// §19 re-export debt (CIRISEdge#359 F-4): the SHA-256 construction is
+/// the §10.5.8 A/V nonce shape owned by
+/// [`ciris_verify_core::holonomic::av_chunk::inner_nonce`] (KAT-locked
+/// there). This edge-newtyped wrapper delegates to it byte-for-byte —
+/// `StreamId`/`Epoch`/`ChunkSeq` are edge-only newtypes so a plain
+/// re-export is not type-compatible.
 pub fn derive_inner_nonce(stream_id: StreamId, epoch: Epoch, chunk_seq: ChunkSeq) -> [u8; 12] {
-    let mut h = Sha256::new();
-    h.update(b"CIRIS-AV-INNER-V1");
-    h.update(stream_id.0);
-    h.update(epoch.0.to_be_bytes());
-    h.update(chunk_seq.0.to_be_bytes());
-    let full = h.finalize();
-    let mut out = [0u8; 12];
-    out.copy_from_slice(&full[..12]);
-    out
+    ciris_verify_core::holonomic::av_chunk::inner_nonce(&stream_id.0, epoch.0, chunk_seq.0)
 }
 
 /// Derive the outer-AEAD nonce per Link from `(link_id, link_seq)`.
 /// The `link_seq` is monotonic per RNS Link and prevents replay across
 /// the transit hop. Construction follows the same shape as
 /// [`derive_inner_nonce`] with a distinct label.
+///
+/// §19 re-export debt (CIRISEdge#359 F-4): delegates to the shared
+/// §10.5.8 nonce owner
+/// [`ciris_verify_core::holonomic::av_chunk::outer_nonce`] byte-for-byte.
 pub fn derive_outer_nonce(link_id: &[u8], link_seq: u64) -> [u8; 12] {
-    let mut h = Sha256::new();
-    h.update(b"CIRIS-AV-OUTER-V1");
-    h.update(link_id);
-    h.update(link_seq.to_be_bytes());
-    let full = h.finalize();
-    let mut out = [0u8; 12];
-    out.copy_from_slice(&full[..12]);
-    out
+    ciris_verify_core::holonomic::av_chunk::outer_nonce(link_id, link_seq)
 }
 
 /// The inner-sealed half of a chunk — E2E ciphertext shared across the

--- a/src/transport/realtime_av_alm/capacity.rs
+++ b/src/transport/realtime_av_alm/capacity.rs
@@ -58,13 +58,20 @@
 //!
 //! ## Replay protection
 //!
-//! Each [`SignedRelayCapacity`] binds:
-//! - `stream_id` — so an advertisement minted for stream A cannot be
-//!   replayed against stream B's roster;
+//! The **signed preimage** is the cross-impl canonical shape owned by
+//! Verify (§19.4 N8) — `peer_id ‖ uplink_mbps ‖ epoch` — so only these
+//! bind the hybrid signature (see
+//! [`RelayCapacity::canonical_bytes_for_signing`], CIRISEdge#359):
+//! - `advertiser_key_id` (= Verify's `peer_id`) — owner-bound identity;
 //! - `epoch` — so an advertisement minted before an MLS epoch rotation
-//!   cannot be replayed at the new epoch;
-//! - `measured_at_unix_ms` + the [`STALE_AFTER_SECS`] receive-side gate
-//!   — so an old measurement can't be replayed indefinitely.
+//!   cannot be replayed at the new epoch.
+//!
+//! `measured_at_unix_ms` + the [`STALE_AFTER_SECS`] receive-side gate
+//! still bounds how long any advert is honoured. `stream_id` and the MDC
+//! `sub_stream_commitments` remain on the wire as **unsigned** planner
+//! fields (the join planner + deterministic topology read them) but are
+//! NOT in the signed preimage — Verify's `verify_relay_capacity` is the
+//! joint source of truth and never signed over them.
 //!
 //! ## CIRISEdge#128 — Multiple Description Coding (MDC, "holographic")
 //!
@@ -84,11 +91,11 @@
 //!   depth-agnostic; the codec layer picks). Receivers compose their
 //!   quality level from the union of available sub-stream parents.
 //!
-//! Signing canonical-bytes domain separator is bumped from
-//! `CIRISALM-CAPv1` → `CIRISALM-CAPv2` so a v1 verifier cannot
-//! accidentally accept a v2 advertisement (and a v2 verifier rejects
-//! any leftover v1 signers uniformly). No v1 advertisements exist in
-//! production yet; the bump is a clean cut.
+//! Signing canonical-bytes domain separator is `CIRISALM-CAPv2\0\0` —
+//! shared byte-for-byte with Verify's
+//! [`ciris_verify_core::holonomic::preimage::DOMAIN_RELAY_CAPACITY`].
+//! The MDC `sub_stream_commitments` are additive planner state; they
+//! ride the wire unsigned and do NOT change the signed preimage.
 
 use base64::Engine as _;
 use serde::{Deserialize, Serialize};
@@ -353,79 +360,54 @@ impl RelayCapacity {
         false
     }
 
-    /// Canonical bytes for hybrid signing — deterministic encoding
-    /// independent of serde_json formatting.
+    /// Canonical bytes for hybrid signing — **delegated verbatim to
+    /// Verify** so an edge-minted advert verifies under Verify's
+    /// [`ciris_verify_core::holonomic::alm::verify_relay_capacity`]
+    /// (§19.4 N8; CIRISEdge#359 Crypto-DRY).
     ///
-    /// Layout (all multi-byte integers BIG-ENDIAN — same convention as
-    /// [`crate::transport::realtime_av::SealedAvChunk::to_bytes`]):
+    /// Layout is Verify's canonical §19.0 preimage:
     ///
     /// ```text
-    ///   0..16   b"CIRISALM-CAPv2\0\0"   // v2 — adds substream commitments
-    ///  16..48   stream_id        (32 bytes)
-    ///  48..56   epoch            (BE u64)
-    ///
-    ///  56..60   uplink_mbps                 (BE f32)
-    ///  60..62   max_streams                 (BE u16)
-    ///  62..64   max_subscribers_per_stream  (BE u16)
-    ///  64..72   measured_at_unix_ms         (BE u64)
-    ///  72..73   max_layer_supported.max_spatial   (u8)
-    ///  73..74   max_layer_supported.max_temporal  (u8)
-    ///  74..75   max_layer_supported.max_quality   (u8)
-    ///
-    /// // MDC sub-stream commitments — length-prefixed Vec.
-    ///  75..79   commitment_count            (BE u32)
-    /// // Each commitment:
-    /// //   path_len     (BE u16)
-    /// //   path bytes
-    /// //   uplink_budget_mbps   (BE f32)
-    /// //   max_subscribers      (BE u16)
-    /// // Iteration order = vector order. Callers MUST preserve order
-    /// // between sign + verify (we never re-sort here — the sub-stream
-    /// // identity IS the path, and an in-order canonical encoding lets
-    /// // the codec layer choose a layout convention without ALM-A's
-    /// // intervention).
+    ///   b"CIRISALM-CAPv2\0\0"            // domain (16 bytes)
+    ///   u32_be(advertiser_key_id.len())  // length prefix
+    ///   advertiser_key_id bytes          // Verify's `peer_id`
+    ///   u32_be(uplink_mbps)              // f32 rounded → u32 Mbps
+    ///   u64_be(epoch)
     /// ```
     ///
-    /// The advertiser's `key_id` is NOT included — bound out-of-band by
-    /// the choice of signing key + the `advertiser_key_id` field on the
-    /// signed wrapper.
+    /// **What is NOT signed** (deliberate, per the finding): `stream_id`,
+    /// `max_streams`, `max_subscribers_per_stream`, `measured_at_unix_ms`,
+    /// `max_layer_supported`, and the MDC `sub_stream_commitments`. These
+    /// were never load-bearing for topology scoring; they remain on the
+    /// wire as **unsigned** planner fields. Edge does NOT fork a wider
+    /// preimage — Verify is the single source of truth for these bytes.
     ///
-    /// **Domain separator bumped to v2** to disambiguate from any
-    /// hypothetical v1 signers — no v1 advertisements exist in
-    /// production yet, so the bump is a clean cut.
+    /// `uplink_mbps` is edge-internal `f32` but Verify's canonical field
+    /// is `u32`, so it is rounded to the nearest integer via
+    /// [`uplink_mbps_to_u32`] before framing. Producer and verifier both
+    /// route through this method, so the rounding is symmetric.
     #[must_use]
-    pub fn canonical_bytes_for_signing(&self, stream_id: StreamId, epoch: Epoch) -> Vec<u8> {
-        const DOMAIN_SEP: &[u8; 16] = b"CIRISALM-CAPv2\0\0";
-        let mut out = Vec::with_capacity(
-            // 75 fixed bytes + 4 for commitment count + each commitment
-            75 + 4 + self.sub_stream_commitments.len() * (2 + 4 + 4 + 2),
-        );
-        out.extend_from_slice(DOMAIN_SEP);
-        out.extend_from_slice(&stream_id.0);
-        out.extend_from_slice(&epoch.0.to_be_bytes());
-        out.extend_from_slice(&self.uplink_mbps.to_be_bytes());
-        out.extend_from_slice(&self.max_streams.to_be_bytes());
-        out.extend_from_slice(&self.max_subscribers_per_stream.to_be_bytes());
-        out.extend_from_slice(&self.measured_at_unix_ms.to_be_bytes());
-        out.push(self.max_layer_supported.max_spatial);
-        out.push(self.max_layer_supported.max_temporal);
-        out.push(self.max_layer_supported.max_quality);
-
-        // MDC sub-stream commitments — length-prefixed Vec.
-        #[allow(clippy::cast_possible_truncation)]
-        let count = self.sub_stream_commitments.len() as u32;
-        out.extend_from_slice(&count.to_be_bytes());
-        for commitment in &self.sub_stream_commitments {
-            // path_len + path bytes
-            #[allow(clippy::cast_possible_truncation)]
-            let path_len = commitment.sub_stream_path.len() as u16;
-            out.extend_from_slice(&path_len.to_be_bytes());
-            out.extend_from_slice(&commitment.sub_stream_path);
-            out.extend_from_slice(&commitment.uplink_budget_mbps.to_be_bytes());
-            out.extend_from_slice(&commitment.max_subscribers.to_be_bytes());
+    pub fn canonical_bytes_for_signing(&self, advertiser_key_id: &str, epoch: Epoch) -> Vec<u8> {
+        // Single shared construction — Verify's builder, not an edge fork.
+        ciris_verify_core::holonomic::alm::SignedRelayCapacity {
+            peer_id: advertiser_key_id.to_string(),
+            uplink_mbps: uplink_mbps_to_u32(self.uplink_mbps),
+            epoch: epoch.0,
         }
-        out
+        .signing_preimage()
     }
+}
+
+/// Deterministic, saturating `f32` Mbps → `u32` Mbps for the signed
+/// preimage. Verify's canonical `uplink_mbps` field is `u32`; edge
+/// measures throughput as `f32`. Rust's `as` cast saturates (NaN → 0,
+/// negative → 0, `> u32::MAX` → `u32::MAX`), so this is total and
+/// stable. Both the signer and the verifier call it, so the rounding
+/// never diverges across the sign/verify boundary.
+#[must_use]
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+pub fn uplink_mbps_to_u32(mbps: f32) -> u32 {
+    mbps.round() as u32
 }
 
 /// The advertiser's federation signing pubkeys — what the verifier
@@ -486,7 +468,7 @@ impl SignedRelayCapacity {
             .as_ref()
             .ok_or(AlmCapacityError::SignerLacksPqc)?;
 
-        let canonical = capacity.canonical_bytes_for_signing(stream_id, epoch);
+        let canonical = capacity.canonical_bytes_for_signing(&advertiser_key_id, epoch);
 
         let ed25519_sig = signer
             .classical
@@ -531,7 +513,7 @@ impl SignedRelayCapacity {
 
         let canonical = self
             .capacity
-            .canonical_bytes_for_signing(self.stream_id, self.epoch);
+            .canonical_bytes_for_signing(&self.advertiser_key_id, self.epoch);
 
         let ed25519_ok = Ed25519Verifier::new()
             .verify(&advertiser_pubkeys.ed25519_pub, &canonical, &ed25519_sig)
@@ -772,8 +754,13 @@ mod tests {
         assert!(matches!(r, Err(AlmCapacityError::SignatureInvalid)));
     }
 
+    /// CIRISEdge#359: `stream_id` is an **unsigned** planner field — it
+    /// left the signed preimage when edge adopted Verify's §19.4 layout.
+    /// Mutating it therefore does NOT break the hybrid signature (the
+    /// stream binding is enforced out-of-band by the roster, not the
+    /// advert signature).
     #[tokio::test]
-    async fn signed_capacity_cross_stream_refused() {
+    async fn signed_capacity_stream_id_is_unsigned() {
         let (signer, pubkeys) = test_signer(0xA4).await;
         let cap = test_capacity(1_700_000_000_000);
 
@@ -784,8 +771,10 @@ mod tests {
 
         signed.stream_id = stream(0xBB);
 
-        let r = signed.verify(&pubkeys);
-        assert!(matches!(r, Err(AlmCapacityError::SignatureInvalid)));
+        // Signature still verifies — stream_id is not in the preimage.
+        signed
+            .verify(&pubkeys)
+            .expect("stream_id is unsigned; verify still ok");
     }
 
     #[tokio::test]
@@ -900,20 +889,24 @@ mod tests {
         assert!(matches!(r, Err(AlmCapacityError::WireDecode(_))));
     }
 
-    /// v2 canonical encoding regression — fixed-size prefix + 4-byte
-    /// commitment count = 79 bytes when no commitments are declared.
+    /// CIRISEdge#359 canonical-length regression — Verify's §19.4 layout:
+    /// domain(16) + u32 len-prefix(4) + peer_id + u32 uplink(4) + u64
+    /// epoch(8). For a 7-byte `peer_id` that is 16+4+7+4+8 = 39 bytes,
+    /// independent of the (now-unsigned) commitments/layer/stream fields.
     #[test]
-    fn canonical_bytes_v2_no_commitments_is_79_bytes() {
-        let cap = test_capacity(1_700_000_000_000);
-        let bytes = cap.canonical_bytes_for_signing(stream(0xAB), Epoch(42));
-        assert_eq!(
-            bytes.len(),
-            79,
-            "v2 canonical layout: 75 fixed + 4 commitment count"
+    fn canonical_bytes_length_is_verify_layout() {
+        let cap = RelayCapacity::with_substream_commitments(
+            100.0,
+            4,
+            16,
+            ReceiverLayerPolicy::UNCAPPED,
+            1_700_000_000_000,
+            // Commitments present but MUST NOT change the preimage length.
+            vec![commitment(vec![0], 10.0, 4), commitment(vec![1], 12.5, 6)],
         );
+        let bytes = cap.canonical_bytes_for_signing("relay-1", Epoch(42));
+        assert_eq!(bytes.len(), 39, "verify layout: 16 + 4 + 7 + 4 + 8");
         assert_eq!(&bytes[..16], b"CIRISALM-CAPv2\0\0");
-        // Commitment count = 0.
-        assert_eq!(&bytes[75..79], &[0u8; 4]);
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -1033,8 +1026,13 @@ mod tests {
         decoded.verify(&pubkeys).expect("verify v2 round-trip");
     }
 
+    /// CIRISEdge#359: MDC `sub_stream_commitments` are **unsigned**
+    /// planner state under Verify's §19.4 layout, so mutating a
+    /// commitment does NOT break the hybrid signature. (Commitment
+    /// integrity for topology admission is the planner's concern; the
+    /// advert signature only covers `peer_id ‖ uplink_mbps ‖ epoch`.)
     #[tokio::test]
-    async fn signed_capacity_v2_tamper_substream_commitment_refused() {
+    async fn signed_capacity_v2_substream_commitments_are_unsigned() {
         let (signer, pubkeys) = test_signer(0xD1).await;
         let cap = RelayCapacity::with_substream_commitments(
             100.0,
@@ -1055,10 +1053,64 @@ mod tests {
         .await
         .expect("sign");
 
-        // Bump the commitment's budget — canonical bytes change →
-        // verification fails.
+        // Bump the commitment's budget — commitments are not in the
+        // signed preimage, so verification still succeeds.
         signed.capacity.sub_stream_commitments[0].uplink_budget_mbps = 99.0;
-        let r = signed.verify(&pubkeys);
-        assert!(matches!(r, Err(AlmCapacityError::SignatureInvalid)));
+        signed
+            .verify(&pubkeys)
+            .expect("commitments are unsigned; verify still ok");
+    }
+
+    /// CIRISEdge#359 golden cross-impl preimage vector (§19.4 N8). ALM was
+    /// absent from the §19 vector set; this pins the edge-produced signing
+    /// bytes to Verify's canonical `signing_preimage()` for a fixed input,
+    /// and to a hard-coded byte literal so neither side can drift silently.
+    ///
+    /// Fixed input: `peer_id = "relay-1"`, `uplink_mbps = 500`, `epoch = 3`
+    /// (the same tuple Verify's own N8 unit test signs).
+    #[test]
+    fn golden_preimage_matches_verify_signing_bytes() {
+        // domain(16) ‖ u32_be(len "relay-1"=7) ‖ "relay-1" ‖ u32_be(500) ‖ u64_be(3)
+        const GOLDEN: &[u8] = &[
+            // b"CIRISALM-CAPv2\0\0"
+            0x43, 0x49, 0x52, 0x49, 0x53, 0x41, 0x4c, 0x4d, 0x2d, 0x43, 0x41, 0x50, 0x76, 0x32,
+            0x00, 0x00, // u32_be(7)
+            0x00, 0x00, 0x00, 0x07, // "relay-1"
+            0x72, 0x65, 0x6c, 0x61, 0x79, 0x2d, 0x31, // u32_be(500) = 0x000001F4
+            0x00, 0x00, 0x01, 0xF4, // u64_be(3)
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,
+        ];
+
+        // Edge producer (f32 500.0 rounds to u32 500).
+        let cap = RelayCapacity::new(
+            500.0,
+            4,
+            16,
+            ReceiverLayerPolicy::UNCAPPED,
+            1_700_000_000_000,
+        );
+        let edge_bytes = cap.canonical_bytes_for_signing("relay-1", Epoch(3));
+
+        // Verify's canonical builder, constructed independently.
+        let verify_bytes = ciris_verify_core::holonomic::alm::SignedRelayCapacity {
+            peer_id: "relay-1".to_string(),
+            uplink_mbps: 500,
+            epoch: 3,
+        }
+        .signing_preimage();
+
+        assert_eq!(
+            edge_bytes, GOLDEN,
+            "edge preimage drifted from the golden vector"
+        );
+        assert_eq!(
+            verify_bytes, GOLDEN,
+            "verify preimage drifted from the golden vector"
+        );
+        assert_eq!(
+            edge_bytes, verify_bytes,
+            "edge and verify must produce byte-identical ALM preimages"
+        );
+        assert_eq!(&edge_bytes[..16], b"CIRISALM-CAPv2\0\0");
     }
 }

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -250,6 +250,20 @@ fn reverse_path_fallback_log() -> &'static crate::log_throttle::LogThrottle {
         .get_or_init(|| crate::log_throttle::LogThrottle::new(5, Duration::from_secs(60), 256))
 }
 
+static NON_CIRIS_ANNOUNCE_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+
+/// CIRISEdge#357 — ambient third-party announces on the shared RNS network whose
+/// app-data is not a CIRIS AV-42 attestation (too short / wrong magic). On a
+/// public fabric this is high-volume NON-actionable traffic; a per-announce WARN
+/// drowns the genuinely-useful "a CIRIS peer failed to root" signal. Rolled up:
+/// a couple of DEBUG lines per minute + a suppressed-count, keyed on a single
+/// fixed discriminant (this is not a per-peer condition — it's "not us").
+fn non_ciris_announce_log() -> &'static crate::log_throttle::LogThrottle {
+    NON_CIRIS_ANNOUNCE_LOG
+        .get_or_init(|| crate::log_throttle::LogThrottle::new(2, Duration::from_secs(60), 4))
+}
+
 /// CIRISEdge#353 ask 2 — the NAT'd/initiator-only topology diagnosis. Before
 /// this, an outbound dial to an undialable phone was a bare 30 s `Timeout` per
 /// kind per round FOREVER (the field symptom: 3 WARNs every 30 s, no cause).
@@ -3917,19 +3931,34 @@ async fn resolve_announce_cold_start(
     let attestation = match AnnounceAttestation::from_app_data(announce.app_data()) {
         Ok(a) => a,
         Err(e) => {
-            tracing::debug!(error = %e, "announce dropped: app-data is not a valid attestation");
-            // CIRISEdge#34 — surface the parse failure on the announce
-            // stream so operators can see malformed peers without
-            // tailing logs. Severity = warning (not error): this is
-            // commonly a v0.3.1 peer sending a bare-key_id announce,
-            // not a hostile event.
+            // CIRISEdge#357 — a payload too short / without the CIRIS attestation
+            // shape is a NON-CIRIS announce (ambient shared-RNS traffic), NOT a
+            // CIRIS peer that failed to root. On a public fabric this floods, so
+            // it is a THROTTLED DEBUG rollup — never a per-announce WARN, which
+            // must stay reserved for the actionable "CIRIS-shaped attestation
+            // failed verification/rooting" case handled below. (A malformed
+            // CIRIS peer is rare and still surfaces via the destination-hash /
+            // rooting WARNs once its app-data parses.)
+            if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                non_ciris_announce_log().check("non-ciris")
+            {
+                tracing::debug!(
+                    error = %e,
+                    suppressed_prev,
+                    "announce ignored: app-data is not a CIRIS attestation \
+                     (ambient non-CIRIS traffic on the shared RNS network, CIRISEdge#357)"
+                );
+            }
+            // CIRISEdge#34 — still surface on the announce stream for operators
+            // who subscribe, but at INFO severity: ambient non-CIRIS traffic is
+            // informational, not a warning (CIRISEdge#357).
             if let Some(bus) = ctx.event_bus {
                 bus.emit_announce(crate::events::NetworkEvent::announce(
                     None,
                     announce.destination_hash().as_bytes().to_vec(),
                     announce.app_data().to_vec(),
-                    crate::events::EventSeverity::Warning,
-                    format!("announce dropped: app-data is not a valid attestation: {e}"),
+                    crate::events::EventSeverity::Info,
+                    format!("announce ignored: app-data is not a CIRIS attestation: {e}"),
                 ));
             }
             return;

--- a/tests/accord_carrier_verify.rs
+++ b/tests/accord_carrier_verify.rs
@@ -24,6 +24,20 @@
 //! `EdgeEnvelope`, and asserts the outcome (acceptance attestation
 //! emitted xor refusal attestation emitted xor neither when the body
 //! is not AccordCarrier).
+//!
+//! CIRISEdge#359 (findings 2 + 3) — `verify_accord_carrier` now gates each
+//! accord signature as a HYBRID (Ed25519 + ML-DSA-65) under
+//! `HybridPolicy::Strict` (finding 2: a classical-only signature is REFUSED),
+//! and counts a signature toward the 2-of-3 threshold only if the holder's
+//! ed25519 key occupies a pinned SEAT in
+//! `accord_holder_bootstrap_anchor()` (finding 3: spares are excluded). The
+//! suite arms `ciris-verify-core`'s `test-anchor` software trust root so the
+//! synthetic holders here are "seated", so it is gated on the `test-anchor`
+//! feature (like `tests/test_anchor_e2e.rs`).
+//!
+//! `cargo test --features "transport-reticulum test-anchor" --test accord_carrier_verify`
+
+#![cfg(all(feature = "transport-reticulum", feature = "test-anchor"))]
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -32,7 +46,7 @@ use async_trait::async_trait;
 use base64::engine::general_purpose::STANDARD as B64;
 use base64::Engine as _;
 use chrono::Utc;
-use ciris_crypto::{ClassicalSigner, Ed25519Signer};
+use ciris_crypto::{ClassicalSigner, Ed25519Signer, HybridSigner, MlDsa65Signer, PqcSigner};
 use ciris_edge::identity::{build_envelope, sign_envelope, LocalSigner};
 use ciris_edge::messages::{
     AccordSignature, AnnouncementKind, AnnouncementPriority, AuthorityClass,
@@ -70,6 +84,55 @@ fn init_tracing() {
     });
 }
 
+/// The FIXED seated accord-holder set every test uses. Their ed25519 pubkeys
+/// are what [`arm_test_anchor`] pins as the `test-anchor` software trust root
+/// (`CIRIS_TEST_TRUST_ROOT`), so `accord_holder_bootstrap_anchor()` returns
+/// exactly these three keys as the SEATED roster (CIRISEdge#359 finding 3).
+/// The seeds are deterministic, so this resolves to the same three pubkeys
+/// whether called from the arming helper or a test body.
+fn seated_holders() -> [FedKey; 3] {
+    [
+        FedKey::new("accord-holder-1", 0x11),
+        FedKey::new("accord-holder-2", 0x22),
+        FedKey::new("accord-holder-3", 0x33),
+    ]
+}
+
+/// A FOURTH accord-holder key that is deliberately NOT in the seated roster —
+/// a "spare" (CIRISEdge#359 finding 3). Registered as an `accord_holder` row
+/// in persist, but its ed25519 key is absent from `CIRIS_TEST_TRUST_ROOT`, so
+/// a signature from it must contribute NOTHING to the 2-of-3 threshold.
+fn spare_holder() -> FedKey {
+    FedKey::new("accord-holder-spare", 0x44)
+}
+
+/// Arm the `test-anchor` software trust root EXACTLY ONCE per process.
+///
+/// `#[tokio::test]`s share one process and run concurrently, and env is
+/// process-global, so the env is set a single time under a [`Once`] BEFORE any
+/// test can call dispatch — never mutated per-test. Every test uses the same
+/// [`seated_holders`] set, so the once-set `CIRIS_TEST_TRUST_ROOT` is correct
+/// for all of them. Contract mirrors `tests/test_anchor_e2e.rs`:
+/// `CIRIS_TESTING_MODE=true`, the three production env signals removed (or the
+/// anti-prod tripwire refuses the override), and `CIRIS_TEST_TRUST_ROOT` set to
+/// the comma-joined base64 ed25519 pubkeys of the seated holders.
+fn arm_test_anchor() {
+    use std::sync::Once;
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        std::env::set_var("CIRIS_TESTING_MODE", "true");
+        for prod in ["ENVIRONMENT", "CIRIS_ENV", "CIRIS_ENVIRONMENT"] {
+            std::env::remove_var(prod);
+        }
+        let trust_root = seated_holders()
+            .iter()
+            .map(FedKey::pubkey_b64)
+            .collect::<Vec<_>>()
+            .join(",");
+        std::env::set_var("CIRIS_TEST_TRUST_ROOT", trust_root);
+    });
+}
+
 // ─── Fixture helpers ────────────────────────────────────────────────
 
 /// A test federation identity: deterministic seed + key_id + the keys
@@ -95,6 +158,35 @@ impl FedKey {
 
     fn pubkey_b64(&self) -> String {
         B64.encode(self.signer().public_key().expect("pubkey"))
+    }
+
+    /// This identity's ML-DSA-65 signer, derived from the SAME seed as the
+    /// ed25519 key — mirrors edge's own fixture pattern
+    /// (`src/edge.rs::hybrid_pubkeys`), so the registered key and the signing
+    /// key collapse to one hybrid identity per `key_id`.
+    fn ml_dsa_signer(&self) -> MlDsa65Signer {
+        MlDsa65Signer::from_seed(&self.seed).expect("ml-dsa from seed")
+    }
+
+    /// Base64-standard ML-DSA-65 public key — what an `accord_holder` row's
+    /// `pubkey_ml_dsa_65_base64` must carry so `verify_hybrid_via_directory`
+    /// finds both halves of the hybrid pair.
+    fn ml_dsa_pubkey_b64(&self) -> String {
+        B64.encode(PqcSigner::public_key(&self.ml_dsa_signer()).expect("ml-dsa pubkey"))
+    }
+
+    /// Hybrid-sign `canonical` (CIRISEdge#359 finding 2). Returns
+    /// `(ed25519_sig_base64, ml_dsa_65_sig_base64)`. The PQC half signs the
+    /// bound payload `canonical ‖ ed25519_sig` exactly as `verify_hybrid`
+    /// re-checks it (CC 3.1.2.1 strip-attack guard), so both halves verify
+    /// against this identity's registered hybrid pubkeys.
+    fn hybrid_sign(&self, canonical: &[u8]) -> (String, String) {
+        let hybrid = HybridSigner::new(self.signer(), self.ml_dsa_signer()).expect("hybrid signer");
+        let sig = hybrid.sign(canonical).expect("hybrid sign");
+        (
+            B64.encode(&sig.classical.signature),
+            B64.encode(&sig.pqc.signature),
+        )
     }
 
     fn write_seed_dir(&self, base: &std::path::Path) -> PathBuf {
@@ -154,10 +246,19 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
     } else {
         None
     };
+    // CIRISEdge#359 finding 2 — accord_holder rows must register the ML-DSA-65
+    // half so `verify_hybrid_via_directory` can gate the HYBRID accord
+    // signature. Non-holder rows stay ed25519-only (their outer-envelope
+    // verify runs under the edge's `Ed25519Fallback` config policy).
+    let pubkey_ml_dsa_65_base64 = if identity_type == "accord_holder" {
+        Some(subject.ml_dsa_pubkey_b64())
+    } else {
+        None
+    };
     KeyRecord {
         key_id: subject.key_id.clone(),
         pubkey_ed25519_base64: subject.pubkey_b64(),
-        pubkey_ml_dsa_65_base64: None,
+        pubkey_ml_dsa_65_base64,
         algorithm: "hybrid".to_string(),
         identity_type: identity_type.to_string(),
         identity_ref: subject.key_id.clone(),
@@ -261,10 +362,11 @@ fn with_accord_sig(mut ann: FederationAnnouncement, holder: &FedKey) -> Federati
     let canonical = ann
         .canonical_bytes_for_accord_signatures()
         .expect("canonical bytes");
-    let sig = holder.sign(&canonical);
+    let (ed_sig, ml_dsa_sig) = holder.hybrid_sign(&canonical);
     ann.accord_signatures.push(AccordSignature {
         key_id: holder.key_id.clone(),
-        signature_ed25519_base64: B64.encode(sig),
+        signature_ed25519_base64: ed_sig,
+        signature_ml_dsa_65_base64: Some(ml_dsa_sig),
     });
     ann
 }
@@ -321,6 +423,7 @@ fn parse_refusal(row: &OutboundRow) -> DeliveryRefusalAttestation {
 #[tokio::test]
 async fn accord_carrier_2_of_3_valid_propagates() {
     init_tracing();
+    arm_test_anchor();
     let tmp = tempfile::tempdir().expect("tempdir");
     let steward = FedKey::new("steward-fed", 0x01);
     let me = FedKey::new("edge-self", 0xAA);
@@ -378,6 +481,7 @@ async fn accord_carrier_2_of_3_valid_propagates() {
 #[tokio::test]
 async fn accord_carrier_1_of_3_refuses_and_emits_refusal() {
     init_tracing();
+    arm_test_anchor();
     let tmp = tempfile::tempdir().expect("tempdir");
     let steward = FedKey::new("steward-fed", 0x01);
     let me = FedKey::new("edge-self", 0xAA);
@@ -439,6 +543,7 @@ async fn accord_carrier_1_of_3_refuses_and_emits_refusal() {
 #[tokio::test]
 async fn accord_carrier_3_of_3_propagates() {
     init_tracing();
+    arm_test_anchor();
     let tmp = tempfile::tempdir().expect("tempdir");
     let steward = FedKey::new("steward-fed", 0x01);
     let me = FedKey::new("edge-self", 0xAA);
@@ -494,6 +599,7 @@ async fn accord_carrier_3_of_3_propagates() {
 #[tokio::test]
 async fn accord_carrier_2_valid_1_invalid_propagates() {
     init_tracing();
+    arm_test_anchor();
     let tmp = tempfile::tempdir().expect("tempdir");
     let steward = FedKey::new("steward-fed", 0x01);
     let me = FedKey::new("edge-self", 0xAA);
@@ -518,10 +624,12 @@ async fn accord_carrier_2_valid_1_invalid_propagates() {
     let mut ann = announcement(AnnouncementPriority::AccordCarrier);
     ann = with_accord_sig(ann, &h1);
     ann = with_accord_sig(ann, &h2);
-    // Append a third entry claiming to be from h3 but with junk bytes.
+    // Append a third entry claiming to be from h3 (a seated holder) but with
+    // junk bytes for BOTH hybrid halves — the hybrid verify rejects it.
     ann.accord_signatures.push(AccordSignature {
         key_id: h3.key_id.clone(),
         signature_ed25519_base64: B64.encode([0xEEu8; 64]),
+        signature_ml_dsa_65_base64: Some(B64.encode([0xEEu8; 64])),
     });
 
     let env_bytes = build_envelope_signed_by(&sender_signer, &me.key_id, &ann).await;
@@ -554,6 +662,7 @@ async fn accord_carrier_2_valid_1_invalid_propagates() {
 #[tokio::test]
 async fn accord_carrier_0_accord_holders_in_directory_refuses_with_no_accord_holders_configured() {
     init_tracing();
+    arm_test_anchor();
     let tmp = tempfile::tempdir().expect("tempdir");
     let steward = FedKey::new("steward-fed", 0x01);
     let me = FedKey::new("edge-self", 0xAA);
@@ -607,6 +716,7 @@ async fn accord_carrier_0_accord_holders_in_directory_refuses_with_no_accord_hol
 #[tokio::test]
 async fn accord_carrier_duplicate_signatures_from_same_holder_count_once() {
     init_tracing();
+    arm_test_anchor();
     let tmp = tempfile::tempdir().expect("tempdir");
     let steward = FedKey::new("steward-fed", 0x01);
     let me = FedKey::new("edge-self", 0xAA);
@@ -639,9 +749,11 @@ async fn accord_carrier_duplicate_signatures_from_same_holder_count_once() {
     let canonical = ann
         .canonical_bytes_for_accord_signatures()
         .expect("canonical");
+    let (ed_sig, ml_dsa_sig) = h1.hybrid_sign(&canonical);
     ann.accord_signatures.push(AccordSignature {
         key_id: h1.key_id.clone(),
-        signature_ed25519_base64: B64.encode(h1.sign(&canonical)),
+        signature_ed25519_base64: ed_sig,
+        signature_ml_dsa_65_base64: Some(ml_dsa_sig),
     });
 
     let env_bytes = build_envelope_signed_by(&sender_signer, &me.key_id, &ann).await;
@@ -675,6 +787,7 @@ async fn accord_carrier_duplicate_signatures_from_same_holder_count_once() {
 #[tokio::test]
 async fn accord_carrier_non_accord_class_announcements_skip_threshold_check() {
     init_tracing();
+    arm_test_anchor();
     let tmp = tempfile::tempdir().expect("tempdir");
     let steward = FedKey::new("steward-fed", 0x01);
     let me = FedKey::new("edge-self", 0xAA);
@@ -720,6 +833,147 @@ async fn accord_carrier_non_accord_class_announcements_skip_threshold_check() {
             .await
             .len(),
         0
+    );
+}
+
+/// CIRISEdge#359 finding 2 (RequireHybrid) — two signatures from DISTINCT
+/// seated holders that carry ONLY the classical Ed25519 half
+/// (`signature_ml_dsa_65_base64: None`) must NOT satisfy the quorum.
+/// `verify_accord_carrier` gates each accord signature at
+/// `HybridPolicy::Strict`, under which a classical-only row is
+/// `HybridPendingRejected` — never `HybridVerified` — so neither signature
+/// counts. Zero verified with attempts present ⇒ refusal with
+/// `InvalidAccordSignature`. Proves the accord carrier (constitutional
+/// kill-switch traffic) refuses classical-only signatures even when they are
+/// cryptographically valid Ed25519 sigs from seated holders.
+#[tokio::test]
+async fn accord_carrier_classical_only_signatures_refused_require_hybrid() {
+    init_tracing();
+    arm_test_anchor();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let steward = FedKey::new("steward-fed", 0x01);
+    let me = FedKey::new("edge-self", 0xAA);
+    let sender = FedKey::new("steward-sender", 0xBB);
+    let [h1, h2, h3] = seated_holders();
+
+    let directory = directory_with(vec![
+        signed_record(&steward, &steward, "steward"),
+        signed_record(&me, &steward, "agent"),
+        signed_record(&sender, &steward, "steward"),
+        signed_record(&h1, &steward, "accord_holder"),
+        signed_record(&h2, &steward, "accord_holder"),
+        signed_record(&h3, &steward, "accord_holder"),
+    ])
+    .await;
+    let queue = directory.clone();
+
+    let edge = build_edge(&tmp, &me, directory, queue.clone()).await;
+    let sender_signer = sender.local_signer(tmp.path()).await;
+
+    // Two CLASSICAL-ONLY signatures from distinct seated holders — valid
+    // Ed25519 bytes, but `signature_ml_dsa_65_base64: None`. Under
+    // RequireHybrid these are refused, so the quorum is NOT met.
+    let mut ann = announcement(AnnouncementPriority::AccordCarrier);
+    let canonical = ann
+        .canonical_bytes_for_accord_signatures()
+        .expect("canonical");
+    for h in [&h1, &h2] {
+        ann.accord_signatures.push(AccordSignature {
+            key_id: h.key_id.clone(),
+            signature_ed25519_base64: B64.encode(h.sign(&canonical)),
+            signature_ml_dsa_65_base64: None, // classical-only ⇒ refused
+        });
+    }
+
+    let env_bytes = build_envelope_signed_by(&sender_signer, &me.key_id, &ann).await;
+    edge.dispatch_inbound_for_test(InboundFrame {
+        envelope_bytes: env_bytes,
+        transport: TransportId::HTTP,
+        received_at: Utc::now(),
+        source_key_id: None,
+    })
+    .await;
+
+    assert_eq!(
+        outbound_rows_of(&queue, "DeliveryAttestation").await.len(),
+        0,
+        "classical-only signatures must NOT propagate an AccordCarrier under RequireHybrid"
+    );
+    let refusals = outbound_rows_of(&queue, "DeliveryRefusalAttestation").await;
+    assert_eq!(
+        refusals.len(),
+        1,
+        "exactly one refusal attestation enqueued"
+    );
+    assert_eq!(
+        parse_refusal(&refusals[0]).refusal_reason,
+        RefusalReason::InvalidAccordSignature,
+        "classical-only accord signatures (ml_dsa None) must be refused under RequireHybrid — \
+         zero verified with attempts present ⇒ InvalidAccordSignature"
+    );
+}
+
+/// CIRISEdge#359 finding 3 (seated-only) — one valid hybrid signature from a
+/// SEATED holder plus one valid hybrid signature from a SPARE holder whose key
+/// is NOT in the seated roster (`CIRIS_TEST_TRUST_ROOT`) counts as ONE, not
+/// two. The spare IS a registered `accord_holder` row in persist (so the old
+/// "distinct accord_holder key_ids" rule would have counted it), but its key
+/// does not occupy a pinned seat, so it contributes nothing. Threshold not met
+/// ⇒ refuses with `InsufficientAccordSignatures { found: 1, required: 2 }`.
+/// Pins that a human's spare cannot pad the 2-of-3 quorum.
+#[tokio::test]
+async fn accord_carrier_spare_holder_not_seated_does_not_count() {
+    init_tracing();
+    arm_test_anchor();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let steward = FedKey::new("steward-fed", 0x01);
+    let me = FedKey::new("edge-self", 0xAA);
+    let sender = FedKey::new("steward-sender", 0xBB);
+    let [h1, h2, h3] = seated_holders();
+    let spare = spare_holder();
+
+    let directory = directory_with(vec![
+        signed_record(&steward, &steward, "steward"),
+        signed_record(&me, &steward, "agent"),
+        signed_record(&sender, &steward, "steward"),
+        signed_record(&h1, &steward, "accord_holder"),
+        signed_record(&h2, &steward, "accord_holder"),
+        signed_record(&h3, &steward, "accord_holder"),
+        // The spare is a bona-fide accord_holder ROW, but its key is not a seat.
+        signed_record(&spare, &steward, "accord_holder"),
+    ])
+    .await;
+    let queue = directory.clone();
+
+    let edge = build_edge(&tmp, &me, directory, queue.clone()).await;
+    let sender_signer = sender.local_signer(tmp.path()).await;
+    let ann = announcement(AnnouncementPriority::AccordCarrier);
+    let ann = with_accord_sig(ann, &h1); // seated ⇒ counts (1)
+    let ann = with_accord_sig(ann, &spare); // NOT seated ⇒ contributes 0
+
+    let env_bytes = build_envelope_signed_by(&sender_signer, &me.key_id, &ann).await;
+    edge.dispatch_inbound_for_test(InboundFrame {
+        envelope_bytes: env_bytes,
+        transport: TransportId::HTTP,
+        received_at: Utc::now(),
+        source_key_id: None,
+    })
+    .await;
+
+    assert_eq!(
+        outbound_rows_of(&queue, "DeliveryAttestation").await.len(),
+        0,
+        "a spare (non-seated) holder must not pad the quorum — only 1 seated signature present"
+    );
+    let refusals = outbound_rows_of(&queue, "DeliveryRefusalAttestation").await;
+    assert_eq!(refusals.len(), 1);
+    assert_eq!(
+        parse_refusal(&refusals[0]).refusal_reason,
+        RefusalReason::InsufficientAccordSignatures {
+            found: 1,
+            required: ACCORD_THRESHOLD_M_OF_N.0,
+        },
+        "spare holder's signature must not count toward the seated 2-of-3 threshold"
     );
 }
 

--- a/tests/test_anchor_e2e.rs
+++ b/tests/test_anchor_e2e.rs
@@ -153,7 +153,7 @@ async fn test_anchor_peer_roots_through_edge_root_binding() {
                 chain.chain.len(),
             );
         }
-        other => panic!(
+        other @ RootingVerdict::Rejected { .. } => panic!(
             "test-anchor peer MUST root through edge's root_binding — the whole admit→root \
              test model rides on it (CIRISEdge#345 / CIRISPersist#451); got {other:?}",
         ),


### PR DESCRIPTION
Substrate: persist **v17.6.0** + CIRISVerify **v10.5.0** (all three verify-repo pins, single checkout). "Verify did the needful" — all six #359 findings become edge-side adoption.

## CIRISEdge#359 — all six crypto-DRY findings
| # | Sev | Fix |
|---|-----|-----|
| **F1** | HIGH | ALM §19.4 preimage delegates to verify's `SignedRelayCapacity::signing_preimage` (f32→u32, lp peer_id, no stream_id in signed bytes); golden vector added |
| **F2** | HIGH | `AccordSignature` gains ML-DSA-65 half; `verify_accord_carrier` requires **hybrid** (`Strict`) — classical-only refused from the kill-switch quorum |
| **F3** | HIGH | quorum counts only **seated** holders (`accord_holder_bootstrap_anchor`), deduped by seat — primary+spare can't meet threshold alone |
| **F4** | LOW | §19 WholenessWitness / fountain / A/V nonces re-exported onto verify, byte-identical |
| **F5** | LOW | SAS v2 = `min‖max` key-unit ordering (v1 default pending fleet flip) |
| **F6** | LOW | RFC 6962 comment corrected (CVE-2012-2459) |

## CIRISEdge#357 — announce-flood hygiene
Non-CIRIS ambient announces → throttled DEBUG rollup + Info event; WARN reserved for real rooting failures.

## Bench accuracy (100% post-quantum)
The old `accord_threshold_verify` measured **replay-reject** (~5µs), amortizing away the ML-DSA cost (accord gate runs *after* the replay window in dispatch). Rewired to measure `verify_accord_carrier` **directly** via a `test-anchor`-fenced seam: **3of3 ~493µs / 2of3 ~392µs / 1of3 ~303µs** (ML-DSA-65-dominated) / no-holders ~22µs. Hybrid `BenchFedKey`; both CI gates wired.

## Verification
`cargo fmt`; all three CI clippy combos `--all-targets -D warnings`; lib **699**, route_table/av42, accord_carrier_verify **10** + test_anchor_e2e **1** (test-anchor lane) — green. Guards: F2 classical-only-refused, F3 spare-not-seated, F1 golden vector, F5 symmetry + multiset-collision.

Refs: #359, #357; CIRISVerify v10.5.0, CIRISPersist#465.

🤖 Generated with [Claude Code](https://claude.com/claude-code)