### PR TITLE
feat(v13.10.0): trace-plane gates — delta-aware bounded proactive push + initiator-final rounds (#380) + observer-capability recipient gating (#379)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.9.1"
+version = "13.10.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.9.0"
+version = "13.9.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.0.0", version = "18", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.1.0", version = "18", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.0.0", version = "18", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.1.0", version = "18", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -381,7 +381,7 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                 )
                 .await
             }
-            EnvelopeKind::Attestation => self.list_attestations().await,
+            EnvelopeKind::Attestation => self.list_attestations(None).await,
             EnvelopeKind::Revocation => self.list_revocations().await,
             EnvelopeKind::Family => self.list_families().await,
             EnvelopeKind::Community => self.list_communities().await,
@@ -404,6 +404,46 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         envelope_hash: &[u8; 32],
     ) -> Option<Vec<u8>> {
         self.cache.lock().await.get(kind, envelope_hash)
+    }
+
+    /// CIRISEdge#379 — recipient-aware listing: the Attestation plane routes
+    /// through the `observer`-gated sweep; every other kind is peer-invariant.
+    async fn list_envelope_refs_for_peer(
+        &self,
+        kind: EnvelopeKind,
+        peer_key_id: Option<&str>,
+    ) -> Vec<EnvelopeRef> {
+        match (kind, peer_key_id) {
+            (EnvelopeKind::Attestation, Some(peer)) => self.list_attestations(Some(peer)).await,
+            _ => self.list_envelope_refs(kind).await,
+        }
+    }
+
+    /// CIRISEdge#379 — recipient-aware fetch: the serve-side twin of the
+    /// listing gate, so a peer excluded from the listing cannot obtain a
+    /// `trace:*` envelope anyway by Diff/Fetch-ing a hash it learned
+    /// out-of-band.
+    async fn fetch_envelope_bytes_for_peer(
+        &self,
+        kind: EnvelopeKind,
+        envelope_hash: &[u8; 32],
+        peer_key_id: Option<&str>,
+    ) -> Option<Vec<u8>> {
+        let bytes = self.fetch_envelope_bytes(kind, envelope_hash).await?;
+        if kind == EnvelopeKind::Attestation {
+            if let Some(peer) = peer_key_id {
+                if Self::envelope_requires_observer(&bytes) && !self.peer_has_observer(peer).await {
+                    tracing::debug!(
+                        peer,
+                        envelope_hash = %hex::encode(&envelope_hash[..8]),
+                        "trace attestation withheld — recipient lacks the `observer` \
+                         capability (CIRISEdge#379)"
+                    );
+                    return None;
+                }
+            }
+        }
+        Some(bytes)
     }
 
     async fn apply_envelope_bytes(&self, kind: EnvelopeKind, envelope_bytes: &[u8]) -> bool {
@@ -738,7 +778,50 @@ impl FederationDirectoryReplicationBridge {
         }
     }
 
