### PR TITLE
feat(v13.3.0): seeder bridge (#362) + advisory-link keepalive survival (#363) + persist v17.8.0 — unblocks the first mobile trace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.2.0"
+version = "13.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.6.0", version = "17", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.8.0", version = "17", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1128,7 +1128,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.6.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.8.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=17.6.0,<18",
+    "ciris-persist>=17.8.0,<18",
 ]
 dynamic = ["version"]
 

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -136,6 +136,75 @@ const LINK_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(30);
 /// never announced — is never regressed.
 const NO_PATH_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// CIRISEdge#363 — the link keepalive interval edge asks leviculum to apply,
+/// node-wide, so a freshly-admitted **advisory/bootstrap** link survives long
+/// enough to complete the Key + IdentityOccurrence anti-entropy that promotes
+/// it to a KEX'd delivery target.
+///
+/// The bug (converged RCA): a mobile/container peer hears canonical A's announce
+/// → advisory admit (`owns_key=false`). To become deliverable it must
+/// anti-entropy A's Key (transport binding) *and* IdentityOccurrence (KEX
+/// enc-keys) planes over that same link. leviculum derives the keepalive
+/// interval from the measured RTT (`calculate_keepalive_from_rtt`) and, on a
+/// fast direct TCP link, clamps it to the `LINK_KEEPALIVE_MIN` floor (5 s). The
+/// stale timer is `keepalive * LINK_STALE_FACTOR` (= 2), so with no explicit
+/// override the link goes **stale at ~10 s and is reaped at ~16 s** — before the
+/// two-plane exchange lands, especially when the canonical peer is under heavy
+/// churn and its keepalive acks are starved (the field symptom: 3 keepalives
+/// sent / 1 acked, dead by `keepalive_timeout`). The enc-keys are NOT derivable
+/// from the announce (the occurrence plane carries an ML-KEM-768 PQC key absent
+/// from the 64-byte transport identity), so keeping the link alive across the
+/// exchange is the load-bearing fix — not promotion from announce data alone.
+///
+/// 30 s is chosen against the replication cadence, not guessed: the anti-entropy
+/// scheduler runs one round every 30 s with a 10 s round timeout
+/// (`SchedulerConfig` cadence / `DEFAULT_ROUND_TIMEOUT`). A 30 s keepalive yields
+/// a `stale_time` of 60 s (2× the cadence), so a bootstrap link tolerates a full
+/// quiet cadence of keepalive-ack silence and still completes the Key +
+/// IdentityOccurrence rounds.
+///
+/// BOUNDED + DoS-aware: leviculum exposes only a **node-global** keepalive knob
+/// (`ReticulumNodeBuilder::link_keepalive`), not a per-link one, so this applies
+/// to every link — but a *longer* interval means *fewer* keepalive packets (less
+/// load, not more), and leviculum still reaps a silently-dead link at
+/// `stale_time + rtt*4 + grace` (~65 s here) rather than never. A silently-dead
+/// link therefore lingers ~65 s instead of ~16 s — a bounded ~4× hold, itself
+/// backstopped by leviculum's link table and edge's `MAX_PEERS` advisory cap. It
+/// is NOT an unbounded-link amplifier. See [`effective_link_keepalive_secs`] for
+/// the clamp that keeps an operator override inside leviculum's valid band.
+const BOOTSTRAP_LINK_KEEPALIVE: Duration = Duration::from_secs(30);
+
+/// CIRISEdge#363 — leviculum's minimum keepalive interval
+/// (`reticulum_core::constants::LINK_KEEPALIVE_MIN_SECS`). leviculum clamps an
+/// override UP to this floor but does not cap the ceiling, so edge enforces both
+/// ends in [`effective_link_keepalive_secs`].
+const LINK_KEEPALIVE_MIN_SECS: u64 = 5;
+
+/// CIRISEdge#363 — leviculum's maximum / RTT-derived keepalive interval
+/// (`reticulum_core::constants::LINK_KEEPALIVE_SECS`, 6 minutes). Edge caps an
+/// operator override here so a stray large value can NOT hold a silently-dead
+/// link open longer than leviculum's own RTT-driven ceiling would — the
+/// DoS-facing upper bound (leviculum only clamps the lower end).
+const LINK_KEEPALIVE_MAX_SECS: u64 = 360;
+
+/// CIRISEdge#363 — the keepalive interval (seconds) edge actually hands
+/// leviculum's builder, or `None` to leave leviculum's RTT-derived default in
+/// place. Pure so it is unit-testable without a live node.
+///
+/// `configured` is [`ReticulumTransportConfig::link_keepalive`]. When `Some`, the
+/// requested interval is clamped into leviculum's valid band
+/// `[LINK_KEEPALIVE_MIN_SECS, LINK_KEEPALIVE_MAX_SECS]` — the lower clamp mirrors
+/// leviculum's own `set_keepalive_override` floor; the upper clamp is edge's
+/// DoS-facing ceiling (leviculum does not cap the top, so an unbounded value
+/// would hold a dead link open indefinitely). A sub-second `Duration` floors to
+/// the minimum rather than to 0.
+fn effective_link_keepalive_secs(configured: Option<Duration>) -> Option<u64> {
+    configured.map(|d| {
+        d.as_secs()
+            .clamp(LINK_KEEPALIVE_MIN_SECS, LINK_KEEPALIVE_MAX_SECS)
+    })
+}
+
 /// How long [`Transport::send`] waits for a resource transfer to
 /// complete after the link is up.
 const RESOURCE_TRANSFER_TIMEOUT: Duration = Duration::from_secs(120);
