### PR TITLE
fix(v15.1.0): #416 local_holdings returns RAW holdings (round convergence) + adopt persist v21.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "15.0.4"
+version = "15.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.14.0", version = "21", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.15.0", version = "21", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1141,7 +1141,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.14.0", version = "21", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v21.15.0", version = "21", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -6,10 +6,10 @@
 # field_conformance::tests::evidence_tsv_matches_emitted — a drift is a build
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.0.4
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.0.4
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.0.4
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.0.4
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.0.4
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.0.4
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.0.4
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.1.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.1.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.1.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.1.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.1.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.1.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=21.14.0,<22",
+    "ciris-persist>=21.15.0,<22",
 ]
 dynamic = ["version"]
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -385,6 +385,18 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         }
     }
 
+    /// CIRISEdge#416 — RAW holdings for the RECEIVE-diff axis. The Attestation
+    /// plane uses the unfiltered [`Self::list_attestation_holdings`] ("what I
+    /// hold"), NOT the projection-filtered advertise view; every other plane's
+    /// advertise view equals its holdings for round convergence, so they keep the
+    /// default ([`Self::list_envelope_refs`]).
+    async fn list_holdings(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+        match kind {
+            EnvelopeKind::Attestation => self.list_attestation_holdings().await,
+            _ => self.list_envelope_refs(kind).await,
+        }
+    }
+
     /// CIRISEdge#379 — recipient-aware fetch: the serve-side twin of the
     /// listing gate, so a peer excluded from the listing cannot obtain a
     /// `trace:*` envelope anyway by Diff/Fetch-ing a hash it learned
@@ -1061,6 +1073,42 @@ impl FederationDirectoryReplicationBridge {
             *memo = Some((set.clone(), Instant::now()));
         }
         Some(set)
