### PR TITLE
fix(v14.2.2): bootstrap attribution carve-out — fix #402 deadlock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "14.2.1"
+version = "14.2.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/benches/content_fetch_roundtrip.rs
+++ b/benches/content_fetch_roundtrip.rs
@@ -183,6 +183,7 @@ fn bench_content_fetch(c: &mut Criterion) {
                         transport: TransportId::HTTP,
                         received_at: Utc::now(),
                         source_key_id: None,
+                        link_key_id: None,
                     };
                     edge.dispatch_inbound_for_test(black_box(frame)).await;
                 }

--- a/benches/dispatch_inbound.rs
+++ b/benches/dispatch_inbound.rs
@@ -234,6 +234,7 @@ fn bench_dispatch(c: &mut Criterion) {
                         transport: TransportId::HTTP,
                         received_at: Utc::now(),
                         source_key_id: None,
+                        link_key_id: None,
                     };
                     edge.dispatch_inbound_for_test(black_box(frame)).await;
                 }

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -3940,6 +3940,8 @@ static INBOUND_ROUTED_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle>
     std::sync::OnceLock::new();
 static INBOUND_BACKPRESSURE_DROP_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
     std::sync::OnceLock::new();
+static INBOUND_BOOTSTRAP_CARVEOUT_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
 
 /// CIRISEdge#373 — an inbound frame was DROPPED because the coordinator's inbound
 /// channel was full (a stalled responder reply parked the drain). Keyed on peer
@@ -3968,6 +3970,16 @@ fn inbound_routed_log() -> &'static crate::log_throttle::LogThrottle {
     })
 }
 
+/// CIRISEdge#402 — an un-attributed CRPL frame was admitted via the bootstrap
+/// carve-out (a self-authenticating Key/IdentityOccurrence on the link's
+/// transport identity). Keyed on transport id (bounded) so a bootstrapping
+/// peer's multi-frame round doesn't flood; verification still gates at admission.
+fn inbound_bootstrap_carveout_log() -> &'static crate::log_throttle::LogThrottle {
+    INBOUND_BOOTSTRAP_CARVEOUT_LOG.get_or_init(|| {
+        crate::log_throttle::LogThrottle::new(5, std::time::Duration::from_secs(60), 16)
+    })
+}
+
 /// CIRISEdge#348 — the SHARED transport→replication ingest hop.
 ///
 /// Called by BOTH inbound loops ([`Edge::run`] AND
