### PR TITLE
feat(v13.14.0): adopt persist v19.1.0 — the trace plane goes bright (#480 finisher)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.13.0"
+version = "13.14.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.0.0", version = "19", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.0", version = "19", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.0.0", version = "19", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.0", version = "19", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=19.0.0,<20",
+    "ciris-persist>=19.1.0,<20",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Adopts **persist v19.1.0**, which bakes the assembled genesis trust-root (#490) and **closes CIRISPersist#480**. This is the cut where **the trace plane stops being dark by construction.**

## Why this un-darks the plane

The chain that was broken end-to-end is now whole:
- **v13.12.0** (edge) — the gate is correct: leg A needs an accord-conferred `infra:serve` read via `has_effective_role`.
- **v19.0.0** (#486) — persist stops dropping verify's envelope-attested roles on the floor; `lift_envelope_attested_roles` lifts them into the claim surface at admission (visibility, never conferral).
- **v19.1.0** (#490) — the baked `canonical_seed.json` now carries `infra:serve` in its **envelope** roles (`registration_envelope.roles = ["infra:serve"]`).

Net: `has_effective_role(canonical, infra:serve)` finally reads **true** for a genesis-baked canonical, so **#386 leg A can pass.**

## This is a re-pin, not an edge change

Edge's gate was always right; the substrate under it caught up. Both #386 call sites keep their signatures, and the seed lives in persist — edge's own trust-graph fixtures are untouched. **Full lib 621 green, test-anchor lane 622 green, clippy `-D warnings` clean on both feature sets, zero fixture edits.**

## Supersedes v13.13.0

v13.13.0 is tagged on origin but **its wheel never published** — that tag run failed on a runner-disk flake **and** cohab-vs-unpublished-persist-19.0.0, so the tag-gated Publish job was skipped. It also pinned the *darker* v19.0.0. Rather than wait on the queued v19.0.0 wheel to publish a persist that cannot go bright, this re-pins straight to v19.1.0. No consumer holds a v13.13.0 wheel, so nothing is orphaned — the PyPI line goes **v13.12.0 → v13.14.0**.

verify stays v10.6.0 (single instance each — no skew this time); leviculum unmoved; `pyproject` ceiling bumped to `>=19.1.0,<20` in lockstep.

## Still required for a LIVE trace (unchanged by this cut)
1. the fleet runs the #490 genesis bake on the actual nodes (the seed makes the plane *capable*);
2. the server wires `ReplicationRuntimeConfig::local_key_id` (CIRISServer#300 — leg B's `user` half). Absent, the gate fail-closes and WARNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