+    }
+
+    /// CIRISEdge#416 — the RAW Attestation holdings: the content-hash of EVERY
+    /// federation-tier attestation in local state, with NO `attestation_is_advertised`
+    /// projection filter, NO `self_set`, NO recipient gates. This is the RECEIVE
+    /// axis's "what do I hold" — distinct from [`Self::list_attestations`]'s "what
+    /// would I advertise". Using the advertise view for the round's
+    /// `want = remote ∖ holdings` diff meant a held-but-not-advertised row (a
+    /// `self`/`family` attestation from ANOTHER producer, which projects `SelfOwn`
+    /// and is advertised only by its own producer) was permanently absent from the
+    /// node's own holdings view — so it stayed in `want` every round and the round
+    /// never converged (CIRISAgent#932 responder-driver stall). The convergence
+    /// invariant this restores: after admitting an attestation, its hash is here.
+    /// Cheaper than the advertise sweep — it drops the per-row projection resolution.
+    async fn list_attestation_holdings(&self) -> Vec<EnvelopeRef> {
+        let attestations = self
+            .directory
+            .list_attestations_since(None, self.config.operational_page_limit)
+            .await
+            .unwrap_or_default();
+        let mut refs = Vec::new();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        for att in &attestations {
+            // Skip only an unparseable/unhashable row (never a projection filter).
+            let Some((hash, _bytes)) = content_hash_of(att) else {
+                continue;
+            };
+            if !seen.insert(hash) {
+                continue;
+            }
+            refs.push(EnvelopeRef {
+                envelope_hash: hash,
+                seq: Self::ms_seq(att.asserted_at),
+            });
+        }
+        refs
     }
 
     async fn list_attestations(&self, recipient: Option<&str>) -> Vec<EnvelopeRef> {
@@ -1872,6 +1920,88 @@ mod tests {
             refs.len(),
             2,
             "self_provider advertises the node's own + the anchored record, not the cohort"
+        );
+    }
+
+    /// CIRISEdge#416 — the RECEIVE-diff convergence invariant: an attestation the
+    /// node HOLDS must appear in `list_attestation_holdings()` (holdings) EVEN
+    /// WHEN it is not in `list_attestations(None)` (the advertise view). The
+    /// load-bearing case is a `self`-scoped row from ANOTHER producer: it projects
+    /// `SelfOwn` and is advertised only by its own producer, so on this node it is
+    /// held-but-not-advertised. Before #416 the receive diff used the advertise
+    /// view, so this row stayed in `want` forever and the round never converged.
+    #[tokio::test]
+    async fn holdings_include_held_but_not_advertised_rows() {
+        let this_node = "this-node";
+        let other_producer = "other-producer";
+        let (backend, bridge) = make_bridge(&[this_node.to_string(), other_producer.to_string()]);
+        for k in [this_node, other_producer] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+        }
+        // A federation-tier, SELF-scoped attestation authored by `other_producer`
+        // — held here, advertisable only by its own producer.
+        let now = Utc::now();
+        let envelope = serde_json::json!({
+            "attesting_key_id": other_producer,
+            "attested_key_id": other_producer,
+            "attestation_type": "scores",
+            "dimension": "capacity:example:v1",
+            "cohort_scope": "self",
+        });
+        let (hash_hex, ed_sig, pqc_sig) = sign_attestation_envelope(other_producer, &envelope);
+        let att = Attestation {
+            attestation_id: uuid::Uuid::new_v4().to_string(),
+            attesting_key_id: other_producer.to_string(),
+            attested_key_id: other_producer.to_string(),
+            attestation_type: "scores".to_string(),
+            weight: None,
+            asserted_at: now,
+            expires_at: None,
+            attestation_envelope: envelope,
+            original_content_hash: hash_hex,
+            scrub_signature_classical: ed_sig,
+            scrub_signature_pqc: pqc_sig,
+            scrub_key_id: other_producer.to_string(),
+            scrub_timestamp: now,
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            subject_key_ids: vec![other_producer.to_string()],
+            withdraws_admission_rule: None,
+            cohort_scope: "self".to_string(),
+            tier: "federation".to_string(),
+            promoted_at: None,
+        };
+        backend
+            .put_attestation(SignedAttestation { attestation: att })
+            .await
+            .expect("seed self-scoped attestation");
+        // This node publishes only its OWN — NOT other_producer's. (The single
+        // seeded row is the only attestation in local state.)
+        let publish_set = vec![this_node.to_string()];
+        let selector: CohortProvider = Arc::new(move || publish_set.clone());
+        let bridge = bridge.with_self_provider(Some(selector));
+
+        // The ADVERTISE view (projection-filtered) EXCLUDES the row — a self-scoped
+        // row from another producer is held-but-not-own, so it is not advertised.
+        let advertised = bridge.list_attestations(None).await;
+        assert!(
+            advertised.is_empty(),
+            "a self-scoped row from another producer must NOT be advertised here, got {advertised:?}"
+        );
+        // The HOLDINGS view (raw, #416) INCLUDES it — the convergence invariant:
+        // the round's `want = remote ∖ holdings` can now shrink for this row after
+        // admission, where the pre-#416 advertise-filtered view left it stuck.
+        let holdings = bridge.list_attestation_holdings().await;
+        assert_eq!(
+            holdings.len(),
+            1,
+            "list_attestation_holdings MUST contain the held row (#416 convergence \
+             invariant) even though the advertise view excludes it"
         );
     }
 

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -88,6 +88,21 @@ pub trait ReplicationDirectory: Send + Sync {
         self.list_envelope_refs(kind).await
     }
 
+    /// CIRISEdge#416 — the RAW holdings for `kind`: the content-hash of EVERY
+    /// row present in local state, with NO projection / advertise filtering and
+    /// NO recipient reasoning. This is the RECEIVE axis's set — "what do I hold"
+    /// — as distinct from [`Self::list_envelope_refs`] ("what would I advertise",
+    /// projection-filtered). The anti-entropy `want = remote ∖ holdings` diff
+    /// depends on the convergence invariant *after admitting an envelope, its hash
+    /// appears here*; a projection-filtered listing breaks it, so a held-but-not-
+    /// advertised row (e.g. a `self`/`family` attestation from another producer,
+    /// on the Attestation plane) would stay in `want` forever and stall the round.
+    /// Defaults to [`Self::list_envelope_refs`] for planes whose advertise view
+    /// equals their holdings; the bridge overrides the Attestation plane.
+    async fn list_holdings(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+        self.list_envelope_refs(kind).await
+    }
+
     /// Return the byte-exact signed envelope for `(kind,
     /// envelope_hash)`, or `None` if the envelope isn't in local state.
     /// Called during the `Deliver`-message construction step.