@@ -3990,7 +4002,6 @@ async fn route_replication_frame(
     metrics: Option<&crate::observability::EdgeMetrics>,
 ) -> bool {
     use crate::log_throttle::ThrottleDecision;
-    use crate::replication::registry::{RegistryError, RouteOutcome};
 
     // The frame reached ingest — the hop that used to be invisible.
     if let ThrottleDecision::Emit { suppressed_prev } =
@@ -4008,17 +4019,25 @@ async fn route_replication_frame(
     let Some(registry) = registry else {
         return false; // no replication runtime installed → envelope dispatch
     };
-    let Some(source) = frame
-        .source_key_id
-        .as_ref()
-        .map(crate::transport::SourceKeyId::as_str)
-    else {
-        // No attribution: a CRPL frame here is unroutable (drop, loudly); a
-        // non-CRPL frame is a normal unattributed envelope (fall through).
-        if frame
+    // Resolve the routing attribution. A trust-attributed `source_key_id`
+    // (`Rooted ∧ owns_key`, CIRISEdge#393/E3) routes ANY kind. CIRISEdge#402: an
+    // un-attributed CRPL frame carrying ONLY a self-authenticating bootstrap kind
+    // (`Key`/`IdentityOccurrence`) may route on the link's TRANSPORT identity, so
+    // a fresh `UnknownKeyId` peer can introduce its own KeyRecord — the frame is
+    // verified at persist admission (`put_public_key` E2/#502) where verification
+    // belongs, grants no trust, and is served no `trace:*`. Every OTHER
+    // un-attributed CRPL frame drops (`SkippedNoSourceKeyId`); the trace-serve
+    // gate stays strictly `from_rooted_binding`.
+    let source: String = if let Some(sid) = frame.source_key_id.as_ref() {
+        sid.as_str().to_string()
+    } else {
+        if !frame
             .envelope_bytes
             .starts_with(&crate::replication::wire_frame::REPLICATION_FRAME_MAGIC)
         {
+            return false; // non-CRPL unattributed envelope → envelope dispatch
+        }
+        let Some(bootstrap_source) = bootstrap_carve_out_source(frame) else {
             if let ThrottleDecision::Emit { suppressed_prev } =
                 inbound_unroutable_crpl_log().check(frame.transport.0)
             {
@@ -4028,15 +4047,44 @@ async fn route_replication_frame(
                     first_bytes_hex = %first_bytes_hex(&frame.envelope_bytes),
                     route = "SkippedNoSourceKeyId",
                     suppressed_prev,
-                    "inbound CRPL replication frame with source_key_id=None — transport could \
-                     not attribute the sending link to a peer; dropping (CIRISEdge#317)"
+                    "inbound CRPL replication frame with source_key_id=None and not a \
+                     self-authenticating bootstrap kind — transport could not attribute \
+                     the sending link to a peer; dropping (CIRISEdge#317/#402)"
                 );
             }
             return true;
+        };
+        if let ThrottleDecision::Emit { suppressed_prev } =
+            inbound_bootstrap_carveout_log().check(frame.transport.0)
+        {
+            tracing::debug!(
+                transport_id = %frame.transport.0,
+                peer = %bootstrap_source,
+                suppressed_prev,
+                "un-attributed CRPL frame ADMITTED via the bootstrap carve-out — a \
+                 self-authenticating Key/IdentityOccurrence on the link's transport identity, \
+                 verified at persist admission (CIRISEdge#402)"
+            );
         }
-        return false;
+        bootstrap_source
     };
 
+    route_attributed_frame(registry, &source, frame, metrics).await
+}
+
+/// The route-outcome half of [`route_replication_frame`] (CIRISEdge#348): hand
+/// the ATTRIBUTED CRPL bytes to the registry and map the [`RouteOutcome`] to the
+/// "frame consumed?" bool. Extracted so the ingest fn stays within clippy's line
+/// budget; the attribution decision (incl. the CIRISEdge#402 bootstrap carve-out)
+/// is resolved by the caller, so `source` here is always a vetted attribution.
+async fn route_attributed_frame(
+    registry: &std::sync::Arc<crate::replication::registry::ReplicationRegistry>,
+    source: &str,
+    frame: &InboundFrame,
+    metrics: Option<&crate::observability::EdgeMetrics>,
+) -> bool {
+    use crate::log_throttle::ThrottleDecision;
+    use crate::replication::registry::{RegistryError, RouteOutcome};
     match registry
         .route_inbound_bytes(source, &frame.envelope_bytes)
         .await
@@ -4094,6 +4142,28 @@ async fn route_replication_frame(
             true
         }
     }
+}
+
+/// CIRISEdge#402 — the bootstrap attribution carve-out. `Some(key_id)` iff the
+/// frame is a self-authenticating bootstrap kind (`Key`/`IdentityOccurrence`,
+/// [`crate::replication::EnvelopeKind::is_bootstrap`]) AND the link carried a
+/// transport-level identity (`link_key_id`). The kind is peeked from the CRPL
+/// frame; a non-bootstrap kind, an unparseable frame, or an absent link identity
+/// ⇒ `None` (the frame drops; E3's `Rooted ∧ owns_key` trace-serve gate is
+/// untouched). The returned id is the link's transport identity promoted through
+/// [`crate::transport::SourceKeyId::transport_authenticated`] — the "channel
+/// vouches by its own means" constructor, justified here precisely BECAUSE the
+/// kind is self-authenticating (verified at persist admission) and can never
+/// satisfy the trace-serve gate (which requires `from_rooted_binding`).
+fn bootstrap_carve_out_source(frame: &crate::transport::InboundFrame) -> Option<String> {
+    let link_key_id = frame.link_key_id.as_deref()?;
+    let msg = crate::replication::wire_frame::try_unwrap(&frame.envelope_bytes)
+        .ok()
+        .flatten()?;
+    if !msg.kind().is_bootstrap() {
+        return None;
+    }
+    Some(crate::transport::SourceKeyId::transport_authenticated(link_key_id).into_string())
 }
 
 /// Hex of the first up-to-8 bytes of a frame — distinguishes a binary CRPL frame
@@ -7408,6 +7478,7 @@ mod inbound_ingest_tests {
     use crate::replication::protocol::{EnvelopeKind, ReplicationMessage, SummaryMessage};
     use crate::replication::registry::ReplicationRegistry;
     use crate::transport::TransportId;
+    use proptest::prelude::*;
 
     fn frame(bytes: Vec<u8>, source: Option<&str>) -> InboundFrame {
         InboundFrame {
@@ -7415,6 +7486,7 @@ mod inbound_ingest_tests {
             transport: TransportId::RETICULUM_RS,
             received_at: chrono::Utc::now(),
             source_key_id: source.map(crate::transport::SourceKeyId::transport_authenticated),
+            link_key_id: None,
         }
     }
 
@@ -7464,6 +7536,97 @@ mod inbound_ingest_tests {
                 refs: vec![],
             }));
         assert!(!route_replication_frame(None, &frame(crpl, Some("agent-peer")), None).await);
+    }
+
+    /// CIRISEdge#402 — the bootstrap attribution carve-out truth table, tested at
+    /// the decision fn against the EXACT `(kind, link_key_id)` inputs the ingest
+    /// produces. The one E3-load-bearing case is (c): a consentable/trace-bearing
+    /// `Attestation` frame is NEVER carved out, so an advisory peer can never open
+    /// an attributed Attestation round → can never be served `trace:*`. The
+    /// carve-out admits ONLY self-authenticating bootstrap kinds, which persist
+    /// re-verifies at admission.
+    #[test]
+    fn bootstrap_carve_out_admits_only_self_authenticating_bootstrap_kinds() {
+        let with_link = |kind, link: Option<&str>| InboundFrame {
+            envelope_bytes: crate::replication::wire_frame::wrap(&ReplicationMessage::Summary(
+                SummaryMessage { kind, refs: vec![] },
+            )),
+            transport: TransportId::RETICULUM_RS,
+            received_at: chrono::Utc::now(),
+            source_key_id: None,
+            link_key_id: link.map(str::to_string),
+        };
+
+        // (a) Key + link → admitted on the link's transport identity.
+        assert_eq!(
+            bootstrap_carve_out_source(&with_link(EnvelopeKind::Key, Some("fresh-peer"))),
+            Some("fresh-peer".to_string()),
+            "a self-authenticating Key frame bootstraps on the link identity",
+        );
+        // (b) IdentityOccurrence + link → admitted.
+        assert_eq!(
+            bootstrap_carve_out_source(&with_link(
+                EnvelopeKind::IdentityOccurrence,
+                Some("fresh-peer"),
+            )),
+            Some("fresh-peer".to_string()),
+            "IdentityOccurrence is the other self-authenticating bootstrap kind",
+        );
+        // (c) THE E3 INVARIANT: an Attestation (consentable/trace) frame is NEVER
+        //     carved out — the trace-serve gate stays strictly Rooted∧owns_key.
+        assert!(
+            bootstrap_carve_out_source(&with_link(EnvelopeKind::Attestation, Some("fresh-peer")))
+                .is_none(),
+            "Attestation is not a bootstrap kind — it must still drop un-attributed (E3)",
+        );
+        // (d) No transport link identity → nothing to attribute → drop even for a
+        //     bootstrap kind.
+        assert!(
+            bootstrap_carve_out_source(&with_link(EnvelopeKind::Key, None)).is_none(),
+            "no transport link identity → no carve-out",
+        );
+        // (e) An unparseable / non-CRPL frame → no carve-out.
+        let junk = InboundFrame {
+            envelope_bytes: b"not a crpl frame".to_vec(),
+            transport: TransportId::RETICULUM_RS,
+            received_at: chrono::Utc::now(),
+            source_key_id: None,
+            link_key_id: Some("fresh-peer".into()),
+        };
+        assert!(
+            bootstrap_carve_out_source(&junk).is_none(),
+            "an unparseable frame yields no carve-out",
+        );
+    }
+
+    proptest! {
+        /// CIRISEdge#402 — the carve-out decision, EXHAUSTIVELY over ALL 14 kinds
+        /// × link presence × arbitrary link ids. The security invariant, stated
+        /// as one equation: a routing source is produced IFF the frame's kind is
+        /// a self-authenticating bootstrap kind (`is_bootstrap`) AND the link
+        /// carries a transport identity. So NO consentable/trace-bearing kind is
+        /// ever attributed via the carve-out (E3 intact by construction), and no
+        /// carve-out fires without a link to attribute to. A hand-picked truth
+        /// table can miss a kind; this cannot.
+        #[test]
+        fn bootstrap_carve_out_source_holds_over_all_kinds(
+            kind_idx in 0usize..EnvelopeKind::ALL.len(),
+            link in prop::option::of("[a-z0-9-]{1,32}"),
+        ) {
+            let kind = EnvelopeKind::ALL[kind_idx];
+            let frame = InboundFrame {
+                envelope_bytes: crate::replication::wire_frame::wrap(
+                    &ReplicationMessage::Summary(SummaryMessage { kind, refs: vec![] }),
+                ),
+                transport: TransportId::RETICULUM_RS,
+                received_at: chrono::Utc::now(),
+                source_key_id: None,
+                link_key_id: link.clone(),
+            };
+            // Some(link) exactly when kind is a bootstrap kind AND a link exists.
+            let expected = link.filter(|_| kind.is_bootstrap());
+            prop_assert_eq!(bootstrap_carve_out_source(&frame), expected);
+        }
     }
 
     /// CIRISEdge#373 — when a responder reply stalls, the coordinator's bounded

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1059,6 +1059,7 @@ impl PyEdge {
                     transport: tid,
                     received_at: chrono::Utc::now(),
                     source_key_id: None,
+                    link_key_id: None, // CIRISEdge#402
                 };
                 inner
                     .dispatch_inbound_observed_outcome_for_test(frame)

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -178,6 +178,25 @@ impl EnvelopeKind {
         Self::TransportDestination,
     ];
 