@@ -763,6 +832,17 @@ pub struct ReticulumTransportConfig {
     /// always calls it explicitly so this `false` default is honoured
     /// (a leaf edge does NOT relay for strangers unless opted in).
     pub enable_transport: bool,
+    /// **CIRISEdge#363** — node-wide link keepalive interval handed to
+    /// leviculum's `ReticulumNodeBuilder::link_keepalive`. `Some(interval)`
+    /// overrides leviculum's RTT-derived default; `None` leaves it in place.
+    ///
+    /// Defaults to `Some(`[`BOOTSTRAP_LINK_KEEPALIVE`]`)` (30 s) so a
+    /// freshly-admitted advisory/bootstrap link survives the Key +
+    /// IdentityOccurrence anti-entropy instead of being reaped at ~16 s by the
+    /// RTT-clamped 5 s default (stale at 10 s). The value is clamped into
+    /// leviculum's valid band by [`effective_link_keepalive_secs`] before it
+    /// reaches the builder — an operator override cannot escape the DoS bound.
+    pub link_keepalive: Option<Duration>,
 }
 
 impl ReticulumTransportConfig {
@@ -780,6 +860,9 @@ impl ReticulumTransportConfig {
             local_epoch: 0,
             interfaces: Vec::new(),
             enable_transport: false,
+            // CIRISEdge#363 — default the bootstrap keepalive ON so advisory
+            // links survive the two-plane anti-entropy out of the box.
+            link_keepalive: Some(BOOTSTRAP_LINK_KEEPALIVE),
         }
     }
 
