### PR TITLE
feat(v13.6.0): reverse-path reply rides the peer's live link (#353) + inbound drain survives a stalled reply (#373)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.5.1"
+version = "13.6.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -3152,8 +3152,12 @@ impl Edge {
                 // FIRST (the hop `run` had but this loop was missing, so the agent
                 // never delivered round-opens to the responder). Only fall through
                 // to envelope dispatch when it's not consumed by replication.
-                if route_replication_frame(edge_for_dispatch.replication_registry.get(), &frame)
-                    .await
+                if route_replication_frame(
+                    edge_for_dispatch.replication_registry.get(),
+                    &frame,
+                    Some(&edge_for_dispatch.metrics()),
+                )
+                .await
                 {
                     continue;
                 }
@@ -3638,7 +3642,9 @@ impl Edge {
                     // NEVER diverge again. Routes CRPL replication frames to the
                     // registry; returns true when consumed (→ do not envelope-
                     // dispatch). Every branch logs, throttled.
-                    if route_replication_frame(replication_registry.get(), &frame).await {
+                    if route_replication_frame(replication_registry.get(), &frame, Some(&metrics))
+                        .await
+                    {
                         continue;
                     }
                     let verify_clone = verify.clone();
@@ -3932,6 +3938,19 @@ static INBOUND_INGEST_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle>
     std::sync::OnceLock::new();
 static INBOUND_ROUTED_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
     std::sync::OnceLock::new();
+static INBOUND_BACKPRESSURE_DROP_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+
+/// CIRISEdge#373 — an inbound frame was DROPPED because the coordinator's inbound
+/// channel was full (a stalled responder reply parked the drain). Keyed on peer
+/// key_id (attacker-influenceable ⇒ capped map). Throttled because a real stall
+/// drops one frame per ~30 s round for many rounds; the EdgeMetrics counter carries
+/// the true magnitude, the WARN just needs to name the peer + kind without flooding.
+fn inbound_backpressure_drop_log() -> &'static crate::log_throttle::LogThrottle {
+    INBOUND_BACKPRESSURE_DROP_LOG.get_or_init(|| {
+        crate::log_throttle::LogThrottle::new(5, std::time::Duration::from_secs(60), 256)
+    })
+}
 
 /// A frame CROSSED transport→replication ingest. Keyed on transport id (a handful
 /// of values). Makes the previously-invisible hop VISIBLE at `ciris_edge=debug`.
@@ -3966,9 +3985,12 @@ fn inbound_routed_log() -> &'static crate::log_throttle::LogThrottle {
 async fn route_replication_frame(
     registry: Option<&std::sync::Arc<crate::replication::registry::ReplicationRegistry>>,
     frame: &InboundFrame,
+    // CIRISEdge#373 — live metrics handle so the back-pressure drop is COUNTED,
+    // not just WARN'd. `None` in tests / when no metrics bag is threaded.
+    metrics: Option<&crate::observability::EdgeMetrics>,
 ) -> bool {
     use crate::log_throttle::ThrottleDecision;
-    use crate::replication::registry::RouteOutcome;
+    use crate::replication::registry::{RegistryError, RouteOutcome};
 
     // The frame reached ingest — the hop that used to be invisible.
     if let ThrottleDecision::Emit { suppressed_prev } =
@@ -4033,6 +4055,30 @@ async fn route_replication_frame(
                 "CRPL frame DROPPED — no coordinator and no responder factory for (peer, kind); \
                  the ReplicationRuntime is not wired (CIRISEdge#348)"
             );
+            true
+        }
+        Err(e @ RegistryError::BackPressure { .. }) => {
+            // CIRISEdge#373 — the coordinator's bounded inbound channel is full:
+            // a responder reply stalled and parked the drain. This was a SILENT
+            // 100%-loss WARN; now it is counted (so the field sees the magnitude)
+            // and throttled (so a multi-round stall doesn't flood the log). With
+            // #353a/#353b/#373's send bound the stall itself is bounded, but the
+            // count stays as the tripwire.
+            if let Some(m) = metrics {
+                m.inc_inbound_backpressure_drop();
+            }
+            if let ThrottleDecision::Emit { suppressed_prev } =
+                inbound_backpressure_drop_log().check(source)
+            {
+                tracing::warn!(
+                    peer = %source,
+                    error = %e,
+                    suppressed_prev,
+                    "replication inbound frame DROPPED — coordinator channel full (a responder \
+                     reply stalled and the round can't drain); counted in \
+                     EdgeMetrics.replication_inbound_backpressure_drops (CIRISEdge#373)"
+                );
+            }
             true
         }
         Err(e) => {
@@ -7381,7 +7427,7 @@ mod inbound_ingest_tests {
                 refs: vec![],
             }));
         assert!(
-            route_replication_frame(Some(&registry), &frame(crpl, Some("agent-peer"))).await,
+            route_replication_frame(Some(&registry), &frame(crpl, Some("agent-peer")), None).await,
             "a CRPL replication frame MUST be consumed by ingest, never envelope-dispatched (#348)",
         );
     }