+    /// CIRISEdge#402 — the finite, self-authenticating **bootstrap** kinds a
+    /// fresh peer must deliver to introduce itself into the trust graph: its own
+    /// `KeyRecord` (`Key`) and its identity binding (`IdentityOccurrence`).
+    /// These are the ONLY kinds the attribution gate exempts from
+    /// `Rooted ∧ owns_key` (CIRISEdge#393/E3): a fresh peer is `UnknownKeyId`
+    /// until its `Key` is admitted, but the `Key` frame is exactly what admits
+    /// it — a deadlock the gate would otherwise never break. Safe because both
+    /// are hybrid-verified at persist admission (`put_public_key` E2/#502,
+    /// `put_identity_occurrence` `signer_acts_for`), so an un-attributed
+    /// delivery is *verified* at the apply layer where verification belongs; it
+    /// grants no trust and is served no `trace:*` (that plane stays strictly
+    /// `Rooted ∧ owns_key`-attributed). Consentable/structural planes are NOT
+    /// bootstrap kinds — the exemption is exactly these two, forever a compile
+    /// error to widen without touching this method.
+    #[must_use]
+    pub fn is_bootstrap(self) -> bool {
+        matches!(self, Self::Key | Self::IdentityOccurrence)
+    }
+
     /// Stable snake_case wire name for this kind — the manifest/witness key
     /// (CIRISEdge#393 item 3). Stable across releases; a rename is a wire-policy
     /// change that must flip `SERVE_ADVERTISE_POLICY_HASH`.
