### PR TITLE
feat(v14.2.4): TransportDestination bootstrap carve-out — edge half of #406 (item-2 floor)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "14.2.3"
+version = "14.2.4"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -7570,7 +7570,18 @@ mod inbound_ingest_tests {
                 Some("fresh-peer"),
             )),
             Some("fresh-peer".to_string()),
-            "IdentityOccurrence is the other self-authenticating bootstrap kind",
+            "IdentityOccurrence is a self-authenticating bootstrap kind",
+        );
+        // (b2) CIRISEdge#406 — TransportDestination + link → admitted (the signed
+        //      transport binding that satisfies #393 item 2; signer_acts_for-verified
+        //      at admission, else it is itself #317-dropped — the deadlock again).
+        assert_eq!(
+            bootstrap_carve_out_source(&with_link(
+                EnvelopeKind::TransportDestination,
+                Some("fresh-peer"),
+            )),
+            Some("fresh-peer".to_string()),
+            "TransportDestination is the item-2 bootstrap kind (CIRISEdge#406)",
         );
         // (c) THE E3 INVARIANT: an Attestation (consentable/trace) frame is NEVER
         //     carved out — the trace-serve gate stays strictly Rooted∧owns_key.

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -178,23 +178,33 @@ impl EnvelopeKind {
         Self::TransportDestination,
     ];
 
-    /// CIRISEdge#402 — the finite, self-authenticating **bootstrap** kinds a
-    /// fresh peer must deliver to introduce itself into the trust graph: its own
-    /// `KeyRecord` (`Key`) and its identity binding (`IdentityOccurrence`).
+    /// CIRISEdge#402/#406 — the finite, self-authenticating **bootstrap** kinds a
+    /// fresh peer must deliver to introduce itself into the trust graph AND make
+    /// itself attributable:
+    /// - `Key` — its own `KeyRecord` (the `owns_key` half of #393 item 1);
+    /// - `IdentityOccurrence` — its identity binding;
+    /// - `TransportDestination` — its hybrid-signed transport binding, the ONLY
+    ///   thing that satisfies #393 **item 2** (`hybrid_transport_binding_exists`).
+    ///
     /// These are the ONLY kinds the attribution gate exempts from
-    /// `Rooted ∧ owns_key` (CIRISEdge#393/E3): a fresh peer is `UnknownKeyId`
-    /// until its `Key` is admitted, but the `Key` frame is exactly what admits
-    /// it — a deadlock the gate would otherwise never break. Safe because both
-    /// are hybrid-verified at persist admission (`put_public_key` E2/#502,
-    /// `put_identity_occurrence` `signer_acts_for`), so an un-attributed
-    /// delivery is *verified* at the apply layer where verification belongs; it
-    /// grants no trust and is served no `trace:*` (that plane stays strictly
-    /// `Rooted ∧ owns_key`-attributed). Consentable/structural planes are NOT
-    /// bootstrap kinds — the exemption is exactly these two, forever a compile
-    /// error to widen without touching this method.
+    /// `Rooted ∧ owns_key` (CIRISEdge#393/E3). The deadlock the exemption breaks:
+    /// a fresh peer is `UnknownKeyId` until its `Key` is admitted, but the `Key`
+    /// frame is exactly what admits it; and (CIRISEdge#406) its signed
+    /// `TransportDestination` is exactly what item 2 requires, but item 2 would
+    /// drop that frame too — the deadlock, once more. Safe because ALL THREE are
+    /// hybrid-verified at persist admission (`put_public_key` E2/#502,
+    /// `put_identity_occurrence` + `put_signed_transport_destination`,
+    /// `signer_acts_for`), so an un-attributed delivery is *verified* at the apply
+    /// layer where verification belongs; each grants no trust and is served no
+    /// `trace:*` (that plane stays strictly `Rooted ∧ owns_key`-attributed).
+    /// Consentable/other-structural planes are NOT bootstrap kinds — the
+    /// exemption is exactly these three, a deliberate compile-fenced edit to widen.
     #[must_use]
     pub fn is_bootstrap(self) -> bool {
-        matches!(self, Self::Key | Self::IdentityOccurrence)
+        matches!(
+            self,
+            Self::Key | Self::IdentityOccurrence | Self::TransportDestination
+        )
     }
 
     /// Stable snake_case wire name for this kind — the manifest/witness key
