### PR TITLE
chore(v13.9.0): adopt persist v18.0.0 — the envelope-native cut (CIRISPersist#473)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.8.0"
+version = "13.9.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.8.0", version = "17", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.0.0", version = "18", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v17.8.0", version = "17", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.0.0", version = "18", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
 dependencies = [
-    "ciris-persist>=17.8.0,<18",
+    "ciris-persist>=18.0.0,<19",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Pin currency for the persist **17.8.0 → 18.0.0** major (envelope-native: traces = ordinary `scores` attestations, local-tier until `attestation_promote`). Verify stays **v10.5.0** — no cascade.

**Zero edge API breaks** — the cut doesn't touch edge's consumed surfaces. Changes: both Cargo pin blocks + the pyproject wheel range (`>=18,<19`).

**Deliberately not enabled**: the trace plane on mobiles — gated on **#380** (delta-aware bounded proactive Deliver) and **#379** (observer-capability gating before the fleet promotes), per the CEG-native/contextual-integrity audit.

Local: clippy `-D warnings` full gate clean; 110 replication lib tests green.

Note: the persist v18.0.0 **wheel** may still be publishing to PyPI — if the cohab legs red on `pip install ciris-persist==18.0.0`, they need one re-run after it indexes (build legs source the git tag and are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r