@@ -1569,6 +1652,31 @@ impl ReticulumTransport {
             .identity(identity.clone())
             .storage_path(storage_path)
             .enable_transport(config.enable_transport);
+        // CIRISEdge#363 — apply the bootstrap link keepalive so an advisory /
+        // bootstrap link is not reaped (stale at ~10 s, dead at ~16 s under the
+        // RTT-clamped 5 s default) before the Key + IdentityOccurrence
+        // anti-entropy that promotes it to a KEX'd delivery target completes.
+        // `effective_link_keepalive_secs` clamps into leviculum's valid band so
+        // an operator override stays inside the DoS bound. The wiring decision
+        // is logged (unthrottled — one line per node build, not attacker-driven)
+        // so a silent keepalive misconfig can never again cost a trace weeks.
+        match effective_link_keepalive_secs(config.link_keepalive) {
+            Some(secs) => {
+                builder = builder.link_keepalive(secs);
+                tracing::info!(
+                    keepalive_secs = secs,
+                    stale_secs = secs.saturating_mul(2),
+                    "reticulum link keepalive pinned for advisory/bootstrap link \
+                     survival (CIRISEdge#363)"
+                );
+            }
+            None => {
+                tracing::info!(
+                    "reticulum link keepalive left at leviculum's RTT-derived default \
+                     (CIRISEdge#363: bootstrap links may reap at ~16 s)"
+                );
+            }
+        }
         let mut share_instance_local: Option<String> = None;
         let mut connect_instance_local: Option<String> = None;
         if config.interfaces.is_empty() {
@@ -5062,6 +5170,75 @@ mod tests {
                     EXPLICIT
                 ),
                 RouteSupersession::IgnoreStale,
+            );
+        }
+    }
+
+    // ── CIRISEdge#363 bootstrap-link keepalive — the delivery-convergence fix ──
+    //
+    // The advisory/bootstrap link must outlive the Key + IdentityOccurrence
+    // anti-entropy that promotes it to a KEX'd target. leviculum's RTT-derived
+    // default reaps a fast direct link at ~16 s (5 s keepalive → 10 s stale);
+    // these lock in the clamp + the shipped default over the PURE decision fn so
+    // a regression is a compile-fast unit failure, never another lost trace.
+    mod bootstrap_keepalive {
+        use super::*;
+
+        /// The shipped default keepalive (30 s) survives the clamp unchanged and
+        /// is at least 2× the 30 s anti-entropy cadence' worth of stale slack
+        /// (stale = keepalive × 2 = 60 s), so a bootstrap link tolerates a full
+        /// quiet cadence of keepalive-ack silence.
+        #[test]
+        fn shipped_default_is_thirty_seconds_and_survives_the_clamp() {
+            assert_eq!(BOOTSTRAP_LINK_KEEPALIVE, Duration::from_secs(30));
+            assert_eq!(
+                effective_link_keepalive_secs(Some(BOOTSTRAP_LINK_KEEPALIVE)),
+                Some(30),
+            );
+            // `ReticulumTransportConfig::new` ships the bootstrap keepalive ON.
+            let cfg = ReticulumTransportConfig::new(std::path::PathBuf::from("/x"), "k");
+            assert_eq!(cfg.link_keepalive, Some(BOOTSTRAP_LINK_KEEPALIVE));
+            assert_eq!(effective_link_keepalive_secs(cfg.link_keepalive), Some(30));
+        }
+
+        /// `None` leaves leviculum's RTT-derived default in place (opt-out).
+        #[test]
+        fn none_leaves_leviculum_default() {
+            assert_eq!(effective_link_keepalive_secs(None), None);
+        }
+
+        /// A below-floor / sub-second override clamps UP to leviculum's minimum
+        /// (matches leviculum's own `set_keepalive_override` floor) — never 0.
+        #[test]
+        fn below_floor_clamps_up_to_min() {
+            assert_eq!(
+                effective_link_keepalive_secs(Some(Duration::from_secs(1))),
+                Some(LINK_KEEPALIVE_MIN_SECS),
+            );
+            assert_eq!(
+                effective_link_keepalive_secs(Some(Duration::from_millis(200))),
+                Some(LINK_KEEPALIVE_MIN_SECS),
+            );
+        }
+
+        /// The DoS bound: an unbounded override is capped at leviculum's own
+        /// RTT-driven ceiling so a stray value can NOT hold a silently-dead link
+        /// open longer than leviculum itself ever would (leviculum only clamps
+        /// the lower end).
+        #[test]
+        fn above_ceiling_clamps_down_to_max() {
+            assert_eq!(
+                effective_link_keepalive_secs(Some(Duration::from_secs(86_400))),
+                Some(LINK_KEEPALIVE_MAX_SECS),
+            );
+        }
+
+        /// An in-band operator override passes through untouched.
+        #[test]
+        fn in_band_override_passes_through() {
+            assert_eq!(
+                effective_link_keepalive_secs(Some(Duration::from_secs(45))),
+                Some(45),
             );
         }
     }

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -4352,6 +4352,25 @@ async fn resolve_announce_cold_start(
                 attestation.epoch,
             )
             .await;
+        // CIRISEdge#362 (seeder bridge, persist v17.8.0) — also record the
+        // announced peer as a non-canonical, untrusted directory BOOKMARK so a
+        // LAN-announced peer surfaces in the server's `GET /v1/federation/peers`
+        // (`canonical=false`, `trust="unknown"`, `last_seen`). Safe on BOTH
+        // Advisory and Rooted admits: the bookmark is invisible to every
+        // admission/quorum/rooting path, and once the key roots for real persist
+        // anti-joins the bookmark away (no dup, no downgrade). The announce
+        // carries only the FEDERATION ed25519 (no PQC pubkey, no claimed
+        // identity_type) — persist COALESCE-enriches those on later announces.
+        rooting
+            .record_announced_peer(
+                &persisted_key,
+                &base64::engine::general_purpose::STANDARD
+                    .encode(attestation.federation_pubkey_ed25519),
+                None,
+                None,
+                chrono::Utc::now(),
+            )
+            .await;
     }
 }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -249,6 +249,29 @@ pub trait RootingDirectory: Send + Sync + 'static {
         _epoch: u64,
     ) {
     }
