### PR TITLE
feat(v13.7.0): initiator-first proactive publish for NAT'd peers (#927) + collapse the register_peer footgun

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.6.1"
+version = "13.7.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2313,10 +2313,15 @@ impl PyReplicationHandle {
         })
     }
 
-    /// Hot-add a `(peer_key_id, kind)` after start. Defaults to
-    /// Responder role — for the CEG-driven reconciler path that
-    /// needs the new peer to actively initiate rounds, use
-    /// [`Self::register_initiator_peer`] (CIRISEdge#173 / v5.1.0).
+    /// Hot-add a `(peer_key_id, kind)` peer this node actively replicates with
+    /// — routes inbound AND drives periodic anti-entropy rounds.
+    ///
+    /// v13.7.0 — this is the ONE hot-add and it does the unsurprising thing
+    /// (active replication). It no longer defaults to a passive Responder that
+    /// never pulls (a footgun). **Serve-only peers need no call** — the
+    /// responder factory auto-registers them on their first inbound round.
+    /// [`Self::register_initiator_peer`] is now a redundant alias (kept for
+    /// back-compat). Raises `RuntimeError` if the runtime has stopped.
     fn register_peer(&self, py: Python<'_>, peer_key_id: &str, kind: &str) -> PyResult<()> {
         let kind = parse_envelope_kind(kind)?;
         let peer = peer_key_id.to_string();
@@ -2325,12 +2330,17 @@ impl PyReplicationHandle {
         py.detach(|| {
             run_async(&executor, async move {
                 let guard = inner.lock().await;
-                if let Some(rt) = guard.as_ref() {
-                    rt.register_peer(peer, kind).await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .register_peer(peer, kind)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
                 }
-            });
-        });
-        Ok(())
+            })
+        })
     }
 
     /// CIRISEdge#173 / v5.1.0 — hot-add an Initiator peer at runtime.

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -155,6 +155,17 @@ impl ReplicationCoordinator {
         }
     }
 
+    /// CIRISEdge#927 — enable initiator-first proactive publish on this
+    /// coordinator's session (see [`Session::with_proactive_publish`]). Builder
+    /// form so [`Self::new`]'s signature (many call sites) stays put; the session
+    /// is fresh at construction, so replacing it is safe. Only meaningful for
+    /// Initiators — Responders never `start_round`.
+    #[must_use]
+    pub fn with_proactive_publish(self, yes: bool) -> Self {
+        let session = Mutex::new(Session::new(self.role, self.kind).with_proactive_publish(yes));
+        Self { session, ..self }
+    }
+
     /// Deliver an inbound replication message into this coordinator's
     /// queue. Called by the application's [`Transport::listen`] loop
     /// after [`Self::parse_inbound_bytes`] yields a

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -232,6 +232,10 @@ pub struct ReplicationRuntime {
     /// live coordinator tasks. Drives [`Self::set_peers`]'s diff.
     /// Pre-v5.1 entries (passed to `start`) populate this on init.
     current_initiators: Arc<Mutex<HashSet<(String, EnvelopeKind)>>>,
+    /// CIRISEdge#927 — whether this node's Initiator rounds proactively deliver
+    /// their publish set (set iff `start` got a `self_provider`). Applied to
+    /// every Initiator coordinator this runtime builds, including hot-adds.
+    proactive_publish: bool,
 }
 
 /// Failure modes for the v5.1.0 runtime peer-mutation API
@@ -294,6 +298,13 @@ impl ReplicationRuntime {
         // common path.
         let cohort_snapshot: Vec<String> = peers.iter().map(|p| p.peer_key_id.clone()).collect();
         let cohort: CohortProvider = Arc::new(move || cohort_snapshot.clone());
+
+        // CIRISEdge#927 — a node started with a self-publish set (`self_provider`
+        // / `key_publish_set`) is one whose Initiator rounds should proactively
+        // DELIVER that set (initiator-first, so a carrier-NAT'd peer's round can
+        // complete without a return-path Diff). Capture before `self_provider` is
+        // moved into the bridge.
+        let proactive_publish = self_provider.is_some();
 
         let bridge = Arc::new(
             FederationDirectoryReplicationBridge::with_config(
@@ -359,14 +370,17 @@ impl ReplicationRuntime {
                 let applier: Arc<tokio::sync::Mutex<dyn StateApplier>> = Arc::new(
                     tokio::sync::Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)),
                 );
-                Arc::new(ReplicationCoordinator::new(
-                    Arc::clone(&transport),
-                    &peer.peer_key_id,
-                    peer.kind,
-                    SessionRole::Initiator,
-                    provider,
-                    applier,
-                ))
+                Arc::new(
+                    ReplicationCoordinator::new(
+                        Arc::clone(&transport),
+                        &peer.peer_key_id,
+                        peer.kind,
+                        SessionRole::Initiator,
+                        provider,
+                        applier,
+                    )
+                    .with_proactive_publish(proactive_publish),
+                )
             })
             .collect();
 