@@ -512,19 +522,27 @@ mod tests {
         }
     }
 
-    /// CIRISEdge#402 — `is_bootstrap` is EXACTLY `{Key, IdentityOccurrence}`.
-    /// Checked over ALL 14 kinds so widening the attribution carve-out can't slip
-    /// in unnoticed: a new bootstrap kind must be a deliberate edit here.
+    /// CIRISEdge#402/#406 — `is_bootstrap` is EXACTLY
+    /// `{Key, IdentityOccurrence, TransportDestination}`. Checked over ALL 14
+    /// kinds so widening the attribution carve-out can't slip in unnoticed: a new
+    /// bootstrap kind must be a deliberate edit here.
     #[test]
-    fn is_bootstrap_is_exactly_key_and_identity_occurrence() {
+    fn is_bootstrap_is_exactly_the_three_bootstrap_kinds() {
         for kind in EnvelopeKind::ALL {
-            let expected = matches!(kind, EnvelopeKind::Key | EnvelopeKind::IdentityOccurrence);
+            let expected = matches!(
+                kind,
+                EnvelopeKind::Key
+                    | EnvelopeKind::IdentityOccurrence
+                    | EnvelopeKind::TransportDestination
+            );
             assert_eq!(
                 kind.is_bootstrap(),
                 expected,
-                "{kind:?}: is_bootstrap must be true iff Key/IdentityOccurrence",
+                "{kind:?}: is_bootstrap must be true iff Key/IdentityOccurrence/TransportDestination",
             );
         }
+        // The load-bearing E3 negative: the trace-bearing plane is never bootstrap.
+        assert!(!EnvelopeKind::Attestation.is_bootstrap());
     }
 
     /// Wire-stability sanity: confirm no two kinds collide on their


### PR DESCRIPTION
Edge's half of **CIRISEdge#406** — graduate #393 item 2 to required-floor by making it satisfiable. **v14.2.4.**

Live v14.2.3 diagnosis proved item 1 (`Rooted ∧ owns_key`) now passes end-to-end; the last drop is **item 2** (`hybrid_transport_binding_exists`), which needs a stored `SignedTransportDestination` with an ML-DSA half — and nothing produces one (the announce path writes unsigned). Decision A: keep the PQ gate blocking, ship the producer.

## Path chosen: **standalone**, not projection
- **Projection** (persist projects the signed IdentityOccurrence's transport binding) is DRY but **couples to #313**, whose fold occurrence-publish may early-return.
- **Standalone** decouples from #313: the server swaps `publish_self_transport_destination` to the generic signed producer, and **edge (this PR)** adds `TransportDestination` to the bootstrap carve-out so a fresh peer's signed dest reaches the canonical past item 2 — else the signed dest is itself #317-dropped (the #402 deadlock, once more).
- The carve-out addition is **path-agnostic-safe**: harmless if projection is later chosen (a projected dest needs no delivery). So this doesn't foreclose projection — it just unblocks the decoupled path now.

## Edge's half
`EnvelopeKind::is_bootstrap()` is now `{Key, IdentityOccurrence, TransportDestination}`. `TransportDestination` genuinely belongs — the third thing a fresh peer introduces (key, identity, *transport binding for item 2*) — and is self-authenticating: `put_signed_transport_destination` verifies `signer_acts_for` at admission (a spoofed dest binding a victim's key_id is refused), same safety class as Key/IdOcc. **E3 intact by construction:** no consentable/trace kind is carved out; the trace-serve gate stays strictly `Rooted ∧ owns_key`. Apply already exists (`apply_transport_destination`); item 2 reads the applied row.

## Tests
- `is_bootstrap` exact-set is now the three kinds over all 14 (`Attestation` stays **false** — the E3 negative).
- The carve-out truth table gains the `TransportDestination` admit case.
- The exhaustive proptest **auto-adapts** — it oracles on `is_bootstrap`, so all-kinds × link-presence stays correct.
- Clippy `-D warnings` clean across pyo3/ffi-uniffi/test-anchor; fmt green. No persist ask for edge's half.

**Server wires its half:** signed `publish_self_transport_destination` (call the generic producer instead of writing unsigned). When both land, item 2 passes and traces flow. Cohab-red is the known server-skew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8uDCuRxAQVRzdjcuDVrBF
