### PR TITLE
feat(v14.0.0): persist v21 Registry-of-Record + trace-serve attribution gate (#393 E3) + MLS Welcome directory-only (#331 E8)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "13.15.1"
+version = "14.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v20.1.0", version = "20", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.1.0", version = "21", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v20.1.0", version = "20", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.1.0", version = "21", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=20.1.0,<21",
+    "ciris-persist>=21.1.0,<22",
 ]
 dynamic = ["version"]
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -4008,7 +4008,11 @@ async fn route_replication_frame(
     let Some(registry) = registry else {
         return false; // no replication runtime installed → envelope dispatch
     };
-    let Some(source) = frame.source_key_id.as_deref() else {
+    let Some(source) = frame
+        .source_key_id
+        .as_ref()
+        .map(crate::transport::SourceKeyId::as_str)
+    else {
         // No attribution: a CRPL frame here is unroutable (drop, loudly); a
         // non-CRPL frame is a normal unattributed envelope (fall through).
         if frame
@@ -7410,7 +7414,7 @@ mod inbound_ingest_tests {
             envelope_bytes: bytes,
             transport: TransportId::RETICULUM_RS,
             received_at: chrono::Utc::now(),
-            source_key_id: source.map(str::to_string),
+            source_key_id: source.map(crate::transport::SourceKeyId::transport_authenticated),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,37 @@ mod wire_vocabulary_hash_tests {
     }
 }
 
+/// CIRISEdge#393 / persist v21 (#501/#502) — the cross-repo drift witness for
+/// the Registry-of-Record admission policy. persist owns the APPLY policy for
+/// all 14 replicated kinds and exports it as
+/// [`ciris_persist::federation::replication_policy::REPLICATION_POLICY_HASH`];
+/// edge (the SERVE/ADVERTISE half) and CIRISServer both PIN it. A persist-side
+/// change to which signer-source admits a kind — the class that silently
+/// widened trust before v21 — flips this hash, failing edge's build until the
+/// re-pin is a deliberate, reviewed act across the triple (the same posture as
+/// [`WIRE_VOCABULARY_HASH`], now for the admission surface rather than the wire
+/// vocabulary).
+pub const PERSIST_REPLICATION_POLICY_HASH: &str =
+    "351912ead0aab4847f40d2b54a7a326546c37d43507deb38ea24d6094d29d63b";
+
+#[cfg(test)]
+mod replication_policy_hash_tests {
+    /// Pins persist's `REPLICATION_POLICY_HASH` from the linked crate against
+    /// edge's expected value. A mismatch is a coordinated admission-policy
+    /// change persist made that edge's serve/advertise half must be re-reviewed
+    /// against — never a silent skew. See CIRISEdge#393 §4.3 manifest witness.
+    #[test]
+    fn persist_replication_policy_hash_pinned() {
+        assert_eq!(
+            ciris_persist::federation::replication_policy::REPLICATION_POLICY_HASH,
+            super::PERSIST_REPLICATION_POLICY_HASH,
+            "persist's REPLICATION_POLICY_HASH changed — its admission policy for \
+             one of the 14 replicated kinds moved. Re-review edge's serve/advertise \
+             half against the new policy, then re-pin deliberately (CIRISEdge#393)."
+        );
+    }
+}
+
 pub use blob_swarm::{
     BlobChunkSource, BlobChunkVerifier, ChunkManifestLite, ChunkSourceRefusal, ChunkVerifyError,
     PeerState, SwarmConfig, SwarmError, SwarmScheduler,

--- a/src/mls/welcome_wrap.rs
+++ b/src/mls/welcome_wrap.rs
@@ -41,9 +41,11 @@ pub const WELCOME_WRAP_INFO: &[u8] = b"ciris-edge/scope-privacy/welcome-wrap/v1"
 /// Edge ships the four-tuple `(hpke_sealed, inviter_signature,
 /// inviter_pk_id, inviter_pk_bytes)`. The recipient resolves the
 /// inviter's ML-DSA-65 public key from a directory keyed by
-/// `inviter_pk_id` (and falls back to the inline `inviter_pk_bytes`
-/// when the directory has not seen the key yet, with the directory's
-/// trust gate then applied at admission time).
+/// `inviter_pk_id`. CIRISEdge#331 (E8) — the inline `inviter_pk_bytes`
+/// is NO LONGER a verification input: a directory miss is `InviterUnknown`,
+/// never a fall-through to the sender-supplied inline key (self-certifying
+/// TOFU). The field is retained for wire parity / diagnostics only and MUST
+/// NOT be trusted.
 #[derive(Debug, Clone)]
 pub struct WrappedWelcome {
     /// HPKE seal of the inner MLS Welcome bytes under the invitee's
@@ -56,9 +58,10 @@ pub struct WrappedWelcome {
     /// scoped: a fingerprint, key_id, or federation_id — edge does
     /// not interpret).
     pub inviter_pk_id: String,
-    /// Inviter's ML-DSA-65 public key bytes (the
-    /// `EncodedVerifyingKey<MlDsa65>` form, as returned by
-    /// [`PqcSigner::public_key`]).
+    /// Inviter's ML-DSA-65 public key bytes, as returned by
+    /// [`PqcSigner::public_key`]. CIRISEdge#331 — sender-supplied and NOT a
+    /// verification input; the joiner verifies only against the
+    /// directory-resolved key. Retained for wire parity / diagnostics.
     pub inviter_pk_bytes: Vec<u8>,
 }
 
@@ -131,12 +134,9 @@ pub fn wrap_welcome(
 /// supplies a closure that resolves `pk_id → bytes`; this struct is
 /// the minimal hand-off shape.
 ///
-/// `verify_inline_match` controls fallback policy when the directory
-/// returns `None` for `pk_id`:
-/// - `true` (default for v6.0.0) — fall back to the inline
-///   `inviter_pk_bytes` carried on the wrap.
-/// - `false` — refuse the unwrap with
-///   [`WelcomeWrapError::InviterUnknown`].
+/// CIRISEdge#331 (E8) — resolution is the SOLE trust input: when the
+/// closure returns `None` for `pk_id`, [`unwrap_welcome`] fails closed with
+/// [`WelcomeWrapError::InviterUnknown`] (no inline fallback).
 #[derive(Debug, Clone)]
 pub struct FederationDirectoryEntry {
     /// Inviter's federation identifier (key_id, fingerprint, or
@@ -154,14 +154,16 @@ pub struct FederationDirectoryEntry {
 /// §3.3 Welcome unwrap. Verifies the inviter signature on
 /// [`hpke::encap_signing_bytes`] FIRST, then runs HPKE `open_base`.
 ///
-/// `directory_lookup` resolves the inviter's ML-DSA-65 public key
-/// from `inviter_pk_id`; when it returns `None`, the function falls
-/// back to the inline `wrapped.inviter_pk_bytes` (v6.0.0 behaviour —
-/// the cached-directory + TOFU posture; a directory-required mode
-/// flips at the caller's discretion).
+/// `directory_lookup` resolves the inviter's ML-DSA-65 public key from
+/// `inviter_pk_id`. CIRISEdge#331 (E8) — DIRECTORY-RESOLVED ONLY: a `None`
+/// (directory miss) fails closed with [`WelcomeWrapError::InviterUnknown`],
+/// never falling back to the sender-supplied inline key. The joiner verifies
+/// the inviter signature over [`hpke::encap_signing_bytes`] against the
+/// directory-resolved key FIRST, then runs HPKE `open_base`.
 ///
 /// # Errors
 ///
+/// - Inviter not directory-resolvable → [`WelcomeWrapError::InviterUnknown`]
 /// - Signature verify fail → [`WelcomeWrapError::SignatureRejected`]
 /// - HPKE open fail → [`WelcomeWrapError::Crypto`]
 pub fn unwrap_welcome<F>(
@@ -173,11 +175,22 @@ pub fn unwrap_welcome<F>(
 where
     F: FnMut(&str) -> Option<FederationDirectoryEntry>,
 {
-    // Resolve the inviter's public key. Directory wins; inline is
-    // the v6.0.0 TOFU fallback.
+    // CIRISEdge#331 (E8) — the inviter key is DIRECTORY-RESOLVED ONLY. A
+    // directory MISS is `InviterUnknown`, NOT a fall-through to the
+    // sender-supplied inline `inviter_pk_bytes`. The old TOFU fallback was
+    // self-certifying: an attacker signs `encap_signing_bytes` with its OWN
+    // ML-DSA key, ships that key inline, and the signature verifies against it →
+    // the Welcome is accepted and the joiner cannot tell WHO actually invited it
+    // (exactly the property the X-Wing-unavailable HPKE `mode_auth` would have
+    // given, per CC 5.4.4). Fail closed: an inviter the local directory can't
+    // resolve is refused, never trusted on its own say-so.
     let inviter_pk_bytes: Vec<u8> = match directory_lookup(&wrapped.inviter_pk_id) {
         Some(entry) => entry.ml_dsa_pk,
-        None => wrapped.inviter_pk_bytes.clone(),
+        None => {
+            return Err(WelcomeWrapError::InviterUnknown(
+                wrapped.inviter_pk_id.clone(),
+            ))
+        }
     };
 
     // §3.3 PRECONDITION — verify the signature before open_base.
@@ -218,6 +231,19 @@ mod tests {
         (pk, sk)
     }
 
+    /// A directory lookup that resolves ANY `pk_id` to `inviter`'s registered
+    /// ML-DSA key — the directory-resolved path CIRISEdge#331 now requires.
+    fn directory_of(inviter: &MlDsa65Signer) -> impl Fn(&str) -> Option<FederationDirectoryEntry> {
+        let pk = inviter.public_key().unwrap();
+        move |id: &str| {
+            Some(FederationDirectoryEntry {
+                pk_id: id.to_string(),
+                ml_dsa_pk: pk.clone(),
+                x_wing_pk: None,
+            })
+        }
+    }
+
     #[test]
     fn wrap_then_unwrap_recovers_welcome_bytes() {
         let inviter = MlDsa65Signer::new().unwrap();
@@ -226,9 +252,37 @@ mod tests {
         let wrapped =
             wrap_welcome(&inviter, "inviter-key-1", &invitee_pk, welcome, b"group-42").unwrap();
 
-        // Directory has no entry — falls through to inline pk.
-        let opened = unwrap_welcome(&invitee_sk, &wrapped, b"group-42", |_| None).unwrap();
+        // CIRISEdge#331 — directory-resolved (no inline TOFU): the joiner
+        // resolves the inviter's registered ML-DSA key.
+        let opened =
+            unwrap_welcome(&invitee_sk, &wrapped, b"group-42", directory_of(&inviter)).unwrap();
         assert_eq!(opened, welcome);
+    }
+
+    /// CIRISEdge#331 (E8) acceptance — a Welcome whose inviter the local
+    /// directory cannot resolve is REFUSED (`InviterUnknown`), NOT accepted via
+    /// the old sender-supplied inline key. Closes the self-certifying TOFU: the
+    /// attacker signs the encap with its OWN ML-DSA key and ships that key
+    /// inline, but a directory miss now fails closed. (Against the pre-#331 code
+    /// this returned `Ok` — the vuln.)
+    #[test]
+    fn unknown_inviter_on_directory_miss_is_rejected_not_tofu_accepted() {
+        let attacker = MlDsa65Signer::new().unwrap();
+        let (invitee_pk, invitee_sk) = fresh_invitee();
+        let wrapped = wrap_welcome(
+            &attacker,
+            "unknown-inviter",
+            &invitee_pk,
+            b"hostile welcome",
+            b"",
+        )
+        .unwrap();
+        let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| None).unwrap_err();
+        assert!(
+            matches!(err, WelcomeWrapError::InviterUnknown(ref id) if id == "unknown-inviter"),
+            "a directory-unresolvable inviter must be InviterUnknown, never TOFU-accepted \
+             via the inline pk (CIRISEdge#331)",
+        );
     }
 
     #[test]
@@ -262,7 +316,7 @@ mod tests {
         let mut wrapped = wrap_welcome(&inviter, "inv-x", &invitee_pk, welcome, b"").unwrap();
         // Flip a byte of the signature.
         wrapped.inviter_signature[0] ^= 0x01;
-        let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| None).unwrap_err();
+        let err = unwrap_welcome(&invitee_sk, &wrapped, b"", directory_of(&inviter)).unwrap_err();
         assert!(matches!(err, WelcomeWrapError::SignatureRejected));
     }
 
@@ -303,7 +357,7 @@ mod tests {
                 &wrapped.hpke_sealed.encapsulation,
             ))
             .unwrap();
-        let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| None).unwrap_err();
+        let err = unwrap_welcome(&invitee_sk, &wrapped, b"", directory_of(&inviter)).unwrap_err();
         assert!(matches!(err, WelcomeWrapError::Crypto(_)));
     }
 
@@ -317,7 +371,8 @@ mod tests {
         // Verify-side uses a different aad → AEAD open fails. The
         // signature is fine (it covers encap bytes, not aad), so the
         // failure surfaces as a CryptoError from open_base.
-        let err = unwrap_welcome(&invitee_sk, &wrapped, b"aad-2", |_| None).unwrap_err();
+        let err =
+            unwrap_welcome(&invitee_sk, &wrapped, b"aad-2", directory_of(&inviter)).unwrap_err();
         assert!(matches!(err, WelcomeWrapError::Crypto(_)));
     }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1048,99 +1048,155 @@ impl FederationDirectoryReplicationBridge {
         .await
     }
 
+    // ── CIRISEdge#504 — the 5 E4 keyless-declaration planes advertise via
+    //    persist v21.1.0's SIGNED, since-cursor bulk reads ──────────────────
+    //
+    // v21 #502 E4 gave these planes an authority signature (`authority_key_id`
+    // + hybrid scrub sigs on the `Signed*` wrapper), which edge — NOT the
+    // authority — cannot produce. persist self-signs on write and now exposes
+    // `list_signed_<kind>_since(since, limit) -> Vec<Signed*>` (mirroring the
+    // org/orgmembership/partner reads), so edge serves those wrappers BYTE-EXACT
+    // (their JCS `v2_envelope_hash` is the wire hash, same §3.2.2 basis as the
+    // org kinds). This also retires the per-member `fan_out_for_member` for
+    // these 5: ONE paginated read per plane per round instead of O(cohort)
+    // round-trips (CIRISPersist#504 hot-path floor).
+    //
+    // ADVERTISE SCOPE is preserved from the pre-v21 fan_out per the §4.3
+    // 14-kind table: Family / Community / LocationProof are **Cohort**-scoped
+    // (filtered in-memory to rows touching a cohort member — the bulk read is
+    // over edge's OWN directory, so reading-then-filtering leaks nothing), and
+    // the two membership-revocation planes are **Global** (advertised whole,
+    // matching the pre-v21 `subjects_for_projection(Global)` subject set).
+
+    /// Advertise a bulk signed operational plane: keep rows in `in_scope`, hash
+    /// each already-signed wrapper by its JCS `v2_envelope_hash`, cache its wire
+    /// bytes, dedupe.
+    async fn advertise_signed_operational<S, TS, IN>(
+        &self,
+        kind: EnvelopeKind,
+        rows: Vec<S>,
+        seq_of: TS,
+        in_scope: IN,
+    ) -> Vec<EnvelopeRef>
+    where
+        S: serde::Serialize,
+        TS: Fn(&S) -> chrono::DateTime<chrono::Utc>,
+        IN: Fn(&S) -> bool,
+    {
+        let mut refs = Vec::new();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        for signed in rows.iter().filter(|s| in_scope(s)) {
+            let Some(hash) = v2_envelope_hash(signed) else {
+                continue;
+            };
+            if !seen.insert(hash) {
+                continue;
+            }
+            let bytes = serde_json::to_vec(signed).unwrap_or_default();
+            self.cache_insert(kind, hash, bytes).await;
+            refs.push(EnvelopeRef {
+                envelope_hash: hash,
+                seq: Self::ms_seq(seq_of(signed)),
+            });
+        }
+        refs
+    }
+
+    /// The operator-configured cohort as a set, for the Cohort-scoped advertise
+    /// filters.
+    fn cohort_set(&self) -> HashSet<String> {
+        (self.cohort)().into_iter().collect()
+    }
+
     async fn list_families(&self) -> Vec<EnvelopeRef> {
-        self.fan_out_for_member(
+        let cohort = self.cohort_set();
+        let rows = self
+            .directory
+            .list_signed_families_since(None, self.config.operational_page_limit)
+            .await
+            .unwrap_or_default();
+        self.advertise_signed_operational(
             EnvelopeKind::Family,
-            (self.cohort)(),
-            |key_id| async move {
-                self.directory
-                    .list_families_for_member(&key_id)
-                    .await
-                    .unwrap_or_default()
-            },
-            |row| SignedFamily {
-                family: row.clone(),
-            },
-            |row| row.founded_at,
-            |row| row.persist_row_hash.as_str(),
+            rows,
+            |s| s.family.founded_at,
+            |s| s.family.members.iter().any(|m| cohort.contains(&m.key_id)),
         )
         .await
     }
 
     async fn list_communities(&self) -> Vec<EnvelopeRef> {
-        self.fan_out_for_member(
+        let cohort = self.cohort_set();
+        let rows = self
+            .directory
+            .list_signed_communities_since(None, self.config.operational_page_limit)
+            .await
+            .unwrap_or_default();
+        self.advertise_signed_operational(
             EnvelopeKind::Community,
-            (self.cohort)(),
-            |key_id| async move {
-                self.directory
-                    .list_communities_for_member(&key_id)
-                    .await
-                    .unwrap_or_default()
+            rows,
+            |s| s.community.founded_at,
+            |s| {
+                s.community
+                    .members
+                    .iter()
+                    .any(|m| cohort.contains(&m.key_id))
             },
-            |row| SignedCommunity {
-                community: row.clone(),
-            },
-            |row| row.founded_at,
-            |row| row.persist_row_hash.as_str(),
         )
         .await
     }
 
     async fn list_family_membership_revocations(&self) -> Vec<EnvelopeRef> {
-        // #311 tombstone fix — membership revocation projects `Global`.
-        self.fan_out_for_member(
+        // #311 tombstone fix — membership revocation projects `Global`
+        // (advertised whole, no cohort filter).
+        let rows = self
+            .directory
+            .list_signed_family_membership_revocations_since(
+                None,
+                self.config.operational_page_limit,
+            )
+            .await
+            .unwrap_or_default();
+        self.advertise_signed_operational(
             EnvelopeKind::FamilyMembershipRevocation,
-            self.subjects_for_projection(Projection::Global),
-            |key_id| async move {
-                self.directory
-                    .list_family_membership_revocations_for(&key_id)
-                    .await
-                    .unwrap_or_default()
-            },
-            |row| SignedFamilyMembershipRevocation {
-                family_membership_revocation: row.clone(),
-            },
-            |row| row.removed_at,
-            |row| row.persist_row_hash.as_str(),
+            rows,
+            |s| s.family_membership_revocation.removed_at,
+            |_| true,
         )
         .await
     }
 
     async fn list_community_membership_revocations(&self) -> Vec<EnvelopeRef> {
-        // #311 tombstone fix — membership revocation projects `Global`.
-        self.fan_out_for_member(
+        // #311 tombstone fix — membership revocation projects `Global`
+        // (advertised whole, no cohort filter).
+        let rows = self
+            .directory
+            .list_signed_community_membership_revocations_since(
+                None,
+                self.config.operational_page_limit,
+            )
+            .await
+            .unwrap_or_default();
+        self.advertise_signed_operational(
             EnvelopeKind::CommunityMembershipRevocation,
-            self.subjects_for_projection(Projection::Global),
-            |key_id| async move {
-                self.directory
-                    .list_community_membership_revocations_for(&key_id)
-                    .await
-                    .unwrap_or_default()
-            },
-            |row| SignedCommunityMembershipRevocation {
-                community_membership_revocation: row.clone(),
-            },
-            |row| row.removed_at,
-            |row| row.persist_row_hash.as_str(),
+            rows,
+            |s| s.community_membership_revocation.removed_at,
+            |_| true,
         )
         .await
     }
 
     async fn list_location_proofs(&self) -> Vec<EnvelopeRef> {
-        self.fan_out_for_member(
+        let cohort = self.cohort_set();
+        let rows = self
+            .directory
+            .list_signed_location_proofs_since(None, self.config.operational_page_limit)
+            .await
+            .unwrap_or_default();
+        self.advertise_signed_operational(
             EnvelopeKind::LocationProof,
-            (self.cohort)(),
-            |key_id| async move {
-                self.directory
-                    .list_location_proofs_for(&key_id)
-                    .await
-                    .unwrap_or_default()
-            },
-            |row| SignedLocationProof {
-                location_proof: row.clone(),
-            },
-            |row| row.asserted_at,
-            |row| row.persist_row_hash.as_str(),
+            rows,
+            |s| s.location_proof.asserted_at,
+            |s| cohort.contains(&s.location_proof.subject_key_id),
         )
         .await
     }
@@ -1440,48 +1496,44 @@ impl FederationDirectoryReplicationBridge {
     // commitment "merge policy stays persist-side per §10.1.6 declared
     // intents."
 
+    // CIRISEdge#504 / persist v21 #502 E9 — persist now resolves the steward
+    // roster from its OWN registered directory (never a caller-passed roster:
+    // that was itself a classical FK-existence edge). So `put_organization` /
+    // `put_org_membership` / `put_partner_record` no longer take
+    // key_directory/root_stewards/steward_roster args. The `operational` gate
+    // stays the opt-in for whether THIS edge participates in operational-kind
+    // admission at all — admission SCOPE is unchanged, only the (now
+    // persist-internal) roster plumbing is dropped. The `OperationalProviders`
+    // roster fields are vestigial post-E9; the server drops computing them when
+    // it adopts v14.
     async fn apply_organization(&self, bytes: &[u8]) -> bool {
-        let Some(ops) = self.operational.as_ref() else {
+        if self.operational.is_none() {
             return false;
-        };
+        }
         let Ok(signed) = serde_json::from_slice::<SignedOrganization>(bytes) else {
             return false;
         };
-        let key_directory = (ops.key_directory)();
-        let root_stewards = (ops.root_stewards)();
-        self.directory
-            .put_organization(signed, key_directory.as_slice(), root_stewards.as_slice())
-            .await
-            .is_ok()
+        self.directory.put_organization(signed).await.is_ok()
     }
 
     async fn apply_org_membership(&self, bytes: &[u8]) -> bool {
-        let Some(ops) = self.operational.as_ref() else {
+        if self.operational.is_none() {
             return false;
-        };
+        }
         let Ok(signed) = serde_json::from_slice::<SignedOrgMembership>(bytes) else {
             return false;
         };
-        let key_directory = (ops.key_directory)();
-        let root_stewards = (ops.root_stewards)();
-        self.directory
-            .put_org_membership(signed, key_directory.as_slice(), root_stewards.as_slice())
-            .await
-            .is_ok()
+        self.directory.put_org_membership(signed).await.is_ok()
     }
 
     async fn apply_partner_record(&self, bytes: &[u8]) -> bool {
-        let Some(ops) = self.operational.as_ref() else {
+        if self.operational.is_none() {
             return false;
-        };
+        }
         let Ok(signed) = serde_json::from_slice::<SignedPartnerRecord>(bytes) else {
             return false;
         };
-        let steward_roster = (ops.steward_roster)();
-        self.directory
-            .put_partner_record(signed, steward_roster.as_slice())
-            .await
-            .is_ok()
+        self.directory.put_partner_record(signed).await.is_ok()
     }
 }
 

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -123,6 +123,7 @@ pub mod protocol;
 pub mod registry;
 pub mod runtime;
 pub mod scheduler;
+pub mod serve_policy;
 pub mod session;
 pub mod storage_contention;
 pub mod summary;

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -157,6 +157,50 @@ pub enum EnvelopeKind {
 }
 
 impl EnvelopeKind {
+    /// All 14 replicated wire kinds, in declaration order. Mirrors persist's
+    /// `replication_policy::EnvelopeKind::ALL` (same 14 names/order, pinned by
+    /// `REPLICATION_POLICY_HASH`). Basis for the serve/advertise manifest
+    /// (CIRISEdge#393 item 3).
+    pub const ALL: [EnvelopeKind; 14] = [
+        Self::Key,
+        Self::Attestation,
+        Self::Revocation,
+        Self::IdentityOccurrence,
+        Self::Family,
+        Self::Community,
+        Self::IdentityOccurrenceRevocation,
+        Self::FamilyMembershipRevocation,
+        Self::CommunityMembershipRevocation,
+        Self::LocationProof,
+        Self::Organization,
+        Self::OrgMembership,
+        Self::PartnerRecord,
+        Self::TransportDestination,
+    ];
+
+    /// Stable snake_case wire name for this kind — the manifest/witness key
+    /// (CIRISEdge#393 item 3). Stable across releases; a rename is a wire-policy
+    /// change that must flip `SERVE_ADVERTISE_POLICY_HASH`.
+    #[must_use]
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::Key => "key",
+            Self::Attestation => "attestation",
+            Self::Revocation => "revocation",
+            Self::IdentityOccurrence => "identity_occurrence",
+            Self::Family => "family",
+            Self::Community => "community",
+            Self::IdentityOccurrenceRevocation => "identity_occurrence_revocation",
+            Self::FamilyMembershipRevocation => "family_membership_revocation",
+            Self::CommunityMembershipRevocation => "community_membership_revocation",
+            Self::LocationProof => "location_proof",
+            Self::Organization => "organization",
+            Self::OrgMembership => "org_membership",
+            Self::PartnerRecord => "partner_record",
+            Self::TransportDestination => "transport_destination",
+        }
+    }
+
     /// The minimum [`crate::replication::wire_frame::WIRE_PROTOCOL_VERSION`]
     /// at which this kind can be exchanged on the wire.
     ///

--- a/src/replication/serve_policy.rs
+++ b/src/replication/serve_policy.rs
@@ -1,0 +1,116 @@
+//! CIRISEdge#393 (E3, item 3) — the SERVE/ADVERTISE policy manifest: edge's
+//! responder half of the Registry-of-Record contract.
+//!
+//! persist owns the APPLY policy for all 14 replicated kinds and exports it as
+//! `ciris_persist::federation::replication_policy::REPLICATION_POLICY_HASH`
+//! (pinned by edge in `lib.rs`). Edge owns the **serve/advertise** half — for
+//! each kind, WHICH peers it advertises to (the projection scope) and WHETHER
+//! serving is capability-gated. This module exports that half as a canonical
+//! manifest + a sha256 const, exactly like [`crate::WIRE_VOCABULARY_HASH`], so
+//! CIRISServer pins BOTH hashes (`tests/release_gates/`) and any drift in edge's
+//! responder policy — e.g. silently un-gating the `trace:*` serve path — is a
+//! build failure across the triple, not a quiet confidentiality regression.
+//!
+//! The one load-bearing fact this witnesses is E3's closure: `trace:*`
+//! attestations serve ONLY to `capability:infra:serve` recipients; every other
+//! kind serves public (public signed envelopes). A change to that column flips
+//! the hash.
+
+use super::protocol::EnvelopeKind;
+
+/// The per-kind serve/advertise policy edge (the responder) enforces.
+fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
+    // `advertise`: the projection scope the bridge fans a kind out over.
+    //   - `per_record_projection` — persist `projection_for` decides per row
+    //     (SelfOwn / Cohort / Global from the record's own dimension/cohort_scope).
+    //   - `cohort` / `global` — the operator cohort set / the whole plane.
+    //   - `bulk_since` — the paginated since-cursor operational reads.
+    // `serve`: `public` (public signed envelope) or a `capability:*` gate.
+    let (advertise, serve) = match kind {
+        EnvelopeKind::Key
+        | EnvelopeKind::IdentityOccurrence
+        | EnvelopeKind::TransportDestination
+        | EnvelopeKind::IdentityOccurrenceRevocation
+        | EnvelopeKind::Revocation => ("per_record_projection", "public"),
+        // E3: the trace plane is the sole capability-gated serve path.
+        EnvelopeKind::Attestation => (
+            "per_record_projection",
+            "trace:* → capability:infra:serve; else public",
+        ),
+        EnvelopeKind::Family | EnvelopeKind::Community | EnvelopeKind::LocationProof => {
+            ("cohort", "public")
+        }
+        EnvelopeKind::FamilyMembershipRevocation | EnvelopeKind::CommunityMembershipRevocation => {
+            ("global", "public")
+        }
+        EnvelopeKind::Organization | EnvelopeKind::OrgMembership | EnvelopeKind::PartnerRecord => {
+            ("bulk_since", "public")
+        }
+    };
+    serde_json::json!({ "kind": kind.as_wire_str(), "advertise": advertise, "serve": serve })
+}
+
+/// The canonical serve/advertise policy manifest (mirrors persist's
+/// `replication_policy_manifest` shape). JCS-canonicalized + hashed for the
+/// cross-repo drift witness.
+#[must_use]
+pub fn serve_advertise_manifest() -> serde_json::Value {
+    serde_json::json!({
+        "contract": "replication_serve_advertise_policy",
+        "version": 1,
+        "policies": EnvelopeKind::ALL
+            .iter()
+            .map(|k| policy_for(*k))
+            .collect::<Vec<_>>(),
+    })
+}
+
+/// sha256(JCS(manifest)), hex — the responder half of the drift witness.
+#[must_use]
+pub fn serve_advertise_policy_sha256() -> String {
+    use sha2::Digest as _;
+    let canonical = ciris_verify_core::jcs::canonicalize(&serve_advertise_manifest())
+        .expect("serve/advertise manifest canonicalizes");
+    hex::encode(sha2::Sha256::digest(&canonical))
+}
+
+/// The pinned serve/advertise policy hash. A change to edge's responder policy
+/// (advertise scope or serve gate for ANY of the 14 kinds) flips this — a
+/// deliberate, reviewed re-pin, visible to CIRISServer which pins it alongside
+/// persist's `REPLICATION_POLICY_HASH`. See CIRISEdge#393 §4.2/§4.3.
+pub const SERVE_ADVERTISE_POLICY_HASH: &str =
+    "79f5c63a4e4945995f9beba6f3746c380e0bee3fe805866ebfaff34ac6d7c9ff";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serve_advertise_policy_hash_pinned() {
+        assert_eq!(
+            serve_advertise_policy_sha256(),
+            SERVE_ADVERTISE_POLICY_HASH,
+            "edge's serve/advertise responder policy changed — re-review it (esp. the \
+             trace:* serve gate), then re-pin deliberately (CIRISEdge#393 §4.2). \
+             CIRISServer pins this alongside persist's REPLICATION_POLICY_HASH.",
+        );
+    }
+
+    /// The load-bearing E3 fact must hold in the manifest: exactly ONE kind is
+    /// capability-gated (Attestation's trace:* path), the rest public.
+    #[test]
+    fn only_the_trace_attestation_plane_is_capability_gated() {
+        let manifest = serve_advertise_manifest();
+        let policies = manifest["policies"].as_array().unwrap();
+        let gated: Vec<&str> = policies
+            .iter()
+            .filter(|p| p["serve"].as_str().unwrap().contains("capability:"))
+            .map(|p| p["kind"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            gated,
+            vec!["attestation"],
+            "E3: only the attestation plane's trace:* serve path is capability-gated",
+        );
+    }
+}

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -601,7 +601,10 @@ async fn inbound_handler(
     // tracked in #120 § HTTPS.
     let source_key_id = if let Some(auth) = state.bearer_auth.as_ref() {
         match verify_bearer_token(headers, auth).await {
-            Ok(kid) => Some(kid),
+            // #393 — the bearer token is the channel's own attribution proof;
+            // wrap it as `transport_authenticated` (not the Reticulum rooting
+            // graph, so the E3 announce-spoof class does not apply here).
+            Ok(kid) => Some(crate::transport::SourceKeyId::transport_authenticated(kid)),
             Err(rej) => {
                 tracing::warn!(reason = %rej, "HTTPS bearer-token rejected");
                 return (StatusCode::UNAUTHORIZED, rej).into_response();

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -246,6 +246,104 @@ pub enum TransportError {
     },
 }
 
+/// CIRISEdge#393 (E3) — a transport-attributed source `key_id` that is
+/// TYPE-GUARANTEED to come from an attribution its transport can vouch for. The
+/// inner `String` is private, so a `SourceKeyId` is unconstructible except
+/// through one of the vetted constructors below — a code path cannot fabricate
+/// an attribution, only obtain one a transport actually proved.
+///
+/// This closes the E3 hole: the Reticulum attribution derived `source_key_id`
+/// from a link↔`RootedPeer` match with NO `provenance`/`owns_key` check, so an
+/// Advisory or non-key-owning binding (an attacker announcing a serve-capable
+/// victim's `key_id` under its own transport identity, `owns_key=false`) was
+/// attributed as the victim → `peer_has_serve_capability(victim)` → the attacker
+/// was served the victim's `trace:*` corpus. Now the Reticulum constructor
+/// ([`Self::from_rooted_binding`]) yields `Some` ONLY for a `Rooted ∧ owns_key`
+/// binding; everything else is `None`, so the frame carries no attribution and
+/// the replication router drops it (`SkippedNoSourceKeyId`) before the serve
+/// gate is ever consulted.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SourceKeyId(String);
+
+impl SourceKeyId {
+    /// Reticulum attribution gate. `Some` iff the peer binding is BOTH
+    /// directory-`Rooted` AND proved control of the federation key
+    /// (`owns_key`) — the two signals that separate an authenticated owner from
+    /// a self-consistent Advisory hint or an outright announce-spoof. Any other
+    /// provenance/ownership → `None` (the frame is left unattributed and dropped
+    /// downstream, never served).
+    #[must_use]
+    pub fn from_rooted_binding(
+        key_id: impl Into<String>,
+        provenance: ciris_persist::federation::self_at_login::BindingProvenance,
+        owns_key: bool,
+    ) -> Option<Self> {
+        use ciris_persist::federation::self_at_login::BindingProvenance::Rooted;
+        (matches!(provenance, Rooted) && owns_key).then(|| SourceKeyId(key_id.into()))
+    }
+
+    /// Attribution from a transport whose CHANNEL itself authenticates the peer
+    /// — HTTPS mTLS / bearer-decoded identity, packet-radio's addressed frame,
+    /// or an FFI caller supplying an already-verified id. NOT the Reticulum
+    /// rooting graph; these transports vouch by their own means, so the E3
+    /// announce-spoof class does not apply to them.
+    #[must_use]
+    pub fn transport_authenticated(key_id: impl Into<String>) -> Self {
+        SourceKeyId(key_id.into())
+    }
+
+    /// The attributed federation `key_id`.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Consume into the inner `key_id` string.
+    #[must_use]
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod source_key_id_tests {
+    use super::SourceKeyId;
+    use ciris_persist::federation::self_at_login::BindingProvenance::{Advisory, Rooted};
+
+    /// CIRISEdge#393 (E3) — the attribution gate truth table, tested against the
+    /// EXACT inputs the admit path produces (`BindingProvenance` × `owns_key`),
+    /// not convenient ones. The one admitting case is `Rooted ∧ owns_key`; the
+    /// three refusing cases are each a real field/attack shape:
+    ///   - `Rooted ∧ ¬owns_key`   — cannot occur post-admit, but the type must
+    ///     still refuse it (defense in depth against a future admit bug).
+    ///   - `Advisory ∧ owns_key`  — the fresh-federation owner not steward-rooted
+    ///     HERE; §4.3 refuses it for trace attribution by design.
+    ///   - `Advisory ∧ ¬owns_key` — THE ATTACK: an attacker announcing a
+    ///     serve-capable victim's key_id under its own pubkey (PubkeyMismatch ⇒
+    ///     owns_key=false). Refusing it is what closes E3.
+    #[test]
+    fn from_rooted_binding_admits_only_rooted_and_owns_key() {
+        assert_eq!(
+            SourceKeyId::from_rooted_binding("victim", Rooted, true).map(SourceKeyId::into_string),
+            Some("victim".to_string()),
+            "Rooted ∧ owns_key is the sole attributable binding",
+        );
+        assert!(
+            SourceKeyId::from_rooted_binding("victim", Rooted, false).is_none(),
+            "Rooted but non-owning must never attribute",
+        );
+        assert!(
+            SourceKeyId::from_rooted_binding("victim", Advisory, true).is_none(),
+            "an Advisory (not-steward-rooted-here) owner is not attributable for trace (§4.3)",
+        );
+        assert!(
+            SourceKeyId::from_rooted_binding("victim", Advisory, false).is_none(),
+            "THE ATTACK — advisory admit of a victim's key_id under the attacker's own \
+             pubkey (owns_key=false) — is refused (CIRISEdge#393 E3)",
+        );
+    }
+}
+
 /// One inbound frame from a transport — raw envelope bytes plus the
 /// transport-level metadata that survives across the verify pipeline.
 #[derive(Debug)]
@@ -272,7 +370,12 @@ pub struct InboundFrame {
     /// Transports that don't yet populate this field set `None`;
     /// per-transport attribution lands as separate cuts (Reticulum
     /// link-rooted lookup, HTTPS mTLS surfacing).
-    pub source_key_id: Option<String>,
+    ///
+    /// CIRISEdge#393 (E3) — now a [`SourceKeyId`], not a bare `String`: the type
+    /// guarantees every attribution came from a vetted transport constructor
+    /// (Reticulum `Rooted ∧ owns_key`, or a channel-authenticated transport),
+    /// so a spoofed/advisory attribution is unrepresentable at this boundary.
+    pub source_key_id: Option<SourceKeyId>,
 }
 
 /// The trait every transport implements. Edge holds a

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -4145,26 +4145,62 @@ async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8
     } else {
         None
     };
-    // Gate: look up the candidate's binding and admit the attribution only if it
-    // is `Rooted ∧ owns_key`. Missing peer / Advisory / non-owning → `None`.
+    // Gate (CIRISEdge#393): admit the attribution only if the candidate's binding
+    // is `Rooted ∧ owns_key` (item 1) AND its transport identity is bound by a
+    // hybrid-verified `SignedTransportDestination` (item 2, the PQ half). Any
+    // shortfall → `None` (SkippedNoSourceKeyId downstream, never served).
     let source_key_id = match candidate_key_id {
         Some(key_id) => {
-            let gated = {
+            // Item 1 — Rooted ∧ owns_key, plus capture the peer's dest for the
+            // item-2 lookup. `dest` is `None` when the peer isn't in the map.
+            let (item1, dest) = {
                 let peers = ctx.peers.lock().await;
-                peers.get(&key_id).and_then(|rooted| {
-                    crate::transport::SourceKeyId::from_rooted_binding(
-                        key_id.clone(),
-                        rooted.provenance,
-                        rooted.owns_key,
-                    )
-                })
+                match peers.get(&key_id) {
+                    Some(rooted) => (
+                        crate::transport::SourceKeyId::from_rooted_binding(
+                            key_id.clone(),
+                            rooted.provenance,
+                            rooted.owns_key,
+                        ),
+                        Some(rooted.peer.dest_hash.into_bytes()),
+                    ),
+                    None => (None, None),
+                }
+            };
+            // Item 2 — the PQ transport binding. Fail-closed without a rooting
+            // directory (can't prove the hybrid route ⇒ not attributable).
+            let gated = match (item1, dest, ctx.rooting) {
+                (Some(sid), Some(d), Some(rooting)) => {
+                    if rooting.hybrid_transport_binding_exists(&key_id, d).await {
+                        Some(sid)
+                    } else {
+                        tracing::debug!(
+                            link = ?link_id,
+                            peer = %key_id,
+                            "inbound frame NOT attributed — no hybrid-verified \
+                             TransportDestination binds this transport identity (PQ \
+                             attribution gate, CIRISEdge#393 item 2)"
+                        );
+                        None
+                    }
+                }
+                (Some(_), _, None) => {
+                    tracing::debug!(
+                        link = ?link_id,
+                        peer = %key_id,
+                        "inbound frame NOT attributed — no rooting directory to verify \
+                         the hybrid transport binding (fail-closed, CIRISEdge#393 item 2)"
+                    );
+                    None
+                }
+                _ => None,
             };
             if gated.is_none() {
                 tracing::debug!(
                     link = ?link_id,
                     peer = %key_id,
-                    "inbound frame NOT attributed — peer binding is not Rooted∧owns_key \
-                     (advisory/spoof-resistant serve gate, CIRISEdge#393)"
+                    "inbound frame NOT attributed — binding is not Rooted∧owns_key∧hybrid \
+                     (advisory/spoof/PQ-resistant serve gate, CIRISEdge#393)"
                 );
             }
             gated

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -944,6 +944,16 @@ struct RootedPeer {
     /// unreachable). `[0u8; 16]` for a test-injected peer whose x25519 half is
     /// unavailable (never matches a real identity hash).
     transport_identity_hash: [u8; 16],
+    /// CIRISEdge#393 (E3) — did this binding PROVE control of the federation key
+    /// the directory binds to `key_id`? Captured at admit from the announce
+    /// verdict (`Confirmed ⇒ true`; an Advisory admit ⇒ true only when the
+    /// rejection was neither `UnknownKeyId` nor `PubkeyMismatch`, i.e. the pubkey
+    /// matched and the self-signature verified). This is the load-bearing signal
+    /// — alongside `provenance == Rooted` — that
+    /// [`crate::transport::SourceKeyId::from_rooted_binding`] gates trace-serve
+    /// attribution on: an Advisory or non-owning binding is never attributed, so
+    /// it can never be served a peer's `trace:*` corpus.
+    owns_key: bool,
 }
 
 // ─── Configuration ──────────────────────────────────────────────────
@@ -2312,6 +2322,9 @@ impl ReticulumTransport {
                 // never matches a real link identity (explicit-hash test peers
                 // are attributed by dest-hash, not this path).
                 transport_identity_hash: [0u8; 16],
+                // #393 — an operator-primed binding asserts key ownership (the
+                // operator baked it, e.g. the canonical), so it is attributable.
+                owns_key: true,
             },
         );
     }
@@ -2347,6 +2360,9 @@ impl ReticulumTransport {
                 chain: None,
                 provenance: ciris_persist::federation::self_at_login::BindingProvenance::Rooted,
                 transport_identity_hash,
+                // #393 — full-identity test injector simulates an announce-rooted
+                // owning peer (the precondition #340 attribution needs).
+                owns_key: true,
             },
         );
     }
@@ -4091,7 +4107,15 @@ async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8
             .await
             .insert(link_id, now_secs);
     }
-    let mut source_key_id = ctx.link_to_peer_key_id.lock().await.get(&link_id).cloned();
+    // CIRISEdge#393 (E3) — resolve the candidate peer key_id for this link, then
+    // gate it through `SourceKeyId::from_rooted_binding`: attribution survives
+    // ONLY for a `Rooted ∧ owns_key` peer. An Advisory or non-owning binding —
+    // the announce-spoof vector (an attacker announcing a serve-capable victim's
+    // key_id under its own transport identity) — yields `None`, so the frame is
+    // delivered unattributed and dropped downstream (`SkippedNoSourceKeyId`),
+    // never reaching `peer_has_serve_capability`. Both attribution bases are
+    // gated identically (the #348 "two loops must never diverge" lesson).
+    let candidate_key_id = ctx.link_to_peer_key_id.lock().await.get(&link_id).cloned();
     // CIRISEdge#353 — INITIATOR-side attribution. `link_to_peer_key_id` is fed by
     // `LinkIdentified`, which only fires on links a PEER dialed to us; a reply
     // arriving on a link WE dialed (the reverse path a NAT'd peer's responder
@@ -4099,25 +4123,54 @@ async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8
     // DESTINATION (leviculum `link_destination`): we dialed a dest resolved from
     // the VERIFIED route table, and RNS establishment proves the remote controls
     // that dest's keys — same trust the outbound send used.
-    if source_key_id.is_none() {
-        if let Some(dest) = ctx.node.link_destination(&link_id) {
-            source_key_id = ctx
-                .peers
-                .lock()
-                .await
-                .iter()
-                .find(|(_, rooted)| rooted.peer.dest_hash == dest)
-                .map(|(key_id, _)| key_id.clone());
-            if let Some(key_id) = &source_key_id {
+    let candidate_key_id = if candidate_key_id.is_some() {
+        candidate_key_id
+    } else if let Some(dest) = ctx.node.link_destination(&link_id) {
+        let via_dest = ctx
+            .peers
+            .lock()
+            .await
+            .iter()
+            .find(|(_, rooted)| rooted.peer.dest_hash == dest)
+            .map(|(key_id, _)| key_id.clone());
+        if let Some(key_id) = &via_dest {
+            tracing::debug!(
+                link = ?link_id,
+                peer = %key_id,
+                "inbound frame on a link WE dialed attributed via its destination \
+                 (initiator-side reverse path, CIRISEdge#353)"
+            );
+        }
+        via_dest
+    } else {
+        None
+    };
+    // Gate: look up the candidate's binding and admit the attribution only if it
+    // is `Rooted ∧ owns_key`. Missing peer / Advisory / non-owning → `None`.
+    let source_key_id = match candidate_key_id {
+        Some(key_id) => {
+            let gated = {
+                let peers = ctx.peers.lock().await;
+                peers.get(&key_id).and_then(|rooted| {
+                    crate::transport::SourceKeyId::from_rooted_binding(
+                        key_id.clone(),
+                        rooted.provenance,
+                        rooted.owns_key,
+                    )
+                })
+            };
+            if gated.is_none() {
                 tracing::debug!(
                     link = ?link_id,
                     peer = %key_id,
-                    "inbound frame on a link WE dialed attributed via its destination \
-                     (initiator-side reverse path, CIRISEdge#353)"
+                    "inbound frame NOT attributed — peer binding is not Rooted∧owns_key \
+                     (advisory/spoof-resistant serve gate, CIRISEdge#393)"
                 );
             }
+            gated
         }
-    }
+        None => None,
+    };
     let frame = InboundFrame {
         envelope_bytes: data,
         transport: TransportId::RETICULUM_RS,
@@ -5096,6 +5149,10 @@ async fn resolve_announce_cold_start(
                         chain: chain_opt,
                         provenance,
                         transport_identity_hash,
+                        // #393 — captured from the admit verdict (destructured at
+                        // the `match verdict` above): Confirmed ⇒ true; Advisory ⇒
+                        // true only when the pubkey matched + self-sig verified.
+                        owns_key,
                     },
                 );
                 Some(persisted_key)

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -272,6 +272,109 @@ pub trait RootingDirectory: Send + Sync + 'static {
         _last_seen: chrono::DateTime<chrono::Utc>,
     ) {
     }
+
+    /// CIRISEdge#393 (E3, item 2) — does a HYBRID-verified (ML-DSA-65)
+    /// `SignedTransportDestination` bind `key_id`'s reticulum transport identity
+    /// to `dest_hash`?
+    ///
+    /// The post-quantum half of attribution. The announce binding is Ed25519-only
+    /// and MTU-bounded (an ML-DSA-65 signature is ~3.3 KB vs the 300 B announce
+    /// budget), so PQ assurance rides the replicated, hybrid-Strict
+    /// `TransportDestination` plane instead — which edge already applies and
+    /// persist already verifies the ML-DSA half of on `put`. A stored route
+    /// carrying an `mldsa65_signature_base64` is therefore hybrid-verified; the
+    /// Ed25519-only announce write-through ([`Self::persist_transport_binding`])
+    /// carries `None` and does NOT satisfy this. A quantum adversary who forged
+    /// the Ed25519 announce still cannot produce this ML-DSA-signed route, so
+    /// attribution gated on it stays PQ-safe. Default `false` (test doubles /
+    /// no-directory ⇒ fail-closed); the `FederationDirectory` blanket impl reads
+    /// the stored routes.
+    async fn hybrid_transport_binding_exists(&self, _key_id: &str, _dest_hash: [u8; 16]) -> bool {
+        false
+    }
+}
+
+/// CIRISEdge#393 (E3, item 2) — pure predicate under
+/// [`RootingDirectory::hybrid_transport_binding_exists`]: is any of `routes` a
+/// reticulum route to `dest_hash` carrying a verified ML-DSA-65 half? Extracted
+/// pure so the PQ gate is unit-testable against the exact stored shapes without
+/// a live directory.
+#[must_use]
+pub fn hybrid_reticulum_route_present(
+    routes: &[ciris_persist::federation::self_at_login::SignedTransportDestination],
+    dest_hash: [u8; 16],
+) -> bool {
+    let want = hex::encode(dest_hash);
+    routes.iter().any(|r| {
+        r.transport_destination.transport_kind == "reticulum"
+            && r.transport_destination.destination == want
+            && r.signature.mldsa65_signature_base64.is_some()
+    })
+}
+
+#[cfg(test)]
+mod hybrid_transport_binding_tests {
+    use super::hybrid_reticulum_route_present;
+    use ciris_persist::federation::self_at_login::{
+        BindingProvenance, SignedTransportDestination, TransportDestination,
+    };
+    use ciris_verify_core::transport_binding::TransportBindingSignature;
+
+    fn route(dest_hash: [u8; 16], kind: &str, mldsa: Option<&str>) -> SignedTransportDestination {
+        SignedTransportDestination {
+            transport_destination: TransportDestination {
+                occurrence_key_id: "peer".into(),
+                transport_kind: kind.into(),
+                destination: hex::encode(dest_hash),
+                asserted_at: chrono::DateTime::UNIX_EPOCH,
+                last_seen_at: None,
+                transport_ed25519_pubkey_base64: None,
+                transport_x25519_pubkey_base64: None,
+                binding_provenance: BindingProvenance::Rooted,
+                epoch: 0,
+                retired_at: None,
+            },
+            attesting_key_id: "peer".into(),
+            signed_envelope: serde_json::json!({}),
+            signature: TransportBindingSignature {
+                ed25519_signature_base64: "ed".into(),
+                mldsa65_signature_base64: mldsa.map(str::to_string),
+            },
+        }
+    }
+
+    /// CIRISEdge#393 item 2 — the PQ attribution predicate against the EXACT
+    /// stored shapes. Only a reticulum route to the peer's dest carrying an
+    /// ML-DSA-65 half counts; the Ed25519-only announce write-through (`None`)
+    /// and a wrong-dest / wrong-kind route do NOT — so a quantum-forged
+    /// Ed25519 announce cannot make its peer attributable.
+    #[test]
+    fn only_a_hybrid_reticulum_route_to_the_dest_counts() {
+        let dest = [0xab; 16];
+        let other = [0xcd; 16];
+        // Hybrid reticulum route to the dest → present.
+        assert!(hybrid_reticulum_route_present(
+            &[route(dest, "reticulum", Some("mldsa-sig"))],
+            dest
+        ));
+        // Ed25519-only write-through (mldsa None) → NOT present (the PQ gap).
+        assert!(!hybrid_reticulum_route_present(
+            &[route(dest, "reticulum", None)],
+            dest
+        ));
+        // Hybrid route to a DIFFERENT dest → not present for this dest.
+        assert!(!hybrid_reticulum_route_present(
+            &[route(other, "reticulum", Some("mldsa-sig"))],
+            dest
+        ));
+        // Hybrid but non-reticulum kind → not present.
+        assert!(!hybrid_reticulum_route_present(
+            &[route(dest, "websocket", Some("mldsa-sig"))],
+            dest
+        ));
+        // Empty → not present (fresh boot, no route yet).
+        assert!(!hybrid_reticulum_route_present(&[], dest));
+    }
 }
 
 #[async_trait]
@@ -286,6 +389,15 @@ impl<F: FederationDirectory + Send + Sync + 'static> RootingDirectory for F {
 
     async fn provenance_chain(&self, key_id: &str) -> Result<ProvenanceChain, RootingRejection> {
         persist_provenance_chain(self, key_id).await
+    }
+
+    async fn hybrid_transport_binding_exists(&self, key_id: &str, dest_hash: [u8; 16]) -> bool {
+        // Fail-closed on a backend read error: no VERIFIABLE hybrid route ⇒ not
+        // PQ-attributable (a directory hiccup must never widen attribution).
+        match self.list_signed_transport_destinations_for(key_id).await {
+            Ok(routes) => hybrid_reticulum_route_present(&routes, dest_hash),
+            Err(_) => false,
+        }
     }
 
     async fn persist_transport_binding(

--- a/tests/route_table_e2e.rs
+++ b/tests/route_table_e2e.rs
@@ -181,8 +181,17 @@ async fn no_path_send_fails_fast_and_loud_not_a_silent_30s_timeout() {
 /// `InboundFrame::source_key_id` — the exact operand that was `None` in the
 /// field logs. Delivery alone (the existing loopback test) does not catch this;
 /// attribution does.
+// CIRISEdge#393 (E3) — this test now asserts the SECURITY property: B's binding
+// at A is admitted ADVISORY (B's key does not root to a pinned steward in this
+// un-seeded test env), so the responder DELIVERS the frame but REFUSES to
+// attribute it — an advisory/spoofable source is never fed to the trace serve
+// gate. Pre-#393 this attributed `edge-key-bbbb` (the vuln: an advisory admit
+// was treated as authoritative attribution). Attribution-works for a genuinely
+// Rooted∧owns_key peer is covered by the reverse-path test below (the reply from
+// non-announcing A stays Rooted at B). The `SourceKeyId::from_rooted_binding`
+// truth table (transport/mod.rs) is the direct gate proof.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn identified_link_lets_the_responder_attribute_the_inbound_frame() {
+async fn identified_link_from_advisory_peer_is_delivered_but_not_attributed_393() {
     let _ = tracing_subscriber::fmt()
         .with_env_filter("warn,ciris_edge=debug")
         .try_init();
@@ -265,11 +274,18 @@ async fn identified_link_lets_the_responder_attribute_the_inbound_frame() {
         .expect("frame must arrive within 60s")
         .expect("inbound channel open");
 
+    // The frame was DELIVERED (received above) — the #340 link mechanism works.
+    // But B is Advisory here, so #393 withholds attribution.
     assert_eq!(
-        frame.source_key_id.as_deref(),
-        Some("edge-key-bbbb"),
-        "the responder must ATTRIBUTE the inbound frame to the sender via the \
-         identified link — source_key_id=None is the #340 SkippedNoSourceKeyId drop",
+        frame
+            .source_key_id
+            .as_ref()
+            .map(ciris_edge::transport::SourceKeyId::as_str),
+        None,
+        "CIRISEdge#393 (E3) — B's binding is ADVISORY (not steward-rooted here), so \
+         the responder must REFUSE attribution even though the link identified. \
+         Pre-#393 this returned Some(\"edge-key-bbbb\") — the advisory-spoofable \
+         attribution that let an attacker be served a victim's trace corpus.",
     );
 }
 
@@ -374,10 +390,16 @@ async fn reply_to_a_nat_d_initiator_rides_the_live_inbound_link() {
         .await
         .expect("A must receive B's frame within 60s")
         .expect("A inbound channel open");
+    // CIRISEdge#393 — B dialed A (announcing to A), so B's binding at A is
+    // ADVISORY (un-pinned steward here) → attribution REFUSED. The frame is
+    // still DELIVERED (received above); only the source is withheld.
     assert_eq!(
-        inbound_at_a.source_key_id.as_deref(),
-        Some("edge-key-bbbb"),
-        "precondition (#340): A must attribute B's inbound link",
+        inbound_at_a
+            .source_key_id
+            .as_ref()
+            .map(ciris_edge::transport::SourceKeyId::as_str),
+        None,
+        "#393 (E3): an advisory-admitted inbound source is not attributed",
     );
 
     // Leg 2 — the REPLY: A -> B must ride B's live inbound link. Before the
@@ -398,7 +420,10 @@ async fn reply_to_a_nat_d_initiator_rides_the_live_inbound_link() {
         .expect("B inbound channel open");
     assert_eq!(reply_at_b.envelope_bytes, b"reply-over-the-reverse-path");
     assert_eq!(
-        reply_at_b.source_key_id.as_deref(),
+        reply_at_b
+            .source_key_id
+            .as_ref()
+            .map(ciris_edge::transport::SourceKeyId::as_str),
         Some("edge-key-aaaa"),
         "the reply on B's own dialed link must be ATTRIBUTED via link_destination \
          (initiator-side half of CIRISEdge#353) — None is the #317 \
@@ -513,5 +538,11 @@ async fn busy_reverse_path_delivers_a_packet_reply_interleaving_the_transfer() {
         .expect("B receives the retried reply within 60s")
         .expect("B channel open");
     assert_eq!(reply.envelope_bytes, b"reply-over-a-busy-link-as-a-packet");
-    assert_eq!(reply.source_key_id.as_deref(), Some("edge-key-aaaa"));
+    assert_eq!(
+        reply
+            .source_key_id
+            .as_ref()
+            .map(ciris_edge::transport::SourceKeyId::as_str),
+        Some("edge-key-aaaa")
+    );
 }

--- a/tests/route_table_e2e.rs
+++ b/tests/route_table_e2e.rs
@@ -419,15 +419,20 @@ async fn reply_to_a_nat_d_initiator_rides_the_live_inbound_link() {
         .expect("B must receive A's reply within 60s")
         .expect("B inbound channel open");
     assert_eq!(reply_at_b.envelope_bytes, b"reply-over-the-reverse-path");
+    // CIRISEdge#393 item 2 — the reply DELIVERS over B's dialed link (the #353
+    // mechanism, the load-bearing assertion above). Attribution now additionally
+    // requires a hybrid-verified TransportDestination for A, which this test env
+    // does not seed, so source_key_id is withheld. Attribution-WORKS under a
+    // hybrid route is proven by the from_rooted_binding + hybrid_reticulum_route_present
+    // unit truth-tables (a live-route e2e is a test-harness follow-up).
     assert_eq!(
         reply_at_b
             .source_key_id
             .as_ref()
             .map(ciris_edge::transport::SourceKeyId::as_str),
-        Some("edge-key-aaaa"),
-        "the reply on B's own dialed link must be ATTRIBUTED via link_destination \
-         (initiator-side half of CIRISEdge#353) — None is the #317 \
-         SkippedNoSourceKeyId drop and the round dies delivered-but-dead",
+        None,
+        "#393 item 2: no hybrid TransportDestination for A → attribution withheld \
+         (delivery intact)",
     );
 }
 
@@ -538,11 +543,15 @@ async fn busy_reverse_path_delivers_a_packet_reply_interleaving_the_transfer() {
         .expect("B receives the retried reply within 60s")
         .expect("B channel open");
     assert_eq!(reply.envelope_bytes, b"reply-over-a-busy-link-as-a-packet");
+    // CIRISEdge#393 item 2 — delivery over the busy reverse-path link is the
+    // assertion here; attribution requires a hybrid TransportDestination (not
+    // seeded in this env), so source_key_id is withheld (proven by the unit
+    // truth-tables). Delivery is intact.
     assert_eq!(
         reply
             .source_key_id
             .as_ref()
             .map(ciris_edge::transport::SourceKeyId::as_str),
-        Some("edge-key-aaaa")
+        None
     );
 }

--- a/tests/welcome_wrap_e2e.rs
+++ b/tests/welcome_wrap_e2e.rs
@@ -27,6 +27,19 @@ fn fresh_invitee() -> (XWingRecipientPublic, XWingRecipientSecret) {
     (pk, sk)
 }
 
+/// CIRISEdge#331 — a directory that resolves any pk_id to `inviter`'s registered
+/// ML-DSA key (the directory-resolved path unwrap now requires).
+fn directory_of(inviter: &MlDsa65Signer) -> impl Fn(&str) -> Option<FederationDirectoryEntry> {
+    let pk = inviter.public_key().unwrap();
+    move |id: &str| {
+        Some(FederationDirectoryEntry {
+            pk_id: id.to_string(),
+            ml_dsa_pk: pk.clone(),
+            x_wing_pk: None,
+        })
+    }
+}
+
 #[test]
 fn wrap_and_unwrap_round_trip() {
     let inviter = MlDsa65Signer::new().unwrap();
@@ -42,8 +55,14 @@ fn wrap_and_unwrap_round_trip() {
     )
     .unwrap();
 
-    // Directory lookup returns None — falls back to inline pk.
-    let opened = unwrap_welcome(&invitee_sk, &wrapped, b"group-id-42", |_| None).unwrap();
+    // CIRISEdge#331 — directory-resolved (no inline fallback).
+    let opened = unwrap_welcome(
+        &invitee_sk,
+        &wrapped,
+        b"group-id-42",
+        directory_of(&inviter),
+    )
+    .unwrap();
     assert_eq!(opened, welcome);
 }
 
@@ -59,7 +78,7 @@ fn signature_verification_is_precondition_to_open() {
     // Flip a byte of the inviter signature.
     wrapped.inviter_signature[0] ^= 0x01;
 
-    let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| None).unwrap_err();
+    let err = unwrap_welcome(&invitee_sk, &wrapped, b"", directory_of(&inviter)).unwrap_err();
     assert!(
         matches!(err, WelcomeWrapError::SignatureRejected),
         "tampered inviter signature MUST be rejected"
@@ -67,7 +86,7 @@ fn signature_verification_is_precondition_to_open() {
 }
 
 #[test]
-fn directory_resolved_pk_takes_precedence_over_inline() {
+fn directory_resolved_pk_is_the_sole_trust_input() {
     let inviter = MlDsa65Signer::new().unwrap();
     let (invitee_pk, invitee_sk) = fresh_invitee();
     let welcome = b"directory-bound Welcome";
@@ -119,6 +138,21 @@ fn aad_mismatch_fails_open_after_signature_verifies() {
     let welcome = b"aad-bound Welcome";
     let wrapped = wrap_welcome(&inviter, "inv-aad", &invitee_pk, welcome, b"aad-A").unwrap();
 
-    let err = unwrap_welcome(&invitee_sk, &wrapped, b"aad-B", |_| None).unwrap_err();
+    let err = unwrap_welcome(&invitee_sk, &wrapped, b"aad-B", directory_of(&inviter)).unwrap_err();
     assert!(matches!(err, WelcomeWrapError::Crypto(_)));
+}
+
+#[test]
+fn directory_miss_is_inviter_unknown_not_tofu_accepted() {
+    // CIRISEdge#331 (E8) acceptance — an inviter the directory cannot resolve is
+    // REFUSED, not accepted by falling back to the sender-supplied inline key.
+    // Pre-#331 the attacker's self-signed inline-key Welcome was accepted.
+    let attacker = MlDsa65Signer::new().unwrap();
+    let (invitee_pk, invitee_sk) = fresh_invitee();
+    let wrapped = wrap_welcome(&attacker, "unknown-inviter", &invitee_pk, b"hostile", b"").unwrap();
+    let err = unwrap_welcome(&invitee_sk, &wrapped, b"", |_| None).unwrap_err();
+    assert!(
+        matches!(err, WelcomeWrapError::InviterUnknown(ref id) if id == "unknown-inviter"),
+        "a directory-unresolvable inviter must be InviterUnknown, never TOFU-accepted",
+    );
 }


### PR DESCRIPTION
The v14 major cut: adopt persist **v21.0.0/v21.1.0** (Registry-of-Record) and land the two E3/E8 security closures from the CEG→replication audit. Closes **#393**, closes **#331**.

## Phase 1 — persist v21.1.0 adoption
- The 5 E4 keyless-declaration planes (Family/Community/LocationProof/2 membership revocations) rewired from per-member `fan_out` onto persist's new **signed since-cursor bulk reads** (CIRISPersist#504 floor) — one paginated read/plane/round vs O(cohort) round-trips. Advertise **scope preserved** per §4.3 (Cohort/Global).
- E9: `put_*` drop the roster args (persist self-resolves).
- `PERSIST_REPLICATION_POLICY_HASH` pinned (cross-repo drift witness).

## #393 (E3) — trace-serve attribution, closed by construction
The serve gate is now type-guaranteed **`Rooted ∧ owns_key ∧ hybrid_transport_binding`**:
- **Item 1** — `SourceKeyId` newtype constructible only from `Rooted ∧ owns_key`; an advisory / `owns_key=false` announce-spoof is unrepresentable at the boundary → dropped `SkippedNoSourceKeyId`, never served.
- **Item 2** — PQ half: attribution additionally requires a hybrid-verified `SignedTransportDestination` (ML-DSA-65). The announce stays Ed25519 (a 3.3 KB ML-DSA sig can't fit the 300 B announce budget); PQ assurance rides the plane that already carries it. A quantum-forged Ed25519 announce still can't produce the ML-DSA route.
- **Item 3** — edge exports its serve/advertise policy manifest + `SERVE_ADVERTISE_POLICY_HASH`; the sole capability-gated serve path (`trace:*` → `infra:serve`) is now hash-pinned. CIRISServer pins it beside persist's hash (CIRISServer#320).

## #331 (E8) — MLS Welcome, directory-resolved only
The §3.3 wrap already carries the CC-5.4.4 ML-DSA-65 inviter signature; the hole was the **resolution** — a directory miss fell back to the **sender-supplied inline key** (self-certifying TOFU). Now directory-resolved only: a miss is `InviterUnknown`, fail-closed.

## Discipline
Every gate is proven by a pure unit truth-table against the exact inputs the field produces (`from_rooted_binding`, `hybrid_reticulum_route_present`, the serve-manifest invariant, the #331 adversarial test — the last two verified to FAIL against the pre-fix code). Two hard design forks (advisory attribution scope; the MTU-impossible hybrid announce) were resolved with the maintainer. e2e delivery mechanisms stay intact; where attribution now requires rooting/hybrid data the test env doesn't seed, the assertions reflect that (delivery still asserted).

627 lib tests + test-anchor lane green; clippy `-D warnings` clean across default + pyo3 + test-anchor feature sets.

Follow-ups filed (non-blocking): CIRISPersist#507 (hot-path point-read + primary-plane since-cursors), CIRISServer#320 (pin edge's serve hash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012rbUxFApD8wfMHshLbhh4r