@@ -423,27 +437,37 @@ impl ReplicationRuntime {
             config,
             scheduler_handle,
             current_initiators: Arc::new(Mutex::new(initial_initiator_set)),
+            proactive_publish,
         }
     }
 
-    /// Hot-add a new `(peer_key_id, kind)` Initiator. Constructs a
-    /// coordinator, registers it, **but does NOT add to the
-    /// scheduler's Initiator set** for v1 — that requires the
-    /// scheduler to expose dynamic adds (not in the v1 API).
+    /// Hot-add a `(peer_key_id, kind)` peer this node actively replicates
+    /// with — routes inbound AND drives periodic anti-entropy rounds.
     ///
-    /// For now hot-add lets the Responder-side route inbound for
-    /// the new peer; the Initiator side would need a runtime
-    /// restart to fire periodic rounds. This is acceptable for the
-    /// hot-add-is-uncommon v1 posture; a v1.x patch will extend
-    /// the scheduler with a dynamic-add API.
-    pub async fn register_peer(&self, peer_key_id: impl Into<String>, kind: EnvelopeKind) {
-        let peer_key_id = peer_key_id.into();
-        let coord = self.build_coordinator(&peer_key_id, kind, SessionRole::Responder);
-        self.registry.register(peer_key_id, kind, coord).await;
+    /// v13.7.0 — this is now the ONE hot-add, and it does the unsurprising
+    /// thing (active replication). It previously defaulted to a passive
+    /// **Responder** (routed inbound but never pulled) — a footgun: it read
+    /// like "register this peer" but silently did no rounds, and it duplicated
+    /// the #312 responder factory, which already auto-registers a Responder on
+    /// the first inbound round from any uncoordinated peer. So **serve-only
+    /// peers need no call at all** — the factory handles them; callers who mean
+    /// "replicate with this peer" get exactly that.
+    ///
+    /// Delegates to [`Self::register_initiator_peer`] (the CIRISEdge#173 control
+    /// plane); returns its error if the scheduler has stopped.
+    pub async fn register_peer(
+        &self,
+        peer_key_id: impl Into<String>,
+        kind: EnvelopeKind,
+    ) -> Result<(), ReplicationRuntimeError> {
+        self.register_initiator_peer(peer_key_id, kind).await
     }
 
     /// Hot-add a `(peer_key_id, kind)` **Initiator** coordinator —
     /// CIRISEdge#173, v5.1.0.
+    ///
+    /// v13.7.0 — [`Self::register_peer`] now does exactly this, so this method
+    /// is a redundant alias kept for back-compat; prefer `register_peer`.
     ///
     /// Builds a coordinator in [`SessionRole::Initiator`], registers
     /// it with the registry (so inbound replies route correctly),
@@ -563,14 +587,19 @@ impl ReplicationRuntime {
             Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
         let applier: Arc<Mutex<dyn StateApplier>> =
             Arc::new(Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)));
-        Arc::new(ReplicationCoordinator::new(
-            Arc::clone(&self.transport),
-            peer_key_id.to_string(),
-            kind,
-            role,
-            provider,
-            applier,
-        ))
+        // CIRISEdge#927 — hot-added Initiators inherit the runtime's proactive-
+        // publish posture. Harmless for Responders (they never `start_round`).
+        Arc::new(
+            ReplicationCoordinator::new(
+                Arc::clone(&self.transport),
+                peer_key_id.to_string(),
+                kind,
+                role,
+                provider,
+                applier,
+            )
+            .with_proactive_publish(self.proactive_publish),
+        )
     }
 
     /// Shared registry handle. The operator's `Transport::listen`
@@ -782,8 +811,9 @@ mod tests {
         rt.shutdown().await;
     }
 
