### PR TITLE
fix(v15.0.2): #414 — split RECEIVE from SEND so the #396 consent gate stops darkening inbound rounds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "15.0.1"
+version = "15.0.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -6,10 +6,10 @@
 # field_conformance::tests::evidence_tsv_matches_emitted — a drift is a build
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.0.1
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.0.1
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.0.1
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.0.1
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.0.1
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.0.1
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.0.1
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.0.2
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.0.2
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.0.2
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.0.2
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.0.2
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.0.2
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.0.2

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -180,6 +180,20 @@ impl StateProvider for DirectoryStateAdapter {
         })
     }
 
+    /// CIRISEdge#414 — the node's REAL holdings for the round's RECEIVE diff: the
+    /// PEER-BLIND [`ReplicationDirectory::list_envelope_refs`] (recipient `None` —
+    /// the ungated projection view), NEVER `list_envelope_refs_for_peer`. The
+    /// per-peer #396 send gate belongs on the offer + delivery, not on the node's
+    /// knowledge of what it itself holds; using the peer-gated view here darkened
+    /// the receive side of a round with a peer this node has no consent to SEND to.
+    fn local_holdings(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(async move { inner.list_envelope_refs(kind).await })
+        })
+    }
+
     fn fetch_envelope(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> Option<Vec<u8>> {
         let inner = Arc::clone(&self.inner);
         let hash = *envelope_hash;

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -348,7 +348,13 @@ impl Session {
             return ReplicationOutcome::UnexpectedMessage;
         }
         self.last_remote_summary = Some(remote.clone());
-        let local = provider.local_refs(self.kind);
+        // CIRISEdge#414 — RECEIVE axis: what this node still LACKS is computed
+        // from its REAL holdings, not from its (send-gated) offer. Using
+        // `local_refs` here fused the #396 SEND gate onto the RECEIVE side — a
+        // responder with no consent to send to the initiator saw an empty offer,
+        // so `want` became "everything" or the round went dark. `local_holdings`
+        // is the node's peer-blind own-state; the offer + delivery stay send-gated.
+        let local = provider.local_holdings(self.kind);
         let want = diff_refs(&local, &remote.refs);
         let mut outbound = Vec::new();
         // Responder ALSO needs to send its Summary so the
@@ -696,6 +702,80 @@ mod tests {
         match bob.on_message(m_alice_deliver, &b_provider, &mut b_applier) {
             ReplicationOutcome::Applied { admitted, .. } => assert_eq!(admitted, 1),
             o => panic!("unexpected: {o:?}"),
+        }
+    }
+
+    /// CIRISEdge#414 — the RECEIVE axis is computed from the node's real
+    /// HOLDINGS, not its (send-gated) OFFER. A responder that holds `infra:serve`
+    /// but has NO consent to SEND to the initiator advertises nothing (its offer
+    /// is empty), yet must still service the round — requesting exactly the rows
+    /// it LACKS. Before the split, `want` was computed from the empty offer, which
+    /// fused the #396 send gate onto the receive side and darkened the plane.
+    #[test]
+    fn receive_uses_holdings_not_the_send_gated_offer() {
+        // A provider whose OFFER (local_refs) is empty — the responder has no
+        // consent to SEND to this peer — but whose real HOLDINGS (local_holdings)
+        // contain {A}. The initiator offers {A, B}.
+        struct SplitProvider {
+            holdings: Vec<super::super::protocol::EnvelopeRef>,
+        }
+        impl StateProvider for SplitProvider {
+            fn local_refs(&self, _kind: EnvelopeKind) -> Vec<super::super::protocol::EnvelopeRef> {
+                Vec::new() // send-gated: this node offers NOTHING to the peer
+            }
+            fn local_holdings(
+                &self,
+                _kind: EnvelopeKind,
+            ) -> Vec<super::super::protocol::EnvelopeRef> {
+                self.holdings.clone() // the node's REAL state, peer-blind
+            }
+            fn fetch_envelope(&self, _k: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+        }
+        let provider = SplitProvider {
+            holdings: vec![EnvelopeRef {
+                envelope_hash: h(1),
+                seq: 1,
+            }],
+        };
+        let mut responder = Session::new(SessionRole::Responder, EnvelopeKind::Attestation);
+        let mut applier = applier_for(&[]);
+
+        let remote_summary = ReplicationMessage::Summary(SummaryMessage {
+            kind: EnvelopeKind::Attestation,
+            refs: vec![
+                EnvelopeRef {
+                    envelope_hash: h(1),
+                    seq: 1,
+                },
+                EnvelopeRef {
+                    envelope_hash: h(2),
+                    seq: 2,
+                },
+            ],
+        });
+        let out = match responder.on_message(remote_summary, &provider, &mut applier) {
+            ReplicationOutcome::Send(m) => m,
+            o => panic!("unexpected: {o:?}"),
+        };
+        // Outbound = [Summary(EMPTY — the send-gated offer), Diff(want)].
+        let (summary, diff) = (out[0].clone(), out[1].clone());
+        match summary {
+            ReplicationMessage::Summary(s) => assert!(
+                s.refs.is_empty(),
+                "the responder's OFFER must stay send-gated-empty (#396) even while it receives"
+            ),
+            o => panic!("expected Summary first: {o:?}"),
+        }
+        match diff {
+            ReplicationMessage::Diff(d) => assert_eq!(
+                d.want,
+                vec![h(2)],
+                "want must be remote ∖ HOLDINGS = only the lacked row {{B}}, NOT all of \
+                 remote (which the pre-#414 empty-offer diff would have produced)"
+            ),
+            o => panic!("expected Diff: {o:?}"),
         }
     }
 

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -82,10 +82,27 @@ impl LocalState {
 /// `list_attestations` / `list_federation_keys` / `list_revocations`
 /// surfaces.
 pub trait StateProvider: Send + Sync {
-    /// Snapshot local state for the given kind. Implementations
-    /// should be cheap (the state is read once per anti-entropy
-    /// round); callers don't memoize.
+    /// Snapshot the refs this node OFFERS to the round's peer for `kind` — the
+    /// SEND axis. On the Attestation plane this is CIRISEdge#396-send-gated (a
+    /// peer outside this node's live `consent:replication` send-set is offered
+    /// nothing). Read once per round; callers don't memoize.
     fn local_refs(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef>;
+
+    /// CIRISEdge#414 — the refs this node actually HOLDS for `kind` — the
+    /// RECEIVE axis. Used ONLY to compute what the node still LACKS
+    /// (`want = remote ∖ local_holdings`) so an inbound round is serviced from
+    /// the node's real state, NOT from its (send-gated, possibly empty) offer.
+    ///
+    /// This split fixes the axis-fusion where the #396 SEND gate darkened the
+    /// RECEIVE side: a responder holding `infra:serve` but no consent to SEND to
+    /// the initiator must still receive the initiator's offered rows. Holdings
+    /// never leave the node — the offer ([`Self::local_refs`]) and delivery
+    /// (`fetch_envelope_bytes_for_peer`) stay independently send-gated, so send
+    /// fail-secure is unchanged. Defaults to [`Self::local_refs`] for providers
+    /// with no peer-gating (every non-Attestation plane, and the test providers).
+    fn local_holdings(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+        self.local_refs(kind)
+    }
 
     /// Return the byte-exact signed envelope for the given content
     /// hash, or `None` if the envelope isn't in local state. Called


### PR DESCRIPTION
Fixes **CIRISEdge#414** — an axis-fusion defect in my own #396 work, found in a live agent-harness run against v15.0.1 (CIRISAgent#932). It was the **last** predicate between offered rows and arrival.

## The defect
The #396 send-consent gate (`resolve_attestation_recipient` → `list_consent_peers`) correctly bounds who this node **advertises/delivers** to. But it flowed through `list_attestations(Some(peer))` → `StateProvider::local_refs`, which the session overloaded for **two** purposes:
- **(a) the OFFER** — the Summary the peer diffs against (SEND — correctly gated); and
- **(b) the `local` in `want = diff_refs(local, remote)`** — the node's own state for the RECEIVE diff.

Emptying it on no-send-consent fused the SEND gate onto RECEIVE: a canonical holding `infra:serve` but with no `consent:replication` grant *toward the initiator* returned an empty listing → the Attestation plane went dark for the round, including the direction where the initiator was **pushing** its traces. (Same class as CIRISPersist#528: one predicate answering two questions.)

## The fix — a clean split (`StateProvider::local_holdings`)
- **OFFER** (`local_refs`) stays #396-send-gated — no send-consent → advertises nothing.
- **RECEIVE** (`local_holdings`, the node's **peer-blind** real state) drives `want`, so an inbound round is serviced from what the node actually holds. Holdings never leave the node.

**Send fail-secure is unchanged and doubly enforced:** the offer is empty **and** `fetch_envelope_bytes_for_peer` independently gates delivery on send-consent. The receive gate is **attribution (#393, unchanged)** — an unattributed frame never reaches the responder coordinator — plus **admission** (`put_attestation` verifies the sig): *"ingest is open and cheap; admission is the gate."* Being a canonical (conferred `infra:serve`) is itself the standing consent to receive; requiring a second producer-authored grant to *receive* inverted that.

## Scope
One line in `session.rs` `on_summary` (`local_refs`→`local_holdings`); a **defaulted** trait method (covers every non-Attestation plane + the test providers — no behaviour change there); the `DirectoryStateAdapter` override to the peer-blind view. `start_round`'s offer + proactive-Deliver and the responder's own Summary stay on `local_refs` (send-gated).

## Verification
- New `receive_uses_holdings_not_the_send_gated_offer`: a send-gated-empty offer + real holdings → `want = remote ∖ holdings` (only the lacked row), and the offer stays empty. This test **fails** against pre-#414 behaviour.
- The #396 (`consent_membership_fan_out_bound`) and #379 (`trace_attestation_gated_on_serve_capability`) send-gate regression tests still pass — the fan-out bound on the SEND axis is intact.
- 721 lib tests; clippy `-D warnings` clean across pyo3/ffi-uniffi/test-anchor; fmt + pin-skew green.

Cohab-red is the known server-skew. Closes #414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8uDCuRxAQVRzdjcuDVrBF