### PR TITLE
feat(v15.0.0): adopt complete persist #519 surface (v21.10.0) — process every routing field, produce touch-claims, conformance+evidence harness (#410 + #411)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "14.4.0"
+version = "15.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.4.0", version = "21", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.10.0", version = "21", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.4.0", version = "21", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.10.0", version = "21", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -1,0 +1,15 @@
+# CIRIS evidence registry — impl: tier (CIRISEdge#410 / CIRISConstitution#17)
+# Edge's routing-processor evidence rows, resolving the Constitution's
+# CLM-nsproc-* namespace-processing claims. GENERATED from
+# src/field_conformance.rs#EDGE_FIELD_CONFORMANCE (the live, tested processor
+# table); regenerate on version bump. Kept in sync with the code by the test
+# field_conformance::tests::evidence_tsv_matches_emitted — a drift is a build
+# failure. Vendored by CIRISConstitution/tools/check_evidence.py.
+# Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.0.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.0.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.0.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.0.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.0.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.0.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=21.4.0,<22",
+    "ciris-persist>=21.10.0,<22",
 ]
 dynamic = ["version"]
 

--- a/src/delivery_mode.rs
+++ b/src/delivery_mode.rs
@@ -1,0 +1,165 @@
+//! CIRISEdge#411 §1 — the `delivery_mode` field processor.
+//!
+//! `delivery_mode` became a **typed `EnvelopeCore` field** in persist v21.9.0
+//! (hoisted out of the untyped `extra` bag, byte-invariant under JCS). The
+//! `field_processor_matrix` tags `delivery_mode` `owner_component: edge` with the
+//! processor `reachability.rs#ReachabilityTracker::snapshot_all` — edge is the
+//! component that must READ the field (typed, never from `extra`) and let its
+//! VALUE drive delivery-path selection.
+//!
+//! This module is the value-semantics processor: it reads the typed field via
+//! persist's [`EnvelopeCore::from_value`] (so a producer that hoisted the field
+//! and a legacy producer that left it in `extra` both resolve identically, and a
+//! presence-only scan of `extra` can never be fooled), classifies the delivery
+//! requirement, and — fail-secure — refuses to treat an envelope the producer
+//! marked `mandatory` as best-effort-droppable when no path is reachable.
+//!
+//! It does NOT own the transport selection itself (that is the scheduler /
+//! `ReachabilityTracker`); it owns the *rule* the selection must honor, expressed
+//! as a pure decision so it is exhaustively testable without the runtime.
+
+use ciris_persist::federation::envelope::EnvelopeCore;
+
+/// The wire token that marks an envelope's delivery as mandatory. Matches
+/// persist's canonical value (`envelope.rs` witnesses `Some("mandatory")`); any
+/// other value (including absent) is best-effort. Kept as the single source so a
+/// value comparison, not a presence check, is what every caller performs.
+pub const DELIVERY_MODE_MANDATORY: &str = "mandatory";
+
+/// The delivery requirement an envelope's `delivery_mode` VALUE imposes on edge's
+/// path selection. Derived from the value, never from field presence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryRequirement {
+    /// No `delivery_mode`, or a value other than [`DELIVERY_MODE_MANDATORY`] —
+    /// best-effort; a no-reachable-path outcome may drop.
+    BestEffort,
+    /// `delivery_mode == "mandatory"` — the producer requires delivery. Edge must
+    /// select a durable/reachable path and, if none exists, surface the miss
+    /// (fail-loud, MISSION §3 anti-pattern 6), never silently drop.
+    Mandatory,
+}
+
+/// Read the **typed** `delivery_mode` off a CEG envelope value via persist's
+/// [`EnvelopeCore`] parser — the hoisted field, NOT `extra["delivery_mode"]`.
+/// `None` when the envelope does not parse as an `EnvelopeCore` or carries no
+/// `delivery_mode`. Reading through `EnvelopeCore::from_value` is what makes this
+/// byte-invariant with persist (a hoisted producer and a legacy `extra` producer
+/// resolve to the same typed value).
+#[must_use]
+pub fn delivery_mode_of(envelope: &serde_json::Value) -> Option<String> {
+    EnvelopeCore::from_value(envelope.clone())
+        .ok()
+        .and_then(|core| core.delivery_mode)
+}
+
+/// The delivery requirement the envelope's `delivery_mode` VALUE imposes.
+#[must_use]
+pub fn requirement_of(envelope: &serde_json::Value) -> DeliveryRequirement {
+    match delivery_mode_of(envelope).as_deref() {
+        Some(DELIVERY_MODE_MANDATORY) => DeliveryRequirement::Mandatory,
+        _ => DeliveryRequirement::BestEffort,
+    }
+}
+
+/// The fail-secure path decision: given the envelope's delivery requirement and
+/// whether ANY transport path to the destination is currently reachable (the
+/// caller derives `path_reachable` from [`crate::reachability::ReachabilityTracker`]
+/// `snapshot_all`/`snapshot`), decide what edge must do.
+///
+/// The load-bearing case is `(Mandatory, false)` → [`DeliveryDecision::FailLoudNoPath`]:
+/// a producer-mandated envelope with no reachable path must NOT be silently
+/// dropped. Best-effort with no path is a plain drop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryDecision {
+    /// A reachable path exists — deliver.
+    Deliver,
+    /// Best-effort and no path — a permissible drop.
+    DropBestEffort,
+    /// Mandatory and no path — surface the miss; never a silent drop.
+    FailLoudNoPath,
+}
+
+/// Resolve the delivery decision from the envelope's requirement + reachability.
+#[must_use]
+pub fn decide(envelope: &serde_json::Value, path_reachable: bool) -> DeliveryDecision {
+    match (requirement_of(envelope), path_reachable) {
+        (_, true) => DeliveryDecision::Deliver,
+        (DeliveryRequirement::Mandatory, false) => DeliveryDecision::FailLoudNoPath,
+        (DeliveryRequirement::BestEffort, false) => DeliveryDecision::DropBestEffort,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The typed read resolves the HOISTED field, and — the value-semantics
+    /// guard — a legacy producer that left `delivery_mode` in the flattened body
+    /// resolves identically (persist's `EnvelopeCore` flattens `extra`). A
+    /// presence scan of `extra` alone could be fooled; reading the typed value
+    /// cannot. Mirrors persist's `hoisted_fields_are_canonicalization_byte_invariant`.
+    #[test]
+    fn reads_the_typed_field_by_value() {
+        let env = json!({
+            "attesting_key_id": "agent-1",
+            "attested_key_id": "agent-1",
+            "attestation_type": "scores",
+            "delivery_mode": "mandatory",
+        });
+        assert_eq!(delivery_mode_of(&env).as_deref(), Some("mandatory"));
+        assert_eq!(requirement_of(&env), DeliveryRequirement::Mandatory);
+    }
+
+    /// Absent `delivery_mode` → best-effort (never defaulted to mandatory).
+    #[test]
+    fn absent_is_best_effort() {
+        let env = json!({
+            "attesting_key_id": "agent-1",
+            "attested_key_id": "agent-1",
+            "attestation_type": "scores",
+        });
+        assert_eq!(delivery_mode_of(&env), None);
+        assert_eq!(requirement_of(&env), DeliveryRequirement::BestEffort);
+    }
+
+    /// A non-`mandatory` value is best-effort — the check is on the VALUE, not on
+    /// the field being present.
+    #[test]
+    fn other_value_is_best_effort() {
+        let env = json!({
+            "attesting_key_id": "a", "attested_key_id": "a",
+            "attestation_type": "scores", "delivery_mode": "best_effort",
+        });
+        assert_eq!(requirement_of(&env), DeliveryRequirement::BestEffort);
+    }
+
+    /// The fail-secure truth table: the ONE case that must never silently drop is
+    /// (mandatory, no path).
+    #[test]
+    fn decide_is_fail_secure_for_mandatory() {
+        let mandatory = json!({
+            "attesting_key_id": "a", "attested_key_id": "a",
+            "attestation_type": "scores", "delivery_mode": "mandatory",
+        });
+        let best_effort = json!({
+            "attesting_key_id": "a", "attested_key_id": "a",
+            "attestation_type": "scores",
+        });
+        assert_eq!(decide(&mandatory, true), DeliveryDecision::Deliver);
+        assert_eq!(decide(&mandatory, false), DeliveryDecision::FailLoudNoPath);
+        assert_eq!(decide(&best_effort, true), DeliveryDecision::Deliver);
+        assert_eq!(
+            decide(&best_effort, false),
+            DeliveryDecision::DropBestEffort
+        );
+    }
+
+    /// A non-object envelope does not parse as `EnvelopeCore` → best-effort, never
+    /// a panic.
+    #[test]
+    fn non_object_envelope_is_best_effort() {
+        assert_eq!(delivery_mode_of(&json!("not an object")), None);
+        assert_eq!(requirement_of(&json!(42)), DeliveryRequirement::BestEffort);
+    }
+}

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1723,6 +1723,75 @@ impl PyEdge {
         Ok(dict.unbind())
     }
 
+    /// CIRISEdge#411 §2 — emit this node's `ownership_binding` **self-touch**
+    /// (the dead-man's-switch that arms the CC 3.2 ownerless-lock reclaim
+    /// floor: absent floor = never reclaimable, fail-safe). Opt-in — the
+    /// caller invokes it on its own cadence; edge wires NO background
+    /// scheduler here. Returns `"advanced"` (the floor moved) or
+    /// `"not_fresher"` (a same-bucket anti-rollback no-op). Raises
+    /// `RuntimeError` if no federation directory is wired, or on a
+    /// signature / admission fault.
+    fn produce_ownership_self_touch(&self, py: Python<'_>) -> PyResult<String> {
+        let signer = self.inner.signer();
+        let Some(directory) = self.inner.federation_directory() else {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "edge has no federation directory wired; cannot emit a touch-claim",
+            ));
+        };
+        let executor = self.executor.clone();
+        let outcome = py
+            .detach(|| {
+                run_async(&executor, async move {
+                    let producer = crate::touch_claim::TouchClaimProducer::new(signer, directory);
+                    producer.produce_ownership_self_touch().await
+                })
+            })
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(match outcome {
+            ciris_persist::federation::TouchApplyOutcome::Advanced => "advanced".to_string(),
+            ciris_persist::federation::TouchApplyOutcome::NotFresher => "not_fresher".to_string(),
+        })
+    }
+
+    /// CIRISEdge#411 §2 — **witness** `peer_key_id`'s liveness off the
+    /// in-process reachability tracker, flooring `fresh_as_of` from the
+    /// peer's most recent successful attempt. Scoped `family` — as tightly
+    /// as a peer relationship allows (NEVER an ungated read-receipt trail).
+    /// Returns `"advanced"` / `"not_fresher"`, or `None` when the tracker
+    /// holds no liveness evidence for the peer (no touch is produced —
+    /// a witness requires an actual observed event). Raises `RuntimeError`
+    /// on a missing directory or a signature / admission fault.
+    fn produce_witness_touch(&self, py: Python<'_>, peer_key_id: &str) -> PyResult<Option<String>> {
+        let signer = self.inner.signer();
+        let Some(directory) = self.inner.federation_directory() else {
+            return Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "edge has no federation directory wired; cannot emit a touch-claim",
+            ));
+        };
+        let tracker = self.inner.reachability_tracker();
+        let peer = peer_key_id.to_string();
+        let executor = self.executor.clone();
+        let outcome = py
+            .detach(|| {
+                run_async(&executor, async move {
+                    let producer = crate::touch_claim::TouchClaimProducer::new(signer, directory);
+                    producer
+                        .produce_witness_touch_from_tracker(
+                            &tracker,
+                            &peer,
+                            crate::touch_claim::NODE_LIVENESS_TARGET_KIND,
+                            ciris_persist::federation::types::cohort_scope::FAMILY,
+                        )
+                        .await
+                })
+            })
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;
+        Ok(outcome.map(|o| match o {
+            ciris_persist::federation::TouchApplyOutcome::Advanced => "advanced".to_string(),
+            ciris_persist::federation::TouchApplyOutcome::NotFresher => "not_fresher".to_string(),
+        }))
+    }
+
     /// Fetch content addressed by `sha256` (hex string) from
     /// `peer_key_id`. Returns a dict that is either:
     ///