-    /// `register_peer` hot-adds and the registry reflects the
-    /// add immediately.
+    /// `register_peer` hot-adds an ACTIVE (Initiator) peer — routes AND
+    /// drives — and the registry reflects the add immediately (v13.7.0: it
+    /// no longer defaults to a passive Responder).
     #[tokio::test]
     async fn register_peer_hot_adds() {
         let backend = Arc::new(MemoryBackend::new());
@@ -798,7 +828,8 @@ mod tests {
         )
         .await;
         rt.register_peer("agent-bob", EnvelopeKind::Attestation)
-            .await;
+            .await
+            .expect("register_peer succeeds on a live runtime");
         assert_eq!(rt.registry().len().await, 1);
         rt.shutdown().await;
     }

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -117,6 +117,14 @@ pub struct Session {
     diff_want_count: Option<usize>,
     /// Whether the round has completed from this side's view.
     completed: bool,
+    /// CIRISEdge#927 — initiator-first push. When set (a self-publishing node,
+    /// i.e. the runtime was started with a `self_provider` / `key_publish_set`),
+    /// an Initiator's [`Self::start_round`] proactively DELIVERS its advertised
+    /// publish set right after the Summary, without waiting for the responder's
+    /// Diff. This is the only way to reach a carrier-NAT'd peer: the Diff can't
+    /// traverse back, so the side that can reach (the initiator) pushes its
+    /// key/attestation. Responders never `start_round`, so it's a no-op for them.
+    proactive_publish: bool,
 }
 
 impl Session {
@@ -128,7 +136,16 @@ impl Session {
             last_remote_summary: None,
             diff_want_count: None,
             completed: false,
+            proactive_publish: false,
         }
+    }
+
+    /// CIRISEdge#927 — enable initiator-first proactive publish (see the
+    /// `proactive_publish` field). Builder form so `Session::new` stays 2-arg.
+    #[must_use]
+    pub fn with_proactive_publish(mut self, yes: bool) -> Self {
+        self.proactive_publish = yes;
+        self
     }
 
     /// Clear per-round state so the session can drive a new round
@@ -159,10 +176,34 @@ impl Session {
         let refs = provider.local_refs(self.kind);
         let summary = SummaryMessage {
             kind: self.kind,
-            refs,
+            refs: refs.clone(),
         };
         self.last_summary_sent = Some(summary.clone());
-        ReplicationOutcome::Send(vec![ReplicationMessage::Summary(summary)])
+        let mut outbound = vec![ReplicationMessage::Summary(summary)];
+        // CIRISEdge#927 — initiator-first push. A carrier-NAT'd initiator's round
+        // can't complete responder-reply-first: the responder's Diff can't
+        // traverse back, so the Deliver is never solicited and the key/attestation
+        // never lands (the field's `round_outcomes {error:N}`). A self-publishing
+        // node therefore DELIVERS its advertised set proactively, alongside the
+        // Summary — the responder applies whatever it lacks (idempotent; a bare
+        // Deliver has no phase gate, see `responder_applies_unsolicited_bare_deliver`).
+        // `local_refs` for a self-publisher is its own publish set (for SelfOwn
+        // kinds it IS the `self_provider` set — small), so this pushes exactly the
+        // node's identity, not its whole state. Wasteful re-delivery each round is
+        // bounded (small set) + idempotent; correctness > a few duplicate bytes.
+        if self.proactive_publish {
+            let envelopes: Vec<Vec<u8>> = refs
+                .iter()
+                .filter_map(|r| provider.fetch_envelope(self.kind, &r.envelope_hash))
+                .collect();
+            if !envelopes.is_empty() {
+                outbound.push(ReplicationMessage::Deliver(DeliverMessage {
+                    kind: self.kind,
+                    envelopes,
+                }));
+            }
+        }
+        ReplicationOutcome::Send(outbound)
     }
 
     /// Process an inbound replication message.
@@ -631,6 +672,72 @@ mod tests {
             &mut applier,
         );
         assert_eq!(r, ReplicationOutcome::UnexpectedMessage);