@@ -7396,7 +7442,8 @@ mod inbound_ingest_tests {
                 &frame(
                     b"{\"edge_schema_version\":\"2.0.0\"}".to_vec(),
                     Some("agent-peer")
-                )
+                ),
+                None,
             )
             .await,
             "a plain envelope must fall through to envelope dispatch",
@@ -7412,6 +7459,104 @@ mod inbound_ingest_tests {
                 kind: EnvelopeKind::Key,
                 refs: vec![],
             }));
-        assert!(!route_replication_frame(None, &frame(crpl, Some("agent-peer"))).await);
+        assert!(!route_replication_frame(None, &frame(crpl, Some("agent-peer")), None).await);
+    }
+
+    /// CIRISEdge#373 — when a responder reply stalls, the coordinator's bounded
+    /// inbound channel fills and the frame is dropped. Pre-#373 that was a SILENT
+    /// `tracing::warn!` — 100% of a churning mobile's trace vanished uncounted.
+    /// Now the drop is COUNTED (and the frame still CONSUMED, never mis-dispatched
+    /// to the envelope verifier). Reproduces the exact drop condition: a full
+    /// channel with no drain (a parked responder) → `BackPressure` → counted.
+    #[tokio::test]
+    async fn backpressure_drop_is_counted_not_silent() {
+        use crate::observability::EdgeMetrics;
+        use crate::replication::coordinator::ReplicationCoordinator;
+        use crate::replication::protocol::EnvelopeRef;
+        use crate::replication::session::SessionRole;
+        use crate::replication::summary::{StateApplier, StateProvider};
+        use crate::transport::{Transport, TransportError, TransportSendOutcome};
+        use std::sync::Arc;
+        use tokio::sync::Mutex;
+
+        struct NoopTransport;
+        #[async_trait::async_trait]
+        impl Transport for NoopTransport {
+            fn id(&self) -> TransportId {
+                TransportId::RETICULUM_RS
+            }
+            async fn send(
+                &self,
+                _d: &str,
+                _b: &[u8],
+            ) -> Result<TransportSendOutcome, TransportError> {
+                Ok(TransportSendOutcome::Delivered)
+            }
+            async fn listen(
+                &self,
+                _s: tokio::sync::mpsc::Sender<InboundFrame>,
+            ) -> Result<(), TransportError> {
+                unimplemented!("this test never drives listen")
+            }
+        }
+        struct NoProvider;
+        impl StateProvider for NoProvider {
+            fn local_refs(&self, _k: EnvelopeKind) -> Vec<EnvelopeRef> {
+                vec![]
+            }
+            fn fetch_envelope(&self, _k: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+        }
+        struct NoApplier;
+        impl StateApplier for NoApplier {
+            fn apply_envelope(&mut self, _k: EnvelopeKind, _b: &[u8]) -> bool {
+                false
+            }
+        }
+
+        let peer = "stalled-mobile";
+        let coord = Arc::new(ReplicationCoordinator::new(
+            Arc::new(NoopTransport),
+            peer,
+            EnvelopeKind::Key,
+            SessionRole::Responder,
+            Arc::new(NoProvider) as Arc<dyn StateProvider>,
+            Arc::new(Mutex::new(NoApplier)) as Arc<Mutex<dyn StateApplier>>,
+        ));
+        // Fill the bounded inbound channel to capacity with NOTHING draining it —
+        // exactly a responder parked on a stalled reply (the #353 root of #373).
+        for _ in 0..ReplicationCoordinator::INBOUND_CHANNEL_CAPACITY {
+            coord
+                .deliver_inbound(ReplicationMessage::Summary(SummaryMessage {
+                    kind: EnvelopeKind::Key,
+                    refs: vec![],
+                }))
+                .expect("channel not yet full");
+        }
+        let registry = std::sync::Arc::new(ReplicationRegistry::new());
+        registry
+            .register(peer.to_string(), EnvelopeKind::Key, Arc::clone(&coord))
+            .await;
+
+        let metrics = EdgeMetrics::new();
+        let crpl =
+            crate::replication::wire_frame::wrap(&ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Key,
+                refs: vec![],
+            }));
+        // This frame can't fit → BackPressure. Pre-#373: a silent WARN, lost.
+        let consumed =
+            route_replication_frame(Some(&registry), &frame(crpl, Some(peer)), Some(&metrics))
+                .await;
+        assert!(
+            consumed,
+            "a back-pressure-dropped CRPL frame is still CONSUMED, never envelope-dispatched",
+        );
+        assert_eq!(
+            metrics.inbound_backpressure_drops(),
+            1,
+            "the back-pressure drop MUST be counted, not silent (CIRISEdge#373)",
+        );
     }
 }

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2120,6 +2120,14 @@ impl PyEdge {
         }
         root.set_item("replication_round_outcomes_total", round_outcomes)?;
 
