### PR TITLE
feat(v13.15.0): adopt persist v20.0.0 (serde_json::Value walls removed) — source-compatible for edge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.14.1"
+version = "13.15.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.1", version = "19", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v20.0.0", version = "20", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v19.1.1", version = "19", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v20.0.0", version = "20", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=19.1.1,<20",
+    "ciris-persist>=20.0.0,<21",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Adopts **persist v20.0.0** — a major bump. **Source-compatible for edge, zero edits.**

## What v20 is (persist#495)
Replaces two opaque `serde_json::Value` boundary payloads with typed structs, so cross-boundary field drift becomes a **build/test failure** instead of a silent NULL — the disease behind most of this arc's dark-plane RCAs.

## Why edge is unaffected (verified, not assumed)
Edge both reads envelope keys *and* builds `Attestation` fixtures, so it's exactly the drift class #495 targets — I checked against the removed walls specifically:
- `EmitAttestationInput.attestation_envelope` stays `serde_json::Value` (unchanged);
- `LocalAttestationInput.attestation_envelope` → typed `EnvelopeCore` (**new**), **but edge constructs `Attestation`** (`types.rs:934`), whose `attestation_envelope` is **still `serde_json::Value`**. Edge never builds `LocalAttestationInput`.

So edge's three `Attestation`-construction sites and the bridge's `/attestation_envelope/dimension` read compile and behave identically. #494's single-source trace-summary contract is persist's scorer feature matrix (sqlite/postgres/agent), not an edge consumer. **The trace serve gate — and the bright plane — are untouched.**

## Lockstep
Bundles v19.2.0 (#493 self-enc accessor + #494); edge consumes neither directly. verify stays **v10.6.1** (v20's pin; edge already there) — single instance each, no skew; leviculum unmoved; `pyproject` → `>=20.0.0,<21`.

## Supersedes v13.14.1 (phantom tag)
v13.14.1 tagged but never published — its tag run was **cancelled**, Publish skipped (same as v13.13.0). Its only substance was the verify 10.6.1 interop fix, which v20 carries, so nothing is lost: PyPI goes **v13.14.0 → v13.15.0**.

Gates: full lib **621 green**, test-anchor lane **622 green**, clippy `-D warnings` clean on **both** feature sets, zero fixture edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