@@ -180,17 +195,19 @@ impl StateProvider for DirectoryStateAdapter {
         })
     }
 
-    /// CIRISEdge#414 — the node's REAL holdings for the round's RECEIVE diff: the
-    /// PEER-BLIND [`ReplicationDirectory::list_envelope_refs`] (recipient `None` —
-    /// the ungated projection view), NEVER `list_envelope_refs_for_peer`. The
-    /// per-peer #396 send gate belongs on the offer + delivery, not on the node's
-    /// knowledge of what it itself holds; using the peer-gated view here darkened
-    /// the receive side of a round with a peer this node has no consent to SEND to.
+    /// CIRISEdge#414 + #416 — the node's REAL holdings for the round's RECEIVE
+    /// diff: [`ReplicationDirectory::list_holdings`], the RAW per-kind
+    /// content-hash set with NO projection / advertise filtering and NO recipient
+    /// reasoning. #414 correctly moved the SEND gate off the receive axis but
+    /// wired this to `list_envelope_refs` — still the *advertise* view; #416 fixes
+    /// it to true holdings, so `want` shrinks after admission and the round
+    /// converges. The per-peer #396 send gate + projection stay on the offer
+    /// ([`Self::local_refs`]) and delivery (`fetch_envelope_bytes_for_peer`).
     fn local_holdings(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
         let inner = Arc::clone(&self.inner);
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current()
-                .block_on(async move { inner.list_envelope_refs(kind).await })
+                .block_on(async move { inner.list_holdings(kind).await })
         })
     }
 


### PR DESCRIPTION
Combines the **#416** fix (the follow-on to #414 that unblocks the agent-harness Attestation-round stall) with the routine **persist v21.15.0** adoption.

## #416 — `local_holdings` returned the advertise view, not real holdings
My #414 receive-split wired `local_holdings` → `list_envelope_refs(Attestation)` = `list_attestations(None)` — which **still applies `attestation_is_advertised`**. So the RECEIVE-diff set was *"what I would advertise"*, not *"what I hold"*. A row **held-but-not-advertised** — a `self`/`family` attestation from **another producer** (projects `SelfOwn`, advertised only by its own producer) — was permanently absent from the node's holdings view, so it stayed in `want` every round; admitting it never changed advertisability → `want` never shrank → the Attestation round **never converged** (CIRISAgent#932: responder driver starts, never terminates, initiator times out). Same one-name-two-axes class as #414 / #532 / CIRISPersist#528.

**Fix:** `ReplicationDirectory::list_holdings(kind)` (default = `list_envelope_refs`; the bridge overrides Attestation → new `list_attestation_holdings`: page `list_attestations_since` + `content_hash_of` **every** row, **no** `attestation_is_advertised`, **no** `self_set`, **no** recipient gates — cheaper than the advertise sweep). The adapter's `local_holdings` (the #414 receive axis) now calls `list_holdings`. The **offer** (`local_refs`) + **delivery** (`fetch_envelope_bytes_for_peer`) keep projection + the #396 send gate — **send fail-secure unchanged**.

**Invariant test** `holdings_include_held_but_not_advertised_rows`: a self-scoped row from another producer appears in holdings (1) but not in the advertise view (0) — the convergence invariant *"after admitting an envelope, its hash appears in holdings"* the set-difference round depends on.

Scope: other planes keep the default (their advertise view equals holdings for convergence, per the harness — Key/IdOcc/TransportDest complete normally).

## persist v21.15.0
#536 `establish_trust_root` fixture (persist-internal test tooling). Verify stays v10.6.3; all 4 manifest/policy hashes + `namespace_supersets.json` unchanged; all 6 drift-witness pins match; evidence TSV regenerated.

722 lib tests; clippy `-D warnings` clean across pyo3/ffi-uniffi/test-anchor; fmt + pin-skew green. Cohab-red is the known server-skew. Closes #416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8uDCuRxAQVRzdjcuDVrBF