### PR TITLE
feat(#371,#370): adopt leviculum v0.10.1+ciris.1 (reticulum-* → leviculum-* rename) + round-outcome metrics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.4.0"
+version = "13.5.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -566,8 +566,18 @@ tempfile       = { version = "3", optional = true }
 # new AnnounceError::Pack(PacketError) — a breaking enum change, but edge only
 # matches AnnounceError::ExplicitHashCannotAnnounce (untouched), so the bump is
 # pin currency + the budget-const rewire with no match-arm churn.
-reticulum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.4+ciris.1", version = "0.9", optional = true }
-reticulum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.9.4+ciris.1", version = "0.9", optional = true }
+# v0.10.1+ciris.1 (CIRISEdge#371) — re-anchor on upstream leviculum/master
+# which adopts the `reticulum-* -> leviculum-*` crate rename. The fork carries
+# forward the CIRIS-only driver features (link_is_established, link_destination,
+# FramesDropped) + fork CI. Two fork APIs edge used were folded into upstream
+# idioms: `driver::send_on_link` -> `LinkHandle::try_send` (same core Channel
+# path) and `register_destination_at`/`connect_at` -> native
+# `register_destination`/`connect(dest_hash)`. v0.10.1 (leviculum#30) re-ports the
+# one remaining fork-only constructor `Destination::with_explicit_hash` — edge's
+# federation explicit-hash listen path (CIRISEdge#191) that upstream has no
+# equivalent for. The `+ciris.1` is fork build-metadata; the crate semver is 0.10.
+leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.10.1+ciris.1", version = "0.10", optional = true }
+leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.10.1+ciris.1", version = "0.10", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in
@@ -725,7 +735,8 @@ transport-http        = [
 ]
 
 # Phase 1 — Reticulum canonical wire (OQ-07 first impl). Backed by
-# Leviculum's reticulum-core + reticulum-std. `TransportId::RETICULUM_RS`
+# Leviculum's leviculum-core + leviculum-std (the upstream `reticulum-* ->
+# leviculum-*` rename, adopted in CIRISEdge#371). `TransportId::RETICULUM_RS`
 # is the metrics tag; the impl lives in `src/transport/reticulum.rs`.
 #
 # v0.12.0 (CIRISEdge#24) — refactored from a single umbrella feature
@@ -784,16 +795,16 @@ transport-reticulum             = [
     "transport-reticulum-local",
     "transport-reticulum-rnode",
     "transport-reticulum-i2p",
-    "dep:reticulum-std",
-    "dep:reticulum-core",
+    "dep:leviculum-std",
+    "dep:leviculum-core",
 ]
-transport-reticulum-auto        = ["dep:reticulum-std", "dep:reticulum-core", "_reticulum-module"]
-transport-reticulum-tcp-server  = ["dep:reticulum-std", "dep:reticulum-core", "_reticulum-module"]
-transport-reticulum-tcp-client  = ["dep:reticulum-std", "dep:reticulum-core", "_reticulum-module"]
-transport-reticulum-udp         = ["dep:reticulum-std", "dep:reticulum-core", "_reticulum-module"]
-transport-reticulum-local       = ["dep:reticulum-std", "dep:reticulum-core", "_reticulum-module"]
-transport-reticulum-rnode       = ["dep:reticulum-std", "dep:reticulum-core", "_reticulum-module"]
-transport-reticulum-i2p         = ["dep:reticulum-std", "dep:reticulum-core", "_reticulum-module"]
+transport-reticulum-auto        = ["dep:leviculum-std", "dep:leviculum-core", "_reticulum-module"]
+transport-reticulum-tcp-server  = ["dep:leviculum-std", "dep:leviculum-core", "_reticulum-module"]
+transport-reticulum-tcp-client  = ["dep:leviculum-std", "dep:leviculum-core", "_reticulum-module"]
+transport-reticulum-udp         = ["dep:leviculum-std", "dep:leviculum-core", "_reticulum-module"]
+transport-reticulum-local       = ["dep:leviculum-std", "dep:leviculum-core", "_reticulum-module"]
+transport-reticulum-rnode       = ["dep:leviculum-std", "dep:leviculum-core", "_reticulum-module"]
+transport-reticulum-i2p         = ["dep:leviculum-std", "dep:leviculum-core", "_reticulum-module"]
 
 # Internal aggregator — any reticulum-* sub-feature flips this on, and
 # every cfg site in the code that needs "the Reticulum transport module

--- a/benches/realtime_av_mesh_e2e.rs
+++ b/benches/realtime_av_mesh_e2e.rs
@@ -124,8 +124,8 @@ use ciris_edge::transport::realtime_av_alm::{
 };
 use ciris_edge::transport::realtime_av_relay::{PeerKeyId, RelayForwardOut, RelayNode};
 
-use reticulum_core::{DestinationHash, Identity};
-use reticulum_std::driver::{ReticulumNode, ReticulumNodeBuilder};
+use leviculum_core::{DestinationHash, Identity};
+use leviculum_std::driver::{ReticulumNode, ReticulumNodeBuilder};
 
 // ─── Frame layout constants (the "8K → 2×4K → 4×2K" narrative) ─────
 

--- a/benches/realtime_av_relay.rs
+++ b/benches/realtime_av_relay.rs
@@ -50,7 +50,7 @@
 //!
 //! [`RelayNode`] construction is non-trivial — the test pattern in
 //! `src/transport/realtime_av_relay.rs::tests::test_node` builds a
-//! real [`reticulum_std::driver::ReticulumNode`] (writes an identity
+//! real [`leviculum_std::driver::ReticulumNode`] (writes an identity
 //! file to a temp dir, allocates a tokio runtime, etc., via
 //! `ReticulumNodeBuilder::build_sync`). The full subscriber roster
 //! is also wired at setup time. Every `bench_with_input` group uses
@@ -149,8 +149,8 @@ use ciris_edge::transport::realtime_av::{
 };
 use ciris_edge::transport::realtime_av_relay::{PeerKeyId, RelayNode};
 
-use reticulum_core::{DestinationHash, Identity};
-use reticulum_std::driver::{ReticulumNode, ReticulumNodeBuilder};
+use leviculum_core::{DestinationHash, Identity};
+use leviculum_std::driver::{ReticulumNode, ReticulumNodeBuilder};
 
 // ─── Parameter sweep tables (held here so every group reads the
 //     same constants — keeps cross-bench results lined up). ───────────

--- a/src/announce_suppression.rs
+++ b/src/announce_suppression.rs
@@ -39,7 +39,7 @@ use parking_lot::RwLock;
 use crate::cohort_scope::CohortScope;
 
 #[cfg(feature = "_reticulum-module")]
-use reticulum_core::{AnnounceControl, DestinationHash};
+use leviculum_core::{AnnounceControl, DestinationHash};
 
 /// FSD §3.3 announce-suppression decision rule. Returns `true` iff
 /// the destination's [`CohortScope`] is anything other than

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1264,13 +1264,13 @@ impl PyEdge {
                      (disable_reticulum=True, or wheel built without _reticulum-module)",
                 )
             })?;