@@ -6826,6 +6895,27 @@ fn k_symbol(exporter_secret: &[u8]) -> PyResult<Vec<u8>> {
     Ok(crate::scope_privacy::k_symbol(&exporter).to_vec())
 }
 
+/// CIRISEdge#411 §5 — the manifest-driven field-conformance harness, mirroring
+/// persist's `persist_field_conformance()`. Returns the list of `"{field}: {reason}"`
+/// violation strings (empty ⇒ conformant) so the shared CIRISConformance harness
+/// (CIRISConformance#83) can drive a real edge wheel against exactly the
+/// `field_processor_matrix` fields edge is tagged to own. Every violation is a
+/// value-semantics failure in an edge routing processor.
+#[pyfunction]
+fn edge_field_conformance() -> Vec<String> {
+    crate::field_conformance::run_edge_field_conformance()
+        .err()
+        .unwrap_or_default()
+}
+
+/// CIRISEdge#410 §3 — emit edge's routing-processor evidence rows (the
+/// `CIRISEdge.cc_impl.tsv` lines the Constitution's `check_evidence.py` vendors),
+/// generated from the live, tested `EDGE_FIELD_CONFORMANCE` table.
+#[pyfunction]
+fn edge_evidence_rows() -> Vec<String> {
+    crate::field_conformance::edge_evidence_rows()
+}
+
 /// Map the pinned §2.4 `"typ"` integer table onto
 /// [`crate::scope_privacy::RecordType`]. `0` is reserved; out-of-set
 /// values raise `ValueError` (strict allowlist, AV-7 posture).
