### PR TITLE
feat(v13.13.0): adopt persist v19.0.0 (RC3 charter alignment) + verify v10.6.0 lockstep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.12.0"
+version = "13.13.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.3.0", version = "18", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.0.0", version = "19", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.3.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.5.0", version = "10", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.5.0", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.0", version = "10", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.0", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.5.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.5.0", version = "10" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.0", version = "10" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v18.3.0", version = "18", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.0.0", version = "19", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,8 +51,12 @@ classifiers = [
 # the pyproject ceiling with what Cargo actually links. All co-resident
 # consumers must still share one ciris-persist version process-wide
 # (the OnceLock-backed Engine singleton; CIRISPersist#85 EPIC).
+# v13.13.0 — lockstep with the Cargo pin at persist v19.0.0 (RC3 charter
+# alignment). The bundled cdylib links persist 19; a `<19` ceiling here would
+# republish the exact v2.0.2 failure above (Requires-Dist asking for a version
+# the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=18.0.0,<19",
+    "ciris-persist>=19.0.0,<20",
 ]
 dynamic = ["version"]
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1984,6 +1984,38 @@ mod tests {
         id
     }
 
+    /// Seed a root's SELF-CHARTER — `delegates_to(root → root)`. persist v19
+    /// (CIRISPersist#488) tightened this shape twice, and both are enforced at
+    /// admission, so the fixture carries what the field must carry:
+    /// `scope` must contain BOTH `infra:serve` AND `infra:attest` (the finalized
+    /// charter minimum; v18's OR is gone), and the envelope must carry a
+    /// well-formed `pre_rotation_commitment` — sha256 over the canonicalized,
+    /// sorted pre-committed successor key set — without which root-key
+    /// compromise is unrecoverable by construction (the KERI prior-art lesson).
+    /// Built with persist's own `pre_rotation_commitment` helper rather than a
+    /// hand-rolled digest, so the fixture cannot drift from the verifier.
+    async fn seed_root_charter(
+        backend: &MemoryBackend,
+        root: &str,
+        successor_keys: &[String],
+    ) -> String {
+        let id = uuid::Uuid::new_v4().to_string();
+        let commitment =
+            ciris_persist::federation::trust_root::pre_rotation_commitment(successor_keys)
+                .expect("pre-rotation commitment");
+        let envelope = serde_json::json!({
+            "id": id,
+            "references_attestation_id": id,
+            "attesting_key_id": root,
+            "attested_key_id": root,
+            "attestation_type": "delegates_to",
+            "scope": ["infra:serve", "infra:attest"],
+            "pre_rotation_commitment": commitment,
+        });
+        seed_raw_attestation(backend, &id, root, root, "delegates_to", envelope).await;
+        id
+    }
+
     /// Seed a fresh `accord:lifecycle:v1` scores row ABOUT `root` — the
     /// liveness leg of `trust_root_valid`.
     async fn seed_accord_lifecycle(backend: &MemoryBackend, attester: &str, root: &str) {
@@ -2185,8 +2217,7 @@ mod tests {
         //   2. delegates_to(local → root)                 — WE trust the root
         //   3. accord:lifecycle scores about root, fresh  — root is live
         //   4. delegates_to(root → trusted_peer, infra:serve) — the grant
-        let infra_scope = serde_json::json!(["infra:attest", "infra:serve"]);
-        let trust_edge_id = seed_delegates_to(&backend, root, root, &infra_scope).await;
+        let trust_edge_id = seed_root_charter(&backend, root, &[format!("{root}-successor")]).await;
         let our_trust_edge = seed_delegates_to(
             &backend,
             local,
@@ -2380,9 +2411,14 @@ mod tests {
 
         // Trust graph: root self-declares, WE trust it, it is live, and it
         // grants `infra:serve` to full_peer ONLY.
-        let infra = serde_json::json!(["infra:attest", "infra:serve"]);
-        seed_delegates_to(&backend, root, root, &infra).await;
-        let our_trust_edge = seed_delegates_to(&backend, local, root, &infra).await;
+        seed_root_charter(&backend, root, &[format!("{root}-successor")]).await;
+        let our_trust_edge = seed_delegates_to(
+            &backend,
+            local,
+            root,
+            &serde_json::json!(["infra:attest", "infra:serve"]),
+        )
+        .await;
         seed_accord_lifecycle(&backend, lifecycle_attester, root).await;
         seed_delegates_to(
             &backend,


### PR DESCRIPTION
Adopts **persist v19.0.0** (RC3 charter alignment: #486 roles lift + #488 charter recovery/AND/expiry + #487 crystal vocabulary) and bumps verify to **v10.6.0** in lockstep.

A major bump, but **source-compatible for edge**: both #386 call sites (`has_effective_role`, `capability_roots_to_trusted_root`) keep their signatures, and `TrustRootVerdict` only gains a field edge never constructs. **No edge logic changed** — this is the pin, plus the test fixtures v19's tightened admission now rejects.

## What v19 means for the trace plane (#486 is the real root cause)

Persist never read verify's envelope-attested roles: `roles_in_envelope()` was called **nowhere**, and `register.rs` built records with `roles: Vec::new()`. So an accord co-scrub could attest `infra:serve` and every `claims_role` / `has_effective_role` consumer still saw `[]` — **the conferral was made and dropped on the floor.**

That means **#386 leg A was gated on a surface that could never populate.** v19's `lift_envelope_attested_roles` fixes it — carefully: visibility, never conferral. It runs *before* the role write-gates, tampering the envelope breaks the scrub signatures, and effectiveness is still re-derived against the live roster.

**The plane is still dark, and this does not change that** — `canonical_seed.json` carries no roles in *either* surface (top-level or envelope), and CIRISPersist#480 remains open. What changed is that **re-genesis is now viable**: before v19, the ceremony would have produced a correctly-attested record that still read `[]`.

## Fixtures — v19 tightened the root charter twice, and the suite caught both

Both are enforced at admission (#488):
- `scope` must carry **both** `infra:serve` **and** `infra:attest` — v18's OR is gone;
- the charter envelope must carry a well-formed `pre_rotation_commitment` (sha256 over the canonicalized, sorted successor set), or admission refuses with `CharterInvalid` — without it root-key compromise is unrecoverable by construction (the KERI prior-art lesson).

New `seed_root_charter` helper builds this with persist's **own public** `pre_rotation_commitment`, so the fixture cannot drift from the verifier — the same discipline that caught my guessed `withdraws` key last cut.

## Verify lockstep (the cascade this stack has hit before)

persist v19 pulls verify **v10.6.0**, which left `ciris-crypto` / `ciris-keyring` / `ciris-verify-core` duplicated at **both** 10.5.0 and 10.6.0 in the lock — the cross-cdylib duplication class that surfaces as SIGSEGV-on-import rather than a compile error. Bumped edge's three direct pins to v10.6.0; verified **one instance each**, leviculum pin unmoved.

Also bumps the `pyproject` ceiling to `>=19.0.0,<20` in lockstep (the pre-commit skew hook caught this) — a stale `<19` would republish the v2.0.2 `ResolutionImpossible` failure documented inline.

Gates: full lib **621 green**, test-anchor lane **622 green**, clippy `-D warnings` clean on **both** feature sets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