+        // CIRISEdge#373 — inbound frames dropped on coordinator channel
+        // back-pressure (a stalled responder reply parking the drain). Was a
+        // silent WARN; a non-zero value is the tripwire for the #353 reply stall.
+        root.set_item(
+            "replication_inbound_backpressure_drops",
+            bundle.replication_inbound_backpressure_drops,
+        )?;
+
         Ok(root.unbind().into_any())
     }
 

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -287,6 +287,15 @@ pub struct EdgeMetrics {
     /// field signature of the transport concurrency ceiling — the whole
     /// reason this counter exists.
     pub replication_round_outcomes_total: Arc<RwLock<HashMap<RoundOutcome, u64>>>,
+    /// CIRISEdge#373 — cumulative count of inbound replication frames dropped
+    /// because the target coordinator's bounded inbound channel was full
+    /// (`RegistryError::BackPressure`). Before this counter the drop was a bare
+    /// `tracing::warn!` — 100% of a churning mobile's Attestation trace was
+    /// destroyed *silently*. A non-zero value means a responder reply stalled
+    /// long enough to park the inbound drain (pairs with #370: the round would
+    /// also show `timed_out`). Single `Arc<AtomicU64>`; the offending peer + kind
+    /// ride the matching throttled WARN.
+    pub replication_inbound_backpressure_drops: Arc<std::sync::atomic::AtomicU64>,
 }
 
 impl EdgeMetrics {
@@ -350,6 +359,22 @@ impl EdgeMetrics {
         *guard.entry(outcome).or_insert(0) += 1;
     }
 
+    /// CIRISEdge#373 — increment the inbound-backpressure-drop counter. Called
+    /// once per dropped frame at the `route_replication_frame` back-pressure
+    /// path, so the previously-silent 100% trace loss is countable.
+    pub fn inc_inbound_backpressure_drop(&self) {
+        self.replication_inbound_backpressure_drops
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// CIRISEdge#373 — read the inbound-backpressure-drop counter (tests +
+    /// snapshot projection).
+    #[must_use]
+    pub fn inbound_backpressure_drops(&self) -> u64 {
+        self.replication_inbound_backpressure_drops
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// CIRISEdge#48-B (v0.19.6) — increment the
     /// `inbound_dropped_low_trust` counter. Called from
     /// `dispatch_inbound` once per drop.
@@ -394,6 +419,7 @@ impl EdgeMetrics {
             peer_reachability_ratio: self.peer_reachability_ratio.read().clone(),
             inbound_dropped_low_trust: self.inbound_dropped_low_trust(),
             replication_round_outcomes_total: self.replication_round_outcomes_total.read().clone(),
+            replication_inbound_backpressure_drops: self.inbound_backpressure_drops(),
         }
     }
 }
@@ -419,6 +445,9 @@ pub struct EdgeMetricsBundle {
     /// (keyed by [`RoundOutcome`]). Empty until the runtime is started
     /// with a live metrics handle configured.
     pub replication_round_outcomes_total: HashMap<RoundOutcome, u64>,
+    /// CIRISEdge#373 — cumulative inbound frames dropped on coordinator
+    /// channel back-pressure (previously a silent WARN).
+    pub replication_inbound_backpressure_drops: u64,
 }
 
 #[cfg(test)]

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -64,6 +64,14 @@ use super::session::SessionRole;
 use super::summary::{StateApplier, StateProvider};
 use crate::transport::Transport;
 
+/// CIRISEdge#373 — upper bound on a single responder reply send inside the
+/// drive loop. Chosen well under the 30 s anti-entropy cadence so a stalled
+/// reply (a reverse-path corpse + NAT-blocked dial can otherwise run ~130 s)
+/// yields the inbound drain before the capacity-8 channel overflows and starts
+/// dropping the peer's trace frames. With #353a/#353b the reply usually lands in
+/// a few seconds on the peer's live link; this only bites the degenerate case.
+const RESPONDER_REPLY_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
 /// CIRISEdge#348 — drive a factory-created **Responder** coordinator.
 ///
 /// The registry only STORES a coordinator; the [`ReplicationScheduler`] drives
@@ -93,12 +101,40 @@ fn spawn_responder_drive(coord: Arc<ReplicationCoordinator>) {
             match coord.drive_round_step(Some(msg)).await {
                 Ok(DriveStep::SendThenWait(msgs)) => {
                     for m in &msgs {
-                        if let Err(e) = coord.send_message(m).await {
-                            tracing::warn!(
-                                peer = %peer, ?kind, error = %e,
-                                "responder reply send failed — round will not complete (CIRISEdge#348)"
-                            );
-                            break;
+                        // CIRISEdge#373 — BOUND the reply send. This loop is the
+                        // responder's only inbound drain; a reply that blocks here
+                        // (a reverse-path stall to a churning NAT'd peer + the
+                        // NAT-blocked dial fallback = up to ~130 s) parks the drain
+                        // while the peer keeps pushing frames, overflowing the
+                        // capacity-8 inbound channel and silently dropping 100% of
+                        // the trace. Cap it well under the round cadence so a stalled
+                        // reply yields the drain; the abandoned send is safe (its
+                        // awaits — resource wait, dial — are cancellation-tolerant,
+                        // and the anti-entropy protocol is idempotent + retried).
+                        match tokio::time::timeout(
+                            RESPONDER_REPLY_SEND_TIMEOUT,
+                            coord.send_message(m),
+                        )
+                        .await
+                        {
+                            Ok(Ok(())) => {}
+                            Ok(Err(e)) => {
+                                tracing::warn!(
+                                    peer = %peer, ?kind, error = %e,
+                                    "responder reply send failed — round will not complete (CIRISEdge#348)"
+                                );
+                                break;
+                            }
+                            Err(_elapsed) => {
+                                tracing::warn!(
+                                    peer = %peer, ?kind,
+                                    timeout_secs = RESPONDER_REPLY_SEND_TIMEOUT.as_secs(),
+                                    "responder reply send TIMED OUT — abandoning it so the inbound \
+                                     drain resumes and the peer's trace is not dropped (CIRISEdge#373); \
+                                     the next round rides the peer's fresh link"
+                                );
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -242,6 +242,18 @@ impl ShipError {
 const REVERSE_PATH_BUSY_RETRY_WINDOW: Duration = Duration::from_secs(8);
 /// Pause between busy-retries on the reverse path.
 const REVERSE_PATH_BUSY_BACKOFF: Duration = Duration::from_millis(500);
+/// CIRISEdge#353b — resource-completion timeout for a REVERSE-PATH reply,
+/// deliberately far shorter than the 120 s [`RESOURCE_TRANSFER_TIMEOUT`] used on
+/// the outbound-dial path. A reply's small Summary/Diff/Deliver payload completes
+/// in a few seconds on a genuinely live link; if it hasn't in 10 s the link is a
+/// NAT-dead-but-`Active` corpse (the mobile churns links every ~30 s), and edge
+/// must NOT commit 120 s to it — the round times out and, worse, the stalled send
+/// parks the responder's inbound drain until every queued frame is dropped (#373).
+/// 10 s > the round-open RTT + transfer on a live link, but bounds the corpse case
+/// so the NEXT round rides the peer's fresh link. `link_last_inbound_at` selection
+/// (#353a) already avoids the corpse when a live link exists; this bounds the
+/// degenerate window where it is momentarily the only `Active` candidate.
+const REVERSE_PATH_RESOURCE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// CIRISEdge#336 (fast heal) — minimum interval between EVENT-DRIVEN announces.
 ///
@@ -1359,6 +1371,18 @@ pub struct ReticulumTransport {
     /// been LinkIdentified yet, or when the link's remote identity
     /// doesn't match any rooted peer (pre-handshake / cold-start).
     link_to_peer_key_id: Arc<Mutex<HashMap<LinkId, String>>>,
+    /// CIRISEdge#353 — per-link last-inbound timestamp (unix seconds),
+    /// stamped by `attribute_and_deliver` on EVERY inbound frame this link
+    /// carries. This is the RNS `last_inbound` liveness signal (leviculum-core
+    /// tracks it internally for staleness — `link/mod.rs::last_inbound_secs` —
+    /// but the std driver doesn't expose it, so edge mirrors it from the frames
+    /// it sees). `live_attributed_link_to` selects the peer's link with the
+    /// FRESHEST inbound — the link the peer is actively sending its round on —
+    /// so a NAT-dead link that leviculum still reports `Active` (no recent
+    /// inbound) is never chosen as the reply target, which is exactly the #353
+    /// field failure (a 120 s resource timeout shipping into a dead-but-Active
+    /// link). Removed on `LinkClosed`.
+    link_last_inbound_at: Arc<Mutex<HashMap<LinkId, u64>>>,
     /// CIRISEdge#32 (v0.14.0) — request/response slot. The listen-loop
     /// populates this on `NodeEvent::ResponseReceived` keyed by
     /// `request_id`; [`Self::link_request`] polls + removes.
@@ -1883,6 +1907,7 @@ impl ReticulumTransport {
             interface_specs: Arc::new(std::sync::Mutex::new(interface_specs)),
             link_established_at: Arc::new(Mutex::new(HashMap::new())),
             link_to_peer_key_id: Arc::new(Mutex::new(HashMap::new())),
+            link_last_inbound_at: Arc::new(Mutex::new(HashMap::new())),
             request_responses: Arc::new(Mutex::new(HashMap::new())),
             timed_out_requests: Arc::new(Mutex::new(HashSet::new())),
             blackhole: blackhole_rules,
@@ -3028,11 +3053,26 @@ impl ReticulumTransport {
             .filter(|(_, peer)| peer.as_str() == destination_key_id)
             .map(|(id, _)| *id)
             .collect();
+        let last_inbound = self.link_last_inbound_at.lock().await;
         let established_at = self.link_established_at.lock().await;
-        candidates
+        // CIRISEdge#353 — build the (link, last_inbound, established_at) tuples
+        // for the peer's links leviculum still holds `Active`, then let the pure
+        // selector choose. `link_is_established` is a NECESSARY liveness gate but
+        // NOT sufficient (a NAT-dead link stays `Active` for the whole stale
+        // window), so the selector additionally prefers the freshest INBOUND —
+        // the link the peer is demonstrably sending on right now.
+        let live: Vec<(LinkId, u64, u64)> = candidates
             .into_iter()
             .filter(|id| self.node.link_is_established(id))
-            .max_by_key(|id| established_at.get(id).copied().unwrap_or(0))
+            .map(|id| {
+                (
+                    id,
+                    last_inbound.get(&id).copied().unwrap_or(0),
+                    established_at.get(&id).copied().unwrap_or(0),
+                )
+            })
+            .collect();
+        select_reply_link(&live)
     }
 
     /// CIRISEdge#353 — REVERSE PATH FIRST. If the peer holds a LIVE link to us
@@ -3083,7 +3123,10 @@ impl ReticulumTransport {
                 return false;
             };
             attempts += 1;
-            match self.ship_resource_on_link(&link_id, envelope_bytes).await {
+            match self
+                .ship_resource_on_link(&link_id, envelope_bytes, REVERSE_PATH_RESOURCE_TIMEOUT)
+                .await
+            {
                 Ok(()) => {
                     tracing::debug!(
                         destination_key_id,
@@ -3190,6 +3233,10 @@ impl ReticulumTransport {
         &self,
         link_id: &LinkId,
         envelope_bytes: &[u8],
+        // CIRISEdge#353b — completion timeout. The reverse-path reply passes the
+        // short [`REVERSE_PATH_RESOURCE_TIMEOUT`] (fail fast on a dead-but-Active
+        // link); the outbound-dial path passes [`RESOURCE_TRANSFER_TIMEOUT`].
+        completion_timeout: Duration,
     ) -> Result<(), ShipError> {
         // CIRISEdge#353 test seam — deterministically simulate the
         // one-transfer-per-link collision (see `test_force_busy`).
@@ -3225,17 +3272,17 @@ impl ReticulumTransport {
         // Wait for the sender-side `ResourceCompleted` — the driver
         // paces + retransmits resource parts, and completion means
         // every part was delivered + proven. If the transfer does not
-        // complete within the window, treat it as a timeout so edge's
-        // durable dispatcher retries.
-        let completed = wait_until_async(
-            RESOURCE_TRANSFER_TIMEOUT,
-            Duration::from_millis(100),
-            || async { self.sent_resources.lock().await.remove(&resource_hash) },
-        )
-        .await;
+        // complete within `completion_timeout` (short on the reverse path,
+        // #353b), treat it as a timeout so edge's durable dispatcher retries
+        // and the responder's inbound drain is not parked (#373).
+        let completed =
+            wait_until_async(completion_timeout, Duration::from_millis(100), || async {
+                self.sent_resources.lock().await.remove(&resource_hash)
+            })
+            .await;
         if !completed {
             return Err(ShipError::Other(TransportError::Timeout(
-                RESOURCE_TRANSFER_TIMEOUT,
+                completion_timeout,
             )));
         }
         Ok(())
@@ -3425,7 +3472,9 @@ impl Transport for ReticulumTransport {
         // The outbound-dial path we just established this link; a `Busy`
         // collision here is not the reverse-path retry case, so both variants
         // surface as the send's transport error (the durable dispatcher retries).
-        self.ship_resource_on_link(&link_id, envelope_bytes)
+        // Full [`RESOURCE_TRANSFER_TIMEOUT`] here — this is a freshly-dialed link
+        // we control, not the churn-prone reverse path.
+        self.ship_resource_on_link(&link_id, envelope_bytes, RESOURCE_TRANSFER_TIMEOUT)
             .await
             .map_err(ShipError::into_transport)?;
 
@@ -3532,6 +3581,7 @@ impl Transport for ReticulumTransport {
                         request_responses: &self.request_responses,
                         timed_out_requests: &self.timed_out_requests,
                         link_to_peer_key_id: &self.link_to_peer_key_id,
+                        link_last_inbound_at: &self.link_last_inbound_at,
                     };
                     handle_event(event, &ctx).await;
 
@@ -3616,6 +3666,10 @@ struct EventCtx<'a> {
     /// `InboundFrame::source_key_id` for the
     /// `Edge::install_replication_routing` lookup.
     link_to_peer_key_id: &'a Mutex<HashMap<LinkId, String>>,
+    /// CIRISEdge#353 — per-link last-inbound timestamp (RNS `last_inbound`
+    /// liveness signal); stamped in `attribute_and_deliver`, consumed by
+    /// `live_attributed_link_to` to reply over the peer's freshest live link.
+    link_last_inbound_at: &'a Mutex<HashMap<LinkId, u64>>,
 }
 
 /// Handle one [`NodeEvent`]. Announce events populate the peer map;
@@ -3638,6 +3692,19 @@ struct EventCtx<'a> {
 /// DESTINATION (a link WE dialed — the reverse path), then `None`
 /// (SkippedNoSourceKeyId downstream, never a silent drop).
 async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8>) {
+    // CIRISEdge#353 — stamp last-inbound for the reverse-path link selector
+    // (RNS `last_inbound`). This frame proves the peer is ALIVE on THIS link
+    // right now, so a subsequent reply rides it rather than a dead-but-`Active`
+    // link leviculum hasn't yet flipped to Stale. Stamped for both the resource
+    // and packet inbound paths (both funnel here), so any traffic keeps the link
+    // fresh in the selector.
+    {
+        let now_secs = u64::try_from(chrono::Utc::now().timestamp().max(0)).unwrap_or(0);
+        ctx.link_last_inbound_at
+            .lock()
+            .await
+            .insert(link_id, now_secs);
+    }
     let mut source_key_id = ctx.link_to_peer_key_id.lock().await.get(&link_id).cloned();
     // CIRISEdge#353 — INITIATOR-side attribution. `link_to_peer_key_id` is fed by
     // `LinkIdentified`, which only fires on links a PEER dialed to us; a reply
@@ -3674,6 +3741,34 @@ async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8
     if let Err(e) = ctx.sink.send(frame).await {
         tracing::error!(error = %e, "inbound channel send failed");
     }
+}
+
+/// CIRISEdge#353 — choose which of a peer's live links a reply rides.
+///
+/// Prefer the link with the most recent INBOUND activity (RNS's `last_inbound`
+/// liveness signal, `RNS.Link.last_inbound` / leviculum `last_inbound_secs`):
+/// the peer is demonstrably sending its round on that link right now, so the
+/// reply lands. A NAT-dead link that leviculum still reports `Active` has stale
+/// inbound and loses — which stops the reply from committing to a corpse (the
+/// #353 field failure: a 120 s resource timeout shipping into a dead-but-Active
+/// link, then a NAT-blocked fallback dial). Tie-break on establishment time
+/// (newer wins) so two links opened in the same second choose deterministically.
+///
+/// Threat-model guardrail: `live` is ALREADY liveness-filtered AND attributed to
+/// the peer by the caller (identity-proof / verified-dest). This fn only ORDERS
+/// those candidates — it never widens attribution, so it can never route a reply
+/// to a link the peer did not prove control of.
+fn select_reply_link(
+    live: &[(
+        LinkId,
+        u64, /* last_inbound */
+        u64, /* established_at */
+    )],
+) -> Option<LinkId> {
+    live.iter()
+        .copied()
+        .max_by_key(|(_, last_inbound, established_at)| (*last_inbound, *established_at))
+        .map(|(id, _, _)| id)
 }
 
 #[allow(clippy::too_many_lines)] // one exhaustive NodeEvent dispatch match; splitting it hurts readability
@@ -3947,6 +4042,9 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             // v3.5.1 (CIRISEdge#119 + #120) — drop the link's rooted
             // peer attribution when the link closes.
             ctx.link_to_peer_key_id.lock().await.remove(&link_id);
+            // CIRISEdge#353 — drop the link's last-inbound stamp too, so a
+            // closed link can never win the reverse-path selector.
+            ctx.link_last_inbound_at.lock().await.remove(&link_id);
             tracing::debug!(link = ?link_id, reason = ?reason, "link closed");
             // CIRISEdge#34 link half (v0.14.0) — emit `link_closed`
             // event. Severity reflects whether the close was graceful.
@@ -5123,6 +5221,52 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── CIRISEdge#353 reverse-path reply-link selection — the pure decision ──
+    //
+    // Field failure (Node A ↔ mobile, edge v13.5.0): the mobile churns ~10 links
+    // /30 s; a NAT-dead link stays leviculum-`Active` for the stale window and is
+    // the NEWEST-established, so the pre-fix selector (`max_by established_at`)
+    // shipped the reply into a corpse → 120 s resource timeout → NAT-blocked dial.
+    // The fix orders by last-INBOUND (RNS `last_inbound`): a dead link receives
+    // nothing, so the peer's CURRENT live link wins. Pure fn ⇒ compile-fast guard.
+    mod reply_link_selection {
+        use super::*;
+
+        fn lid(b: u8) -> LinkId {
+            LinkId::new([b; 16])
+        }
+
+        #[test]
+        fn prefers_freshest_inbound_over_newest_established() {
+            let dead = lid(0xDE); // NEWEST established, but STALE inbound (NAT-dead, still Active)
+            let live = lid(0x11); // older established, FRESH inbound (the peer's current link)
+                                  // (link, last_inbound, established_at)
+            let candidates = [(dead, 100, 200), (live, 150, 150)];
+            // Pre-fix `max_by(established_at)` picks `dead`; the fix picks `live`.
+            assert_eq!(select_reply_link(&candidates), Some(live));
+        }
+
+        #[test]
+        fn tie_breaks_on_established_when_inbound_equal() {
+            let older = lid(0x01);
+            let newer = lid(0x02);
+            assert_eq!(
+                select_reply_link(&[(older, 100, 10), (newer, 100, 20)]),
+                Some(newer)
+            );
+        }
+
+        #[test]
+        fn only_a_corpse_left_still_returns_it_so_the_caller_can_fast_fail() {
+            // The peer's only Active link is the dead one (its fresh link is still
+            // Pending). We still return it; #353b fast-fails the send so the next
+            // round rides the fresh link — no 120 s hang on the corpse.
+            let dead = lid(0xDE);
+            assert_eq!(select_reply_link(&[(dead, 100, 200)]), Some(dead));
+            assert_eq!(select_reply_link(&[]), None);
+        }
+    }
 
     // ── CIRISEdge#336/#337 route-supersession decision — the saga's tombstone ──
     //


### PR DESCRIPTION
The first mobile trace's **final inch** — the two stacked edge defects that lost the Attestation trace (0 `trace_events` rows) despite the mobile actively sending. Adopts the **RNS/LXMF liveness primitive** instead of hand-rolled heuristics (see the store-and-forward + threat-model analysis in #353/#373 discussion).

Closes #353, #373. Advances #370 (new drop counter).

## #353 — reverse-path reply rides the peer's *current live* link
- **Root** (corrects the ticket's premise): the reply was never pinned to the arrival link — `live_attributed_link_to` already re-resolves per-peer, but it picked **newest-established** and gated on `link_is_established` (leviculum `Active`). A NAT-dead link stays `Active` for the whole stale window (up to 2×keepalive), so the reply shipped into a **corpse** → 120s resource timeout → NAT-blocked dial.
- **Fix** (RNS `last_inbound`, `RNS.Link.last_inbound` / leviculum `last_inbound_secs`): stamp per-link last-inbound in `attribute_and_deliver`; select the **freshest-inbound** link — the one the peer is demonstrably sending its round on. A dead link receives nothing and loses. Extracted to a pure `select_reply_link` fn, unit-tested with the exact field scenario.
- **Fast-fail**: reverse-path resource send bounds at `REVERSE_PATH_RESOURCE_TIMEOUT` (10s) not the 120s dial timeout — no committing 120s to a corpse.

## #373 — a stalled reply must not destroy the inbound trace
- **Root**: the responder drive loop is serial (`recv → step → send.await`); a reply blocking ~130s (reverse-path corpse + NAT dial) parks the capacity-8 inbound drain, dropping 100% of subsequent frames **silently + uncounted**.
- **Fix**: bound the reply send (`RESPONDER_REPLY_SEND_TIMEOUT` 20s, < 30s cadence) so a stall yields the drain — the abandoned send is cancellation-safe + idempotent-retried; **count** the drop in `EdgeMetrics.replication_inbound_backpressure_drops` + throttle the WARN.

## Threat model (per the store-and-forward review)
B/A add **no new surface** — selection only *orders* links already identity-proven/dest-verified for the peer; the reply stays signed end-to-end. **Store-and-forward was deliberately not used** (its third-party-propagation variant is the only option that widens the privacy/availability surface, and the anti-entropy retry is already the pull). **A** (reply-over-arrival-link) held as a zero-new-surface field-gated follow-up.

## Verification (local)
- **Reproductions** (each fails without its fix): `reply_link_selection` ×3 (old `max_by established_at` picks the dead link), `backpressure_drop_is_counted_not_silent` (old branch never counts).
- **Regression**: busy-reverse-path e2e green (touched `ship_resource_on_link`).
- **Gate**: `clippy -D warnings` (transport-http + transport-reticulum + pyo3, `--all-targets`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