-            let factory: Arc<dyn reticulum_std::interfaces::RNodeChannelFactory> =
+            let factory: Arc<dyn leviculum_std::interfaces::RNodeChannelFactory> =
                 Arc::new(PyRNodeChannelFactory {
                     read_cb,
                     write_cb,
                     chunk_size: buffer_size.max(1) * 1024,
                 });
-            let config = reticulum_std::interfaces::RNodeChannelConfig {
+            let config = leviculum_std::interfaces::RNodeChannelConfig {
                 factory,
                 frequency: frequency_hz,
                 bandwidth: bandwidth_hz,
@@ -2110,6 +2110,16 @@ impl PyEdge {
         }
         root.set_item("peer_reachability_ratio", reachability)?;
 
+        // CIRISEdge#370 — per-outcome anti-entropy round counts
+        // (completed / refused / timed_out / error). A `timed_out` share
+        // that climbs with active-peer count is the field signature of the
+        // transport concurrency ceiling (leviculum#29).
+        let round_outcomes = pyo3::types::PyDict::new(py);
+        for (outcome, v) in &bundle.replication_round_outcomes_total {
+            round_outcomes.set_item(outcome.as_str(), *v)?;
+        }
+        root.set_item("replication_round_outcomes_total", round_outcomes)?;
+
         Ok(root.unbind().into_any())
     }
 
@@ -2189,6 +2199,11 @@ impl PyEdge {
         if let Some(secs) = cadence_seconds {
             config.scheduler.cadence = std::time::Duration::from_secs(secs);
         }
+        // CIRISEdge#370 — hand the live metrics bag to the runtime so its
+        // scheduler event-sink consumer folds each round's outcome into the
+        // round-outcome counter surfaced by `metrics_snapshot`. Cheap clone;
+        // the counters are `Arc`-backed and shared with `self.inner`.
+        config.metrics = Some(self.inner.metrics());
 
         // CIRISEdge#311 — the #257 Key-plane set + #305 occurrence-plane set
         // collapse into ONE `SelfOwn` provider; the unified engine advertises
@@ -2735,8 +2750,8 @@ struct PyRNodeChannelFactory {
 }
 
 #[cfg(feature = "_reticulum-module")]
-impl reticulum_std::interfaces::RNodeChannelFactory for PyRNodeChannelFactory {
-    fn open(&self) -> reticulum_std::interfaces::RNodeChannelOpenFuture {
+impl leviculum_std::interfaces::RNodeChannelFactory for PyRNodeChannelFactory {
+    fn open(&self) -> leviculum_std::interfaces::RNodeChannelOpenFuture {
         let read_cb = Python::attach(|py| self.read_cb.clone_ref(py));
         let write_cb = Python::attach(|py| self.write_cb.clone_ref(py));
         let chunk = self.chunk_size;
@@ -2825,7 +2840,7 @@ impl reticulum_std::interfaces::RNodeChannelFactory for PyRNodeChannelFactory {
             });
 
             Ok::<
-                reticulum_std::interfaces::RNodeChannelHalves,
+                leviculum_std::interfaces::RNodeChannelHalves,
                 Box<dyn std::error::Error + Send + Sync>,
             >((Box::new(leviculum_rx), Box::new(leviculum_tx)))
         })
@@ -2845,7 +2860,7 @@ impl reticulum_std::interfaces::RNodeChannelFactory for PyRNodeChannelFactory {
 #[cfg(feature = "_reticulum-module")]
 #[pyclass(name = "RNodeChannelHandle", module = "ciris_edge", unsendable)]
 pub struct PyRNodeChannelHandle {
-    inner: std::sync::Mutex<Option<reticulum_std::interfaces::RNodeChannelHandle>>,
+    inner: std::sync::Mutex<Option<leviculum_std::interfaces::RNodeChannelHandle>>,
 }
 
 #[cfg(feature = "_reticulum-module")]
@@ -5971,7 +5986,7 @@ fn rns_destination_hash(
     x25519_pub: &[u8],
     ed25519_pub: &[u8],
 ) -> PyResult<[u8; 16]> {
-    use reticulum_core::{Destination, Identity};
+    use leviculum_core::{Destination, Identity};
     let x_pub = fixed_bytes::<32>("x25519_pub", x25519_pub)?;
     let ed_pub = fixed_bytes::<32>("ed25519_pub", ed25519_pub)?;
     let identity = Identity::from_public_keys(&x_pub, &ed_pub)
@@ -6517,15 +6532,15 @@ impl PyRelayNode {
     /// hand-off back to a peer's open path).
     ///
     /// `address_hash_bytes` is the 16-byte
-    /// [`DestinationHash`](reticulum_core::DestinationHash) value
+    /// [`DestinationHash`](leviculum_core::DestinationHash) value
     /// (CEG §5.6.8.8.1.1 TRUNCATED_HASHLENGTH). Pass any synthetic
     /// 16-byte value for harness-only use; production callers should
     /// derive this via [`rns_destination_hash`].
     #[staticmethod]
     #[pyo3(signature = (address_hash_bytes))]
     fn with_synthetic_node(address_hash_bytes: &[u8]) -> PyResult<Self> {
-        use reticulum_core::{DestinationHash, Identity};
-        use reticulum_std::driver::ReticulumNodeBuilder;
+        use leviculum_core::{DestinationHash, Identity};
+        use leviculum_std::driver::ReticulumNodeBuilder;
         let addr_bytes = fixed_bytes::<16>("address_hash_bytes", address_hash_bytes)?;
         // Synthetic 64-byte private key — deterministic, never
         // intended for real I/O. Matches the relay's own test

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -160,6 +160,50 @@ impl DeliveryClass {
     }
 }
 
+/// Terminal outcome of a single anti-entropy replication round, as the
+/// scheduler's per-coordinator run loop observed it (the metrics-facing
+/// projection of [`crate::replication::scheduler::RoundEvent`]). It is
+/// `Copy + Eq + Hash` so it sits in the counter `HashMap` key; the
+/// [`crate::replication::RoundReport`] payload the `Completed` event
+/// carries is deliberately dropped here — high-cardinality per-round
+/// detail belongs on the tracing span, not the counter label.
+///
+/// CIRISEdge#370 — this is the instrument that makes the transport
+/// concurrency ceiling measurable in the field. Below the saturation
+/// cliff rounds `Completed`; once inbound crypto + outbound sends
+/// serialize on leviculum's single `Mutex<StdNodeCore>` past the peer
+/// count one link can service, rounds shift to `TimedOut`. A climbing
+/// `timed_out` share against a flat `completed` count is the signature
+/// of the ceiling — a throughput wall, not a per-peer latency gradient.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RoundOutcome {
+    /// The round drove to `Complete` — the peer replied and the
+    /// diff/deliver phases finished within `round_timeout`.
+    Completed,
+    /// The coordinator refused the round (malformed / out-of-state
+    /// peer message); the scheduler reset the session.
+    Refused,
+    /// `round_timeout` elapsed waiting for the peer's reply between
+    /// SendThenWait phases — the dominant saturation signal.
+    TimedOut,
+    /// A transport / protocol / inbound-closed error aborted the round.
+    Error,
+}
+
+impl RoundOutcome {
+    /// Snake-case stable label string. Used as the dict-key on the
+    /// PyO3 `metrics_snapshot` surface.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Refused => "refused",
+            Self::TimedOut => "timed_out",
+            Self::Error => "error",
+        }
+    }
+}
+
 /// The live counter/gauge bag every [`crate::Edge`] owns.
 ///
 /// # Concurrency
@@ -233,6 +277,16 @@ pub struct EdgeMetrics {
     /// `signing_key_id` already rides on the matching
     /// `EventKind::TrustShortCircuited` event.
     pub inbound_dropped_low_trust: Arc<std::sync::atomic::AtomicU64>,
+    /// CIRISEdge#370 — per-[`RoundOutcome`] count of anti-entropy
+    /// replication rounds the scheduler has driven to a terminal state
+    /// (Completed / Refused / TimedOut / Error). Incremented once per
+    /// round by [`crate::replication::runtime::ReplicationRuntime::start`]'s
+    /// scheduler event-sink consumer, active only when a live metrics
+    /// handle is set on [`crate::replication::ReplicationRuntimeConfig`].
+    /// A `timed_out` share that climbs with active-peer count is the
+    /// field signature of the transport concurrency ceiling — the whole
+    /// reason this counter exists.
+    pub replication_round_outcomes_total: Arc<RwLock<HashMap<RoundOutcome, u64>>>,
 }
 
 impl EdgeMetrics {
@@ -287,6 +341,15 @@ impl EdgeMetrics {
         *guard.entry(class).or_insert(0) += 1;
     }
 
+    /// CIRISEdge#370 — increment the anti-entropy round-outcome counter
+    /// for `outcome`. Called once per terminated round by the runtime's
+    /// scheduler event-sink consumer (see
+    /// [`crate::replication::runtime::ReplicationRuntime::start`]).
+    pub fn inc_round_outcome(&self, outcome: RoundOutcome) {
+        let mut guard = self.replication_round_outcomes_total.write();
+        *guard.entry(outcome).or_insert(0) += 1;
+    }
+
     /// CIRISEdge#48-B (v0.19.6) — increment the
     /// `inbound_dropped_low_trust` counter. Called from
     /// `dispatch_inbound` once per drop.
@@ -330,6 +393,7 @@ impl EdgeMetrics {
             transport_bytes_out_total: self.transport_bytes_out_total.read().clone(),
             peer_reachability_ratio: self.peer_reachability_ratio.read().clone(),
             inbound_dropped_low_trust: self.inbound_dropped_low_trust(),
+            replication_round_outcomes_total: self.replication_round_outcomes_total.read().clone(),
         }
     }
 }
@@ -351,6 +415,10 @@ pub struct EdgeMetricsBundle {
     /// CIRISEdge#48-B (v0.19.6) — cumulative count of envelopes
     /// dropped at `dispatch_inbound` due to trust short-circuit.
     pub inbound_dropped_low_trust: u64,
+    /// CIRISEdge#370 — cumulative per-outcome anti-entropy round count
+    /// (keyed by [`RoundOutcome`]). Empty until the runtime is started
+    /// with a live metrics handle configured.
+    pub replication_round_outcomes_total: HashMap<RoundOutcome, u64>,
 }
 
 #[cfg(test)]
@@ -411,6 +479,39 @@ mod tests {
         for (e, want) in cases {
             assert_eq!(VerifyErrorClass::from_verify_error(&e), want);
         }
+    }
+
+    #[test]
+    fn round_outcomes_accumulate_per_outcome() {
+        // CIRISEdge#370 — the field instrument: each terminal round outcome
+        // increments its own counter, and the snapshot renders them keyed by
+        // the stable snake-case label the PyO3 surface uses.
+        let m = EdgeMetrics::new();
+        m.inc_round_outcome(RoundOutcome::Completed);
+        m.inc_round_outcome(RoundOutcome::Completed);
+        m.inc_round_outcome(RoundOutcome::TimedOut);
+        m.inc_round_outcome(RoundOutcome::TimedOut);
+        m.inc_round_outcome(RoundOutcome::TimedOut);
+        m.inc_round_outcome(RoundOutcome::Refused);
+        let snap = m.snapshot();
+        assert_eq!(
+            snap.replication_round_outcomes_total[&RoundOutcome::Completed],
+            2
+        );
+        assert_eq!(
+            snap.replication_round_outcomes_total[&RoundOutcome::TimedOut],
+            3
+        );
+        assert_eq!(
+            snap.replication_round_outcomes_total[&RoundOutcome::Refused],
+            1
+        );
+        // Never-emitted outcome stays absent (not zero-initialised) — the map
+        // is a sparse bag, mirroring the other per-key counters.
+        assert!(!snap
+            .replication_round_outcomes_total
+            .contains_key(&RoundOutcome::Error));
+        assert_eq!(RoundOutcome::TimedOut.as_str(), "timed_out");
     }
 
     #[test]

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -49,7 +49,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use ciris_persist::federation::FederationDirectory;
-use tokio::sync::{watch, Mutex};
+use tokio::sync::{mpsc, watch, Mutex};
 use tokio::task::JoinHandle;
 
 use super::bridge::{BridgeConfig, CohortProvider, FederationDirectoryReplicationBridge};
@@ -58,7 +58,7 @@ use super::directory::{DirectoryStateAdapter, MutableDirectoryStateAdapter, Repl
 use super::protocol::EnvelopeKind;
 use super::registry::ReplicationRegistry;
 use super::scheduler::{
-    ReplicationScheduler, SchedulerCommandError, SchedulerConfig, SchedulerHandle,
+    ReplicationScheduler, RoundEvent, SchedulerCommandError, SchedulerConfig, SchedulerHandle,
 };
 use super::session::SessionRole;
 use super::summary::{StateApplier, StateProvider};
@@ -127,6 +127,21 @@ fn spawn_responder_drive(coord: Arc<ReplicationCoordinator>) {
     });
 }
 
+/// CIRISEdge#370 — project a scheduler [`RoundEvent`] onto the
+/// metrics-facing [`crate::observability::RoundOutcome`] label. The
+/// `Completed` report payload and the `Error` string are intentionally
+/// dropped here — high-cardinality per-round detail rides the round's
+/// tracing span, not the counter key.
+fn round_outcome_of(event: &RoundEvent) -> crate::observability::RoundOutcome {
+    use crate::observability::RoundOutcome;
+    match event {
+        RoundEvent::Completed(_) => RoundOutcome::Completed,
+        RoundEvent::Refused => RoundOutcome::Refused,
+        RoundEvent::TimedOut => RoundOutcome::TimedOut,
+        RoundEvent::Error(_) => RoundOutcome::Error,
+    }
+}
+
 /// A `(peer_key_id, kind)` pair the runtime should anti-entropy with
 /// as the Initiator side. Each pair gets one [`ReplicationCoordinator`]
 /// in the Initiator role.
@@ -145,6 +160,18 @@ pub struct ReplicationRuntimeConfig {
     /// Cache + paging tuning for the bridge. Defaults to
     /// [`BridgeConfig::default`].
     pub bridge: BridgeConfig,
+    /// CIRISEdge#370 — optional live metrics handle. When `Some`,
+    /// [`ReplicationRuntime::start`] wires the scheduler's `event_sink`
+    /// to a consumer task that folds each round's
+    /// [`RoundEvent`](crate::replication::scheduler::RoundEvent) into
+    /// the [`EdgeMetrics::inc_round_outcome`](crate::observability::EdgeMetrics::inc_round_outcome)
+    /// counter — the field instrument for the transport concurrency
+    /// ceiling. `None` (the default) preserves the pre-#370
+    /// `run_until_cancelled` path with no event-sink overhead. This is a
+    /// live shared handle (its counters are `Arc`-backed), not tuning —
+    /// it rides on the config only because `start` already threads the
+    /// config through to the scheduler-spawn site.
+    pub metrics: Option<crate::observability::EdgeMetrics>,
 }
 
 /// Live replication runtime — bridge + registry + scheduler task +
@@ -319,9 +346,30 @@ impl ReplicationRuntime {
         }
 
         let (cancel_tx, cancel_rx) = watch::channel(false);
-        let scheduler_task = tokio::spawn(async move {
-            scheduler.run_until_cancelled(cancel_rx).await;
-        });
+        // CIRISEdge#370 — when a live metrics handle is configured, route
+        // the scheduler's per-round `RoundEvent`s through the purpose-built
+        // `event_sink` into a consumer task that folds each into the
+        // `EdgeMetrics` round-outcome counter (the field instrument for the
+        // transport concurrency ceiling, leviculum#29). Absent a handle we
+        // keep the zero-overhead `run_until_cancelled` path — no channel, no
+        // consumer task. The scheduler tolerates a closed sink, and the
+        // consumer's `recv()` returns `None` when the scheduler task ends and
+        // drops the sender, so the consumer winds down without its own cancel.
+        let scheduler_task = if let Some(metrics) = config.metrics.clone() {
+            let (evt_tx, mut evt_rx) = mpsc::channel::<(String, RoundEvent)>(256);
+            tokio::spawn(async move {
+                while let Some((_peer, event)) = evt_rx.recv().await {
+                    metrics.inc_round_outcome(round_outcome_of(&event));
+                }
+            });
+            tokio::spawn(async move {
+                scheduler.run_with_events(cancel_rx, Some(evt_tx)).await;
+            })
+        } else {
+            tokio::spawn(async move {
+                scheduler.run_until_cancelled(cancel_rx).await;
+            })
+        };
 
         // `directory` is consumed by the bridge above (held inside
         // `bridge`'s Arc<dyn FederationDirectory>). Drop the local

--- a/src/transport/attestation.rs
+++ b/src/transport/attestation.rs
@@ -251,7 +251,7 @@ impl TransportBindingEnforcement {
 /// payload (180 B) is larger than the un-ratcheted case, so 300 B (not 332 B) is
 /// the value a smaller-fits-so-does-larger argument does NOT get to assume.
 /// (leviculum#22 / v0.9.0+ciris.1 exported this; before, edge duplicated `300`.)
-pub const ANNOUNCE_APP_DATA_BUDGET: usize = reticulum_core::announce_app_data_budget(true);
+pub const ANNOUNCE_APP_DATA_BUDGET: usize = leviculum_core::announce_app_data_budget(true);
 
 /// The binary wire tag for [`AnnounceAttestation::to_app_data`]. A version byte
 /// so a future shape is distinguishable rather than mis-parsed.

--- a/src/transport/realtime_av.rs
+++ b/src/transport/realtime_av.rs
@@ -835,7 +835,7 @@ impl RealtimeFanout {
     /// // Apply the per-Link outer seal only for admitted receivers.
     /// for p in &admitted {
     ///     let sealed = seal_av_outer(&inner, &transit_key(p), &p.link_id, link_seq(p))?;
-    ///     send_on_link(&p.link_id, sealed);
+    ///     node.link_handle(&p.link_id).try_send(&sealed).await?; // leviculum v0.10.0 idiom
     /// }
     /// # Ok::<(), ciris_edge::transport::realtime_av::RealtimeAvError>(())
     /// ```

--- a/src/transport/realtime_av_relay.rs
+++ b/src/transport/realtime_av_relay.rs
@@ -92,8 +92,8 @@ use std::collections::{HashMap, HashSet};
 
 use zeroize::Zeroize;
 
-use reticulum_core::DestinationHash;
-use reticulum_std::driver::ReticulumNode;
+use leviculum_core::DestinationHash;
+use leviculum_std::driver::ReticulumNode;
 
 use super::realtime_av::{
     open_av_outer, seal_av_outer, InnerSealed, RealtimeAvError, ReceiverLayerPolicy, SealedAvChunk,
@@ -526,8 +526,8 @@ mod tests {
         CODEC_OPAQUE,
     };
 
-    use reticulum_core::{DestinationHash, Identity};
-    use reticulum_std::driver::ReticulumNodeBuilder;
+    use leviculum_core::{DestinationHash, Identity};
+    use leviculum_std::driver::ReticulumNodeBuilder;
     use std::sync::Arc;
 
     /// A throwaway leviculum node — used to construct a `RelayNode`

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -84,11 +84,11 @@ use base64::Engine as _;
 use chrono::{DateTime, Utc};
 use tokio::sync::{mpsc, Mutex};
 
-use reticulum_core::link::LinkId;
-use reticulum_core::resource::ResourceStrategy;
-use reticulum_core::{Destination, DestinationHash, DestinationType, Direction, Identity};
-use reticulum_std::driver::{EventReceiver, ReticulumNode, ReticulumNodeBuilder};
-use reticulum_std::NodeEvent;
+use leviculum_core::link::LinkId;
+use leviculum_core::resource::ResourceStrategy;
+use leviculum_core::{Destination, DestinationHash, DestinationType, Direction, Identity};
+use leviculum_std::driver::{EventReceiver, ReticulumNode, ReticulumNodeBuilder};
+use leviculum_std::NodeEvent;
 
 use super::attestation::{
     AnnounceAttestation, AttestationError, AttestationPayload, TransportBindingEnforcement,
@@ -175,13 +175,13 @@ const NO_PATH_ESTABLISH_TIMEOUT: Duration = Duration::from_secs(5);
 const BOOTSTRAP_LINK_KEEPALIVE: Duration = Duration::from_secs(30);
 
 /// CIRISEdge#363 — leviculum's minimum keepalive interval
-/// (`reticulum_core::constants::LINK_KEEPALIVE_MIN_SECS`). leviculum clamps an
+/// (`leviculum_core::constants::LINK_KEEPALIVE_MIN_SECS`). leviculum clamps an
 /// override UP to this floor but does not cap the ceiling, so edge enforces both
 /// ends in [`effective_link_keepalive_secs`].
 const LINK_KEEPALIVE_MIN_SECS: u64 = 5;
 
 /// CIRISEdge#363 — leviculum's maximum / RTT-derived keepalive interval
-/// (`reticulum_core::constants::LINK_KEEPALIVE_SECS`, 6 minutes). Edge caps an
+/// (`leviculum_core::constants::LINK_KEEPALIVE_SECS`, 6 minutes). Edge caps an
 /// operator override here so a stray large value can NOT hold a silently-dead
 /// link open longer than leviculum's own RTT-driven ceiling would — the
 /// DoS-facing upper bound (leviculum only clamps the lower end).
@@ -946,7 +946,7 @@ pub enum ReticulumInterfaceConfig {
     /// firmware. Off-grid relays + solar-powered meshes. Leviculum's
     /// Rust builder doesn't expose an `add_rnode` method yet, so the
     /// adapter pipes this config into the underlying
-    /// `reticulum_std::config::InterfaceConfig` row via
+    /// `leviculum_std::config::InterfaceConfig` row via
     /// [`ReticulumTransport::add_interface`]'s internal config path.
     #[cfg(feature = "transport-reticulum-rnode")]
     RNode(RNodeInterfaceConfig),
@@ -1788,6 +1788,14 @@ impl ReticulumTransport {
         let explicit_dest_hash = crate::transport::addressing::reticulum_destination_for_pubkey(
             &federation_ed25519_pubkey,
         );
+        // CIRISEdge#371 / leviculum#30 — `Destination::with_explicit_hash` is the
+        // ONE fork-only API with no upstream equivalent: upstream `Destination.hash`
+        // is private and `Destination::new` derives it from app_name+aspects+identity,
+        // so a node cannot otherwise listen on the federation-rooted hash peers
+        // address it by (CIRISEdge#191). Re-ported onto the leviculum-* rename in
+        // v0.10.1+ciris.1 (the other dropped fork APIs all migrated to upstream
+        // idioms: send_on_link → LinkHandle::try_send, connect_at → connect(dest_hash),
+        // register_destination_at → register_destination).
         let mut dest = Destination::with_explicit_hash(
             Some(identity.clone()),
             Direction::In,
@@ -1804,7 +1812,13 @@ impl ReticulumTransport {
             &explicit_dest_hash,
             "explicit-hash destination must index by the caller-supplied hash",
         );
-        node.register_destination_at(local_dest_hash, dest);
+        // CIRISEdge#371 — the explicit hash rides on the `Destination` itself
+        // (via `with_explicit_hash` above), and the core keys the routing table
+        // on `dest.hash()`, so upstream's native `register_destination` registers
+        // it at exactly `explicit_dest_hash` — the fork-only `register_destination_at`
+        // is unnecessary. (The debug_assert above proves `dest.hash()` == the
+        // explicit hash we asked for.)
+        node.register_destination(dest);
 
         // v7.4.0 (CIRISEdge#231) — register a NAMED destination on
         // the SAME transport identity. Its hash is the standard RNS
@@ -1828,7 +1842,9 @@ impl ReticulumTransport {
         .map_err(|e| TransportError::Config(format!("named destination build: {e}")))?;
         named_dest.set_accepts_links(true);
         let local_named_dest_hash = *named_dest.hash();
-        node.register_destination_at(local_named_dest_hash, named_dest);
+        // CIRISEdge#371 — the named dest already carries its RNS-derived hash, so
+        // `register_destination` (native) registers it at `local_named_dest_hash`.
+        node.register_destination(named_dest);
 
         // Take the single event receiver before starting, then start
         // the event loop. `listen` claims the stashed receiver.
@@ -2392,7 +2408,7 @@ impl ReticulumTransport {
     //
     // Paths / blackhole / rate / tunnels / announce / reverse. v1.1.0
     // (CIRISEdge#44) flips on the 5 Leviculum accessors that the fork
-    // now exposes publicly (`reticulum_std::driver::ReticulumNode::
+    // now exposes publicly (`leviculum_std::driver::ReticulumNode::
     // {path_table_entries, rate_table_entries, get_path_clone,
     // remove_path, drop_all_paths_via}`). The remaining 3 read
     // surfaces (`routing_tunnels`, `routing_announce_table`,
@@ -3082,20 +3098,30 @@ impl ReticulumTransport {
                     // CIRISEdge#353 ask #2 (leviculum#27) — the link is
                     // mid-transfer, so a resource reply can't get on (and the
                     // field proved the 8 s retry window loses). A PACKET can:
-                    // `send_on_link` interleaves an in-flight resource transfer
-                    // (it goes through the link Channel, never the one-resource
-                    // gate). Ship the reply as a packet if it fits the link MDU —
-                    // the reverse path carries small control-plane replies
-                    // (Summary/Diff, the Key + IdentityOccurrence planes) that
-                    // do. This is the field-proven fix (reproduced deterministically
-                    // in leviculum#27) for the busy-window contention. If the reply
-                    // is too large or the channel itself is backpressured, fall
-                    // through to the existing resource busy-retry / dial.
+                    // a link-Channel send interleaves an in-flight resource
+                    // transfer (it goes through the link Channel, never the
+                    // one-resource gate). Ship the reply as a packet if it fits
+                    // the link MDU — the reverse path carries small control-plane
+                    // replies (Summary/Diff, the Key + IdentityOccurrence planes)
+                    // that do. This is the field-proven fix (reproduced
+                    // deterministically in leviculum#27) for the busy-window
+                    // contention. If the reply is too large or the channel itself
+                    // is backpressured, fall through to the existing resource
+                    // busy-retry / dial.
+                    //
+                    // CIRISEdge#371 — since leviculum v0.10.0 the fork-only
+                    // `driver::send_on_link` wrapper is folded into upstream's
+                    // `LinkHandle`; `link_handle(&id).try_send(..)` is the same
+                    // core `send_on_link` (Channel / `RawBytesMessage`) and still
+                    // returns `Busy` non-blocking, so the interleave semantics are
+                    // unchanged. `try_send` (not `send`) keeps the one-shot
+                    // behaviour — this call is already inside the busy-retry path.
                     let mdu = self.node.link_mdu(&link_id).unwrap_or(0);
                     if envelope_bytes.len() <= mdu
                         && self
                             .node
-                            .send_on_link(&link_id, envelope_bytes)
+                            .link_handle(&link_id)
+                            .try_send(envelope_bytes)
                             .await
                             .is_ok()
                     {
@@ -3188,8 +3214,8 @@ impl ReticulumTransport {
             .send_resource(link_id, envelope_bytes, None, true)
             .await
             .map_err(|e| match e {
-                reticulum_std::error::Error::Resource(
-                    reticulum_core::resource::ResourceError::TransferInProgress,
+                leviculum_std::error::Error::Resource(
+                    leviculum_core::resource::ResourceError::TransferInProgress,
                 ) => ShipError::Busy,
                 other => ShipError::Other(TransportError::Io(format!(
                     "reticulum send_resource: {other}"
@@ -3884,8 +3910,9 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             attribute_and_deliver(ctx, link_id, data).await;
         }
         // CIRISEdge#353 ask #2 / #363 — a reverse-path reply that arrived as a
-        // link PACKET (`send_on_link`) rather than a resource, because the link
-        // was mid-transfer. leviculum#27: a packet interleaves an in-flight
+        // link PACKET (a link-Channel send, `LinkHandle::try_send` since
+        // CIRISEdge#371 / leviculum v0.10.0) rather than a resource, because the
+        // link was mid-transfer. leviculum#27: a packet interleaves an in-flight
         // resource transfer (it goes through the link Channel, never the
         // one-resource gate), so a small anti-entropy reply (Summary/Diff — the
         // Key + IdentityOccurrence planes) gets through a busy link instead of
@@ -3894,7 +3921,7 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
         // dispatches it identically — the sender chose packet-vs-resource purely
         // on payload size; the receiver need not care which arrived.
         //
-        // `send_on_link` ships via the link's CHANNEL, so it arrives as
+        // The link-Channel send ships via the link's CHANNEL, so it arrives as
         // `MessageReceived` (the channel-demuxed variant), NOT the raw
         // `LinkDataReceived`. We route BOTH: any bytes delivered over an
         // established link are candidate replication frames (CRPL-gated
@@ -3925,7 +3952,7 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             // event. Severity reflects whether the close was graceful.
             if let Some(bus) = ctx.event_bus {
                 let severity = match reason {
-                    reticulum_core::link::LinkCloseReason::Normal => {
+                    leviculum_core::link::LinkCloseReason::Normal => {
                         crate::events::EventSeverity::Info
                     }
                     _ => crate::events::EventSeverity::Warning,
@@ -4114,7 +4141,7 @@ fn route_supersession_decision(
 
 #[allow(clippy::too_many_lines)]
 async fn resolve_announce_cold_start(
-    announce: &reticulum_core::ReceivedAnnounce,
+    announce: &leviculum_core::ReceivedAnnounce,
     ctx: &EventCtx<'_>,
 ) {
     use ciris_persist::federation::self_at_login::BindingProvenance;
@@ -4757,7 +4784,7 @@ async fn build_local_attestation(
 ///    return; uses hardware RNG where the tier offers it), then
 ///    `keystore.load(key_id)` for the bytes.
 ///
-/// All branches return a constructed `reticulum_std::Identity`.
+/// All branches return a constructed `leviculum_std::Identity`.
 /// Failure to construct the Identity from the loaded bytes is a hard
 /// `TransportError::Config` — fail-loud, never a silently-misshapen
 /// identity.
@@ -4877,7 +4904,7 @@ fn load_or_generate_identity(path: &std::path::Path) -> Result<Identity, Transpo
         });
     }
 
-    let identity = reticulum_std::generate_identity();
+    let identity = leviculum_std::generate_identity();
     let bytes = identity
         .private_key_bytes()
         .map_err(|e| TransportError::Config(format!("serialize identity: {e}")))?;
@@ -4939,7 +4966,7 @@ fn apply_interface_config(
     match iface {
         #[cfg(feature = "transport-reticulum-auto")]
         ReticulumInterfaceConfig::Auto(cfg) => {
-            use reticulum_std::interfaces::auto_interface::AutoInterfaceConfig as LevAuto;
+            use leviculum_std::interfaces::auto_interface::AutoInterfaceConfig as LevAuto;
             let mut lev = LevAuto::default();
             if let Some(group_id) = &cfg.group_id {
                 lev.group_id = group_id.as_bytes().to_vec();

--- a/tests/explicit_hash_addressing.rs
+++ b/tests/explicit_hash_addressing.rs
@@ -47,12 +47,12 @@ use ciris_edge::cohort_scope::CohortScope;
 use ciris_edge::transport::addressing::{
     destination_from_pubkey_bytes, reticulum_destination_for_pubkey, RETICULUM_DEST_LEN,
 };
-use rand::rngs::OsRng;
-use rand::RngCore;
-use reticulum_core::{
+use leviculum_core::{
     AnnounceControl, AnnounceError, Destination, DestinationHash, DestinationType, Direction,
     Identity,
 };
+use rand::rngs::OsRng;
+use rand::RngCore;
 
 // ─── 1. Byte-equal determinism ──────────────────────────────────────
 

--- a/tests/relay_multi_tier_inner_byte_identity.rs
+++ b/tests/relay_multi_tier_inner_byte_identity.rs
@@ -20,8 +20,8 @@ use ciris_edge::transport::realtime_av::{
 };
 use ciris_edge::transport::realtime_av_relay::{PeerKeyId, RelayNode};
 
-use reticulum_core::{DestinationHash, Identity};
-use reticulum_std::driver::{ReticulumNode, ReticulumNodeBuilder};
+use leviculum_core::{DestinationHash, Identity};
+use leviculum_std::driver::{ReticulumNode, ReticulumNodeBuilder};
 use std::sync::Arc;
 
 /// Distinct synthetic per-link transit key per hop — each relay→relay


### PR DESCRIPTION
Adopt **leviculum v0.10.1+ciris.1** (the `reticulum-* → leviculum-*` upstream
catch-up) and land the **#370 round-outcome metrics instrument**.

Closes #371. Advances #370 (instrument only; the adaptive-timeout lever stays held
pending the load repro).

## Why move now

Upstream leviculum is active and adopts our patches. Staying on the pre-rename
`reticulum-*` pin means carrying fork-only deltas forever and *not* receiving
upstream fixes — most importantly the transport concurrency-ceiling fix tracked in
**leviculum#29** (one synchronous `Mutex<StdNodeCore>` serializing all inbound
crypto + outbound sends; the transport root of #370). This move puts us on the line
that will carry it.

## The re-anchor dropped four fork APIs — three migrated, one re-ported

| Dropped fork API | Resolution |
|---|---|
| `driver::send_on_link(id, data)` | → `driver.link_handle(id).try_send(data)` — folded into upstream `LinkHandle` over the **same** core Channel send; still returns real `Busy`, still arrives as `MessageReceived` |
| `register_destination_at(hash, dest)` | → `register_destination(dest)` — core already keys the routing table on `dest.hash()` (both call sites) |
| `connect_at(dest_hash, key)` | already subsumed by `connect(dest_hash, key)` |
| `Destination::with_explicit_hash(...)` | **no upstream equivalent** (private, derived hash) — the federation explicit-hash listen path (#191). Re-ported onto the rename in **leviculum#30 → v0.10.1+ciris.1** |

Plus the mechanical rename: Cargo.toml deps + `dep:` feature refs + 62
`reticulum_{core,std}::` import paths across 5 src / 2 test / 2 bench files. Edge's
own naming (`transport-reticulum*` features, the `reticulum.rs` module,
`TransportId::RETICULUM_RS`) and the `ReticulumNode`/`Builder` type names are kept —
upstream retained those.

## #370 round-outcome metrics

The field instrument for the leviculum#29 ceiling: a per-outcome anti-entropy round
counter (`completed` / `refused` / `timed_out` / `error`) on `EdgeMetrics`, wired
from the scheduler's existing `RoundEvent` event-sink through a runtime consumer
(zero-overhead when no metrics handle is configured), and surfaced on
`metrics_snapshot`. A `timed_out` share that climbs with active-peer count is the
field signature of the ceiling.

## Validation (local)

- `cargo check -D warnings` green across **core / reticulum / all-transports / pyo3**
  combos; `cargo clippy --all-targets -D warnings` (pyo3 combo) clean.
- `observability::round_outcomes_accumulate_per_outcome` — new unit test.
- `route_table_e2e::busy_reverse_path_delivers_a_packet_reply_interleaving_the_transfer`
  — validates the `LinkHandle::try_send` migration end-to-end.
- `explicit_hash_addressing` (9 tests) — validates `with_explicit_hash` +
  `register_destination` + explicit-hash announce suppression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