-    async fn list_attestations(&self) -> Vec<EnvelopeRef> {
+    /// CIRISEdge#379 — role token a peer must advertise on its federation
+    /// KeyRecord (`roles` vector, accord-conferred per CIRISPersist#441) to
+    /// receive trace scores-attestations (`dimension` = `trace:*`,
+    /// CIRISPersist#473/v18). The contextual-integrity Recipient parameter:
+    /// promotion (`attestation_promote`) consents to sharing WITH OBSERVERS,
+    /// not with every cohort peer.
+    pub const OBSERVER_ROLE: &'static str = "observer";
+
+    /// CIRISEdge#379 — does this attestation row require the recipient to
+    /// hold the `observer` capability? True iff its `dimension` (CC 2.1 —
+    /// inside `attestation_envelope`) is in the `trace:*` namespace.
+    fn attestation_requires_observer(canonical_json: &serde_json::Value) -> bool {
+        canonical_json
+            .pointer("/attestation_envelope/dimension")
+            .and_then(|v| v.as_str())
+            .is_some_and(|d| d.starts_with("trace:"))
+    }
+
+    /// CIRISEdge#379 — the fetch-path twin of
+    /// [`Self::attestation_requires_observer`], over WIRE bytes (the
+    /// `{"attestation": …}` wrap `adapt_record` produces; also accepts the
+    /// bare row for robustness). Parse failure → `false` (only `trace:*`
+    /// is gated; cached envelopes are JSON this bridge serialized).
+    fn envelope_requires_observer(bytes: &[u8]) -> bool {
+        let Ok(v) = serde_json::from_slice::<serde_json::Value>(bytes) else {
+            return false;
+        };
+        let inner = v.get("attestation").unwrap_or(&v);
+        Self::attestation_requires_observer(inner)
+    }
+
+    /// CIRISEdge#379 — does `peer_key_id`'s federation KeyRecord advertise
+    /// the [`Self::OBSERVER_ROLE`]? Roles are accord-conferred (never
+    /// self-claimed — CIRISPersist#441 admission gate), so a `true` here is
+    /// a conferral, not a claim. Unknown peer / lookup error → `false`
+    /// (fail-closed: an unresolvable recipient gets no gated rows).
+    async fn peer_has_observer(&self, peer_key_id: &str) -> bool {
+        match self.directory.lookup_public_key(peer_key_id).await {
+            Ok(Some(rec)) => rec.roles.iter().any(|r| r == Self::OBSERVER_ROLE),
+            _ => false,
+        }
+    }
+
+    async fn list_attestations(&self, recipient: Option<&str>) -> Vec<EnvelopeRef> {
         // v10 — per-record dynamic policy for the scores/Attestation plane.
         // Each attestation's projection is resolved from its ACTUAL dimension
         // (across all 95 namespace families), cohort_scope, and attestation_type
@@ -763,6 +846,9 @@ impl FederationDirectoryReplicationBridge {
             .collect();
         let mut refs = Vec::new();
         let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        // CIRISEdge#379 — lazily-resolved recipient capability (one directory
+        // lookup per listing sweep, and only when a gated row is encountered).
+        let mut observer_allowed: Option<bool> = None;
         for subject in self.subjects_for_projection(Projection::Global) {
             // about — via the uniform signed read (`list_attestations_for`).
             let about = self
@@ -783,6 +869,23 @@ impl FederationDirectoryReplicationBridge {
             for canonical_json in about.chain(by) {
                 if !Self::attestation_is_advertised(&canonical_json, &self_set) {
                     continue;
+                }
+                // CIRISEdge#379 — RECIPIENT gate (the contextual-integrity
+                // Recipient parameter): a `trace:*` scores-attestation is
+                // listed for a peer ONLY if that peer's KeyRecord advertises
+                // the accord-conferred `observer` role. Non-trace rows are
+                // untouched; a `None` recipient (projection-only view / tests)
+                // is ungated — every production provider is peer-bound
+                // (`DirectoryStateAdapter::with_peer`).
+                if let Some(peer) = recipient {
+                    if Self::attestation_requires_observer(&canonical_json) {
+                        if observer_allowed.is_none() {
+                            observer_allowed = Some(self.peer_has_observer(peer).await);
+                        }
+                        if observer_allowed != Some(true) {
+                            continue;
+                        }
+                    }
                 }
                 let Some((bytes, hash, seq)) =
                     Self::adapt_record(ReplicatedKind::Attestation, &canonical_json)
@@ -1736,6 +1839,156 @@ mod tests {
         assert!(
             !refs.is_empty(),
             "federation-PRESENT attestation MUST appear (FSD §7.1)"
+        );
+    }
+
+    // ── CIRISEdge#379 — observer-capability recipient gate (trace plane) ──
+
+    /// Seed a `trace:complete:v1` scores-attestation + two recipients (one
+    /// whose KeyRecord advertises the `observer` role, one without), then
+    /// assert the contextual-integrity Recipient parameter on BOTH the
+    /// advertise (listing) and the serve (fetch) paths, and that non-trace
+    /// attestations are untouched by the gate.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)] // seed + both peers + both paths, one coherent scenario
+    async fn trace_attestation_gated_on_observer_capability() {
+        let producer = "agent-mobile";
+        let observer_peer = "canonical-observer";
+        let plain_peer = "peer-no-observer";
+        let (backend, bridge) = make_bridge(&[
+            producer.to_string(),
+            observer_peer.to_string(),
+            plain_peer.to_string(),
+        ]);
+
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fixture_key_record(producer, identity_type::AGENT),
+            })
+            .await
+            .expect("seed producer key");
+        let mut observer_rec = fixture_key_record(observer_peer, identity_type::AGENT);
+        observer_rec.roles = vec![FederationDirectoryReplicationBridge::OBSERVER_ROLE.to_string()];
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: observer_rec,
+            })
+            .await
+            .expect("seed observer key");
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fixture_key_record(plain_peer, identity_type::AGENT),
+            })
+            .await
+            .expect("seed plain key");
+
+        // A trace scores-attestation (self-subject, federation tier =
+        // promoted) + a NON-trace attestation for the control.
+        let now = Utc::now();
+        for (attestation_type, dimension) in [
+            ("scores", Some("trace:complete:v1")),
+            ("delegates_to", None),
+        ] {
+            let mut envelope = serde_json::json!({
+                "attesting_key_id": producer,
+                "attested_key_id": producer,
+                "attestation_type": attestation_type,
+            });
+            if let Some(d) = dimension {
+                // The persist v18.1.0 trace:* Information-Type validator
+                // (CIRISPersist#479) enforces the inline shape at admission:
+                // trace_id + agent_id_hash strings + a `trace` object.
+                envelope["dimension"] = serde_json::json!(d);
+                envelope["trace_id"] = serde_json::json!("t-fixture-1");
+                envelope["agent_id_hash"] = serde_json::json!("ah-fixture-1");
+                envelope["trace"] = serde_json::json!({ "steps": [] });
+            }
+            let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(producer, &envelope);
+            let att = Attestation {
+                attestation_id: uuid::Uuid::new_v4().to_string(),
+                attesting_key_id: producer.to_string(),
+                attested_key_id: producer.to_string(),
+                attestation_type: attestation_type.to_string(),
+                weight: None,
+                asserted_at: now,
+                expires_at: None,
+                attestation_envelope: envelope,
+                original_content_hash: hash,
+                scrub_signature_classical: ed_sig,
+                scrub_signature_pqc: pqc_sig,
+                scrub_key_id: producer.to_string(),
+                scrub_timestamp: now,
+                pqc_completed_at: None,
+                persist_row_hash: String::new(),
+                subject_key_ids: vec![producer.to_string()],
+                withdraws_admission_rule: None,
+                cohort_scope: "federation".to_string(),
+                tier: "federation".to_string(),
+                promoted_at: None,
+            };
+            backend
+                .put_attestation(SignedAttestation { attestation: att })
+                .await
+                .expect("seed attestation");
+        }
+
+        // Peerless (projection-only) view: both rows.
+        let all = bridge
+            .list_envelope_refs(EnvelopeKind::Attestation)
+            .await
+            .len();
+        assert_eq!(all, 2, "projection-only view lists both rows");
+
+        // Observer peer: both rows.
+        let observer_refs = bridge
+            .list_envelope_refs_for_peer(EnvelopeKind::Attestation, Some(observer_peer))
+            .await;
+        assert_eq!(
+            observer_refs.len(),
+            2,
+            "observer-capability peer receives the trace row + the plain row"
+        );
+
+        // Non-observer peer: ONLY the non-trace row.
+        let plain_refs = bridge
+            .list_envelope_refs_for_peer(EnvelopeKind::Attestation, Some(plain_peer))
+            .await;
+        assert_eq!(
+            plain_refs.len(),
+            1,
+            "non-observer peer must NOT be offered the trace attestation \
+             (CIRISEdge#379 — the Recipient parameter)"
+        );
+
+        // Serve-side twin: the trace row's bytes are withheld from the
+        // non-observer even by direct hash fetch, served to the observer.
+        let trace_hash = observer_refs
+            .iter()
+            .map(|r| r.envelope_hash)
+            .find(|h| !plain_refs.iter().any(|p| p.envelope_hash == *h))
+            .expect("the trace row is the one the plain peer was not offered");
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &trace_hash,
+                    Some(observer_peer)
+                )
+                .await
+                .is_some(),
+            "observer peer fetches the trace envelope"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &trace_hash,
+                    Some(plain_peer)
+                )
+                .await
+                .is_none(),
+            "non-observer peer must not obtain the trace envelope by hash \
+             (out-of-band Diff/Fetch bypass, CIRISEdge#379)"
         );
     }
 

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -221,7 +221,13 @@ impl ReplicationCoordinator {
         let step = Self::outcome_to_step(outcome);
         // Auto-reset on round completion so the next call can drive
         // a fresh round without the caller threading state.
-        if matches!(step, DriveStep::Complete(_)) {
+        // (#380: `reset` preserves the cross-round knowledge — the peer's
+        // last Summary + the proactive-push ledger — so an initiator-final
+        // session keeps completing instead of re-blasting.)
+        if matches!(
+            step,
+            DriveStep::Complete(_) | DriveStep::SendThenComplete(_, _)
+        ) {
             session.reset();
         }
         Ok(step)
@@ -262,6 +268,18 @@ impl ReplicationCoordinator {
     fn outcome_to_step(outcome: ReplicationOutcome) -> DriveStep {
         match outcome {
             ReplicationOutcome::Send(msgs) => DriveStep::SendThenWait(msgs),
+            // CIRISEdge#380 — confirmed-sync initiator-final round: report
+            // InSync (the completion is gated on the peer's own Summary
+            // confirming it holds our full set + we want nothing of its).
+            ReplicationOutcome::SendAndComplete { msgs, kind } => DriveStep::SendThenComplete(
+                msgs,
+                RoundReport {
+                    kind,
+                    admitted: 0,
+                    refused: 0,
+                    staleness: StalenessSignal::InSync,
+                },
+            ),
             ReplicationOutcome::Applied {
                 kind,
                 admitted,
@@ -364,6 +382,11 @@ pub enum DriveStep {
     /// [`ReplicationCoordinator::send_message`], then awaits the
     /// next inbound message + calls `drive_round_step(Some(msg))`.
     SendThenWait(Vec<ReplicationMessage>),
+    /// CIRISEdge#380 — INITIATOR-FINAL: send these messages, then the round is
+    /// complete with the given report — nothing further will arrive (the peer's
+    /// last Summary confirmed full sync). The caller sends each message, then
+    /// treats the round as [`Self::Complete`] without waiting.
+    SendThenComplete(Vec<ReplicationMessage>, RoundReport),
     /// The round completed; the report is the final state.
     Complete(RoundReport),
     /// The peer sent a message that didn't make sense in this round's

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -75,6 +75,19 @@ pub trait ReplicationDirectory: Send + Sync {
     /// implementation's job.
     async fn list_envelope_refs(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef>;
 
+    /// CIRISEdge#379 — RECIPIENT-AWARE enumeration: the refs `peer` may
+    /// receive. Defaults to the peer-blind [`Self::list_envelope_refs`];
+    /// implementations with per-recipient policy (the bridge's `observer`-
+    /// capability gate on the trace scores-attestation plane) override.
+    /// `None` = projection-only view (tests / diagnostics), ungated.
+    async fn list_envelope_refs_for_peer(
+        &self,
+        kind: EnvelopeKind,
+        _peer_key_id: Option<&str>,
+    ) -> Vec<EnvelopeRef> {
+        self.list_envelope_refs(kind).await
+    }
+
     /// Return the byte-exact signed envelope for `(kind,
     /// envelope_hash)`, or `None` if the envelope isn't in local state.
     /// Called during the `Deliver`-message construction step.
@@ -83,6 +96,20 @@ pub trait ReplicationDirectory: Send + Sync {
         kind: EnvelopeKind,
         envelope_hash: &[u8; 32],
     ) -> Option<Vec<u8>>;
+
+    /// CIRISEdge#379 — RECIPIENT-AWARE fetch: the serve-side twin of
+    /// [`Self::list_envelope_refs_for_peer`], so a peer excluded from the
+    /// listing cannot obtain a gated envelope anyway by Diff/Fetch-ing its
+    /// hash directly (learned out-of-band). Defaults to the peer-blind
+    /// fetch; the bridge overrides.
+    async fn fetch_envelope_bytes_for_peer(
+        &self,
+        kind: EnvelopeKind,
+        envelope_hash: &[u8; 32],
+        _peer_key_id: Option<&str>,
+    ) -> Option<Vec<u8>> {
+        self.fetch_envelope_bytes(kind, envelope_hash).await
+    }
 
     /// Apply one envelope to local state. The implementation verifies
     /// the signed envelope's signature + canonical-bytes hash before
@@ -116,29 +143,53 @@ pub trait ReplicationDirectory: Send + Sync {
 /// behavior as any other tokio-coupled sync interface.
 pub struct DirectoryStateAdapter {
     inner: Arc<dyn ReplicationDirectory>,
+    /// CIRISEdge#379 — the peer this provider serves. When set, listing +
+    /// fetch route through the recipient-aware trait methods so per-peer
+    /// policy (the `observer`-capability gate on trace attestations) applies
+    /// on BOTH the advertise and the serve path. `None` = peer-blind
+    /// (projection-only view; tests).
+    peer_key_id: Option<String>,
 }
 
 impl DirectoryStateAdapter {
     pub fn new(inner: Arc<dyn ReplicationDirectory>) -> Self {
-        Self { inner }
+        Self {
+            inner,
+            peer_key_id: None,
+        }
+    }
+
+    /// CIRISEdge#379 — bind this provider to the peer it serves (builder).
+    #[must_use]
+    pub fn with_peer(mut self, peer_key_id: impl Into<String>) -> Self {
+        self.peer_key_id = Some(peer_key_id.into());
+        self
     }
 }
 
 impl StateProvider for DirectoryStateAdapter {
     fn local_refs(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
         let inner = Arc::clone(&self.inner);
+        let peer = self.peer_key_id.clone();
         tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(async move { inner.list_envelope_refs(kind).await })
+            tokio::runtime::Handle::current().block_on(async move {
+                inner
+                    .list_envelope_refs_for_peer(kind, peer.as_deref())
+                    .await
+            })
         })
     }
 
     fn fetch_envelope(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> Option<Vec<u8>> {
         let inner = Arc::clone(&self.inner);
         let hash = *envelope_hash;
+        let peer = self.peer_key_id.clone();
         tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current()
-                .block_on(async move { inner.fetch_envelope_bytes(kind, &hash).await })
+            tokio::runtime::Handle::current().block_on(async move {
+                inner
+                    .fetch_envelope_bytes_for_peer(kind, &hash, peer.as_deref())
+                    .await
+            })
         })
     }
 }

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -140,6 +140,24 @@ fn spawn_responder_drive(coord: Arc<ReplicationCoordinator>) {
                         }
                     }
                 }
+                // CIRISEdge#380 — defensive: `SendThenComplete` is initiator-only
+                // (`start_round` emits it; responders never start rounds). If it
+                // ever appears here, honor its semantics: send, then done.
+                Ok(DriveStep::SendThenComplete(msgs, report)) => {
+                    for m in &msgs {
+                        if let Err(e) = coord.send_message(m).await {
+                            tracing::warn!(
+                                peer = %peer, ?kind, error = %e,
+                                "responder SendThenComplete send failed (CIRISEdge#380)"
+                            );
+                            break;
+                        }
+                    }
+                    tracing::debug!(
+                        peer = %peer, ?kind, ?report,
+                        "responder round complete (initiator-final path, CIRISEdge#380)"
+                    );
+                }
                 Ok(DriveStep::Complete(report)) => {
                     tracing::debug!(
                         peer = %peer, ?kind, ?report,
@@ -328,8 +346,11 @@ impl ReplicationRuntime {
             let factory_bridge = Arc::clone(&bridge);
             registry.set_responder_factory(Arc::new(move |peer_key_id: &str, kind| {
                 let bridge_dir: Arc<dyn ReplicationDirectory> = Arc::clone(&factory_bridge) as _;
-                let provider: Arc<dyn StateProvider> =
-                    Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
+                // CIRISEdge#379 — peer-bound provider: the observer-capability
+                // gate on the trace attestation plane applies per recipient.
+                let provider: Arc<dyn StateProvider> = Arc::new(
+                    DirectoryStateAdapter::new(Arc::clone(&bridge_dir)).with_peer(peer_key_id),
+                );
                 let applier: Arc<Mutex<dyn StateApplier>> =
                     Arc::new(Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)));
                 let coord = Arc::new(ReplicationCoordinator::new(
@@ -365,8 +386,11 @@ impl ReplicationRuntime {
             .iter()
             .map(|peer| {
                 let bridge_dir: Arc<dyn ReplicationDirectory> = Arc::clone(&bridge) as _;
-                let provider: Arc<dyn StateProvider> =
-                    Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
+                // CIRISEdge#379 — peer-bound provider (observer gate, see above).
+                let provider: Arc<dyn StateProvider> = Arc::new(
+                    DirectoryStateAdapter::new(Arc::clone(&bridge_dir))
+                        .with_peer(&peer.peer_key_id),
+                );
                 let applier: Arc<tokio::sync::Mutex<dyn StateApplier>> = Arc::new(
                     tokio::sync::Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)),
                 );
@@ -583,8 +607,9 @@ impl ReplicationRuntime {
         role: SessionRole,
     ) -> Arc<ReplicationCoordinator> {
         let bridge_dir: Arc<dyn ReplicationDirectory> = Arc::clone(&self.bridge) as _;
+        // CIRISEdge#379 — peer-bound provider (observer gate).
         let provider: Arc<dyn StateProvider> =
-            Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)));
+            Arc::new(DirectoryStateAdapter::new(Arc::clone(&bridge_dir)).with_peer(peer_key_id));
         let applier: Arc<Mutex<dyn StateApplier>> =
             Arc::new(Mutex::new(MutableDirectoryStateAdapter::new(bridge_dir)));
         // CIRISEdge#927 — hot-added Initiators inherit the runtime's proactive-

--- a/src/replication/scheduler.rs
+++ b/src/replication/scheduler.rs
@@ -438,7 +438,12 @@ async fn run_one_coordinator_forever(
                 let span = tracing::info_span!("anti_entropy_round", peer = %peer_id, kind = %kind_str);
                 let _enter = span.enter();
                 let event = match run_one_round(&coord, round_timeout).await {
-                    Ok(DriveStep::Complete(report)) => RoundEvent::Completed(report),
+                    // CIRISEdge#380 — run_one_round converts SendThenComplete to
+                    // Complete after sending; the merged arm is defensive if it
+                    // ever leaks through.
+                    Ok(DriveStep::Complete(report) | DriveStep::SendThenComplete(_, report)) => {
+                        RoundEvent::Completed(report)
+                    }
                     Ok(DriveStep::Refused) => {
                         tracing::warn!("round refused; resetting session");
                         RoundEvent::Refused
@@ -495,6 +500,18 @@ async fn run_one_round(
 ) -> Result<DriveStep, RoundError> {
     let mut step = coord.drive_round_step(None).await?;
     loop {
+        // CIRISEdge#380 — initiator-final: send the messages, then the round
+        // is complete WITHOUT waiting (the peer's last Summary confirmed full
+        // sync; there is nothing on the wire to wait for). This is what turns
+        // a NAT'd initiator's steady-state from perpetual `error`/`timed_out`
+        // into honest `completed` on the round-outcome instrument (#370).
+        if let DriveStep::SendThenComplete(ref msgs, ref report) = step {
+            let report = report.clone();
+            for m in msgs {
+                coord.send_message(m).await?;
+            }
+            return Ok(DriveStep::Complete(report));
+        }
         let msgs = match step {
             DriveStep::SendThenWait(ref msgs) => msgs.clone(),
             _ => return Ok(step),

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -36,7 +36,8 @@
 //! Delivers have been applied.
 
 use super::protocol::{
-    DeliverMessage, DiffMessage, EnvelopeKind, FetchMessage, ReplicationMessage, SummaryMessage,
+    DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, ReplicationMessage,
+    SummaryMessage,
 };
 use super::summary::{diff_refs, StalenessSignal, StateApplier, StateProvider};
 
@@ -58,6 +59,18 @@ pub enum ReplicationOutcome {
     /// the caller MUST emit them in order on the underlying
     /// transport.
     Send(Vec<ReplicationMessage>),
+    /// CIRISEdge#380 — INITIATOR-FINAL: send these messages, then the round is
+    /// COMPLETE without waiting for a reply. Emitted by a proactive-publish
+    /// initiator when the peer's last-known Summary shows it already holds our
+    /// full publish set (nothing left to push) and we want nothing from it —
+    /// there is nothing to wait for. This is what lets a NAT'd initiator's
+    /// rounds report `completed` instead of permanently normalizing
+    /// `error`/`timed_out` as the signature of working delivery (which poisoned
+    /// the #370 round-outcome instrument).
+    SendAndComplete {
+        msgs: Vec<ReplicationMessage>,
+        kind: EnvelopeKind,
+    },
     /// The session applied envelopes received from the peer. The
     /// caller can surface a `StalenessSignal` update at this point.
     Applied {
@@ -125,7 +138,30 @@ pub struct Session {
     /// traverse back, so the side that can reach (the initiator) pushes its
     /// key/attestation. Responders never `start_round`, so it's a no-op for them.
     proactive_publish: bool,
+    /// CIRISEdge#380 — per-envelope proactive-push ledger: hash → the
+    /// `round_counter` value when it was last pushed. Survives [`Self::reset`]
+    /// (cross-round knowledge, not round state) so an envelope is not re-pushed
+    /// every round; entries refresh after [`PROACTIVE_REFRESH_ROUNDS`] as
+    /// insurance for peers whose reverse-path Summary never arrives.
+    proactive_sent: std::collections::BTreeMap<[u8; 32], u64>,
+    /// CIRISEdge#380 — monotonic count of initiator rounds this session has
+    /// started. Basis for the `proactive_sent` refresh window.
+    round_counter: u64,
 }
+
+/// CIRISEdge#380 — per-round byte budget for the proactive Deliver. The
+/// v13.7.0 push was UNBOUNDED (full `local_refs(kind)` every round), which was
+/// tolerable for the small `SelfOwn` publish sets it was built for but breaks
+/// on the Attestation plane, where persist v18 puts inline trace payloads up
+/// to 1 MiB — a mobile would re-blast megabytes every 30 s. The plane now
+/// converges over successive rounds instead. A single envelope larger than
+/// the whole budget is still pushed (alone) — a budget must bound the batch,
+/// never strand an envelope.
+pub const PROACTIVE_PUSH_BUDGET_BYTES: usize = 256 * 1024;
+/// CIRISEdge#380 — rounds before an already-pushed envelope becomes eligible
+/// for an idempotent re-push (insurance when the peer's reverse-path Summary
+/// never arrives to confirm receipt). 20 rounds ≈ 10 min at the 30 s cadence.
+pub const PROACTIVE_REFRESH_ROUNDS: u64 = 20;
 
 impl Session {
     pub fn new(role: SessionRole, kind: EnvelopeKind) -> Self {
@@ -137,6 +173,8 @@ impl Session {
             diff_want_count: None,
             completed: false,
             proactive_publish: false,
+            proactive_sent: std::collections::BTreeMap::new(),
+            round_counter: 0,
         }
     }
 
@@ -151,9 +189,16 @@ impl Session {
     /// Clear per-round state so the session can drive a new round
     /// with the same peer. Preserves `role` + `kind`. Idempotent —
     /// calling on a fresh session is a no-op.
+    ///
+    /// CIRISEdge#380 — ALSO preserves the cross-round knowledge: the peer's
+    /// `last_remote_summary` (the delta basis for the proactive push + the
+    /// initiator-final completion test — it reflects what the peer HOLDS,
+    /// which a round boundary doesn't invalidate) and the `proactive_sent`
+    /// ledger / `round_counter` (what we already pushed). Clearing those on
+    /// every completed round would re-blast the publish set and un-complete
+    /// the next round for no reason.
     pub fn reset(&mut self) {
         self.last_summary_sent = None;
-        self.last_remote_summary = None;
         self.diff_want_count = None;
         self.completed = false;
     }
@@ -187,16 +232,77 @@ impl Session {
         // node therefore DELIVERS its advertised set proactively, alongside the
         // Summary — the responder applies whatever it lacks (idempotent; a bare
         // Deliver has no phase gate, see `responder_applies_unsolicited_bare_deliver`).
-        // `local_refs` for a self-publisher is its own publish set (for SelfOwn
-        // kinds it IS the `self_provider` set — small), so this pushes exactly the
-        // node's identity, not its whole state. Wasteful re-delivery each round is
-        // bounded (small set) + idempotent; correctness > a few duplicate bytes.
+        //
+        // CIRISEdge#380 — the push is DELTA-AWARE and BOUNDED (the v13.7.0
+        // unbounded full-set push broke on the Attestation plane, where persist
+        // v18 puts inline trace payloads up to 1 MiB):
+        //  - skip refs the peer's last reverse-path Summary shows it holds;
+        //  - skip refs already pushed within `PROACTIVE_REFRESH_ROUNDS`
+        //    (idempotent re-push insurance for a peer we never hear from);
+        //  - cap the batch at `PROACTIVE_PUSH_BUDGET_BYTES`, oldest-seq first,
+        //    spillover converging over subsequent rounds (an envelope larger
+        //    than the whole budget still ships, alone).
         if self.proactive_publish {
-            let envelopes: Vec<Vec<u8>> = refs
+            self.round_counter += 1;
+            let peer_has: std::collections::BTreeSet<[u8; 32]> = self
+                .last_remote_summary
+                .as_ref()
+                .map(|s| s.refs.iter().map(|r| r.envelope_hash).collect())
+                .unwrap_or_default();
+            let mut candidates: Vec<&EnvelopeRef> = refs
                 .iter()
-                .filter_map(|r| provider.fetch_envelope(self.kind, &r.envelope_hash))
+                .filter(|r| !peer_has.contains(&r.envelope_hash))
+                .filter(|r| {
+                    self.proactive_sent.get(&r.envelope_hash).map_or(
+                        true,
+                        // `map_or(true, …)` not `is_none_or` — MSRV 1.75.
+                        |sent| self.round_counter.saturating_sub(*sent) >= PROACTIVE_REFRESH_ROUNDS,
+                    )
+                })
                 .collect();
-            if !envelopes.is_empty() {
+            candidates.sort_by_key(|r| r.seq);
+            let mut envelopes: Vec<Vec<u8>> = Vec::new();
+            let mut budget_used = 0usize;
+            for r in candidates {
+                let Some(bytes) = provider.fetch_envelope(self.kind, &r.envelope_hash) else {
+                    continue;
+                };
+                if budget_used + bytes.len() > PROACTIVE_PUSH_BUDGET_BYTES && !envelopes.is_empty()
+                {
+                    // Spillover — the NEXT round carries it (deterministic:
+                    // candidates are seq-sorted). Not marked sent.
+                    continue;
+                }
+                budget_used += bytes.len();
+                self.proactive_sent
+                    .insert(r.envelope_hash, self.round_counter);
+                envelopes.push(bytes);
+            }
+            if envelopes.is_empty() {
+                // CIRISEdge#380 — INITIATOR-FINAL completion, strictly gated on
+                // CONFIRMED sync: the peer's own last Summary shows it holds our
+                // full advertised set (so nothing was pushed), and we lack
+                // nothing it advertises. There is nothing on the wire to wait
+                // for — the round is complete NOW, and `round_outcomes` reports
+                // `completed` instead of normalizing `error`/`timed_out` as the
+                // signature of working NAT'd delivery. Pushed-but-unconfirmed
+                // rounds do NOT complete (the peer's next reverse-path Summary
+                // is the confirmation), so `completed` keeps meaning what it
+                // says.
+                let peer_holds_all = self.last_remote_summary.is_some()
+                    && refs.iter().all(|r| peer_has.contains(&r.envelope_hash));
+                let want_nothing = self
+                    .last_remote_summary
+                    .as_ref()
+                    .is_some_and(|remote| diff_refs(&refs, &remote.refs).is_empty());
+                if peer_holds_all && want_nothing {
+                    self.completed = true;
+                    return ReplicationOutcome::SendAndComplete {
+                        msgs: outbound,
+                        kind: self.kind,
+                    };
+                }
+            } else {
                 outbound.push(ReplicationMessage::Deliver(DeliverMessage {
                     kind: self.kind,
                     envelopes,
@@ -738,6 +844,190 @@ mod tests {
             ReplicationOutcome::Send(msgs) => assert_eq!(msgs.len(), 1, "Summary only"),
             o => panic!("expected Send, got {o:?}"),
         }
+    }
+
+    // ── CIRISEdge#380 — delta-aware bounded proactive push + initiator-final ──
+
+    /// The peer's last reverse-path Summary is the delta basis: refs it
+    /// already holds are NOT re-pushed.
+    #[test]
+    fn proactive_push_skips_refs_the_peer_summary_holds() {
+        let provider = provider_with(&[
+            (EnvelopeKind::Attestation, h(1), b"env-a".to_vec(), 1),
+            (EnvelopeKind::Attestation, h(2), b"env-b".to_vec(), 2),
+        ]);
+        let mut applier = applier_for(&[]);
+        let mut s = Session::new(SessionRole::Initiator, EnvelopeKind::Attestation)
+            .with_proactive_publish(true);
+        // The responder's reverse-path Summary arrives first: it holds h(1).
+        let _ = s.on_message(
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Attestation,
+                refs: vec![EnvelopeRef {
+                    envelope_hash: h(1),
+                    seq: 1,
+                }],
+            }),
+            &provider,
+            &mut applier,
+        );
+        match s.start_round(&provider) {
+            ReplicationOutcome::Send(msgs) => {
+                let deliver = msgs.iter().find_map(|m| match m {
+                    ReplicationMessage::Deliver(d) => Some(d),
+                    _ => None,
+                });
+                let d = deliver.expect("delta push fires for the ref the peer lacks");
+                assert_eq!(d.envelopes, vec![b"env-b".to_vec()], "only h(2) pushed");
+            }
+            o => panic!("expected Send, got {o:?}"),
+        }
+    }
+
+    /// An envelope pushed this round is NOT re-pushed next round (sent-cache);
+    /// it re-qualifies only after `PROACTIVE_REFRESH_ROUNDS`.
+    #[test]
+    fn proactive_push_does_not_repush_within_refresh_window() {
+        let provider = provider_with(&[(EnvelopeKind::Key, h(1), b"env-a".to_vec(), 1)]);
+        let mut s =
+            Session::new(SessionRole::Initiator, EnvelopeKind::Key).with_proactive_publish(true);
+        match s.start_round(&provider) {
+            ReplicationOutcome::Send(msgs) => assert_eq!(msgs.len(), 2, "round 1 pushes"),
+            o => panic!("expected Send, got {o:?}"),
+        }
+        match s.start_round(&provider) {
+            ReplicationOutcome::Send(msgs) => {
+                assert_eq!(
+                    msgs.len(),
+                    1,
+                    "round 2: Summary only — no re-push (v13.7.0 re-blasted)"
+                );
+            }
+            o => panic!("expected Send, got {o:?}"),
+        }
+    }
+
+    /// The per-round byte budget bounds the batch; spillover converges on the
+    /// next round (oldest seq first), and an envelope bigger than the whole
+    /// budget still ships alone.
+    #[test]
+    fn proactive_push_respects_budget_with_spillover() {
+        let big_a = vec![0xAAu8; PROACTIVE_PUSH_BUDGET_BYTES - 1024];
+        let big_b = vec![0xBBu8; PROACTIVE_PUSH_BUDGET_BYTES - 1024];
+        let oversize = vec![0xCCu8; PROACTIVE_PUSH_BUDGET_BYTES + 4096];
+        let provider = provider_with(&[
+            (EnvelopeKind::Attestation, h(1), big_a.clone(), 1),
+            (EnvelopeKind::Attestation, h(2), big_b.clone(), 2),
+            (EnvelopeKind::Attestation, h(3), oversize.clone(), 3),
+        ]);
+        let mut s = Session::new(SessionRole::Initiator, EnvelopeKind::Attestation)
+            .with_proactive_publish(true);
+        let round_envelopes = |s: &mut Session| -> Vec<Vec<u8>> {
+            match s.start_round(&provider) {
+                ReplicationOutcome::Send(msgs) => msgs
+                    .into_iter()
+                    .find_map(|m| match m {
+                        ReplicationMessage::Deliver(d) => Some(d.envelopes),
+                        _ => None,
+                    })
+                    .unwrap_or_default(),
+                o => panic!("expected Send, got {o:?}"),
+            }
+        };
+        assert_eq!(
+            round_envelopes(&mut s),
+            vec![big_a],
+            "round 1: seq-1 fits, rest spills"
+        );
+        assert_eq!(round_envelopes(&mut s), vec![big_b], "round 2: seq-2");
+        assert_eq!(
+            round_envelopes(&mut s),
+            vec![oversize],
+            "round 3: the over-budget envelope still ships, alone — a budget \
+             bounds the batch, never strands an envelope"
+        );
+        assert!(
+            round_envelopes(&mut s).is_empty(),
+            "round 4: everything sent"
+        );
+    }
+
+    /// INITIATOR-FINAL: when the peer's own Summary confirms it holds our full
+    /// set and we want nothing of its, the round completes at send — no wire
+    /// wait, and `round_outcomes` reports `completed` (the #370 instrument
+    /// stops normalizing error). Pushed-but-unconfirmed rounds do NOT complete.
+    #[test]
+    fn initiator_final_completes_only_on_confirmed_sync() {
+        let provider = provider_with(&[(EnvelopeKind::Key, h(1), b"env-a".to_vec(), 1)]);
+        let mut applier = applier_for(&[]);
+        let mut s =
+            Session::new(SessionRole::Initiator, EnvelopeKind::Key).with_proactive_publish(true);
+        // Round 1: never heard the peer → pushes, must NOT complete.
+        assert!(
+            matches!(s.start_round(&provider), ReplicationOutcome::Send(_)),
+            "unconfirmed push stays Send-then-wait"
+        );
+        // The reverse-path Summary arrives: peer holds h(1) (and nothing more).
+        let _ = s.on_message(
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Key,
+                refs: vec![EnvelopeRef {
+                    envelope_hash: h(1),
+                    seq: 1,
+                }],
+            }),
+            &provider,
+            &mut applier,
+        );
+        // Round 2: confirmed sync → SendAndComplete.
+        match s.start_round(&provider) {
+            ReplicationOutcome::SendAndComplete { msgs, kind } => {
+                assert_eq!(kind, EnvelopeKind::Key);
+                assert_eq!(msgs.len(), 1, "Summary only — nothing to push");
+            }
+            o => panic!("expected SendAndComplete on confirmed sync, got {o:?}"),
+        }
+        // reset() (the coordinator's auto-reset on Complete) preserves the
+        // cross-round knowledge → the NEXT round completes too.
+        s.reset();
+        assert!(
+            matches!(
+                s.start_round(&provider),
+                ReplicationOutcome::SendAndComplete { .. }
+            ),
+            "knowledge survives reset — steady-state stays completed"
+        );
+    }
+
+    /// A peer whose Summary advertises rows WE lack blocks initiator-final —
+    /// the pull half of anti-entropy still matters when it can work.
+    #[test]
+    fn initiator_final_blocked_when_we_want_their_rows() {
+        let provider = provider_with(&[(EnvelopeKind::Key, h(1), b"env-a".to_vec(), 1)]);
+        let mut applier = applier_for(&[]);
+        let mut s =
+            Session::new(SessionRole::Initiator, EnvelopeKind::Key).with_proactive_publish(true);
+        let _ = s.on_message(
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Key,
+                refs: vec![
+                    EnvelopeRef {
+                        envelope_hash: h(1),
+                        seq: 1,
+                    },
+                    EnvelopeRef {
+                        envelope_hash: h(9), // theirs, we lack it
+                        seq: 9,
+                    },
+                ],
+            }),
+            &provider,
+            &mut applier,
+        );
+        assert!(
+            matches!(s.start_round(&provider), ReplicationOutcome::Send(_)),
+            "wanting their rows keeps the round open"
+        );
     }
 
     /// Fetch — on-demand envelope retrieval, distinct from anti-


### PR DESCRIPTION
The two edge gates from the CEG-native / contextual-integrity audit, bundled per the plan — with this cut (+ persist v18.1.0's shape validator, already pinned), **the v18 trace plane can be exercised on mobiles**.

Closes #380, closes #379.

## #380 — carriage hardening
- **Delta-aware** proactive Deliver: skips refs the peer's last reverse-path Summary confirms it holds (v13.7.0 re-blasted the full set every round — catastrophic once Attestation rows carry ≤1 MiB inline traces).
- **Bounded**: 256 KiB/round budget, oldest-seq first, spillover converges across rounds; an over-budget envelope still ships alone (a budget bounds the batch, never strands an envelope). Sent-cache (20-round refresh) prevents re-blasting when no Summary ever arrives.
- **Initiator-final rounds**: `SendAndComplete`/`SendThenComplete` — when the peer's own Summary **confirms** full sync and we want nothing of its, the round completes at send. `round_outcomes` reports honest `completed` (un-poisons the #370 instrument). Strictly confirmation-gated — pushed-but-unconfirmed rounds still wait.

## #379 — the Recipient parameter
- `trace:*` scores-attestations are listed **and** served only to peers whose federation KeyRecord advertises the accord-conferred **`observer`** role (fail-closed on unknown peers). Non-trace attestations untouched; a `None` recipient (tests/diagnostics) is projection-only.
- Enforced on **both** paths — the listing sweep and `fetch_envelope_bytes_for_peer` — so exclusion can't be bypassed by Fetch-ing a hash learned out-of-band.
- Plumbing: defaulted recipient-aware trait methods (only the bridge overrides) + `DirectoryStateAdapter::with_peer` at all three coordinator build sites.

## Verification
- 6 new #380 session tests (delta / sent-cache / budget+spillover / oversize-alone / confirmed-sync completion / blocked-when-we-want-theirs).
- #379 end-to-end gate test (observer vs non-observer × listing + fetch, non-trace control) — which **also validates persist v18.1.0's `trace:*` shape validator from edge** (the fixture must carry `trace_id`/`agent_id_hash`/`trace` to admit).
- Full lib suite 621 green; clippy `-D warnings` (http+reticulum+pyo3 `--all-targets`) clean.

## Sequencing note
This satisfies the #379 rule from the audit: the observer gate lands **before** the fleet exercises `attestation_promote`. The consent round-trip (`attestation_demote` → WITHDRAWS to observers) remains CIRISPersist#476's P3 scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