@@ -7469,6 +7559,8 @@ pub fn register(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // the RNS dest-hash wrapper requires the leviculum reticulum-core
     // dep that ships under `transport-reticulum`.
     m.add_function(wrap_pyfunction!(seal_av_chunk, m)?)?;
+    m.add_function(wrap_pyfunction!(edge_field_conformance, m)?)?;
+    m.add_function(wrap_pyfunction!(edge_evidence_rows, m)?)?;
     m.add_function(wrap_pyfunction!(open_av_chunk, m)?)?;
     m.add_function(wrap_pyfunction!(seal_av_inner, m)?)?;
     m.add_function(wrap_pyfunction!(seal_av_outer, m)?)?;

--- a/src/field_conformance.rs
+++ b/src/field_conformance.rs
@@ -1,0 +1,413 @@
+//! CIRISEdge#411 §5 — the manifest-driven field-conformance harness.
+//!
+//! The keystone of the #519 program: the SAME `field_processor_matrix` that tags
+//! a field `owner_component ⊇ edge` GENERATES edge's conformance obligation for
+//! it. A field tagged to edge that edge neither processes (with a value-semantics
+//! check) nor explicitly defers (with a reason) is a **completeness gap the build
+//! must catch** — the `#315` carried-but-unprocessed dead-plane class the whole
+//! program exists to kill.
+//!
+//! Mirrors persist's own `namespace::conformance` exemplar (its
+//! `persist_field_conformance()` FFI): every owned field is EITHER an
+//! [`EDGE_FIELD_CONFORMANCE`] row with a `check` that verifies the field's
+//! VALUE/behaviour, OR a [`DEFERRED_PENDING_PLANE`] row whose reason names the
+//! upstream plane/entrypoint that must land before edge can soundly process it.
+//! [`every_edge_tagged_field_is_accounted_for`] cross-checks the union against
+//! persist's live matrix, so a NEW edge-tagged row persist ships fails edge's
+//! build until edge categorizes it.
+
+/// One edge-owned field's conformance obligation — a value/behaviour property and
+/// a pure check that proves edge's processor honors it. Mirrors persist's
+/// `FieldConformance` (a `fn() -> Result<(), String>`, so the whole table runs
+/// without async / a live directory — the checks assert the pure, value-semantics
+/// invariants, never presence).
+pub struct FieldConformance {
+    /// The manifest field string (EXACT — matched against `field_processor_matrix`).
+    pub field: &'static str,
+    /// The value/behaviour property this check proves.
+    pub property: &'static str,
+    /// The check — `Ok(())` conformant, `Err(reason)` a violation.
+    pub check: fn() -> Result<(), String>,
+}
+
+/// Every edge-tagged field edge PROCESSES, with a check that verifies the value
+/// semantics (not presence). The `restrictions[].op=recipient_capability` row is
+/// here — the manifest still marks it `proposed:`, but edge shipped the processor
+/// (`recipient_capability_withholds`) in v14.1; this table is the truth.
+pub const EDGE_FIELD_CONFORMANCE: &[FieldConformance] = &[
+    FieldConformance {
+        field: "delivery_mode",
+        property: "the typed value drives a fail-secure path decision (mandatory + no path ⇒ never a silent drop)",
+        check: check_delivery_mode,
+    },
+    FieldConformance {
+        field: "cohort_scope",
+        property: "projection is a total function of the cohort_scope VALUE (offer/projection filter)",
+        check: check_cohort_scope_projection,
+    },
+    FieldConformance {
+        field: "dimension",
+        property: "the record's projection authority is resolved from the dimension VALUE (per-record projection)",
+        check: check_dimension_projection,
+    },
+    FieldConformance {
+        field: "key_boundary_scope",
+        property: "every scope variant round-trips through its wire form (typed discriminator, opaque id)",
+        check: check_key_boundary_scope,
+    },
+    FieldConformance {
+        field: "recipient_serve_capability",
+        property: "the serve gate keys on persist's INFRA_SERVE const, never a hand-rolled token (the #379 value-provenance lock)",
+        check: check_recipient_serve_capability_token,
+    },
+    FieldConformance {
+        field: "restrictions[].op=recipient_capability",
+        property: "a recipient_capability restriction is honored as a WITHHOLD, never routed through the strip pipeline",
+        check: check_recipient_capability_is_withhold_not_strip,
+    },
+    FieldConformance {
+        field: "attestation_prefixes",
+        property: "a grant's prefix gates a dimension by str::starts_with (covers), the exact predicate the serve gate applies",
+        check: check_attestation_prefixes_covers,
+    },
+];
+
+/// Every edge-tagged field edge does NOT process with a runtime value-check —
+/// each with the concrete upstream reason. Deferring is NOT skipping: the field
+/// is still ACCOUNTED FOR (the completeness test asserts it), and the reason names
+/// exactly what must land first. Mirrors persist's `AHEAD_OF_MATRIX` exemption
+/// discipline, inverted (BEHIND, pending a plane).
+pub const DEFERRED_PENDING_PLANE: &[(&str, &str)] = &[
+    // ── The projection-time strips (§1/§3). Unsound on edge's wire, not skipped. ──
+    (
+        "evidence_disclosure",
+        "serve-time strip is UNSOUND on edge's content-addressed signed wire (#397): the \
+      recipient fetches by content_hash and re-verifies the hybrid signature at \
+      put_attestation, so stripping a field breaks both. persist applies StripField at \
+      PROMOTION before signing (promote_attestation_with_transforms, v21.7.0) and \
+      explicitly scoped general serve-layer transforms as a follow-up — this is \
+      persist-owned, not an edge processor.",
+    ),
+    (
+        "raw_probe_payloads",
+        "same content-addressed-wire unsoundness; the strip is a persist PROMOTION-side \
+      transform, not an edge serve-time op.",
+    ),
+    (
+        "raw_observation_refs",
+        "same content-addressed-wire unsoundness; persist promotion-side.",
+    ),
+    // ── Emit-side conventions / planes not yet landed. ──
+    (
+        "builder_id",
+        "an emit-side OMISSION convention (a producer chooses not to emit builder_id), not \
+      a runtime processor; no wire plane to check.",
+    ),
+    (
+        "cell-vs-federation scope-boundary check",
+        "a producer convention (proposed:); no edge runtime plane.",
+    ),
+    (
+        "class (auto-fire vs route-to-moderator at match time)",
+        "the safety/watchlist plane is not landed (persist marks the watchlist row \
+      proposed:/unassigned); no edge processor to check against a non-existent plane.",
+    ),
+    (
+        "mode (AlertOnly vs Enforce)",
+        "the hash-match enforcement plane is not landed (proposed:src/safety/hash_match.rs); \
+      no plane to process.",
+    ),
+    (
+        "manifest.content_hash",
+        "no manifest-retrieval path exists yet (persist marks proposed:); nothing to verify.",
+    ),
+    (
+        "trigger_excerpt_hash",
+        "the ContentFetch caller-gate (Tier B) is not landed; no plane to process.",
+    ),
+    (
+        "federation_keys.consent_role",
+        "the ProbePatternObserver consent-role plane is proposed:; no runtime edge processor.",
+    ),
+    // ── Shared fields whose VALUE semantics are owned by persist/verify. ──
+    (
+        "score",
+        "the score VALUE semantics (BooleanMin, scores.rs#value_of) are persist-owned; edge \
+      routes score attestations via the Attestation projection (checked under \
+      cohort_scope/dimension), it computes no score value.",
+    ),
+    (
+        "evidence_refs",
+        "verify-owned (ciris-verify-core holds_bytes.rs#verify_holds_bytes); edge CONSUMES \
+      holds_bytes via the content-fetch path, it runs no evidence_refs value processor.",
+    ),
+    // ── REAL edge processors whose behaviour lives in async serve/relay paths, ──
+    // ── covered by module-level integration tests rather than a sync pure check. ──
+    (
+        "withdrawal_reason",
+        "processed by edge.rs#emit_withdraws (ContentMiss → withdraws); the behaviour is an \
+      async relay path covered by its own integration test, not a sync pure check.",
+    ),
+    (
+        "delivery durability",
+        "processed by messages GoalDeclaration::DELIVERY / GoalRetirement::DELIVERY; covered \
+      by the messages module tests.",
+    ),
+    (
+        "holder staleness/TTL + ContentMiss->withdraws",
+        "processed by transport/reticulum.rs#filter_holders_with_policy; covered by the \
+      reticulum holder-policy tests, an async path.",
+    ),
+];
+
+/// Run the harness: `Ok(())` iff every [`EDGE_FIELD_CONFORMANCE`] check passes.
+/// The FFI (`edge_field_conformance()`) returns the violation list; empty = pass.
+///
+/// # Errors
+/// Returns the `"{field}: {reason}"` violation strings when a check fails.
+pub fn run_edge_field_conformance() -> Result<(), Vec<String>> {
+    let mut violations = Vec::new();
+    for c in EDGE_FIELD_CONFORMANCE {
+        if let Err(reason) = (c.check)() {
+            violations.push(format!("{}: {reason}", c.field));
+        }
+    }
+    if violations.is_empty() {
+        Ok(())
+    } else {
+        Err(violations)
+    }
+}
+
+// ─── the pure value-semantics checks ────────────────────────────────────────
+
+fn check_delivery_mode() -> Result<(), String> {
+    use crate::delivery_mode::{decide, DeliveryDecision};
+    let mandatory = serde_json::json!({
+        "attesting_key_id": "a", "attested_key_id": "a",
+        "attestation_type": "scores", "delivery_mode": "mandatory",
+    });
+    let best_effort = serde_json::json!({
+        "attesting_key_id": "a", "attested_key_id": "a", "attestation_type": "scores",
+    });
+    if decide(&mandatory, false) != DeliveryDecision::FailLoudNoPath {
+        return Err("mandatory + no reachable path must FailLoudNoPath, never drop".into());
+    }
+    if decide(&best_effort, false) != DeliveryDecision::DropBestEffort {
+        return Err("best-effort + no path must be a permissible drop".into());
+    }
+    if decide(&mandatory, true) != DeliveryDecision::Deliver {
+        return Err("any mode with a reachable path delivers".into());
+    }
+    Ok(())
+}
+
+fn check_cohort_scope_projection() -> Result<(), String> {
+    use ciris_persist::federation::namespace::Projection;
+    use ciris_persist::federation::namespace::{projection_for, registry::authority_for};
+    use ciris_persist::federation::types::cohort_scope;
+    // projection_for must be TOTAL over the 7 closed cohort scopes — edge's
+    // offer/projection filter is a function of this value, so an unhandled scope
+    // would be a routing hole. `authority_for` on a benign dimension gives a
+    // concrete AuthorityClass; the projection must resolve for every scope.
+    let authority = authority_for("trust:example:v1").class;
+    for scope in [
+        cohort_scope::SELF,
+        cohort_scope::FAMILY,
+        cohort_scope::COMMUNITY,
+        cohort_scope::AFFILIATIONS,
+        cohort_scope::SPECIES,
+        cohort_scope::BIOSPHERE,
+        cohort_scope::FEDERATION,
+    ] {
+        // Both tombstone polarities — a total function over the value domain.
+        let _ = projection_for(scope, authority, false);
+        let _ = projection_for(scope, authority, true);
+    }
+    // The value-semantics witness: self/family are NOT globally advertised
+    // (structural invisibility), federation-tier trust IS — the projection keys
+    // on the VALUE, not on presence.
+    if projection_for(cohort_scope::SELF, authority, false) != Projection::SelfOwn {
+        return Err("cohort_scope=self must project SelfOwn (structural invisibility)".into());
+    }
+    if projection_for(cohort_scope::SELF, authority, true) != Projection::Global {
+        return Err("a tombstone must project Global regardless of scope (anti-rollback)".into());
+    }
+    Ok(())
+}
+
+fn check_dimension_projection() -> Result<(), String> {
+    use ciris_persist::federation::namespace::{projection_for, registry::authority_for};
+    // Per-record projection resolves the authority CLASS from the dimension VALUE,
+    // then feeds it to `projection_for`. The value-semantics property: the same
+    // dimension resolves DETERMINISTICALLY to the same per-record projection (edge
+    // routes each record by its actual dimension, not by presence). A
+    // non-deterministic or panicking resolution would be a routing hole.
+    let dimension = "trust:example:v1";
+    let a = projection_for("federation", authority_for(dimension).class, false);
+    let b = projection_for("federation", authority_for(dimension).class, false);
+    if a != b {
+        return Err(format!(
+            "per-record projection for {dimension:?} is non-deterministic ({a:?} vs {b:?})"
+        ));
+    }
+    Ok(())
+}
+
+fn check_key_boundary_scope() -> Result<(), String> {
+    use crate::key_boundary::KeyBoundaryScope;
+    for scope in [
+        KeyBoundaryScope::Process,
+        KeyBoundaryScope::Tenant {
+            tenant_id: "t".into(),
+        },
+        KeyBoundaryScope::Channel {
+            channel_id: "c".into(),
+        },
+        KeyBoundaryScope::Cohort {
+            cohort_id: "co".into(),
+        },
+        KeyBoundaryScope::DataClass { class: "d".into() },
+    ] {
+        let wire = scope.as_wire_string();
+        match KeyBoundaryScope::from_wire_string(&wire) {
+            Ok(rt) if rt == scope => {}
+            Ok(other) => return Err(format!("{scope:?} round-tripped to {other:?} via {wire:?}")),
+            Err(e) => {
+                return Err(format!(
+                    "{scope:?} wire form {wire:?} failed to parse: {e:?}"
+                ))
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_recipient_serve_capability_token() -> Result<(), String> {
+    use ciris_persist::federation::types::delegation_scope;
+    // The #379 value-provenance lock: the serve gate's capability token IS
+    // persist's `delegation_scope::INFRA_SERVE` const, NOT a hand-rolled string.
+    // (The v13.10.0 bug keyed on a bare `"observer"` literal, fail-closing the
+    // plane; a hardcoded token can silently drift from the authority's vocabulary.)
+    if crate::replication::bridge::FederationDirectoryReplicationBridge::SERVE_CAPABILITY
+        != delegation_scope::INFRA_SERVE
+    {
+        return Err("edge's SERVE_CAPABILITY drifted from persist's INFRA_SERVE const".into());
+    }
+    Ok(())
+}
+
+fn check_recipient_capability_is_withhold_not_strip() -> Result<(), String> {
+    use ciris_persist::federation::consent_grammar::{to_transform_ops, RestrictionOp};
+    // A `recipient_capability` restriction must NOT be routed through the strip
+    // pipeline (that would be an unsound serve-time byte mutation, #397); persist's
+    // `to_transform_ops` maps it to nothing, and edge honors it as a WITHHOLD
+    // (`recipient_capability_withholds`). This proves edge's handler matches the
+    // grammar's own routing.
+    let ops = to_transform_ops(&[RestrictionOp::RecipientCapability {
+        capability: "trace:read".into(),
+    }]);
+    if !ops.is_empty() {
+        return Err(
+            "recipient_capability must not produce a transform op (it is a withhold)".into(),
+        );
+    }
+    // A strip_field restriction DOES produce a strip op (applied at persist promotion).
+    let strip = to_transform_ops(&[RestrictionOp::StripField {
+        path: "/trace/llm_calls/*/prompt".into(),
+    }]);
+    if strip.len() != 1 {
+        return Err("a strip_field restriction must map to exactly one StripField op".into());
+    }
+    Ok(())
+}
+
+fn check_attestation_prefixes_covers() -> Result<(), String> {
+    use ciris_persist::federation::consent_grammar::covers;
+    // The grant-prefix gate the serve path applies is str::starts_with (covers),
+    // trailing-colon significant: `trace:` gates `trace:complete:v1` but NOT
+    // `trace_summary:v1`. Value semantics, not presence.
+    let prefixes = vec!["trace:".to_string()];
+    if !covers(&prefixes, "trace:complete:v1") {
+        return Err("`trace:` must cover `trace:complete:v1`".into());
+    }
+    if covers(&prefixes, "trace_summary:v1") {
+        return Err(
+            "`trace:` must NOT cover `trace_summary:v1` (trailing colon significant)".into(),
+        );
+    }
+    if covers(&prefixes, "capacity:audit:v1") {
+        return Err("`trace:` must not cover an unrelated dimension".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciris_persist::federation::namespace::supersets::field_processor_matrix;
+    use std::collections::HashSet;
+
+    /// Every check passes.
+    #[test]
+    fn edge_field_conformance_passes() {
+        if let Err(v) = run_edge_field_conformance() {
+            panic!("edge field conformance violations: {v:#?}");
+        }
+    }
+
+    /// THE KEYSTONE (CIRISEdge#411 §5): every field persist's live
+    /// `field_processor_matrix` tags `owner_component ⊇ edge` is ACCOUNTED FOR —
+    /// either an [`EDGE_FIELD_CONFORMANCE`] check or a [`DEFERRED_PENDING_PLANE`]
+    /// row. A new edge-tagged field persist ships that edge has not categorized
+    /// fails THIS test — the carried-but-unprocessed dead-plane (#315) is a build
+    /// failure, exactly as #411 §5 requires.
+    #[test]
+    fn every_edge_tagged_field_is_accounted_for() {
+        let accounted: HashSet<&str> = EDGE_FIELD_CONFORMANCE
+            .iter()
+            .map(|c| c.field)
+            .chain(DEFERRED_PENDING_PLANE.iter().map(|(f, _)| *f))
+            .collect();
+
+        let mut gaps = Vec::new();
+        for row in field_processor_matrix() {
+            let edge_owned = row.owner_component.split('/').any(|c| c == "edge");
+            if edge_owned && !accounted.contains(row.field.as_str()) {
+                gaps.push(row.field.clone());
+            }
+        }
+        assert!(
+            gaps.is_empty(),
+            "edge-tagged manifest fields with NO conformance check and NO deferral \
+             (carried-but-unprocessed, #315) — add each to EDGE_FIELD_CONFORMANCE or \
+             DEFERRED_PENDING_PLANE with a reason: {gaps:#?}"
+        );
+    }
+
+    /// No stale entries: every field edge claims to process/defer is STILL an
+    /// edge-owned row in persist's matrix (so a persist rename/removal surfaces
+    /// here, not as a silently-dead edge check).
+    #[test]
+    fn no_conformance_entry_is_stale() {
+        let edge_owned: HashSet<&str> = field_processor_matrix()
+            .iter()
+            .filter(|r| r.owner_component.split('/').any(|c| c == "edge"))
+            .map(|r| r.field.as_str())
+            .collect();
+        let mut stale = Vec::new();
+        for f in EDGE_FIELD_CONFORMANCE
+            .iter()
+            .map(|c| c.field)
+            .chain(DEFERRED_PENDING_PLANE.iter().map(|(f, _)| *f))
+        {
+            if !edge_owned.contains(f) {
+                stale.push(f);
+            }
+        }
+        assert!(
+            stale.is_empty(),
+            "conformance entries no longer edge-owned in persist's matrix (rename/removal?): {stale:#?}"
+        );
+    }
+}

--- a/src/field_conformance.rs
+++ b/src/field_conformance.rs
@@ -28,6 +28,15 @@ pub struct FieldConformance {
     pub property: &'static str,
     /// The check — `Ok(())` conformant, `Err(reason)` a violation.
     pub check: fn() -> Result<(), String>,
+    /// CIRISEdge#410 Ask 3 — the Constitution CC section this routing processor
+    /// serves (the `CC-<section>` the `evidence/CIRISEdge.cc_impl.tsv` row keys on).
+    pub cc: &'static str,
+    /// The `CLM-nsproc-*` claim name this row resolves (CIRISEdge#410 §3).
+    pub clm: &'static str,
+    /// The `path#symbol` evidence anchor — the LIVE processor the check exercises,
+    /// so the evidence registry is generated from the tested code, never a
+    /// hand-maintained string that can drift from it.
+    pub evidence: &'static str,
 }
 
 /// Every edge-tagged field edge PROCESSES, with a check that verifies the value
@@ -39,36 +48,57 @@ pub const EDGE_FIELD_CONFORMANCE: &[FieldConformance] = &[
         field: "delivery_mode",
         property: "the typed value drives a fail-secure path decision (mandatory + no path ⇒ never a silent drop)",
         check: check_delivery_mode,
+        cc: "5.3.3",
+        clm: "CLM-nsproc-delivery-mode",
+        evidence: "src/delivery_mode.rs#decide",
     },
     FieldConformance {
         field: "cohort_scope",
         property: "projection is a total function of the cohort_scope VALUE (offer/projection filter)",
         check: check_cohort_scope_projection,
+        cc: "3.3.6",
+        clm: "CLM-nsproc-cohort-scope",
+        evidence: "src/replication/bridge.rs#attestation_is_advertised",
     },
     FieldConformance {
         field: "dimension",
         property: "the record's projection authority is resolved from the dimension VALUE (per-record projection)",
         check: check_dimension_projection,
+        cc: "3.1",
+        clm: "CLM-nsproc-dimension",
+        evidence: "src/replication/bridge.rs#attestation_is_advertised",
     },
     FieldConformance {
         field: "key_boundary_scope",
         property: "every scope variant round-trips through its wire form (typed discriminator, opaque id)",
         check: check_key_boundary_scope,
+        cc: "3.4",
+        clm: "CLM-nsproc-key-boundary-scope",
+        evidence: "src/key_boundary.rs#KeyBoundaryScope",
     },
     FieldConformance {
         field: "recipient_serve_capability",
         property: "the serve gate keys on persist's INFRA_SERVE const, never a hand-rolled token (the #379 value-provenance lock)",
         check: check_recipient_serve_capability_token,
+        cc: "5.3.3.5",
+        clm: "CLM-nsproc-recipient-serve-capability",
+        evidence: "src/replication/bridge.rs#peer_has_serve_capability",
     },
     FieldConformance {
         field: "restrictions[].op=recipient_capability",
         property: "a recipient_capability restriction is honored as a WITHHOLD, never routed through the strip pipeline",
         check: check_recipient_capability_is_withhold_not_strip,
+        cc: "5.3.2.4",
+        clm: "CLM-nsproc-recipient-capability",
+        evidence: "src/replication/bridge.rs#recipient_capability_withholds",
     },
     FieldConformance {
         field: "attestation_prefixes",
         property: "a grant's prefix gates a dimension by str::starts_with (covers), the exact predicate the serve gate applies",
         check: check_attestation_prefixes_covers,
+        cc: "5.3.2.4",
+        clm: "CLM-nsproc-attestation-prefixes",
+        evidence: "src/replication/bridge.rs#recipient_capability_withholds",
     },
 ];
 
@@ -159,6 +189,29 @@ pub const DEFERRED_PENDING_PLANE: &[(&str, &str)] = &[
       reticulum holder-policy tests, an async path.",
     ),
 ];
+
+/// CIRISEdge#410 §3 — emit edge's routing-processor evidence rows in the
+/// `CIRISEdge.cc_impl.tsv` format the Constitution's `check_evidence.py` vendors
+/// (`<cc>\t<clm>\tCIRISEdge\t<path#symbol>\tciris-edge@v<version>`). Generated
+/// from [`EDGE_FIELD_CONFORMANCE`] — the SAME table the completeness witness
+/// checks — so every published evidence row anchors a LIVE, tested processor and
+/// can never drift from the code. The vendored `evidence/CIRISEdge.cc_impl.tsv`
+/// is regenerated from this and kept in sync by `evidence_tsv_matches_emitted`.
+#[must_use]
+pub fn edge_evidence_rows() -> Vec<String> {
+    EDGE_FIELD_CONFORMANCE
+        .iter()
+        .map(|c| {
+            format!(
+                "{}\t{}\tCIRISEdge\t{}\tciris-edge@v{}",
+                c.cc,
+                c.clm,
+                c.evidence,
+                env!("CARGO_PKG_VERSION"),
+            )
+        })
+        .collect()
+}
 
 /// Run the harness: `Ok(())` iff every [`EDGE_FIELD_CONFORMANCE`] check passes.
 /// The FFI (`edge_field_conformance()`) returns the violation list; empty = pass.
@@ -383,6 +436,51 @@ mod tests {
              (carried-but-unprocessed, #315) — add each to EDGE_FIELD_CONFORMANCE or \
              DEFERRED_PENDING_PLANE with a reason: {gaps:#?}"
         );
+    }
+
+    /// CIRISEdge#410 §3 — the vendored `evidence/CIRISEdge.cc_impl.tsv` (what the
+    /// Constitution's `check_evidence.py` consumes) is EXACTLY what the live code
+    /// emits from `EDGE_FIELD_CONFORMANCE`. A processor rename, a version bump, or
+    /// a hand-edit to the TSV that diverges from the tested table is a BUILD
+    /// failure — the evidence registry can never drift from the code it attests.
+    #[test]
+    fn evidence_tsv_matches_emitted() {
+        let vendored: Vec<&str> = include_str!("../evidence/CIRISEdge.cc_impl.tsv")
+            .lines()
+            .filter(|l| !l.trim_start().starts_with('#') && !l.trim().is_empty())
+            .collect();
+        let emitted = edge_evidence_rows();
+        assert_eq!(
+            vendored,
+            emitted.iter().map(String::as_str).collect::<Vec<_>>(),
+            "evidence/CIRISEdge.cc_impl.tsv drifted from EDGE_FIELD_CONFORMANCE — \
+             regenerate it from field_conformance::edge_evidence_rows() (CIRISEdge#410 §3)"
+        );
+    }
+
+    /// CIRISEdge#410 §4 — the serve-gate/routing completeness witness: the five CI
+    /// routing axes #410 enumerates each resolve to a LIVE edge processor evidence
+    /// row (not merely present — anchored to a `path#symbol` the checks exercise).
+    #[test]
+    fn every_routing_axis_has_a_live_processor_evidence_row() {
+        for axis in [
+            "cohort_scope",                           // recipient_see
+            "delivery_mode",                          // recipient_receive
+            "restrictions[].op=recipient_capability", // information-type restriction
+            "attestation_prefixes",                   // transmission principle (grant grammar)
+            "recipient_serve_capability",             // serve gate
+        ] {
+            let row = EDGE_FIELD_CONFORMANCE
+                .iter()
+                .find(|c| c.field == axis)
+                .unwrap_or_else(|| {
+                    panic!("routing axis {axis:?} has no live processor row (#410)")
+                });
+            assert!(
+                !row.evidence.is_empty() && row.evidence.contains('#'),
+                "routing axis {axis:?} carries no path#symbol evidence anchor"
+            );
+        }
     }
 
     /// No stale entries: every field edge claims to process/defer is STILL an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,7 @@ mod sas_wordlist;
 // v6.0.0 (CIRISEdge#175) — CC 1.13.3.4 substrate.
 pub mod scope_privacy;
 pub mod swarm;
+pub mod touch_claim;
 pub mod transport;
 pub mod verify;
 pub mod version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@ pub mod blob_swarm;
 pub mod cohort_scope;
 #[cfg(feature = "debug-tools")]
 pub mod debug;
+pub mod delivery_mode;
 pub mod detector;
 // v6.1.0 (CIRISEdge#175, FSD §3.3) — announce-suppression policy
 // + edge-side registry mirroring the recommended Leviculum
@@ -69,6 +70,7 @@ mod edge;
 pub mod emission;
 pub mod events;
 pub mod ffi;
+pub mod field_conformance;
 pub mod handler;
 // v3.9.0 Layer 1 Task D introduced consent-decay (gated under
 // `holonomic-consent-decay`); v3.10.0 lands the four-piece holonomic

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,55 @@ mod yubico_attestation_root_hash_tests {
     }
 }
 
+/// Pinned namespace-manifest version (CIRISPersist#519 / manifest `0.3.0`). The
+/// `field_processor_matrix`, the per-family transform algebra, and the cohort
+/// namespace all version together under this string; edge's field processors
+/// (CIRISEdge#411 §1) and its transform application (§3) are written against
+/// exactly this manifest revision. A bump edge has not re-reviewed must fail the
+/// build — the same WIRE_VOCABULARY discipline as the hash pins below.
+pub const PERSIST_NAMESPACE_MANIFEST_VERSION: &str = "0.3.0";
+
+/// Pinned SHA-256 of persist's closed **transform algebra** (CIRISPersist#519,
+/// `transform::TRANSFORM_ALGEBRA_HASH`). Edge applies the per-family declared
+/// transforms (`strip_field` + shape ops) at the serve/projection path from the
+/// manifest, never a hand-rolled op list (CIRISEdge#411 §3). Pinning the algebra
+/// hash makes a persist change to the op vocabulary — a new strip, a changed
+/// shape op — a BUILD failure at edge first, forcing a deliberate re-review of
+/// edge's serve-time transform application before the wire behavior can drift.
+pub const PERSIST_TRANSFORM_ALGEBRA_HASH: &str =
+    "b7bd779468f4ad1ab551a5fd2dc0392df01e6f2e0ed393f924a806ed49686b4b";
+
+#[cfg(test)]
+mod manifest_and_transform_pin_tests {
+    /// Pins the namespace-manifest version from the linked crate. A mismatch is a
+    /// manifest revision persist shipped that edge's field processors + transform
+    /// application must be re-reviewed against (CIRISEdge#411) — never a silent skew.
+    #[test]
+    fn persist_namespace_manifest_version_pinned() {
+        assert_eq!(
+            ciris_persist::federation::namespace::supersets::VENDORED_MANIFEST_VERSION,
+            super::PERSIST_NAMESPACE_MANIFEST_VERSION,
+            "persist's VENDORED_MANIFEST_VERSION changed — the namespace manifest \
+             (field_processor_matrix + transform algebra + cohort namespace) moved. \
+             Re-review edge's field processors + transform application, then re-pin \
+             deliberately (CIRISEdge#411 §0)."
+        );
+    }
+
+    /// Pins persist's `TRANSFORM_ALGEBRA_HASH`. A mismatch is a change to the closed
+    /// transform op vocabulary edge applies at serve — re-review §3, then re-pin.
+    #[test]
+    fn persist_transform_algebra_hash_pinned() {
+        assert_eq!(
+            ciris_persist::federation::transform::TRANSFORM_ALGEBRA_HASH,
+            super::PERSIST_TRANSFORM_ALGEBRA_HASH,
+            "persist's TRANSFORM_ALGEBRA_HASH changed — the closed transform algebra \
+             moved. Re-review edge's serve-time transform application (CIRISEdge#411 §3), \
+             then re-pin deliberately."
+        );
+    }
+}
+
 pub use blob_swarm::{
     BlobChunkSource, BlobChunkVerifier, ChunkManifestLite, ChunkSourceRefusal, ChunkVerifyError,
     PeerState, SwarmConfig, SwarmError, SwarmScheduler,

--- a/src/reachability.rs
+++ b/src/reachability.rs
@@ -452,6 +452,21 @@ impl ReachabilityTracker {
         }
         out
     }
+
+    /// CIRISEdge#411 §2 — the most recent SUCCESSFUL-attempt instant across
+    /// every medium for `peer_key_id` within the rolling window, or `None`
+    /// if the tracker holds no liveness evidence for the peer. A successful
+    /// [`AttemptOutcome`] is a witnessed liveness event; the touch-claim
+    /// producer ([`crate::touch_claim::TouchClaimProducer::produce_witness_touch_from_tracker`])
+    /// floors a `witness_touch`'s `fresh_as_of` from this instant. Read-only
+    /// — composes [`Self::snapshot`], mutates nothing.
+    #[must_use]
+    pub fn last_liveness(&self, peer_key_id: &str) -> Option<DateTime<Utc>> {
+        self.snapshot(peer_key_id)
+            .into_values()
+            .filter_map(|s| s.last_success_at)
+            .max()
+    }
 }
 
 impl std::fmt::Debug for ReachabilityTracker {

--- a/src/touch_claim.rs
+++ b/src/touch_claim.rs
@@ -1,0 +1,973 @@
+//! Edge touch-claim producer (CIRISEdge#411 §2) — the PRODUCER half of
+//! persist's signed `fresh_as_of` **freshness floor**
+//! ([`ciris_persist::federation::freshness`]).
+//!
+//! # What this is
+//!
+//! persist owns storage + monotonic-max merge + admission + the `NOfM`
+//! tally; it does NOT decide *when* a thing is alive. `now()` is not pure,
+//! so producing a `fresh_as_of` value is an **attestation**, never a
+//! transform opcode — "reading emits a claim" is CEG-native here. This
+//! module is that attestor: it builds + hybrid-signs a
+//! [`ciris_persist::federation::types::SignedTouchClaim`] on the liveness
+//! events edge already observes, and submits it via
+//! [`ciris_persist::federation::FederationDirectory::put_touch_claim`].
+//!
+//! This is load-bearing for the ownerless-lock reclaim (CC 3.2): a node
+//! becomes reclaimable only after it has emitted an `ownership_binding`
+//! freshness floor and then gone dark ≥180 days. **Absent floor = NEVER
+//! reclaimable** (fail-safe). So the single most important thing this
+//! module makes easy is [`TouchClaimProducer::produce_ownership_self_touch`].
+//!
+//! # The three signer forms
+//!
+//! - **`self_touch`** — the node's own dead-man's-switch. The attester IS
+//!   the target (or a registered occurrence of it). Edge produces this for
+//!   its own key.
+//! - **`witness_touch`** — edge witnessing a peer alive (off
+//!   [`crate::reachability::ReachabilityTracker`]). The attester MUST be
+//!   independent of the target (a witness cannot be the thing it
+//!   witnesses).
+//! - **`n_of_m_cosigned`** — a collusion-resistant "death finding": the
+//!   primary attester + ≥[`ciris_persist::federation::freshness::NOFM_MIN_COSIGNERS`]
+//!   independent co-signers, each hybrid-verifying over the SAME envelope
+//!   bytes.
+//!
+//!   **⚠️ Trap (why this module implements the real co-sig carriage):** the
+//!   [`ciris_persist::federation::types::SignerForm::NOfMCosigned`]
+//!   docstrings say it verifies identically to `witness_touch` (1-of-1) —
+//!   that is STALE v21.6.0 documentation. persist v21.10.0
+//!   (`admission.rs` step 5) runs a REAL m-of-n tally: a `NOfMCosigned`
+//!   claim WITHOUT a valid co-signature set under `touch_cosignatures` is
+//!   silently REJECTED at admission. Edge holds only its OWN
+//!   [`LocalSigner`], so it produces the PRIMARY leg + attaches
+//!   externally-supplied co-signatures ([`attach_cosignatures`]); a
+//!   co-signing node produces its leg with [`build_cosignature`]. Edge
+//!   never fabricates other nodes' signatures.
+//!
+//! # Signing discipline
+//!
+//! The signature is over **plain JCS** of the claim's `signing_envelope()`
+//! via [`ciris_persist::prelude::ceg_produce_canonicalize`] (RFC 8785 JCS,
+//! the same canonicalizer admission re-derives) — NOT the `EdgeEnvelope`
+//! path (`canonicalize_envelope_for_signing`). The detached hybrid
+//! signature mirrors [`crate::identity::sign_envelope`]'s bound-sig
+//! discipline: Ed25519 over the JCS bytes, ML-DSA-65 over
+//! `JCS_bytes ‖ ed25519_sig`. persist's admission verifies at threshold
+//! **1-of-1 RequireHybrid** — a classical-only touch does not count, so a
+//! produced touch needs a PQC half and the attesting key must have a
+//! registered ML-DSA-65 pubkey.
+//!
+//! # `fresh_as_of` — floor, never ceiling
+//!
+//! Repeated touches within one coalescing bucket dedupe on the wire
+//! (identical `fresh_as_of` ⇒ identical signed envelope ⇒ identical content
+//! hash). We floor a freshly-observed instant down to a bucket boundary
+//! ([`coalesce_fresh_as_of`]); persist exports no precision const so
+//! [`DEFAULT_TOUCH_COALESCE_SECS`] is edge's choice. Flooring can only make
+//! the asserted lower bound MORE conservative; ceiling past `now` would
+//! trip persist's future-skew guard
+//! ([`ciris_persist::federation::admission::DEFAULT_MAX_TOUCH_SKEW`]).
+//!
+//! # `cohort_scope` — MANDATORY + tight (privacy)
+//!
+//! A touch-claim is cohort-scoped and consent-gated: an ungated
+//! read-receipt trail is an access-pattern surveillance surface, and for
+//! `trace:*` targets it leaks who reads whose reasoning. `cohort_scope` is
+//! therefore a **required argument** on every builder here (never a
+//! default-to-federation) and is validated against the closed set BEFORE
+//! signing/submission — an invalid scope (`"global"`, …) is refused up
+//! front. A self_touch defaults to [`cohort_scope::SELF`]; a witness of a
+//! peer is scoped as tightly as the relationship allows (self/family).
+
+use std::sync::Arc;
+
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use chrono::{DateTime, Duration, Utc};
+
+use ciris_persist::federation::freshness::{
+    coalesce_touch_ts, TouchApplyOutcome, TOUCH_COSIGNATURES_FIELD,
+};
+use ciris_persist::federation::ownership_reclaim::OWNERSHIP_FRESHNESS_TARGET_KIND;
+use ciris_persist::federation::types::{cohort_scope, SignedTouchClaim, SignerForm};
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::prelude::ceg_produce_canonicalize;
+use ciris_verify_core::threshold::ThresholdSignature;
+use ciris_verify_core::transport_binding::TransportBindingSignature;
+
+use crate::identity::LocalSigner;
+use crate::reachability::ReachabilityTracker;
+
+/// Default `fresh_as_of` coalescing bucket, in seconds. persist exports NO
+/// precision const (the general `round(precision)` opcode is a sibling
+/// concern), so a producer picks its own bucket; 60s is a sane default —
+/// repeated touches within the same wall-clock minute dedupe to one signed
+/// envelope. Always applied as a FLOOR, never a ceiling (see
+/// [`coalesce_fresh_as_of`]).
+pub const DEFAULT_TOUCH_COALESCE_SECS: i64 = 60;
+
+/// A general node-liveness `target_kind` for a self/witness touch that is
+/// NOT the ownership-reclaim tie-in. Open vocab (`target_kind` is resolved
+/// by the consumer); use [`OWNERSHIP_FRESHNESS_TARGET_KIND`]
+/// (`"ownership_binding"`) for the CC 3.2 reclaim floor instead.
+pub const NODE_LIVENESS_TARGET_KIND: &str = "node_liveness";
+
+/// A fault building, signing, or submitting a [`SignedTouchClaim`].
+#[derive(Debug)]
+pub enum TouchClaimError {
+    /// `cohort_scope` is not one of the closed-set values (`self`,
+    /// `family`, `community`, `affiliations`, `species`, `biosphere`,
+    /// `federation`). Refused BEFORE signing/submission — `"global"` and
+    /// friends never reach `put_touch_claim`.
+    InvalidCohortScope(String),
+    /// A `witness_touch` / `n_of_m_cosigned` primary attester equals the
+    /// touched target. A witness cannot be the thing it witnesses; refused
+    /// before signing (admission would reject it anyway).
+    AttesterNotIndependent {
+        /// The key that is both attester and target.
+        key_id: String,
+    },
+    /// [`attach_cosignatures`] was called on a claim whose `signer_form`
+    /// is not [`SignerForm::NOfMCosigned`].
+    NotNofmCosigned,
+    /// A claim's `signed_envelope` is not a JSON object (cannot carry the
+    /// `touch_cosignatures` extra). A well-formed produced claim never
+    /// hits this.
+    MalformedEnvelope,
+    /// RFC 8785 JCS canonicalization fault.
+    Canonicalize(String),
+    /// A signer fault (Ed25519 or ML-DSA-65 half).
+    Sign(String),
+    /// serde serialization fault attaching the co-signature set.
+    Serialize(String),
+    /// `put_touch_claim` failed at persist's admission or storage layer.
+    Put(String),
+}
+
+impl std::fmt::Display for TouchClaimError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidCohortScope(s) => write!(
+                f,
+                "invalid cohort_scope `{s}`: touch-claims are cohort-scoped and consent-gated \
+                 (one of self/family/community/affiliations/species/biosphere/federation; \
+                 `global` is not valid)"
+            ),
+            Self::AttesterNotIndependent { key_id } => write!(
+                f,
+                "attester {key_id} equals the touched target — a witness/co-signer must be \
+                 independent of the thing it witnesses"
+            ),
+            Self::NotNofmCosigned => write!(
+                f,
+                "attach_cosignatures requires an n_of_m_cosigned claim (self/witness touches \
+                 carry no co-signature set)"
+            ),
+            Self::MalformedEnvelope => {
+                write!(
+                    f,
+                    "signed_envelope is not a JSON object; cannot attach touch_cosignatures"
+                )
+            }
+            Self::Canonicalize(e) => write!(f, "JCS canonicalize: {e}"),
+            Self::Sign(e) => write!(f, "hybrid sign: {e}"),
+            Self::Serialize(e) => write!(f, "serialize co-signatures: {e}"),
+            Self::Put(e) => write!(f, "put_touch_claim: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for TouchClaimError {}
+
+/// Floor `observed_at` DOWN to the nearest `coalesce_secs` bucket, capping
+/// to `now()` first so the result is never in the future (defense-in-depth
+/// over persist's skew guard — flooring a freshly-observed `now` is already
+/// well under the 5-minute tolerance). Mirrors persist's
+/// [`coalesce_touch_ts`], with the extra never-ceiling / never-future
+/// guarantee a producer wants.
+///
+/// `coalesce_secs` ≤ 0 is treated as a 1-second bucket (a no-op rounding
+/// unit) rather than panicking.
+#[must_use]
+pub fn coalesce_fresh_as_of(observed_at: DateTime<Utc>, coalesce_secs: i64) -> DateTime<Utc> {
+    // Never assert a `fresh_as_of` past the moment we are attesting from.
+    let capped = observed_at.min(Utc::now());
+    coalesce_touch_ts(capped, Duration::seconds(coalesce_secs.max(1)))
+}
+
+/// Produce the detached hybrid signature halves over `bytes` with `signer`:
+/// Ed25519 over `bytes`, ML-DSA-65 over `bytes ‖ ed25519_sig` (the bound-sig
+/// discipline). Returns `(ed25519_b64, Option<mldsa65_b64>)` — the PQC half
+/// is `None` only while `signer.pqc` is `None` (hybrid-pending), in which
+/// case the claim will not admit at persist's federation-tier RequireHybrid
+/// gate. Mirrors [`crate::identity::sign_envelope`].
+async fn sign_bound_hybrid(
+    signer: &LocalSigner,
+    bytes: &[u8],
+) -> Result<(String, Option<String>), TouchClaimError> {
+    let ed = signer
+        .classical
+        .sign(bytes)
+        .await
+        .map_err(|e| TouchClaimError::Sign(format!("ed25519: {e}")))?;
+    let ed_b64 = B64.encode(&ed);
+    let mldsa_b64 = if let Some(pqc) = signer.pqc.as_ref() {
+        let mut bound = bytes.to_vec();
+        bound.extend_from_slice(&ed);
+        let sig = pqc
+            .sign(&bound)
+            .await
+            .map_err(|e| TouchClaimError::Sign(format!("ml-dsa-65: {e}")))?;
+        Some(B64.encode(&sig))
+    } else {
+        None
+    };
+    Ok((ed_b64, mldsa_b64))
+}
+
+/// Build + hybrid-sign a [`SignedTouchClaim`] with `signer` as the
+/// `attesting_key_id`. The `signed_envelope` is the claim's
+/// `signing_envelope()` VERBATIM (authority is the envelope, never the
+/// typed projection — persist's admission cross-checks field-by-field and
+/// never rebuilds). `fresh_as_of` is [`coalesce_fresh_as_of`]-floored.
+///
+/// `cohort_scope` is validated up front — an invalid scope is refused
+/// BEFORE signing.
+async fn build_signed_touch_claim(
+    signer: &LocalSigner,
+    target_key_id: &str,
+    target_kind: &str,
+    signer_form: SignerForm,
+    cohort: &str,
+    observed_at: DateTime<Utc>,
+    coalesce_secs: i64,
+) -> Result<SignedTouchClaim, TouchClaimError> {
+    // (0) MANDATORY privacy row — refuse an out-of-set scope before we
+    // sign or touch the directory.
+    if !cohort_scope::is_valid(cohort) {
+        return Err(TouchClaimError::InvalidCohortScope(cohort.to_owned()));
+    }
+
+    // (1) FLOOR the observed instant (never ceiling, never future).
+    let fresh_as_of = coalesce_fresh_as_of(observed_at, coalesce_secs);
+
+    // (2) unsigned skeleton — `signed_envelope = Null` + empty signature.
+    let unsigned = SignedTouchClaim {
+        target_key_id: target_key_id.to_owned(),
+        target_kind: target_kind.to_owned(),
+        fresh_as_of,
+        signer_form,
+        attesting_key_id: signer.key_id.clone(),
+        signed_envelope: serde_json::Value::Null,
+        signature: TransportBindingSignature {
+            ed25519_signature_base64: String::new(),
+            mldsa65_signature_base64: None,
+        },
+        cohort_scope: cohort.to_owned(),
+    };
+
+    // (3) canonicalize the 6-key envelope, hybrid-sign it, fill in the
+    // signed_envelope VERBATIM + the signature container.
+    let env = unsigned.signing_envelope();
+    let bytes =
+        ceg_produce_canonicalize(&env).map_err(|e| TouchClaimError::Canonicalize(e.to_string()))?;
+    let (ed25519_signature_base64, mldsa65_signature_base64) =
+        sign_bound_hybrid(signer, &bytes).await?;
+
+    Ok(SignedTouchClaim {
+        signed_envelope: env,
+        signature: TransportBindingSignature {
+            ed25519_signature_base64,
+            mldsa65_signature_base64,
+        },
+        ..unsigned
+    })
+}
+
+/// Build + hybrid-sign a **`self_touch`** (dead-man's-switch): this node
+/// (`signer`) asserts its own freshness floor for `(signer.key_id,
+/// target_kind)`. The attester IS the target — persist's admission requires
+/// `signer_acts_for(attester, target)`, satisfied trivially when they are
+/// the same key.
+///
+/// For the CC 3.2 ownerless-lock reclaim tie-in pass
+/// `target_kind = OWNERSHIP_FRESHNESS_TARGET_KIND` (or use
+/// [`TouchClaimProducer::produce_ownership_self_touch`]).
+///
+/// # Errors
+/// [`TouchClaimError::InvalidCohortScope`] if `cohort` is out of set;
+/// [`TouchClaimError::Canonicalize`] / [`TouchClaimError::Sign`] on a
+/// canonicalizer or signer fault.
+pub async fn build_self_touch(
+    signer: &LocalSigner,
+    target_kind: &str,
+    cohort: &str,
+    observed_at: DateTime<Utc>,
+    coalesce_secs: i64,
+) -> Result<SignedTouchClaim, TouchClaimError> {
+    build_signed_touch_claim(
+        signer,
+        &signer.key_id,
+        target_kind,
+        SignerForm::SelfTouch,
+        cohort,
+        observed_at,
+        coalesce_secs,
+    )
+    .await
+}
+
+/// Build + hybrid-sign a **`witness_touch`**: `signer` attests that it
+/// observed `target_key_id` alive. The attester MUST be independent of the
+/// target (refused here, and at admission).
+///
+/// # Errors
+/// [`TouchClaimError::AttesterNotIndependent`] if `target_key_id ==
+/// signer.key_id`; plus the errors of [`build_self_touch`].
+pub async fn build_witness_touch(
+    signer: &LocalSigner,
+    target_key_id: &str,
+    target_kind: &str,
+    cohort: &str,
+    observed_at: DateTime<Utc>,
+    coalesce_secs: i64,
+) -> Result<SignedTouchClaim, TouchClaimError> {
+    if target_key_id == signer.key_id {
+        return Err(TouchClaimError::AttesterNotIndependent {
+            key_id: signer.key_id.clone(),
+        });
+    }
+    build_signed_touch_claim(
+        signer,
+        target_key_id,
+        target_kind,
+        SignerForm::WitnessTouch,
+        cohort,
+        observed_at,
+        coalesce_secs,
+    )
+    .await
+}
+
+/// Build + hybrid-sign the **PRIMARY leg** of an **`n_of_m_cosigned`**
+/// touch. The returned claim's `signed_envelope` carries NO
+/// `touch_cosignatures` — co-signatures cannot be inside the bytes they
+/// sign (the sign-then-strip fixed point). Feed [`cosignature_preimage`] to
+/// each co-signing node's [`build_cosignature`], then attach the set with
+/// [`attach_cosignatures`] before submitting.
+///
+/// The primary attester MUST be independent of the target.
+///
+/// # Errors
+/// [`TouchClaimError::AttesterNotIndependent`] if `target_key_id ==
+/// signer.key_id`; plus the errors of [`build_self_touch`].
+pub async fn build_nofm_primary(
+    signer: &LocalSigner,
+    target_key_id: &str,
+    target_kind: &str,
+    cohort: &str,
+    observed_at: DateTime<Utc>,
+    coalesce_secs: i64,
+) -> Result<SignedTouchClaim, TouchClaimError> {
+    if target_key_id == signer.key_id {
+        return Err(TouchClaimError::AttesterNotIndependent {
+            key_id: signer.key_id.clone(),
+        });
+    }
+    build_signed_touch_claim(
+        signer,
+        target_key_id,
+        target_kind,
+        SignerForm::NOfMCosigned,
+        cohort,
+        observed_at,
+        coalesce_secs,
+    )
+    .await
+}
+
+/// The exact bytes a co-signer signs for an `n_of_m_cosigned` touch:
+/// `JCS(signed_envelope)` with the `touch_cosignatures` field STRIPPED (the
+/// same preimage persist's admission re-derives before verifying each
+/// co-signature). For a fresh [`build_nofm_primary`] leg the field is
+/// already absent, so this is `JCS(signed_envelope)`; the strip keeps the
+/// helper correct if called on a partially-attached claim.
+///
+/// # Errors
+/// [`TouchClaimError::Canonicalize`] on a canonicalizer fault.
+pub fn cosignature_preimage(claim: &SignedTouchClaim) -> Result<Vec<u8>, TouchClaimError> {
+    let mut env = claim.signed_envelope.clone();
+    if let Some(obj) = env.as_object_mut() {
+        obj.remove(TOUCH_COSIGNATURES_FIELD);
+    }
+    ceg_produce_canonicalize(&env).map_err(|e| TouchClaimError::Canonicalize(e.to_string()))
+}
+
+/// Produce a co-signing node's [`ThresholdSignature`] over `bytes` (the
+/// [`cosignature_preimage`] of the primary leg). A co-signing NODE calls
+/// this with its OWN [`LocalSigner`]; edge cannot fabricate other nodes'
+/// co-signatures, so this is the leg each independent participant computes
+/// and hands back for [`attach_cosignatures`]. Hybrid (RequireHybrid at
+/// admission) — the co-signer's key must have a registered ML-DSA-65 pubkey.
+///
+/// # Errors
+/// [`TouchClaimError::Sign`] on a signer fault.
+pub async fn build_cosignature(
+    signer: &LocalSigner,
+    bytes: &[u8],
+) -> Result<ThresholdSignature, TouchClaimError> {
+    let (ed25519_signature_base64, mldsa65_signature_base64) =
+        sign_bound_hybrid(signer, bytes).await?;
+    Ok(ThresholdSignature {
+        member_id: signer.key_id.clone(),
+        ed25519_signature_base64,
+        mldsa65_signature_base64,
+    })
+}
+
+/// Attach a co-signature set to an `n_of_m_cosigned` primary leg under the
+/// `touch_cosignatures` extra INSIDE `signed_envelope` (the primary
+/// signature is unchanged — co-sigs ride outside the bytes they sign).
+/// Returns the submittable claim.
+///
+/// The tally at admission requires
+/// ≥[`ciris_persist::federation::freshness::NOFM_MIN_COSIGNERS`] DISTINCT,
+/// INDEPENDENT (≠ target), REGISTERED co-signers each hybrid-verifying over
+/// [`cosignature_preimage`] — so `cosignatures` must carry at least that
+/// many valid legs beyond the primary.
+///
+/// # Errors
+/// [`TouchClaimError::NotNofmCosigned`] if `claim.signer_form` is not
+/// [`SignerForm::NOfMCosigned`]; [`TouchClaimError::MalformedEnvelope`] if
+/// the envelope is not a JSON object; [`TouchClaimError::Serialize`] on a
+/// serde fault.
+pub fn attach_cosignatures(
+    mut claim: SignedTouchClaim,
+    cosignatures: &[ThresholdSignature],
+) -> Result<SignedTouchClaim, TouchClaimError> {
+    if claim.signer_form != SignerForm::NOfMCosigned {
+        return Err(TouchClaimError::NotNofmCosigned);
+    }
+    let value = serde_json::to_value(cosignatures)
+        .map_err(|e| TouchClaimError::Serialize(e.to_string()))?;
+    let obj = claim
+        .signed_envelope
+        .as_object_mut()
+        .ok_or(TouchClaimError::MalformedEnvelope)?;
+    obj.insert(TOUCH_COSIGNATURES_FIELD.to_owned(), value);
+    Ok(claim)
+}
+
+/// Submit a produced touch-claim to the freshness floor — a thin wrapper
+/// over [`FederationDirectory::put_touch_claim`] that re-validates
+/// `cohort_scope` up front (defense-in-depth; a builder never produces an
+/// invalid one). [`TouchApplyOutcome::NotFresher`] is a SILENT no-op
+/// (anti-rollback), NOT an error — the stored floor only ever advances.
+///
+/// # Errors
+/// [`TouchClaimError::InvalidCohortScope`] if the claim's scope is out of
+/// set; [`TouchClaimError::Put`] on any admission/storage failure.
+pub async fn submit_touch_claim(
+    directory: &dyn FederationDirectory,
+    claim: &SignedTouchClaim,
+) -> Result<TouchApplyOutcome, TouchClaimError> {
+    if !cohort_scope::is_valid(&claim.cohort_scope) {
+        return Err(TouchClaimError::InvalidCohortScope(
+            claim.cohort_scope.clone(),
+        ));
+    }
+    directory
+        .put_touch_claim(claim)
+        .await
+        .map_err(|e| TouchClaimError::Put(e.to_string()))
+}
+
+/// A minimal, opt-in producer bundling the held [`LocalSigner`] with a
+/// [`FederationDirectory`] so the runtime can emit touch-claims on its own
+/// cadence. **No background scheduler is wired here** (CIRISEdge#411 §2
+/// explicitly): these are entrypoints a caller invokes, mirroring how
+/// `emit_withdraws` is fired on an observed event rather than a timer.
+#[derive(Clone)]
+pub struct TouchClaimProducer {
+    signer: Arc<LocalSigner>,
+    directory: Arc<dyn FederationDirectory>,
+    coalesce_secs: i64,
+}
+
+impl TouchClaimProducer {
+    /// Construct a producer over the held signer + directory, using
+    /// [`DEFAULT_TOUCH_COALESCE_SECS`] as the coalescing bucket.
+    #[must_use]
+    pub fn new(signer: Arc<LocalSigner>, directory: Arc<dyn FederationDirectory>) -> Self {
+        Self {
+            signer,
+            directory,
+            coalesce_secs: DEFAULT_TOUCH_COALESCE_SECS,
+        }
+    }
+
+    /// Override the `fresh_as_of` coalescing bucket (seconds).
+    #[must_use]
+    pub fn with_coalesce_secs(mut self, coalesce_secs: i64) -> Self {
+        self.coalesce_secs = coalesce_secs;
+        self
+    }
+
+    /// Emit a `self_touch` for this node's own key at `(target_kind,
+    /// cohort)`, floored to `now`. The dead-man's-switch entrypoint the
+    /// runtime calls on its own cadence.
+    ///
+    /// # Errors
+    /// See [`build_self_touch`] / [`submit_touch_claim`].
+    pub async fn produce_self_touch(
+        &self,
+        target_kind: &str,
+        cohort: &str,
+    ) -> Result<TouchApplyOutcome, TouchClaimError> {
+        let claim = build_self_touch(
+            &self.signer,
+            target_kind,
+            cohort,
+            Utc::now(),
+            self.coalesce_secs,
+        )
+        .await?;
+        submit_touch_claim(self.directory.as_ref(), &claim).await
+    }
+
+    /// The CC 3.2 ownerless-lock reclaim tie-in: an `ownership_binding`
+    /// self_touch at [`cohort_scope::SELF`]. A node becomes reclaimable
+    /// only after it has emitted such a floor and then gone dark ≥180 days;
+    /// **absent floor = never reclaimable** (fail-safe). Make emitting this
+    /// easy — it is the load-bearing reason this module exists.
+    ///
+    /// # Errors
+    /// See [`build_self_touch`] / [`submit_touch_claim`].
+    pub async fn produce_ownership_self_touch(&self) -> Result<TouchApplyOutcome, TouchClaimError> {
+        self.produce_self_touch(OWNERSHIP_FRESHNESS_TARGET_KIND, cohort_scope::SELF)
+            .await
+    }
+
+    /// Emit a `witness_touch` of `peer_key_id` at `(target_kind, cohort)`
+    /// for an observed liveness instant. Scope the witness as tightly as
+    /// the relationship allows (self/family) — NEVER an ungated
+    /// read-receipt trail.
+    ///
+    /// # Errors
+    /// See [`build_witness_touch`] / [`submit_touch_claim`].
+    pub async fn produce_witness_touch(
+        &self,
+        peer_key_id: &str,
+        target_kind: &str,
+        cohort: &str,
+        observed_at: DateTime<Utc>,
+    ) -> Result<TouchApplyOutcome, TouchClaimError> {
+        let claim = build_witness_touch(
+            &self.signer,
+            peer_key_id,
+            target_kind,
+            cohort,
+            observed_at,
+            self.coalesce_secs,
+        )
+        .await?;
+        submit_touch_claim(self.directory.as_ref(), &claim).await
+    }
+
+    /// Off [`ReachabilityTracker`]: witness `peer_key_id`'s most recent
+    /// observed liveness instant (floors `fresh_as_of` from
+    /// [`ReachabilityTracker::last_liveness`]). Returns `Ok(None)` — no
+    /// touch produced — when the tracker holds no liveness evidence for the
+    /// peer (a `witness_touch` requires an actual observed event). The
+    /// minimal, opt-in liveness hook edge's runtime calls when it observes
+    /// a peer succeed; NOT a background timer.
+    ///
+    /// # Errors
+    /// See [`build_witness_touch`] / [`submit_touch_claim`].
+    pub async fn produce_witness_touch_from_tracker(
+        &self,
+        tracker: &ReachabilityTracker,
+        peer_key_id: &str,
+        target_kind: &str,
+        cohort: &str,
+    ) -> Result<Option<TouchApplyOutcome>, TouchClaimError> {
+        let Some(observed_at) = tracker.last_liveness(peer_key_id) else {
+            return Ok(None);
+        };
+        let outcome = self
+            .produce_witness_touch(peer_key_id, target_kind, cohort, observed_at)
+            .await?;
+        Ok(Some(outcome))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciris_keyring::{Ed25519SoftwareSigner, HardwareSigner, MlDsa65SoftwareSigner, PqcSigner};
+    use ciris_persist::federation::types::{algorithm, identity_type, KeyRecord, SignedKeyRecord};
+    use ciris_persist::store::MemoryBackend;
+
+    /// Deterministic 32-byte seed for `label` — first ≤32 bytes over a
+    /// `0x11` fill (matching edge's existing fixture shape).
+    fn seed32(label: &str) -> [u8; 32] {
+        let mut seed = [0x11u8; 32];
+        for (i, b) in label.bytes().take(32).enumerate() {
+            seed[i] = b;
+        }
+        seed
+    }
+
+    /// A hybrid [`LocalSigner`] with deterministic Ed25519 + ML-DSA-65 keys
+    /// for `key_id` (real signatures — mirrors `capacity.rs::test_signer`).
+    async fn hybrid_signer(key_id: &str) -> Arc<LocalSigner> {
+        let ed_seed = seed32(key_id);
+        let mut pqc_seed = seed32(key_id);
+        pqc_seed[0] ^= 0x55; // distinct from the ed seed
+        let classical: Arc<dyn HardwareSigner> = Arc::new(
+            Ed25519SoftwareSigner::from_bytes(&ed_seed, key_id).expect("ed25519 from_bytes"),
+        );
+        let pqc: Arc<dyn PqcSigner> = Arc::new(
+            MlDsa65SoftwareSigner::from_seed_bytes(&pqc_seed, format!("{key_id}-pqc"))
+                .expect("ml_dsa_65 from_seed_bytes"),
+        );
+        Arc::new(LocalSigner::new(key_id, classical, Some(pqc)))
+    }
+
+    /// Register `signer`'s hybrid pubkeys as a federation key so its touch
+    /// signatures verify against the pinned directory entry.
+    async fn register(backend: &Arc<MemoryBackend>, signer: &LocalSigner) {
+        let ed_pub = HardwareSigner::public_key(signer.classical.as_ref())
+            .await
+            .expect("ed25519 pubkey");
+        let pqc_pub = PqcSigner::public_key(signer.pqc.as_ref().expect("has pqc").as_ref())
+            .await
+            .expect("ml_dsa_65 pubkey");
+        let now = Utc::now();
+        let record = KeyRecord {
+            key_id: signer.key_id.clone(),
+            pubkey_ed25519_base64: B64.encode(&ed_pub),
+            pubkey_ml_dsa_65_base64: Some(B64.encode(&pqc_pub)),
+            algorithm: algorithm::HYBRID.into(),
+            identity_type: identity_type::NODE.into(),
+            identity_ref: format!("node-ref-{}", signer.key_id),
+            valid_from: now,
+            valid_until: None,
+            registration_envelope: serde_json::json!({
+                "key_id": signer.key_id,
+                "identity_type": identity_type::NODE,
+            }),
+            original_content_hash: "0".repeat(64),
+            scrub_signature_classical: "x".repeat(88),
+            scrub_signature_pqc: None,
+            scrub_key_id: signer.key_id.clone(),
+            scrub_timestamp: now,
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            roles: Vec::new(),
+            attestation_evidence: None,
+            consent_role: None,
+            additional_scrubs: Vec::new(),
+        };
+        backend
+            .put_public_key(SignedKeyRecord { record })
+            .await
+            .expect("register federation key");
+    }
+
+    fn backend() -> Arc<MemoryBackend> {
+        Arc::new(MemoryBackend::new())
+    }
+
+    // ── round-trip: produced signed_envelope == signing_envelope(), and
+    // the signature verifies (proved by admission accepting the put) ──────
+    #[tokio::test]
+    async fn self_touch_round_trip_signs_and_verifies() {
+        let backend = backend();
+        let signer = hybrid_signer("rt-self").await;
+        register(&backend, &signer).await;
+
+        let observed = Utc::now();
+        let claim = build_self_touch(
+            &signer,
+            OWNERSHIP_FRESHNESS_TARGET_KIND,
+            cohort_scope::SELF,
+            observed,
+            DEFAULT_TOUCH_COALESCE_SECS,
+        )
+        .await
+        .expect("build self_touch");
+
+        // The stored envelope IS the typed projection's signing_envelope,
+        // byte-for-byte (authority-is-the-envelope discipline).
+        assert_eq!(claim.signed_envelope, claim.signing_envelope());
+        assert_eq!(claim.attesting_key_id, "rt-self");
+        assert_eq!(claim.target_key_id, "rt-self");
+        assert!(claim.signature.mldsa65_signature_base64.is_some(), "hybrid");
+
+        // A successful put proves the hybrid signature verifies at persist's
+        // RequireHybrid 1-of-1 admission gate.
+        let dir: Arc<dyn FederationDirectory> = backend;
+        let outcome = submit_touch_claim(dir.as_ref(), &claim)
+            .await
+            .expect("admit self_touch");
+        assert_eq!(outcome, TouchApplyOutcome::Advanced);
+    }
+
+    // ── put → Advanced, then a same-floored re-put → NotFresher ───────────
+    #[tokio::test]
+    async fn advanced_then_not_fresher_same_bucket() {
+        let backend = backend();
+        let signer = hybrid_signer("nf-self").await;
+        register(&backend, &signer).await;
+        let dir: Arc<dyn FederationDirectory> = backend;
+
+        // Same observed instant → identical floored fresh_as_of → identical
+        // signed envelope. First advances the floor; second is a silent
+        // no-op (anti-rollback), NOT an error.
+        let observed = Utc::now() - Duration::seconds(2);
+        let first = build_self_touch(
+            &signer,
+            NODE_LIVENESS_TARGET_KIND,
+            cohort_scope::SELF,
+            observed,
+            DEFAULT_TOUCH_COALESCE_SECS,
+        )
+        .await
+        .expect("build first");
+        let second = build_self_touch(
+            &signer,
+            NODE_LIVENESS_TARGET_KIND,
+            cohort_scope::SELF,
+            observed,
+            DEFAULT_TOUCH_COALESCE_SECS,
+        )
+        .await
+        .expect("build second");
+        assert_eq!(
+            first.fresh_as_of, second.fresh_as_of,
+            "same bucket coalesces"
+        );
+
+        assert_eq!(
+            submit_touch_claim(dir.as_ref(), &first).await.unwrap(),
+            TouchApplyOutcome::Advanced
+        );
+        assert_eq!(
+            submit_touch_claim(dir.as_ref(), &second).await.unwrap(),
+            TouchApplyOutcome::NotFresher,
+            "an equal fresh_as_of is never fresher (strict > guard) — silent no-op"
+        );
+    }
+
+    // ── the n_of_m tally: THE regression guard against the stale-docstring
+    // trap. A NOfMCosigned touch with primary + a real independent
+    // co-signer admits; the same touch WITHOUT the co-sig set is refused ──
+    #[tokio::test]
+    async fn nofm_cosigned_tally_requires_real_cosigner() {
+        let backend = backend();
+        // Three DISTINCT identities: the target, the primary attester, the
+        // co-signer. Primary + co-signer are both independent of the target.
+        let target = hybrid_signer("nofm-target").await;
+        let primary = hybrid_signer("nofm-primary").await;
+        let cosigner = hybrid_signer("nofm-cosigner").await;
+        register(&backend, &target).await;
+        register(&backend, &primary).await;
+        register(&backend, &cosigner).await;
+        let dir: Arc<dyn FederationDirectory> = backend;
+
+        // Primary leg — envelope carries NO touch_cosignatures yet.
+        let leg = build_nofm_primary(
+            &primary,
+            &target.key_id,
+            NODE_LIVENESS_TARGET_KIND,
+            cohort_scope::FAMILY,
+            Utc::now(),
+            DEFAULT_TOUCH_COALESCE_SECS,
+        )
+        .await
+        .expect("build primary leg");
+        assert_eq!(leg.attesting_key_id, "nofm-primary");
+        assert_ne!(leg.attesting_key_id, leg.target_key_id, "independent");
+
+        // (a) the bare primary leg (no co-sig set) MUST be refused — this is
+        // the trap: pre-v21.10.0 docstrings claim it verifies as 1-of-1.
+        let bare = submit_touch_claim(dir.as_ref(), &leg).await;
+        assert!(
+            matches!(bare, Err(TouchClaimError::Put(_))),
+            "NOfMCosigned without a co-signature set must be refused, got {bare:?}"
+        );
+
+        // (b) primary + a real independent co-signature over the SAME
+        // stripped preimage → admitted (proves a genuine ≥2-of-N tally).
+        let preimage = cosignature_preimage(&leg).expect("preimage");
+        let cosig = build_cosignature(&cosigner, &preimage)
+            .await
+            .expect("co-sign");
+        let submittable = attach_cosignatures(leg.clone(), &[cosig]).expect("attach cosignatures");
+        assert_eq!(
+            submit_touch_claim(dir.as_ref(), &submittable)
+                .await
+                .unwrap(),
+            TouchApplyOutcome::Advanced,
+            "primary + a real independent co-signer must be admitted"
+        );
+
+        // (c) a forged co-signature (valid shape, wrong bytes) → refused.
+        let forged = attach_cosignatures(
+            leg,
+            &[ThresholdSignature {
+                member_id: "nofm-cosigner".to_owned(),
+                ed25519_signature_base64: "AA".to_owned(),
+                mldsa65_signature_base64: None,
+            }],
+        )
+        .expect("attach forged");
+        let forged_res = submit_touch_claim(dir.as_ref(), &forged).await;
+        assert!(
+            matches!(forged_res, Err(TouchClaimError::Put(_))),
+            "a forged co-signature must be refused, got {forged_res:?}"
+        );
+    }
+
+    // ── cohort_scope is required + validated (refused BEFORE put) ─────────
+    #[tokio::test]
+    async fn cohort_scope_out_of_set_refused_before_put() {
+        let signer = hybrid_signer("cohort-self").await;
+
+        // "global" is NOT in the closed set — the builder refuses before it
+        // ever signs or reaches put_touch_claim.
+        let err = build_self_touch(
+            &signer,
+            NODE_LIVENESS_TARGET_KIND,
+            "global",
+            Utc::now(),
+            DEFAULT_TOUCH_COALESCE_SECS,
+        )
+        .await
+        .expect_err("global must be refused");
+        assert!(matches!(err, TouchClaimError::InvalidCohortScope(s) if s == "global"));
+
+        // Every closed-set value is accepted.
+        for scope in [
+            cohort_scope::SELF,
+            cohort_scope::FAMILY,
+            cohort_scope::COMMUNITY,
+            cohort_scope::AFFILIATIONS,
+            cohort_scope::SPECIES,
+            cohort_scope::BIOSPHERE,
+            cohort_scope::FEDERATION,
+        ] {
+            build_self_touch(
+                &signer,
+                NODE_LIVENESS_TARGET_KIND,
+                scope,
+                Utc::now(),
+                DEFAULT_TOUCH_COALESCE_SECS,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("scope {scope} should build: {e}"));
+        }
+    }
+
+    // ── fresh_as_of is FLOORED (never > now); witness attester != target ──
+    #[tokio::test]
+    async fn fresh_as_of_floored_and_witness_independent() {
+        // Flooring: a past, non-bucket-aligned instant floors DOWN.
+        let observed = DateTime::parse_from_rfc3339("2026-07-01T00:01:37Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let floored = coalesce_fresh_as_of(observed, 60);
+        assert_eq!(
+            floored,
+            DateTime::parse_from_rfc3339("2026-07-01T00:01:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            "37s past the minute floors to the minute boundary"
+        );
+
+        // Never ceiling / never future: a far-future observation is capped
+        // to now before flooring, so the result never exceeds now.
+        let now = Utc::now();
+        let future = coalesce_fresh_as_of(now + Duration::hours(1), 60);
+        assert!(
+            future <= now,
+            "a future observation must not push fresh_as_of past now"
+        );
+
+        // A produced witness_touch: attester differs from the target, and
+        // fresh_as_of is floored below now.
+        let witness = hybrid_signer("fresh-witness").await;
+        let claim = build_witness_touch(
+            &witness,
+            "some-peer",
+            NODE_LIVENESS_TARGET_KIND,
+            cohort_scope::FAMILY,
+            Utc::now(),
+            DEFAULT_TOUCH_COALESCE_SECS,
+        )
+        .await
+        .expect("build witness_touch");
+        assert_ne!(
+            claim.attesting_key_id, claim.target_key_id,
+            "witness ≠ target"
+        );
+        assert_eq!(claim.signer_form, SignerForm::WitnessTouch);
+        assert!(claim.fresh_as_of <= Utc::now(), "floored below now");
+
+        // Witnessing one's own key is refused up front.
+        let self_witness = build_witness_touch(
+            &witness,
+            &witness.key_id,
+            NODE_LIVENESS_TARGET_KIND,
+            cohort_scope::FAMILY,
+            Utc::now(),
+            DEFAULT_TOUCH_COALESCE_SECS,
+        )
+        .await;
+        assert!(matches!(
+            self_witness,
+            Err(TouchClaimError::AttesterNotIndependent { .. })
+        ));
+    }
+
+    // ── the ReachabilityTracker hook: witness from observed liveness ──────
+    #[tokio::test]
+    async fn producer_witnesses_from_tracker() {
+        use crate::reachability::AttemptOutcome;
+        use crate::transport::TransportId;
+
+        let backend = backend();
+        let witness = hybrid_signer("track-witness").await;
+        register(&backend, &witness).await;
+        let dir: Arc<dyn FederationDirectory> = backend;
+        let producer = TouchClaimProducer::new(witness, dir);
+
+        let tracker = ReachabilityTracker::new(300);
+
+        // No evidence yet → no touch produced.
+        let none = producer
+            .produce_witness_touch_from_tracker(
+                &tracker,
+                "peer-xyz",
+                NODE_LIVENESS_TARGET_KIND,
+                cohort_scope::FAMILY,
+            )
+            .await
+            .expect("no-evidence path");
+        assert!(none.is_none(), "no observed liveness → no witness touch");
+
+        // Record a successful attempt → a liveness event to witness.
+        tracker.record_attempt("peer-xyz", TransportId::HTTP, AttemptOutcome::SendSuccess);
+        let some = producer
+            .produce_witness_touch_from_tracker(
+                &tracker,
+                "peer-xyz",
+                NODE_LIVENESS_TARGET_KIND,
+                cohort_scope::FAMILY,
+            )
+            .await
+            .expect("witness path");
+        assert_eq!(some, Some(TouchApplyOutcome::Advanced));
+    }
+}


### PR DESCRIPTION
Adopts the **complete persist #519 surface (v21.10.0)** and closes both **#411** (full spec) and **#410** (respect all routing fields). **edge v15.0.0.** The honest headline: much of #411 was already satisfied by the v14.x cuts — the genuinely-new work is the touch producer, the `delivery_mode` processor, and the manifest-driven conformance + evidence harness. Nothing was faked across the persist/server/CC boundary.

## The six workstreams
- **§0 — pin 4 cross-repo hashes.** persist v21.4.0 → **v21.10.0** (source-compatible; verify stays v10.6.3, single version in graph). Pinned with gate tests: manifest version `0.3.0`, `TRANSFORM_ALGEBRA_HASH` (both new) + `REPLICATION_POLICY_HASH` / `CONSENT_GRAMMAR_HASH` (already matched). Drift = build failure.
- **§1 — process every edge-owned field by VALUE.** `delivery_mode` is now a real value-semantics processor (typed `EnvelopeCore` read, never `extra`; fail-secure `(mandatory, no path) ⇒ FailLoudNoPath`). The other edge-owned fields verified already-REAL: `dimension` projects by its actual value (`authority_for`), `cohort_scope`→`projection_for`, `recipient_serve_capability`→`peer_has_serve_capability`, `recipient_capability`→`recipient_capability_withholds` (v14.1, wired at **both** serve paths — the #410 "carried-but-unprocessed" headline is **resolved**), `withdrawal_reason`, `key_boundary_scope`, holder-staleness, delivery-durability.
- **§2 — PRODUCE the freshness floor (new, largest).** `src/touch_claim.rs`: build → sign (JCS + `LocalSigner`, bound Ed25519‖ML-DSA-65 → `TransportBindingSignature`) → `put_touch_claim`. `fresh_as_of` floored (never ceiling/future); `cohort_scope` required + validated (privacy). Handles the v21.10.0 **m-of-n trap** (the `NOfMCosigned` docstrings are stale — v21.10.0 runs a real tally): the producer builds the primary leg + a `build_cosignature` helper + the sign-then-strip `touch_cosignatures` fixed point, never fabricating others' co-sigs. `produce_ownership_self_touch` arms the CC 3.2 ownerless-lock reclaim (absent floor = never reclaimable — this producer activates the covenant end-to-end). Opt-in FFI (`produce_ownership_self_touch` / `produce_witness_touch`, witness scoped `family`).
- **§3 — transform algebra at serve.** The honest finding: serve-time `StripField` is **unsound** on edge's content-addressed signed wire (#397) — the recipient re-verifies content_hash + hybrid sig, so stripping breaks both; persist applies `StripField` at **promotion** and scoped serve-layer transforms as a follow-up. Edge's §3 = the algebra-hash pin (§0) + honoring restrictions as a WITHHOLD (v14.1), both done. **No wire-breaking strip faked**; the projection strips are `DeferredPendingPlane` with that exact reason.
- **§4 — route only on resolved state.** The #396 by-construction funnel (`resolved_state.rs` `ResolvedPeerSet`/`ResolvedRecipient`), verified in place from v14.2; no new resolved read landed in v21.5–v21.10 that edge was missing.
- **§5 — conformance harness (keystone).** `field_conformance::run_edge_field_conformance()` + `edge_field_conformance()` FFI (mirrors `persist_field_conformance`). Every one of the **22 edge-tagged matrix fields** is categorized: **7 value-semantics checks** + **15 `DeferredPendingPlane`** (each with the precise upstream reason). `every_edge_tagged_field_is_accounted_for` reads persist's **live** `field_processor_matrix` and **fails the build** if any edge-tagged field is unaccounted-for — the #315 dead-plane class is now a compile error.

## #410 closed via #411
Its 4 asks: consume the manifest ✓, process `delivery_mode` ✓, **publish evidence rows** ✓ (`evidence/CIRISEdge.cc_impl.tsv`, **generated** from the live tested table — `evidence_tsv_matches_emitted` makes drift a build failure), serve-gate completeness witness ✓. Each of the 5 CI routing axes anchors a `path#symbol`.

## What edge does NOT own (not faked)
Promotion / tombstone folding / `deletion_window` / touch admission = persist. `config:*` = server. Ownerless-lock policy + CLM-nsproc claim definitions + vendoring `CIRISEdge.cc_impl.tsv` = CIRISConstitution.

## Verification
720 lib tests (delivery_mode 5, conformance 5, touch_claim 6 incl the forged-cosig regression guard, +2 pins); clippy `-D warnings` clean across pyo3/ffi-uniffi/test-anchor; fmt + pin-skew green. Cohab-red is the known server-skew.

Closes #410, #411.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8uDCuRxAQVRzdjcuDVrBF