@@ -490,6 +509,21 @@ mod tests {
             let s = std::str::from_utf8(&bytes).unwrap();
             assert!(s.contains(wire), "expected `{wire}` in {s}");
             assert_eq!(ReplicationMessage::from_bytes(&bytes).unwrap(), m);
+        }
+    }
+
+    /// CIRISEdge#402 — `is_bootstrap` is EXACTLY `{Key, IdentityOccurrence}`.
+    /// Checked over ALL 14 kinds so widening the attribution carve-out can't slip
+    /// in unnoticed: a new bootstrap kind must be a deliberate edit here.
+    #[test]
+    fn is_bootstrap_is_exactly_key_and_identity_occurrence() {
+        for kind in EnvelopeKind::ALL {
+            let expected = matches!(kind, EnvelopeKind::Key | EnvelopeKind::IdentityOccurrence);
+            assert_eq!(
+                kind.is_bootstrap(),
+                expected,
+                "{kind:?}: is_bootstrap must be true iff Key/IdentityOccurrence",
+            );
         }
     }
 

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -618,6 +618,9 @@ async fn inbound_handler(
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id,
+        // CIRISEdge#402 — HTTP attributes via mTLS/bearer (`source_key_id`); it
+        // carries no advisory-link identity, so no bootstrap carve-out here.
+        link_key_id: None,
     };
     match state.sink.send(frame).await {
         Ok(()) => StatusCode::ACCEPTED.into_response(),

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -376,6 +376,18 @@ pub struct InboundFrame {
     /// (Reticulum `Rooted ∧ owns_key`, or a channel-authenticated transport),
     /// so a spoofed/advisory attribution is unrepresentable at this boundary.
     pub source_key_id: Option<SourceKeyId>,
+    /// CIRISEdge#402 — the link's TRANSPORT-level key_id (the self-consistent
+    /// advisory binding the link identified to), populated even when the E3
+    /// trust gate refused to attribute it (`source_key_id == None`). This is a
+    /// **routing hint, not a trust claim** — a deliberately bare `String`, never
+    /// a [`SourceKeyId`], so it CANNOT reach the trace-serve path. The only
+    /// legitimate consumer is the replication ingest's bootstrap carve-out,
+    /// which promotes it to a `transport_authenticated` `SourceKeyId` ONLY for a
+    /// self-authenticating [`EnvelopeKind::is_bootstrap`](crate::replication::EnvelopeKind::is_bootstrap)
+    /// frame (`Key`/`IdentityOccurrence`), verified at persist admission. `None`
+    /// for transports that don't carry an advisory-link identity (HTTP, packet
+    /// radio, FFI — those attribute via `source_key_id` or not at all).
+    pub link_key_id: Option<String>,
 }
 
 /// The trait every transport implements. Edge holds a

--- a/src/transport/packet_radio/mod.rs
+++ b/src/transport/packet_radio/mod.rs
@@ -248,6 +248,7 @@ impl Transport for PacketRadioTransport {
                         transport: self.transport_id,
                         received_at: Utc::now(),
                         source_key_id: None,
+                        link_key_id: None, // CIRISEdge#402 — no advisory-link identity
                     };
                     if sink.send(frame).await.is_err() {
                         // Sink closed — listener should exit cleanly.

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -4149,6 +4149,12 @@ async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8
     // is `Rooted ∧ owns_key` (item 1) AND its transport identity is bound by a
     // hybrid-verified `SignedTransportDestination` (item 2, the PQ half). Any
     // shortfall → `None` (SkippedNoSourceKeyId downstream, never served).
+    // CIRISEdge#402 — the raw transport-level link key_id (the self-consistent
+    // advisory binding), captured BEFORE the E3 `Rooted∧owns_key∧hybrid` gate
+    // below narrows it to `None`. A routing hint only (see `InboundFrame::link_key_id`);
+    // the E3 attacker (`PubkeyMismatch`) never reaches `link_to_peer_key_id`, so
+    // this is `Some` only for a self-consistent binding.
+    let link_key_id = candidate_key_id.clone();
     let source_key_id = match candidate_key_id {
         Some(key_id) => {
             // Item 1 — Rooted ∧ owns_key, plus capture the peer's dest for the
@@ -4212,6 +4218,7 @@ async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8
         transport: TransportId::RETICULUM_RS,
         received_at: Utc::now(),
         source_key_id,
+        link_key_id,
     };
     if let Err(e) = ctx.sink.send(frame).await {
         tracing::error!(error = %e, "inbound channel send failed");

--- a/tests/accord_carrier_verify.rs
+++ b/tests/accord_carrier_verify.rs
@@ -455,6 +455,7 @@ async fn accord_carrier_2_of_3_valid_propagates() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 
@@ -512,6 +513,7 @@ async fn accord_carrier_1_of_3_refuses_and_emits_refusal() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 
@@ -576,6 +578,7 @@ async fn accord_carrier_3_of_3_propagates() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 
@@ -638,6 +641,7 @@ async fn accord_carrier_2_valid_1_invalid_propagates() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 
@@ -694,6 +698,7 @@ async fn accord_carrier_0_accord_holders_in_directory_refuses_with_no_accord_hol
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 
@@ -762,6 +767,7 @@ async fn accord_carrier_duplicate_signatures_from_same_holder_count_once() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 
@@ -819,6 +825,7 @@ async fn accord_carrier_non_accord_class_announcements_skip_threshold_check() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 
@@ -891,6 +898,7 @@ async fn accord_carrier_classical_only_signatures_refused_require_hybrid() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 
@@ -957,6 +965,7 @@ async fn accord_carrier_spare_holder_not_seated_does_not_count() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 

--- a/tests/ceg_content_discipline.rs
+++ b/tests/ceg_content_discipline.rs
@@ -188,6 +188,7 @@ impl Transport for InjectTransport {
                 transport: TransportId::HTTP,
                 received_at: chrono::Utc::now(),
                 source_key_id: None,
+                link_key_id: None,
             };
             if sink.send(frame).await.is_err() {
                 break;

--- a/tests/cohort_scope_persist_backed.rs
+++ b/tests/cohort_scope_persist_backed.rs
@@ -224,6 +224,7 @@ async fn dispatch(
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
     Ok(())

--- a/tests/cohort_scope_refusal.rs
+++ b/tests/cohort_scope_refusal.rs
@@ -556,6 +556,7 @@ async fn dispatch_with_cohort_scope(
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
     Ok(())

--- a/tests/content_fetch.rs
+++ b/tests/content_fetch.rs
@@ -192,6 +192,7 @@ impl Transport for InjectTransport {
                 transport: TransportId::HTTP,
                 received_at: chrono::Utc::now(),
                 source_key_id: None,
+                link_key_id: None,
             };
             if sink.send(frame).await.is_err() {
                 break;

--- a/tests/multimedia_tier.rs
+++ b/tests/multimedia_tier.rs
@@ -237,6 +237,7 @@ async fn dispatch_contribution(
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 }

--- a/tests/observability_metrics.rs
+++ b/tests/observability_metrics.rs
@@ -295,6 +295,7 @@ async fn metrics_counter_increments_on_receive() {
         transport: TransportId::HTTP,
         received_at: chrono::Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 
@@ -418,6 +419,7 @@ async fn metrics_transport_bytes_io_counted() {
         transport: TransportId::HTTP,
         received_at: chrono::Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 
@@ -474,6 +476,7 @@ async fn metrics_verify_failure_classified_by_error() {
         transport: TransportId::HTTP,
         received_at: chrono::Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 

--- a/tests/observability_tracing.rs
+++ b/tests/observability_tracing.rs
@@ -284,6 +284,7 @@ async fn dispatch_inbound_emits_structured_span_with_fields() {
         transport: TransportId::HTTP,
         received_at: chrono::Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 
@@ -366,6 +367,7 @@ async fn verify_failure_emits_structured_error_event() {
         transport: TransportId::HTTP,
         received_at: chrono::Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 

--- a/tests/probe_pattern_observer_integration.rs
+++ b/tests/probe_pattern_observer_integration.rs
@@ -290,6 +290,7 @@ async fn unconsented_external_traffic_drives_observations() {
             transport: TransportId::HTTP,
             received_at: Utc::now(),
             source_key_id: None,
+            link_key_id: None,
         })
         .await;
     }
@@ -336,6 +337,7 @@ async fn peer_role_traffic_produces_no_observations() {
             transport: TransportId::HTTP,
             received_at: Utc::now(),
             source_key_id: None,
+            link_key_id: None,
         })
         .await;
     }
@@ -379,6 +381,7 @@ async fn detector_disabled_is_a_full_noop() {
             transport: TransportId::HTTP,
             received_at: Utc::now(),
             source_key_id: None,
+            link_key_id: None,
         })
         .await;
     }

--- a/tests/steward_topology.rs
+++ b/tests/steward_topology.rs
@@ -496,6 +496,7 @@ async fn federation_delivery_emits_attestation_per_recipient() {
         received_at: chrono::Utc::now(),
         transport: TransportId::HTTP,
         source_key_id: None,
+        link_key_id: None,
     };
     receiver_edge.dispatch_inbound_for_test(frame).await;
 

--- a/tests/tier3_fetch_content_and_feed.rs
+++ b/tests/tier3_fetch_content_and_feed.rs
@@ -430,6 +430,7 @@ async fn tier3_dispatch_inbound_signals_fetch_content() {
         transport: TransportId::HTTP,
         received_at: chrono::Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     })
     .await;
 

--- a/tests/trust_recursion_depth_wired.rs
+++ b/tests/trust_recursion_depth_wired.rs
@@ -241,6 +241,7 @@ async fn dispatch(
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
     Ok(())

--- a/tests/trust_short_circuit.rs
+++ b/tests/trust_short_circuit.rs
@@ -250,6 +250,7 @@ async fn dispatch(
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
     Ok(())
@@ -623,6 +624,7 @@ async fn build_signed_envelope_from_software_signer_drives_trust_gate() {
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     let outcome = edge.dispatch_inbound_observed_outcome_for_test(frame).await;
 
@@ -662,6 +664,7 @@ async fn build_outcome(edge: &Edge, sender: &LocalSigner, destination: &str) -> 
         transport: TransportId::HTTP,
         received_at: Utc::now(),
         source_key_id: None,
+        link_key_id: None,
     };
     edge.dispatch_inbound_observed_outcome_for_test(frame).await
 }


### PR DESCRIPTION
Fixes **CIRISEdge#402** — the attribution-gate **bootstrap deadlock**: a fresh peer can never introduce itself because its own `Key` frame is dropped by the gate that needs the key. **v14.2.2**, a correctness floor.

## The deadlock
#393/E3's `Rooted ∧ owns_key` attribution gate drops every un-attributed frame (`source_key_id=None` → `SkippedNoSourceKeyId`, #317). A fresh peer is `UnknownKeyId` → **all** its frames drop, *including the `Key` frame that would admit it*. Key needs a round → round needs attribution → attribution needs the key. No un-blessed NAT'd initiator (#927) can join on v14.2.x.

## Fix — the narrow, typed carve-out (co-designed with E3)
Un-attributed links may deliver **only** the self-authenticating bootstrap kinds:
- `EnvelopeKind::is_bootstrap()` is **exactly** `{Key, IdentityOccurrence}`.
- At the ingest drop, a `source_key_id=None` CRPL frame whose kind `is_bootstrap` routes on the link's **transport** identity (`InboundFrame::link_key_id` — a bare routing hint, **never** a `SourceKeyId`, promoted through `transport_authenticated` only here, only for these kinds). Everything else still drops.
- The frame is verified at **persist admission** (`put_public_key` E2/#502, `put_identity_occurrence` `signer_acts_for`) — fail-closed on *verification*, at the layer where it belongs.

**E3 stays intact by construction:** no consentable/trace kind is ever carved out, and the trace-serve gate stays strictly `from_rooted_binding` (`Rooted ∧ owns_key`). Advisory = transport routing hint, not trust — the code's own `owns_key`/`transport_authenticated` seam. The E3 attacker (`PubkeyMismatch`) never populates `link_to_peer_key_id`, so `link_key_id` is `Some` only for a self-consistent binding; even then only its own key can be introduced (admission verifies).

## Threat model
Checked against `CEG_REPLICATION_MODEL.md` §4.3: E3's attack is being *served trace* via spoofed attribution; the two premises are (a) transport attribution and (b) the apply gate verifying every record. The carve-out leans on (b) for bootstrap kinds and never touches (a)'s trace-serve gate. **No persist ask** — everything it relies on shipped in v21.2.0.

## Tests — property-based where the invariant is universal (proptest)
- `is_bootstrap` is **exactly** `{Key, IdentityOccurrence}` over all 14 kinds.
- `bootstrap_carve_out_source` returns `Some` **iff** (bootstrap kind ∧ link present), **exhaustively** over all kinds × link presence × arbitrary ids — a hand-picked table can miss a kind; this can't. This *is* the E3-preservation invariant (no trace-bearing kind is ever attributed via the carve-out).
- The E3 truth table (`from_rooted_binding` sole trace-serve attributor) is unchanged.
- Not unit-tested (noted): "a spoof announce yields no `link_key_id`" is reticulum-internal and not load-bearing — a forged `Key` fails `put_public_key` regardless of routing id.

Clippy `-D warnings` clean across pyo3 `--all-targets`, ffi-uniffi, test-anchor; fmt green; 125 module tests. Cohab-red is the known server-skew. Closes #402.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8uDCuRxAQVRzdjcuDVrBF
