### PR TITLE
fix(v14.2.1): memoize consent send-set — fix #400 round-timeout regression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "14.2.0"
+version = "14.2.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -54,7 +54,8 @@
 //! FSD §7.1 acceptance criteria.
 
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 
@@ -188,7 +189,23 @@ pub struct FederationDirectoryReplicationBridge {
     /// identity there is no "I" whose trust could be evaluated. Supplied by
     /// `ReplicationRuntimeConfig::local_key_id`.
     local_key_id: Option<String>,
+    /// CIRISEdge#400 — memoized consent send-set (`list_consent_peers(local)`),
+    /// with the [`Instant`] it was resolved. The item-1 fan-out bound must
+    /// re-resolve *per round* but NOT *per envelope*: v14.2.0 called
+    /// `resolve_attestation_recipient` inside `fetch_envelope_bytes_for_peer`,
+    /// so an N-envelope Deliver did N `list_consent_peers` reads inside the
+    /// unbounded reply assembly and blew the 10 s round budget (100% round
+    /// timeouts). This memo collapses a round's advertise + N fetches to ONE
+    /// read; the [`CONSENT_SEND_SET_MEMO_TTL`] window sits under the anti-entropy
+    /// cadence so a between-round withdraw still takes effect next round.
+    consent_memo: Mutex<Option<(ResolvedPeerSet, Instant)>>,
 }
+
+/// CIRISEdge#400 — how long a memoized consent send-set stays fresh. Chosen to
+/// span one anti-entropy round's assembly steps (advertise → Diff → Deliver,
+/// bounded by the scheduler's 10 s round budget) while staying well under the
+/// default 30 s cadence, so the item-1 bound still re-resolves every round.
+const CONSENT_SEND_SET_MEMO_TTL: Duration = Duration::from_secs(10);
 
 impl FederationDirectoryReplicationBridge {
     /// Construct with default [`BridgeConfig`], **v1-only** (no v2
@@ -211,6 +228,7 @@ impl FederationDirectoryReplicationBridge {
             local_key_id: None,
             config,
             operational: None,
+            consent_memo: Mutex::new(None),
         }
     }
 
@@ -243,6 +261,7 @@ impl FederationDirectoryReplicationBridge {
             local_key_id: None,
             config,
             operational: Some(operational),
+            consent_memo: Mutex::new(None),
         }
     }
 
@@ -995,27 +1014,53 @@ impl FederationDirectoryReplicationBridge {
             );
             return None;
         };