+
+    /// CIRISEdge#362 (CIRISPersist#469, persist v17.8.0) — the seeder bridge.
+    /// Record a peer learned from a self-consistent announce as a
+    /// **non-canonical, untrusted** directory BOOKMARK (persist's separate
+    /// `announced_peers` table, V108), so a LAN-announced peer surfaces in the
+    /// server's `GET /v1/federation/peers` (`canonical=false`, `trust="unknown"`,
+    /// `last_seen`). Deliberately NOT an admission — the bookmark is invisible to
+    /// every admission / quorum / rooting path by construction; it never
+    /// satisfies an accord seat / WA / steward count. Idempotent + liveness-
+    /// refreshing; a pubkey change for the same `key_id` is a real identity
+    /// conflict (persist returns `Conflict`). Safe on BOTH Advisory and Rooted
+    /// admits — once the key roots for real, `list_announced_peers` anti-joins
+    /// the bookmark away. Default no-op so test doubles don't break; the blanket
+    /// impl over `FederationDirectory` does the real `record_announced_peer`.
+    async fn record_announced_peer(
+        &self,
+        _key_id: &str,
+        _pubkey_ed25519_base64: &str,
+        _pubkey_ml_dsa_65_base64: Option<&str>,
+        _claimed_identity_type: Option<&str>,
+        _last_seen: chrono::DateTime<chrono::Utc>,
+    ) {
+    }
 }
 
 #[async_trait]
@@ -316,6 +339,48 @@ impl<F: FederationDirectory + Send + Sync + 'static> RootingDirectory for F {
                 epoch,
                 "CIRISEdge#299/#301: write-through of transport binding failed (peer still \
                  admitted in-memory this session, but will not survive a restart)"
+            ),
+        }
+    }
+
+    async fn record_announced_peer(
+        &self,
+        key_id: &str,
+        pubkey_ed25519_base64: &str,
+        pubkey_ml_dsa_65_base64: Option<&str>,
+        claimed_identity_type: Option<&str>,
+        last_seen: chrono::DateTime<chrono::Utc>,
+    ) {
+        match FederationDirectory::record_announced_peer(
+            self,
+            key_id,
+            pubkey_ed25519_base64,
+            pubkey_ml_dsa_65_base64,
+            claimed_identity_type,
+            last_seen,
+        )
+        .await
+        {
+            // Attacker-floodable (one per advisory admit) → DEBUG. A `Conflict`
+            // (a changed pubkey for a known key_id) is a genuine identity signal,
+            // not a churn event, so it surfaces at WARN; any other write error is
+            // a non-fatal bookmark miss (the peer is still admitted in-memory +
+            // routing-bound this session).
+            Ok(()) => tracing::debug!(
+                key_id,
+                claimed_identity_type,
+                "CIRISEdge#362: recorded announced-peer bookmark (seeder bridge)"
+            ),
+            Err(ciris_persist::federation::Error::Conflict { .. }) => tracing::warn!(
+                key_id,
+                "CIRISEdge#362: announced-peer bookmark REJECTED — a different pubkey is \
+                 already recorded for this key_id (identity conflict, not a refresh)"
+            ),
+            Err(e) => tracing::debug!(
+                key_id,
+                error = %e,
+                "CIRISEdge#362: announced-peer bookmark write failed (peer still admitted \
+                 in-memory this session; bookmark will not appear in /v1/federation/peers)"
             ),
         }
     }

