### PR TITLE
fix(v13.5.1): re-pin leviculum v0.10.2+ciris.1 — off-lock resource builds relieve the #370 reply stall

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.5.0"
+version = "13.5.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -566,18 +566,20 @@ tempfile       = { version = "3", optional = true }
 # new AnnounceError::Pack(PacketError) — a breaking enum change, but edge only
 # matches AnnounceError::ExplicitHashCannotAnnounce (untouched), so the bump is
 # pin currency + the budget-const rewire with no match-arm churn.
-# v0.10.1+ciris.1 (CIRISEdge#371) — re-anchor on upstream leviculum/master
-# which adopts the `reticulum-* -> leviculum-*` crate rename. The fork carries
-# forward the CIRIS-only driver features (link_is_established, link_destination,
-# FramesDropped) + fork CI. Two fork APIs edge used were folded into upstream
-# idioms: `driver::send_on_link` -> `LinkHandle::try_send` (same core Channel
-# path) and `register_destination_at`/`connect_at` -> native
-# `register_destination`/`connect(dest_hash)`. v0.10.1 (leviculum#30) re-ports the
-# one remaining fork-only constructor `Destination::with_explicit_hash` — edge's
-# federation explicit-hash listen path (CIRISEdge#191) that upstream has no
-# equivalent for. The `+ciris.1` is fork build-metadata; the crate semver is 0.10.
-leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.10.1+ciris.1", version = "0.10", optional = true }
-leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.10.1+ciris.1", version = "0.10", optional = true }
+# v0.10.x+ciris.1 (CIRISEdge#371) — the `reticulum-* -> leviculum-*` upstream
+# rename line. Two fork APIs edge used were folded into upstream idioms:
+# `driver::send_on_link` -> `LinkHandle::try_send` (same core Channel path) and
+# `register_destination_at`/`connect_at` -> native `register_destination`/
+# `connect(dest_hash)`. v0.10.1 (leviculum#30) re-ported the one remaining
+# fork-only constructor `Destination::with_explicit_hash` — edge's federation
+# explicit-hash listen path (CIRISEdge#191) that upstream has no equivalent for.
+# v0.10.2 (leviculum#29 stage 1) builds resource sends OFF the node lock +
+# pre-hashes inbound packets: the reply-side node-wide inbound stall drops from
+# ~32% to ~1% (bench-measured), directly relieving the CIRISEdge#370 reply-stall
+# component — the round-outcome instrument (v13.5.0) observes it in the field.
+# The `+ciris.1` is fork build-metadata; the crate semver is 0.10.
+leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.10.2+ciris.1", version = "0.10", optional = true }
+leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.10.2+ciris.1", version = "0.10", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in


### PR DESCRIPTION
Re-pin leviculum `v0.10.1 → v0.10.2+ciris.1` (leviculum#29 stage 1). Resource sends now build **off** the node lock + inbound packets are pre-hashed, so a round reply no longer stalls the canonical's inbound processing — bench-measured on the leviculum Pages report as a **~32% → ~1%** drop in reply-side node-wide inbound stall (fan-out ceiling now ~11.7k pkts/s release).

Directly relieves the **#370** reply-stall component; the round-outcome instrument shipped in v13.5.0 observes it in the field. The deeper #370 lever (inbound decrypt serialization on the single mutex) remains leviculum#29 stages 2-3.

**Same-API re-pin** — only the tag string moves; no source change. Verified locally: `clippy -D warnings` (transport-http transport-reticulum pyo3 --all-targets) clean; busy-reverse-path e2e + explicit_hash_addressing pass.

Refs #370 leviculum#29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)