### PR TITLE
feat(v14.3.0): adopt persist v21.3.0 (#513 FIPS anti-Sybil floor) + pin the Yubico attestation root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "14.2.4"
+version = "14.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.2.0", version = "21", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.3.0", version = "21", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.2.0", version = "21", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.3.0", version = "21", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=21.2.0,<22",
+    "ciris-persist>=21.3.0,<22",
 ]
 dynamic = ["version"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,6 +190,39 @@ mod consent_grammar_hash_tests {
     }
 }
 
+/// Pinned SHA-256 of persist's `YUBICO_ATTESTATION_ROOT_1_DER` — the single
+/// trust anchor the CIRISPersist#513 canonical-admission gate chains every
+/// FIPS-140-3 accord custody attestation to (a valid canonical = a co-scrub by a
+/// Yubico-attested FIPS-140-3 accord of ≥3, the hardware anti-Sybil floor on
+/// trust-root minting). Edge does NOT admit canonicals, but it pins the anchor as
+/// a cross-repo drift witness: the root of trust for the anti-Sybil floor must
+/// never move silently. A mismatch is a BUILD failure first, forcing a DELIBERATE
+/// re-pin in lockstep with persist + CIRISServer — the same posture as
+/// [`PERSIST_CONSENT_GRAMMAR_HASH`] / [`PERSIST_REPLICATION_POLICY_HASH`].
+pub const PERSIST_YUBICO_ATTESTATION_ROOT_HASH: &str =
+    "62760c6a6ef91679f454c8902b80fd009825b3f25da90f1fbace2ec6586cd5a8";
+
+#[cfg(test)]
+mod yubico_attestation_root_hash_tests {
+    use sha2::{Digest, Sha256};
+
+    /// Cross-repo lockstep witness for the CIRISPersist#513 anti-Sybil floor's
+    /// trust anchor — mirrors persist's own `yubico_root_pin_sha256_513`. If
+    /// persist ever swaps the pinned Yubico attestation root, this breaks first.
+    #[test]
+    fn persist_yubico_attestation_root_pinned() {
+        assert_eq!(
+            hex::encode(Sha256::digest(
+                ciris_persist::federation::admission::YUBICO_ATTESTATION_ROOT_1_DER
+            )),
+            super::PERSIST_YUBICO_ATTESTATION_ROOT_HASH,
+            "persist's YUBICO_ATTESTATION_ROOT_1_DER changed — the FIPS-140-3 anti-Sybil \
+             floor's root of trust moved. Re-pin DELIBERATELY, in lockstep with persist + \
+             CIRISServer (CIRISPersist#513)."
+        );
+    }
+}
+
 pub use blob_swarm::{
     BlobChunkSource, BlobChunkVerifier, ChunkManifestLite, ChunkSourceRefusal, ChunkVerifyError,
     PeerState, SwarmConfig, SwarmError, SwarmScheduler,


### PR DESCRIPTION
Adopts **ciris-persist v21.3.0** (**edge v14.3.0**) — `#512` route-encoding + `#508` dyn-rooting + **`#513` the FIPS-140-3 anti-Sybil floor**.

## Source-compatible + policy-compatible
Edge compiles unchanged against v21.3.0 (the persist changes are additive/internal), and **all four pinned policy hashes still match** (`REPLICATION_POLICY_HASH` / `CONSENT_GRAMMAR_HASH` / wire-vocabulary / `SERVE_ADVERTISE`). `#512`/`#508` are persist-internal / server-facing (E6 re-anchoring) — no edge behavior change.

## Edge's half of #513 (the hardware anti-Sybil floor)
Persist v21.3.0 makes a valid **canonical** require a co-scrub by a **Yubico-attested FIPS-140-3 accord of ≥3**, chained to its pinned `YUBICO_ATTESTATION_ROOT_1_DER` — minting a trust root now costs 3 hardware-bound, touch-required humans (non-virtualizable), but stays possible.

Edge doesn't admit canonicals, but it **pins the trust anchor as a cross-repo drift witness**: `PERSIST_YUBICO_ATTESTATION_ROOT_HASH = sha256(YUBICO_ATTESTATION_ROOT_1_DER)`, with a gate test that mirrors persist's own `yubico_root_pin_sha256_513`. The anti-Sybil floor's root of trust must never move silently — a swap breaks a **build** first, forcing a deliberate re-pin in lockstep with persist + CIRISServer. Same posture as the other policy pins.

## Verification
- **702 lib tests** (incl. the new `persist_yubico_attestation_root_pinned`); the four existing pin-gate hashes green.
- Clippy `-D warnings` clean across pyo3 `--all-targets`, ffi-uniffi, test-anchor; fmt green; pin-skew (Cargo ↔ pyproject) clean.

Cohab-red is the known server-skew. (#513 was filed from this session and landed in the same persist cut — the expansion seams are flagged in the issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8uDCuRxAQVRzdjcuDVrBF
