### PR TITLE
fix(v13.14.1): re-pin persist v19.1.1 + verify v10.6.1 lockstep (RC3 vocab interop fix)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.14.0"
+version = "13.14.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.0", version = "19", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.1", version = "19", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.0", version = "10", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.0", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.1", version = "10", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.1", version = "10", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.0", version = "10" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v10.6.1", version = "10" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.0", version = "19", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.1", version = "19", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=19.1.0,<20",
+    "ciris-persist>=19.1.1,<20",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Re-pins **persist v19.1.1** + **verify v10.6.1** in lockstep. **No edge behavior change** — a dependency re-pin adopting an interop fix, plus the mandatory verify bump to avoid a duplicate-version skew.

## What v19.1.1 fixes (persist#492)
verify 10.6.0's `INFRA_SCOPES` never got the #487 RC3 vocabulary cut — it still enumerated the retired `infra:join_communities` and lacked the `hold_*_membership` tokens. So an RC3 owner-binding delegation **passed persist's admission but read `UnknownScope` on the verify/FFI surface** — one fact, two gate verdicts, the exact interop-hole RC3 exists to close. 10.6.1 hard-cuts verify into sync; v19.1.1 adds a persist test asserting the two infra-scope vocabularies are the same set so this can't recur silently.

## Why it doesn't change edge, but edge must still take it
- Edge's trace gate keys on **`infra:serve`**, which is **stable** across 10.6.0→10.6.1 (the changed tokens are the community-membership ones edge never gates on), and the new persist guard is a **test**, not a runtime path. Behavior is identical.
- But edge **directly pins** `ciris-keyring` / `ciris-verify-core`. Staying on 10.6.0 while persist v19.1.1 links 10.6.1 duplicates `ciris-crypto` / `ciris-keyring` / `ciris-verify-core` at two versions in the lock — the cross-cdylib duplication that surfaces as **SIGSEGV-on-import**, not a compile error. So all three edge verify pins go to v10.6.1.

Verified: **one instance each** of crypto/keyring/verify-core, persist 19.1.1, leviculum unmoved; `pyproject` floor `>=19.1.1,<20`.

Gates: full lib **621 green**, test-anchor lane **622 green**, clippy `-D warnings` clean on **both** feature sets, zero fixture edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