-        match ResolvedPeerSet::resolve(&*self.directory, local).await {
-            Ok(set) => {
-                let resolved = set.recipient(peer);
-                if resolved.is_none() {
-                    tracing::debug!(
-                        peer,
-                        "attestation plane withheld — recipient is not in this node's live \
-                         consent:replication send-set (CIRISEdge#396 item 1)"
-                    );
+        let Some(set) = self.resolved_peer_set(local).await else {
+            tracing::debug!(
+                peer,
+                "attestation plane withheld — consent send-set unresolved (fail-closed)"
+            );
+            return None;
+        };
+        let resolved = set.recipient(peer);
+        if resolved.is_none() {
+            tracing::debug!(
+                peer,
+                "attestation plane withheld — recipient is not in this node's live \
+                 consent:replication send-set (CIRISEdge#396 item 1)"
+            );
+        }
+        resolved
+    }
+
+    /// CIRISEdge#400 — the memoized consent send-set. Returns the live
+    /// `list_consent_peers(local)` projection, re-reading persist only when the
+    /// memo is empty or older than [`CONSENT_SEND_SET_MEMO_TTL`]. A round's
+    /// advertise + N `fetch_envelope_bytes_for_peer` calls therefore share ONE
+    /// read instead of N (the v14.2.0 regression that blew the round budget),
+    /// while a between-round withdraw still re-resolves next round. `None` (the
+    /// caller fails closed) only on a directory error. The `Arc`-backed
+    /// [`ResolvedPeerSet`] makes the memo-hit clone O(1); the `std` mutex is
+    /// never held across the `await`.
+    async fn resolved_peer_set(&self, local: &str) -> Option<ResolvedPeerSet> {
+        if let Ok(memo) = self.consent_memo.lock() {
+            if let Some((set, resolved_at)) = memo.as_ref() {
+                if resolved_at.elapsed() < CONSENT_SEND_SET_MEMO_TTL {
+                    return Some(set.clone());
                 }
-                resolved
-            }
-            Err(e) => {
-                tracing::debug!(
-                    peer,
-                    error = %e,
-                    "attestation plane withheld — consent send-set unresolved (fail-closed)"
-                );
-                None
             }
         }
+        let peers = match self.directory.list_consent_peers(local).await {
+            Ok(peers) => peers,
+            Err(e) => {
+                tracing::debug!(error = %e, "consent send-set read failed (fail-closed)");
+                return None;
+            }
+        };
+        let set = ResolvedPeerSet::from_consent_peers(peers);
+        if let Ok(mut memo) = self.consent_memo.lock() {
+            *memo = Some((set.clone(), Instant::now()));
+        }
+        Some(set)
     }
 
     async fn list_attestations(&self, recipient: Option<&str>) -> Vec<EnvelopeRef> {
@@ -2634,6 +2679,41 @@ mod tests {
         assert!(
             bridge.list_attestations(Some(peer)).await.is_empty(),
             "no local_key_id → consent send-set unresolvable → whole plane withheld (fail-closed)"
+        );
+    }
+
+    /// CIRISEdge#400 — the consent send-set is memoized across a round window,
+    /// so a round's advertise + N fetches share ONE `list_consent_peers` read
+    /// instead of N. This is the regression witness: v14.2.0 re-read persist
+    /// per envelope inside the unbounded reply assembly, blowing the 10 s round
+    /// budget (100% round timeouts). Two resolves within the TTL must return the
+    /// SAME `Arc`-backed set — a re-read would allocate a distinct one.
+    #[tokio::test]
+    async fn consent_send_set_is_memoized_within_the_round_window() {
+        let local = "this-node";
+        let peer = "peer-consented";
+        let (backend, bridge) = make_bridge(&[local.to_string(), peer.to_string()]);
+        let bridge = bridge.with_local_key_id(Some(local.to_string()));
+        for key_id in [local, peer] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(key_id, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+        }
+        seed_consent_membership(&backend, local, peer).await;
+
+        let set1 = bridge.resolved_peer_set(local).await.expect("resolve 1");
+        let set2 = bridge.resolved_peer_set(local).await.expect("resolve 2");
+        assert!(
+            set1.ptr_eq(&set2),
+            "second resolve within the TTL is a memo HIT, not a per-envelope re-read (CIRISEdge#400)"
+        );
+        // ...and the memoized set is the real consent membership.
+        assert!(
+            set1.recipient(peer).is_some(),
+            "the memoized set resolves the consent-included peer"
         );
     }
 

--- a/src/replication/resolved_state.rs
+++ b/src/replication/resolved_state.rs
@@ -43,33 +43,29 @@
 //! leaves structural replication untouched.
 
 use std::collections::HashSet;
-
-use ciris_persist::federation::{Error, FederationDirectory};
+use std::sync::Arc;
 
 /// The consent-resolved set of peers this node may SEND consentable claims to
 /// this round — persist's live `consent:replication` peer projection for
-/// `local_key_id` (E7, revocation-folded). Re-resolve every round; never cache
-/// across rounds (a between-round withdraw must take effect at the next send).
+/// `local_key_id` (E7, revocation-folded). `Arc`-backed so the bridge can
+/// memoize ONE read across a round's advertise + N fetches (CIRISEdge#400: a
+/// per-envelope re-read blew the round budget); the memo TTL stays under the
+/// anti-entropy cadence, so a between-round withdraw still takes effect at the
+/// next round (nuclear un-trust preserved at round granularity).
+#[derive(Clone)]
 pub(crate) struct ResolvedPeerSet {
-    send_set: HashSet<String>,
+    send_set: Arc<HashSet<String>>,
 }
 
 impl ResolvedPeerSet {
-    /// Resolve `local_key_id`'s live consent send-set from persist's E7
-    /// projection. The operator-addressing half of the intersection is applied
-    /// by the caller's serve path (only a connected peer is ever tested), so
-    /// this reads the consent side alone. Propagates the directory error so the
-    /// caller can fail **closed** (an unresolved consent view withholds).
-    pub(crate) async fn resolve(
-        directory: &dyn FederationDirectory,
-        local_key_id: &str,
-    ) -> Result<Self, Error> {
-        let send_set = directory
-            .list_consent_peers(local_key_id)
-            .await?
-            .into_iter()
-            .collect();
-        Ok(Self { send_set })
+    /// Build from persist's `list_consent_peers(local)` result. The
+    /// operator-addressing half of the intersection is applied by the caller's
+    /// serve path (only a connected peer is ever tested), so this holds the
+    /// consent side alone. The `Arc` makes [`Clone`] O(1) for the memo.
+    pub(crate) fn from_consent_peers(peers: Vec<String>) -> Self {
+        Self {
+            send_set: Arc::new(peers.into_iter().collect()),
+        }
     }
 
     /// A send-authorization for `peer_key_id`, IFF consent includes it. `None`
@@ -82,6 +78,14 @@ impl ResolvedPeerSet {
         self.send_set
             .contains(peer_key_id)
             .then(|| ResolvedRecipient(peer_key_id.to_owned()))
+    }
+
+    /// Test-only: do two handles share the SAME memoized set (the O(1)
+    /// `Arc` clone)? The regression witness for CIRISEdge#400 — a memo HIT
+    /// returns a clone of the same `Arc`; a re-read would allocate a new one.
+    #[cfg(test)]
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.send_set, &other.send_set)
     }
 }
 


### PR DESCRIPTION
Fixes **CIRISEdge#400** — the v14.2.0 regression where 100% of anti-entropy rounds time out (surfaced by the CIRISAgent acceptance ladder, missed by the 188-test suite). **v14.2.1.**

## Root cause
The #396 item-1 fan-out bound called `resolve_attestation_recipient` inside `fetch_envelope_bytes_for_peer` — so an **N-envelope Deliver did N `list_consent_peers(local)` reads** (a projection scan each) inside the reply assembly (`drive_round_step`), against the scheduler's **10 s round budget**. Assembly overran the budget → the round never reached `Complete` → the initiator timed out every round (`envelopes_sent_total: 0`).

## Fix — memoize the consent send-set (O(N) → O(1))
`resolved_peer_set(local)` re-reads persist only when the memo is empty or older than `CONSENT_SEND_SET_MEMO_TTL` (10 s — under the 30 s cadence). A round's advertise + N fetches now share **one** read, while a between-round withdraw still re-resolves next round (nuclear un-trust preserved at round granularity). `ResolvedPeerSet` is now `Arc`-backed so the memo-hit clone is O(1); the `std` mutex is never held across the `await`. Fail-closed + the by-construction `ResolvedRecipient` gate are unchanged. The retired envelope cache (item 3) stays retired — the point-read is still the hot path.

## ⚠️ Note on the other candidate (bounding `drive_round_step`)
Wrapping `drive_round_step` in a `tokio::time::timeout` is **ineffective** here: `DirectoryStateAdapter` runs every persist read via `tokio::task::block_in_place(Handle::block_on(...))`, so the assembly is one *synchronous* block from the future's view — tokio's timer fires but the wrapped future never yields to observe it until the block returns. The #373 send-bound works only because `send_message` is async-awaiting. Reducing the assembly's work (this PR) is the fix, not bounding it. (A true assembly bound would require making that path async-interruptible — a larger change, not warranted now that the O(N) read is gone.)

## Verification
- Regression witness: `consent_send_set_is_memoized_within_the_round_window` — two resolves within the TTL return the **same `Arc`** (a per-envelope re-read would allocate a distinct one). This test fails against v14.2.0.
- Bridge **28** / replication **117**; item-1 correctness (`consent_membership_fan_out_bound`, `fan_out_fail_closed_without_local_key_id`) intact.
- Clippy `-D warnings` clean across pyo3 `--all-targets`, ffi-uniffi, test-anchor; fmt green.

Cohab-red remains the known server-skew. Closes #400 — a required floor for this cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8uDCuRxAQVRzdjcuDVrBF