+    }
+
+    /// CIRISEdge#927 / v13.7.0 — a Responder applies an UNSOLICITED bare
+    /// `Deliver` (no preceding Summary/Diff). This is the load-bearing invariant
+    /// for initiator-first delivery to a carrier-NAT'd peer: the side that can
+    /// reach (the initiator) PUSHES its key/attestation, and the responder —
+    /// which can neither dial back through NAT nor complete a resource the peer
+    /// won't pull — simply APPLIES it. `on_message` dispatches by message TYPE,
+    /// not phase, so there is NO Summary→Diff→Deliver gate that would refuse the
+    /// push. A regression here would silently re-break the mobile trace.
+    #[test]
+    fn responder_applies_unsolicited_bare_deliver() {
+        let provider = provider_with(&[]);
+        let mut applier = applier_for(&[(h(1), b"pushed-key".to_vec())]);
+        let mut bob = Session::new(SessionRole::Responder, EnvelopeKind::Key);
+        // No Summary, no Diff — the initiator just pushes its key envelope.
+        let r = bob.on_message(
+            ReplicationMessage::Deliver(DeliverMessage {
+                kind: EnvelopeKind::Key,
+                envelopes: vec![b"pushed-key".to_vec()],
+            }),
+            &provider,
+            &mut applier,
+        );
+        match r {
+            ReplicationOutcome::Applied {
+                admitted, refused, ..
+            } => {
+                assert_eq!(admitted, 1, "the pushed key envelope MUST be applied");
+                assert_eq!(refused, 0);
+            }
+            o => panic!("a bare Deliver must be Applied (no phase gate), got {o:?}"),
+        }
+        assert!(bob.is_complete(), "the bare-Deliver round completes");
+    }
+
+    /// CIRISEdge#927 — a self-publishing Initiator's `start_round` PROACTIVELY
+    /// delivers its publish set alongside the Summary (initiator-first), so a
+    /// carrier-NAT'd peer's key/attestation lands without a return-path Diff.
+    /// The plain (non-publishing) initiator stays Summary-only — no unsolicited
+    /// dump of a large-state node's contents.
+    #[test]
+    fn proactive_publish_initiator_delivers_alongside_summary() {
+        let provider = provider_with(&[(EnvelopeKind::Key, h(1), b"my-key-env".to_vec(), 1)]);
+        let mut m =
+            Session::new(SessionRole::Initiator, EnvelopeKind::Key).with_proactive_publish(true);
+        match m.start_round(&provider) {
+            ReplicationOutcome::Send(msgs) => {
+                assert_eq!(msgs.len(), 2, "Summary + proactive Deliver");
+                assert!(matches!(msgs[0], ReplicationMessage::Summary(_)));
+                match &msgs[1] {
+                    ReplicationMessage::Deliver(d) => {
+                        assert_eq!(d.kind, EnvelopeKind::Key);
+                        assert_eq!(d.envelopes, vec![b"my-key-env".to_vec()]);
+                    }
+                    o => panic!("expected a proactive Deliver, got {o:?}"),
+                }
+            }
+            o => panic!("expected Send, got {o:?}"),
+        }
+        // Without the flag: Summary only — the default anti-entropy pull.
+        let mut plain = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
+        match plain.start_round(&provider) {
+            ReplicationOutcome::Send(msgs) => assert_eq!(msgs.len(), 1, "Summary only"),
+            o => panic!("expected Send, got {o:?}"),
+        }
     }
 
     /// Fetch — on-demand envelope retrieval, distinct from anti-


### PR DESCRIPTION
Closes the NAT-traversal residual from CIRISEdge#353's arc — and makes it **substrate work underneath the agent's purview**, so the agent delivers to a carrier-NAT'd mobile without touching replication internals.

## #927 — initiator-first proactive publish
**Field fact** (Node A 0.5.129 / edge v13.6.1): the mobile holds a *persistent* live link, but the responder's reverse-path resource makes **zero progress** and the dial can't traverse carrier NAT. An initiator-only NAT'd peer is reachable **only over connections it initiates** — no responder-reply mechanism can close it.

**Fix (invisible to the agent):** a node started with a self-publish set (`self_provider` / `key_publish_set`) now has its Initiator `start_round` **proactively `Deliver` its publish set alongside the Summary**, without waiting for the responder's Diff (which can't come back). The agent's existing `start_replication(key_publish_set=…)` drives it — **no new agent API, no Initiator/Responder juggling**. Scoped to self-publishers; for `SelfOwn` kinds `local_refs` *is* the small self-publish set, so it pushes the node's identity, not its whole state.

**#927 Q2 answered:** the receiver already accepts it. `session::on_message` dispatches by message **type**, not phase — `on_deliver` has **no** `Summary→Diff→Deliver` gate. No receive-side change was needed; locked in by `responder_applies_unsolicited_bare_deliver` so it can't silently regress.

## The register_peer footgun (surfaced by the #927 coordination)
`register_peer` defaulted to a **passive Responder** — it read like "register this peer" but silently drove no rounds, and duplicated the #312 responder factory. Now it hot-adds an **active (Initiator)** peer. **Serve-only peers need no call** (the factory auto-registers them on first inbound). `register_initiator_peer` is a redundant back-compat alias.

## Verification (local)
Session 8/8 (bare-Deliver invariant + proactive-push), runtime 8/8 (register collapse), `clippy -D warnings` (transport-http + transport-reticulum + pyo3, `--all-targets`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