--- a/tests/seeder_bridge.rs
+++ b/tests/seeder_bridge.rs
@@ -1,0 +1,91 @@
+//! CIRISEdge#362 — the seeder-bridge edge adapter.
+//!
+//! `RootingDirectory::record_announced_peer` (edge's adapter over persist's
+//! v17.8.0 `FederationDirectory::record_announced_peer`, CIRISPersist#469)
+//! records a LAN-announced peer as a NON-canonical, untrusted directory
+//! BOOKMARK — so it surfaces in the server's `GET /v1/federation/peers`
+//! (`canonical=false`, `trust="unknown"`, `last_seen`) WITHOUT being an
+//! admission (it never becomes a `federation_keys` row, never satisfies a
+//! quorum/authority path). This guards the edge delegation: the announce-admit
+//! path calls it beside `persist_transport_binding`.
+
+use std::sync::Arc;
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine as _;
+use ciris_edge::verify::RootingDirectory;
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::prelude::FederationDirectorySqlite;
+
+#[tokio::test]
+async fn record_announced_peer_bookmarks_without_admitting() {
+    let backend = FederationDirectorySqlite::open(":memory:")
+        .await
+        .expect("open in-memory federation directory");
+    let pubkey_b64 = B64.encode([0x0au8; 32]);
+
+    // Edge writes the bookmark through the RootingDirectory adapter (exactly as
+    // `resolve_announce_cold_start` does on an advisory admit).
+    let rooting: Arc<dyn RootingDirectory> = backend.clone();
+    rooting
+        .record_announced_peer(
+            "edge-key-lan-peer",
+            &pubkey_b64,
+            None, // announce carries no PQC pubkey (enriches later)
+            None, // no claimed identity_type
+            chrono::Utc::now(),
+        )
+        .await;
+
+    // It appears as an announced-peer bookmark …
+    let bookmarks = FederationDirectory::list_announced_peers(&*backend)
+        .await
+        .expect("list_announced_peers");
+    assert!(
+        bookmarks
+            .iter()
+            .any(|p| p.key_id == "edge-key-lan-peer" && p.pubkey_ed25519_base64 == pubkey_b64),
+        "the LAN-announced peer must be recorded as a bookmark (CIRISEdge#362)",
+    );
+
+    // … but is NOT admitted into the directory as a federation key of any
+    // peer-relevant type (never an authority — the #469 invariant).
+    for ty in [
+        "node",
+        "steward",
+        "wise_authority",
+        "accord_holder",
+        "partner",
+        "witness",
+    ] {
+        let keys = FederationDirectory::list_keys_by_identity_type(&*backend, ty)
+            .await
+            .unwrap_or_default();
+        assert!(
+            !keys.iter().any(|k| k.key_id == "edge-key-lan-peer"),
+            "a bookmark must never become an admitted `{ty}` federation_keys row",
+        );
+    }
+
+    // Idempotent + liveness: a second announce refreshes, never duplicates.
+    rooting
+        .record_announced_peer(
+            "edge-key-lan-peer",
+            &pubkey_b64,
+            None,
+            None,
+            chrono::Utc::now(),
+        )
+        .await;
+    let after = FederationDirectory::list_announced_peers(&*backend)
+        .await
+        .expect("list_announced_peers");
+    assert_eq!(
+        after
+            .iter()
+            .filter(|p| p.key_id == "edge-key-lan-peer")
+            .count(),
+        1,
+        "a repeat announce must refresh the bookmark, not duplicate it",
+    );
+}


### PR DESCRIPTION
Two mobile-bootstrap fixes + persist v17.6.0→**v17.8.0**.

## #363 — advisory/bootstrap link dies before the Key+IdentityOccurrence anti-entropy (the mobile-trace blocker, NAT-independent)
**RCA confirmed:** a dialing peer advisory-admits canonical's announce, but must anti-entropy canonical's **Key** (transport binding) + **IdentityOccurrence** (KEX enc-keys) planes to become a delivery target — and the link died of `keepalive_timeout` (~16s, 1-of-3 acked) **before** the 30s-cadence exchange converged. `knows_peer=false`, `resolve_peer_kex→None`, 0 delivery.

**Ask-2 ruled out honestly:** the KEX enc-keys are an x25519 + **ML-KEM-768** pair from the IdentityOccurrence plane (`resolve_encryption_keys`); the ML-KEM pubkey (~1184 B) is absent from the 64-byte announce transport identity, and the federation x25519 ≠ the transport x25519 (AV-17 separation). So promotion-from-announce can't deliver content — **keepalive survival is the fix.**

**Fix:** edge never called leviculum's node-global `link_keepalive`, so links used the RTT-derived floor (~5s → stale 10s → dead ~16s). Now pinned to **`BOOTSTRAP_LINK_KEEPALIVE`=30s** (stale 60s = 2× the anti-entropy cadence), clamped `[5,360]s`, with a pure `effective_link_keepalive_secs` decision fn + 5 unit tests. DoS-aware: longer interval = fewer packets; a dead link is still reaped ~65s (bounded ~4× vs 16s) + the `MAX_PEERS` advisory cap. Node-global is leviculum's only knob — stated honestly.

## #362 — seeder bridge: announced LAN peers → GET /v1/federation/peers
`RootingDirectory::record_announced_peer` delegates to persist v17.8.0's `record_announced_peer` (CIRISPersist#469): a self-consistent announce becomes a **non-canonical, untrusted** `announced_peers` bookmark (surfaces `canonical=false`/`trust="unknown"`/`last_seen`) **without admission** — invisible to every quorum/rooting path, anti-joined once the key roots for real. Wired beside `persist_transport_binding`. Guard: `tests/seeder_bridge.rs`.

## Verification
compile; all three clippy combos `--all-targets -D warnings`; `transport::reticulum` 21 (incl. 5 new keepalive), `seeder_bridge` 1, route_table/av42 — green.

Refs: #363, #362; CIRISPersist#469 (v17.8.0), CIRISServer#288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)