### PR TITLE
feat(#462): RECEIVE axis — subject-scoped Pull (v15.22.0)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.10.0", version = "30", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.11.0", version = "30", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1216,7 +1216,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.10.0", version = "30", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.11.0", version = "30", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "15.21.8"
+version = "15.22.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/FSD/REPLICATION_WIRE_FORMAT_V1.md
+++ b/FSD/REPLICATION_WIRE_FORMAT_V1.md
@@ -327,6 +327,48 @@ the CRPL wire-frame prefix (#72) plus the long-lived Session (#73)
 plus the scheduler (#75) constitute the v1 anti-entropy protocol.
 CEG defers to edge per #58.
 
+#### 3.4.1 The RECEIVE axis — subject-scoped `Pull` (CIRISEdge#462)
+
+Anti-entropy converges what a peer **advertises**. It structurally
+cannot carry the `SelfOwn` plane (`namespace::projection_for` →
+`SelfOwn` is never advertised), so a fedID that claimed a fresh node
+cannot obtain its own testimony — keys, occurrences, routes,
+occurrence-revocations, and the attestations about-or-by it — even
+though the graph already holds them on another node. `Pull` is the
+fifth verb (a fifth `ReplicationMessage` variant) that closes this:
+
+```text
+  A → B   Pull    { kind, subject_key_id }     // A: "what do you hold for this subject?"
+  A ← B   Summary { kind, refs }               // B answers with the subject's refs
+  ...then the ordinary Diff/Deliver flow carries the bytes
+```
+
+- **Not anti-entropy.** The want-set is SUBJECT-scoped, not the kind's
+  advertised convergence set. The responder answers with an ordinary
+  `Summary`, so the entire existing receive path (`on_summary` →
+  Diff → Deliver → apply) is reused unchanged; only the requester
+  (Initiator) sending `Pull` and the responder's `on_pull` are new.
+- **Scope.** EXACTLY the five replicated kinds (`EnvelopeKind::is_subject_pullable`
+  = the persist `ReplicatedKind` set). The Attestation plane sweeps
+  BOTH testimonial axes: `list_attestations_for` (about-the-subject)
+  and `list_attestations_by` (authored-by-the-subject, recovery).
+- **Entitlement — fail-closed.** The responder serves a subject's rows
+  ONLY to a requester authenticated AS that subject (owner-delegation
+  via `owner_of` is a follow-up). Every byte is re-gated by the
+  responder's per-record serve gate (`fetch_envelope_bytes_for_peer`),
+  so a `Pull` widens nothing.
+- **G2 carve.** Consent-gated peer-authored scores about the subject
+  (persist `admission::consent_gated_claim` — the `capacity:*`
+  reputation family) are withheld on the data-subject axis: landing a
+  score about me onto the node where I am the sole writer is the
+  self-revocation-hole shape. Persist owns this taxonomy; edge consumes
+  it. The subject's OWN authored scores (sender axis) are unaffected.
+- **Wire-compat.** `Pull` is a post-v1 verb; v1 peers serde-refuse the
+  unknown `type` tag (they do NOT silently ignore). Adding it flips the
+  responder-policy witness `SERVE_ADVERTISE_POLICY_HASH` (a `receive`
+  column, manifest v2), which CIRISServer pins — so the cut is
+  coordinated by construction.
+
 ### 3.5 WIRE_PROTOCOL_VERSION
 
 Replication protocol version is carried in the wire-frame:

--- a/deny.toml
+++ b/deny.toml
@@ -105,6 +105,15 @@ ignore = [
     "RUSTSEC-2025-0098",  # unic-* unmaintained
     "RUSTSEC-2025-0100",  # unic-* unmaintained
 
+    # bincode 1.3.3 unmaintained — NOT a vulnerability. The bincode team
+    # permanently ceased development after a doxxing/harassment incident and
+    # consider 1.3.3 a COMPLETE version needing no updates ("No safe upgrade is
+    # available" because none is needed). Transitive DEV-ONLY via
+    # `iai-callgrind v0.16.1` (the CIRISEdge#461 deterministic instruction-count
+    # bench harness); it never ships in any wheel or transport binary. Clears if
+    # the icount harness migrates to gungraun (the post-rename iai successor).
+    "RUSTSEC-2025-0141",  # bincode 1.3.3 unmaintained (dev-only, via iai-callgrind)
+
     # 2026-07-17 — six same-day libcrux advisories, ALL from the ONE dep
     # `openmls_libcrux_crypto v0.3.1` (RFC 9420 MLS backend, CIRISEdge#66) via
     # hpke-rs-libcrux / libcrux-{aead,kem,ml-kem,sha3}. NONE reach the

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.21.8
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.21.8
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.21.8
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.21.8
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.21.8
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.21.8
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.21.8
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.22.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.22.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.22.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.22.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.22.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.22.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.22.0

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2531,6 +2531,44 @@ impl PyReplicationHandle {
         })
     }
 
+    /// CIRISEdge#462 — pull a subject's own testimony from a peer (the RECEIVE
+    /// axis). For each subject-pullable kind, ensures a scheduled Initiator
+    /// coordinator for `peer_key_id` and sends a subject-scoped `Pull`; the peer
+    /// answers with the refs it holds where `subject_key_id` is the data-subject
+    /// or sender (projection-gated + G2-carved), and the ordinary Diff/Deliver
+    /// flow converges the gap over the next rounds. This is how a fedID that
+    /// claimed a fresh node recovers its keys / occurrences / routes /
+    /// revocations and the attestations about-or-by it — the `SelfOwn` plane
+    /// anti-entropy never advertises.
+    ///
+    /// Fire-and-forget: returns once the Pulls are dispatched. Raises
+    /// `RuntimeError` if the runtime has been stopped.
+    fn pull_subject_testimony(
+        &self,
+        py: Python<'_>,
+        peer_key_id: &str,
+        subject_key_id: &str,
+    ) -> PyResult<()> {
+        let peer = peer_key_id.to_string();
+        let subject = subject_key_id.to_string();
+        let inner = self.inner.clone();
+        let executor = self.executor.clone();
+        py.detach(|| {
+            run_async(&executor, async move {
+                let guard = inner.lock().await;
+                match guard.as_ref() {
+                    Some(rt) => rt
+                        .pull_subject_testimony(&peer, &subject)
+                        .await
+                        .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string())),
+                    None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                        "replication runtime is stopped",
+                    )),
+                }
+            })
+        })
+    }
+
     /// CIRISEdge#173 / v5.1.0 — hot-add an Initiator peer at runtime.
     /// The scheduler spawns a task that fires anti-entropy rounds at
     /// the configured cadence immediately. Idempotent.

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2541,8 +2541,9 @@ impl PyReplicationHandle {
     /// revocations and the attestations about-or-by it — the `SelfOwn` plane
     /// anti-entropy never advertises.
     ///
-    /// Fire-and-forget: returns once the Pulls are dispatched. Raises
-    /// `RuntimeError` if the runtime has been stopped.
+    /// Returns once the Pulls are dispatched. Raises `RuntimeError` if the
+    /// runtime has been stopped OR if any Pull send failed (the caller must retry
+    /// — anti-entropy will NOT recover the `SelfOwn` plane on its own).
     fn pull_subject_testimony(
         &self,
         py: Python<'_>,

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -936,7 +936,7 @@ impl FederationDirectoryReplicationBridge {
     ///
     /// The Attestation plane sweeps BOTH testimonial axes: `list_attestations_for`
     /// (records ABOUT the subject — the revocation-reachability set, with the G2
-    /// [`Self::is_self_nonretainable_score`] carve) and `list_attestations_by`
+    /// [`Self::is_consent_gated_score`] carve) and `list_attestations_by`
     /// (records BY the subject — authorship recovery, no carve: mine to recover).
     /// Non-replicated / cohort kinds are not subject-pullable and return empty.
     async fn subject_holdings_inner(
@@ -1017,7 +1017,7 @@ impl FederationDirectoryReplicationBridge {
                     .await
                     .unwrap_or_default()
                 {
-                    if Self::is_self_nonretainable_score(&att) {
+                    if Self::is_consent_gated_score(&att) {
                         continue;
                     }
                     let seq = Self::ms_seq(att.asserted_at);
@@ -1048,27 +1048,28 @@ impl FederationDirectoryReplicationBridge {
         refs
     }
 
-    /// CIRISEdge#462 — the G2 self-revocation-hole carve. A peer-authored SCORE
-    /// about the subject (`capacity:*` / `capacity_assurance:*` / `moderation:*`
-    /// dimension, CC 2.1 — the dimension lives inside `attestation_envelope`) is
-    /// NEVER served on the data-subject Pull axis: landing a score ABOUT me onto
-    /// the node where I am the sole writer conflates read-copy with
-    /// write-authority — the shape that produced the G2 hole. The subject's OWN
-    /// authored scores (the sender axis) are unaffected.
+    /// CIRISEdge#462 — the G2 self-revocation-hole carve, resolved by CONSUMING
+    /// persist's authoritative CEG taxonomy rather than an edge prefix list: an
+    /// attestation whose dimension is a consent-gated peer-authored SCORE (persist
+    /// [`consent_gated_claim`](ciris_persist::federation::admission::consent_gated_claim)
+    /// — the `capacity:*` reputation family, CC 3.4.5 / AV-79) is NEVER served on
+    /// the data-subject Pull axis. Landing a score ABOUT me onto the node where I
+    /// am the sole writer conflates read-copy with write-authority — the shape
+    /// that produced the G2 hole. The subject's OWN authored scores (the sender
+    /// axis) are unaffected: `consent_gated_claim` classifies by dimension and
+    /// edge consults it ONLY on the data-subject axis.
     ///
-    /// The prefix set is edge-local pending persist's `is_subject_retainable`
-    /// predicate (CIRISPersist#635) that would own this on the authoritative
-    /// namespace taxonomy; it is fail-closed in spirit — an unclassifiable score
-    /// dimension should be *added* here, never pulled onto self by default.
-    fn is_self_nonretainable_score(att: &Attestation) -> bool {
-        att.attestation_envelope
-            .pointer("/dimension")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|d| {
-                d.starts_with("capacity:")
-                    || d.starts_with("capacity_assurance:")
-                    || d.starts_with("moderation:")
-            })
+    /// Deliberately persist's decision, not an edge prefix list — the gated set is
+    /// CEG state resolution persist owns (the closed `ConsentGatedFamily` enum
+    /// grows there), so edge tracks new consent-gated score families for free and
+    /// cannot drift. This matches the issue's exact scope (`capacity:*`);
+    /// `moderation:*` / `slashing:*` are role-gated, NOT consent-gated, and are
+    /// community-cohort — they follow the duty, not the individual identity, so
+    /// they do not ride the data-subject axis. CIRISPersist#635 tracks the open
+    /// question of whether the pull carve should ALSO cover the role-gated
+    /// abuse-response families.
+    fn is_consent_gated_score(att: &Attestation) -> bool {
+        ciris_persist::federation::admission::consent_gated_claim(att).is_some()
     }
 
     /// The per-kind apply dispatch behind the #425 choke —
@@ -4402,29 +4403,36 @@ mod tests {
         }
     }
 
-    /// CIRISEdge#462 — the G2 self-revocation-hole carve is EXACTLY the
-    /// peer-authored score families (`capacity:*` / `capacity_assurance:*` /
-    /// `moderation:*`); relationship/charter testimony (and trace:*, which is
-    /// E3-gated at fetch, not carved from the refs) is kept.
+    /// CIRISEdge#462 — the G2 carve is persist's authoritative consent-gated-score
+    /// classification (`consent_gated_claim`), NOT an edge prefix list. That is
+    /// EXACTLY the `capacity:*` reputation family (CC 3.4.5): the peer-authored
+    /// score whose landing on the subject's own node is the self-revocation hole.
+    /// `moderation:*` / `slashing:*` are role-gated (not consent-gated) and
+    /// community-cohort — persist deliberately does not gate them, and they follow
+    /// the duty not the identity, so they are NOT carved here; relationship/charter
+    /// testimony and trace:* (E3-gated at fetch) are kept.
     #[test]
-    fn g2_carve_excludes_peer_scores_keeps_testimony() {
+    fn g2_carve_is_persist_consent_gated_score_taxonomy() {
         use FederationDirectoryReplicationBridge as B;
-        for score in [
-            "capacity:core_identity:v1",
-            "capacity_assurance:composite:v1",
-            "moderation:removal:v1",
+        assert!(
+            B::is_consent_gated_score(&att_with_dimension(Some("capacity:core_identity:v1"))),
+            "capacity:* is the consent-gated reputation family — carved (G2)"
+        );
+        // Consuming persist's taxonomy: these are NOT consent-gated scores, so the
+        // pull does not carve them (persist owns this call — edge cannot drift).
+        for kept in [
+            "capacity_assurance:composite:v1", // not the `capacity:` prefix
+            "moderation:removal:v1",           // role-gated, community-cohort
+            "trace:coherence:v1",              // E3-gated at fetch, not here
         ] {
             assert!(
-                B::is_self_nonretainable_score(&att_with_dimension(Some(score))),
-                "{score} is a peer-authored score about the subject — carved (G2)"
+                !B::is_consent_gated_score(&att_with_dimension(Some(kept))),
+                "{kept} is not a consent-gated score — persist does not gate it, so the pull \
+                 does not carve it (role-gated/other families are handled elsewhere)"
             );
         }
         assert!(
-            !B::is_self_nonretainable_score(&att_with_dimension(Some("trace:coherence:v1"))),
-            "trace:* is served (E3-gated at fetch), not carved from the pull refs"
-        );
-        assert!(
-            !B::is_self_nonretainable_score(&att_with_dimension(None)),
+            !B::is_consent_gated_score(&att_with_dimension(None)),
             "a charter/relationship attestation (no dimension) is testimony — kept"
         );
     }
@@ -4500,6 +4508,160 @@ mod tests {
                 .await
                 .is_empty(),
             "an unattributed Pull serves nothing"
+        );
+    }
+
+    /// CIRISEdge#462 — seed `subject`'s `consent:state:granted` for `covers` on
+    /// the `analyze` scope, so a peer-authored `capacity:*` row about `subject`
+    /// clears persist's `check_capacity_consent_admission` gate
+    /// (`resolve_scoped_consent(attester, subject, "analyze") == Granted`). Lets
+    /// the G2 test admit REAL capacity data rather than assert on a synthetic
+    /// struct.
+    async fn seed_analyze_consent(backend: &MemoryBackend, subject: &str, covers: &str) {
+        let id = uuid::Uuid::new_v4().to_string();
+        seed_scoped_attestation(
+            backend,
+            &id,
+            subject,
+            covers,
+            "scores",
+            "federation",
+            serde_json::json!({ "dimension": "consent:state:granted:v1", "scope": ["analyze"] }),
+        )
+        .await;
+    }
+
+    /// CIRISEdge#462 — the G2 carve holds on REAL admitted capacity data and is
+    /// AXIS-SPECIFIC. Modeled as store mutations so the security assumption is
+    /// proven on the real serve path, not just the predicate:
+    ///   MUTATION 1 — a peer-authored `capacity:*` score ABOUT me is carved from
+    ///     the pull (it must NEVER land on the node where I am the sole writer:
+    ///     the G2 self-revocation-hole shape).
+    ///   MUTATION 2 — a `capacity:*` score I AUTHORED about someone else IS
+    ///     recoverable (the carve must not be over-broad and eat my own
+    ///     authorship).
+    #[tokio::test]
+    async fn g2_carve_holds_on_real_capacity_data_and_is_axis_specific() {
+        let subject = "subject-s";
+        let peer = "peer-p";
+        let other = "other-t";
+        let (backend, bridge) = make_bridge(&[subject.to_string()]);
+        for kid in [subject, peer, other] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, "user"),
+                })
+                .await
+                .expect("register key");
+        }
+        // Consents that let the capacity rows admit: S grants P (so P may score
+        // S); T grants S (so S may score T). Both are `scores` attestations that
+        // also ride S's pull axes — so we snapshot the BASELINE after seeding them
+        // and assert only the DELTAS the two capacity mutations produce.
+        seed_analyze_consent(&backend, subject, peer).await;
+        seed_analyze_consent(&backend, other, subject).await;
+        // A benign attestation ABOUT S (data-subject axis).
+        seed_delegates_to(&backend, peer, subject, &serde_json::json!(["infra:serve"])).await;
+
+        let baseline = bridge
+            .subject_holdings(EnvelopeKind::Attestation, subject, Some(subject))
+            .await
+            .len();
+
+        // MUTATION 1 — a peer-authored capacity score ABOUT S. It admits (S
+        // granted P), but the pull must be UNCHANGED: the score is carved.
+        seed_scoped_attestation(
+            &backend,
+            "cap-p-about-s",
+            peer,
+            subject,
+            "scores",
+            "federation",
+            serde_json::json!({ "dimension": "capacity:core_identity:v1" }),
+        )
+        .await;
+        assert_eq!(
+            bridge
+                .subject_holdings(EnvelopeKind::Attestation, subject, Some(subject))
+                .await
+                .len(),
+            baseline,
+            "G2: a peer-authored capacity score ABOUT me is carved — it must not be pullable \
+             onto my own node (the self-revocation-hole shape)"
+        );
+
+        // MUTATION 2 — a capacity score S AUTHORED about T (sender axis). It
+        // admits (T granted S), and the pull MUST gain it: authorship recovery,
+        // the carve is not over-broad.
+        seed_scoped_attestation(
+            &backend,
+            "cap-s-about-t",
+            subject,
+            other,
+            "scores",
+            "federation",
+            serde_json::json!({ "dimension": "capacity:integrity:v1" }),
+        )
+        .await;
+        assert_eq!(
+            bridge
+                .subject_holdings(EnvelopeKind::Attestation, subject, Some(subject))
+                .await
+                .len(),
+            baseline + 1,
+            "axis-specific: a capacity score I AUTHORED (sender axis) is recoverable — the carve \
+             must not eat my own authorship"
+        );
+    }
+
+    /// CIRISEdge#462 — entitlement DISCRIMINATES, it is not deny-all. Two legit
+    /// registered subjects each hold testimony: each pulls its OWN and gets it;
+    /// neither can pull the OTHER's (the impersonation mutation). This is the
+    /// fail-closed gate proving it still serves the rightful subject.
+    #[tokio::test]
+    async fn subject_pull_entitlement_discriminates() {
+        let s = "subject-s";
+        let t = "subject-t";
+        let (backend, bridge) = make_bridge(&[s.to_string(), t.to_string()]);
+        for kid in [s, t, "peer-p"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, "user"),
+                })
+                .await
+                .expect("register key");
+        }
+        // Each subject has one attestation ABOUT it.
+        seed_delegates_to(&backend, "peer-p", s, &serde_json::json!(["infra:serve"])).await;
+        seed_delegates_to(&backend, "peer-p", t, &serde_json::json!(["infra:serve"])).await;
+
+        let s_pulls_s = bridge
+            .subject_holdings(EnvelopeKind::Attestation, s, Some(s))
+            .await;
+        let t_pulls_t = bridge
+            .subject_holdings(EnvelopeKind::Attestation, t, Some(t))
+            .await;
+        assert!(!s_pulls_s.is_empty(), "S pulling S gets S's testimony");
+        assert!(
+            !t_pulls_t.is_empty(),
+            "T pulling T gets T's testimony (not deny-all)"
+        );
+
+        // The impersonation mutation: S authenticated, pulling T's subject — and
+        // vice versa — gets NOTHING. The gate discriminates on the subject.
+        assert!(
+            bridge
+                .subject_holdings(EnvelopeKind::Attestation, t, Some(s))
+                .await
+                .is_empty(),
+            "S must not pull T's testimony (impersonation blocked)"
+        );
+        assert!(
+            bridge
+                .subject_holdings(EnvelopeKind::Attestation, s, Some(t))
+                .await
+                .is_empty(),
+            "T must not pull S's testimony (impersonation blocked)"
         );
     }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1022,12 +1022,15 @@ impl FederationDirectoryReplicationBridge {
                     }
                     let seq = Self::ms_seq(att.asserted_at);
                     if let Some((hash, _)) = content_hash_of(&att) {
-                        push(hash, seq);
+                        if self.pull_ref_is_serveable(&att, subject_key_id).await {
+                            push(hash, seq);
+                        }
                     }
                 }
                 // SENDER axis — records BY the subject (authorship recovery). No
-                // carve: an attestation I authored is mine to recover, even a
-                // `capacity:*` score I asserted about someone else.
+                // G2 carve (an attestation I authored is mine to recover, even a
+                // `capacity:*` score I asserted about someone else) — but the SAME
+                // serve gate, so a ref and its bytes always agree.
                 for att in self
                     .directory
                     .list_attestations_by(subject_key_id)
@@ -1036,7 +1039,9 @@ impl FederationDirectoryReplicationBridge {
                 {
                     let seq = Self::ms_seq(att.asserted_at);
                     if let Some((hash, _)) = content_hash_of(&att) {
-                        push(hash, seq);
+                        if self.pull_ref_is_serveable(&att, subject_key_id).await {
+                            push(hash, seq);
+                        }
                     }
                 }
             }
@@ -1046,6 +1051,43 @@ impl FederationDirectoryReplicationBridge {
             _ => {}
         }
         refs
+    }
+
+    /// CIRISEdge#462 — may this Attestation ref be disclosed to the requester
+    /// (== the subject)? A Pull answers with refs, and a ref discloses the row's
+    /// existence (hash + seq), so a row the requester could not be SERVED must not
+    /// be LISTED — else the Summary is an info-leak and an advertised-then-
+    /// unfetchable #429.
+    ///
+    /// The gate is deliberately NARROWER than the advertise/`fetch_envelope_bytes_for_peer`
+    /// path: it applies the E3 CONFIDENTIALITY gates (the `trace:*` plane pause,
+    /// author quarantine, and the `trace:* → infra:serve` capability check) but
+    /// NOT the #396 producer-advertise-consent bound (`resolve_attestation_recipient`).
+    /// A peer receiving another producer's advertised attestation is #396-gated;
+    /// a SUBJECT pulling its OWN testimony is not — its first-party right to obtain
+    /// the rows it must act on (a conferred duty, a revocation target) overrides a
+    /// producer's choice of advertise-recipients. So `delegates_to`/`trust:confers`
+    /// about the subject serve unconditionally, while a `trace:*` row still
+    /// requires the subject to hold `infra:serve`. `peer == subject` here (enforced
+    /// by [`Self::subject_holdings`]).
+    async fn pull_ref_is_serveable(&self, att: &Attestation, requester: &str) -> bool {
+        let Ok(value) = serde_json::to_value(att) else {
+            return false; // an unserializable row is not disclosed
+        };
+        if Self::attestation_requires_serve(&value) {
+            // `trace:*` — E3 confidentiality. Withheld while the plane is paused,
+            // and served only to a subject that itself holds `infra:serve`.
+            if self.trace_plane_paused().await {
+                return false;
+            }
+            if !self.peer_has_serve_capability(requester).await {
+                return false;
+            }
+        }
+        // A quarantined author's row is withheld on every path.
+        !self
+            .author_quarantine_withholds(&value, &mut HashMap::new(), requester)
+            .await
     }
 
     /// CIRISEdge#462 — the G2 self-revocation-hole carve, resolved by CONSUMING
@@ -4662,6 +4704,58 @@ mod tests {
                 .await
                 .is_empty(),
             "T must not pull S's testimony (impersonation blocked)"
+        );
+    }
+
+    /// CIRISEdge#462 (Codex #463 Finding 2) — a Pull ref must not DISCLOSE a row
+    /// the requester could not be served. A `trace:*` row is E3-confidential
+    /// (`infra:serve` only); a subject WITHOUT that capability must not even learn
+    /// the row exists (its hash + seq) — so it is gated OUT of the Summary, not
+    /// merely withheld at Deliver. A non-trace attestation about the subject (its
+    /// first-party testimony) is served regardless — the pull gate is E3
+    /// confidentiality, NOT the #396 producer-advertise-consent bound.
+    #[tokio::test]
+    async fn subject_pull_gates_trace_refs_it_cannot_serve() {
+        let subject = "subject-s";
+        let (backend, bridge) = make_bridge(&[subject.to_string()]);
+        for kid in [subject, "peer-p"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, "user"),
+                })
+                .await
+                .expect("register key");
+        }
+        // Non-trace testimony ABOUT the subject — served (first-party right; not
+        // #396-gated).
+        seed_delegates_to(
+            &backend,
+            "peer-p",
+            subject,
+            &serde_json::json!(["infra:serve"]),
+        )
+        .await;
+        let before = bridge
+            .subject_holdings(EnvelopeKind::Attestation, subject, Some(subject))
+            .await
+            .len();
+        assert_eq!(
+            before, 1,
+            "the subject's non-trace testimony is served (not gated by the producer's #396 consent)"
+        );
+
+        // A trace:* row about the subject (self-emitted). The subject holds no
+        // infra:serve capability, so the row must NOT appear in the pull refs —
+        // no hash/seq disclosure of a row that Deliver would withhold.
+        seed_trace_attestation(&backend, subject).await;
+        let after = bridge
+            .subject_holdings(EnvelopeKind::Attestation, subject, Some(subject))
+            .await
+            .len();
+        assert_eq!(
+            after, before,
+            "a trace:* row the requester cannot be served is gated OUT of the Pull refs \
+             (E3 confidentiality — no ref info-leak)"
         );
     }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -685,6 +685,37 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         }
     }
 
+    /// CIRISEdge#462 — serve a subject-scoped RECEIVE-axis Pull. Entitlement is
+    /// FAIL-CLOSED: a Pull for subject `S` is answered only to a requester
+    /// authenticated AS `S` (`peer_key_id == Some(S)`). A requester `P ≠ S` — or
+    /// an unattributed one — gets nothing, and it says so. (Owner-delegation, a
+    /// node key pulling for its owner fedID, needs `owner_of` and is a deliberate
+    /// follow-up, not silently permitted here.) The refs themselves come from
+    /// [`Self::subject_holdings_inner`], which hashes the SAME struct the wire
+    /// index keys on and applies the G2 capacity carve.
+    async fn subject_holdings(
+        &self,
+        kind: EnvelopeKind,
+        subject_key_id: &str,
+        peer_key_id: Option<&str>,
+    ) -> Vec<EnvelopeRef> {
+        match peer_key_id {
+            Some(p) if p == subject_key_id => {
+                self.subject_holdings_inner(kind, subject_key_id).await
+            }
+            other => {
+                tracing::warn!(
+                    subject = %subject_key_id,
+                    requester = ?other,
+                    kind = ?kind,
+                    "subject Pull refused: requester is not the subject — serving nothing \
+                     (#462 fail-closed; owner-delegation via owner_of is a follow-up)"
+                );
+                Vec::new()
+            }
+        }
+    }
+
     /// CIRISEdge#379 — recipient-aware fetch: the serve-side twin of the
     /// listing gate, so a peer excluded from the listing cannot obtain a
     /// `trace:*` envelope anyway by Diff/Fetch-ing a hash it learned
@@ -889,6 +920,155 @@ impl FederationDirectoryReplicationBridge {
             }
             EnvelopeKind::LocationProof => self.list_location_proofs().await,
         }
+    }
+
+    /// CIRISEdge#462 — the subject-scoped RECEIVE-axis ref builder (entitlement
+    /// already checked by [`Self::subject_holdings`]). For each replicated kind
+    /// it calls the SAME per-subject persist read `list_signed_records` composes,
+    /// but hashes the returned STRUCT with [`content_hash_of`] — the wire index
+    /// keys on `sha256(to_vec(row))`, whereas `list_signed_records`' `to_value`
+    /// canonical JSON re-orders keys (no serde_json `preserve_order`) and would
+    /// not resolve through the content-hash fetch path. So the refs here are the
+    /// index's own hashes by construction, and the unchanged Diff/Deliver flow
+    /// (re-gated per record by `fetch_envelope_bytes_for_peer`) serves them.
+    /// (CIRISPersist#634 asks for a subject-scoped wire-index read that would
+    /// return these index hashes directly and retire this compose-and-rehash.)
+    ///
+    /// The Attestation plane sweeps BOTH testimonial axes: `list_attestations_for`
+    /// (records ABOUT the subject — the revocation-reachability set, with the G2
+    /// [`Self::is_self_nonretainable_score`] carve) and `list_attestations_by`
+    /// (records BY the subject — authorship recovery, no carve: mine to recover).
+    /// Non-replicated / cohort kinds are not subject-pullable and return empty.
+    async fn subject_holdings_inner(
+        &self,
+        kind: EnvelopeKind,
+        subject_key_id: &str,
+    ) -> Vec<EnvelopeRef> {
+        let mut refs: Vec<EnvelopeRef> = Vec::new();
+        let mut seen: HashSet<[u8; 32]> = HashSet::new();
+        let mut push = |hash: [u8; 32], seq: u64| {
+            if seen.insert(hash) {
+                refs.push(EnvelopeRef {
+                    envelope_hash: hash,
+                    seq,
+                });
+            }
+        };
+        match kind {
+            EnvelopeKind::Key => {
+                if let Ok(Some(record)) = self.directory.lookup_public_key(subject_key_id).await {
+                    let seq = Self::ms_seq(record.valid_from);
+                    if let Some((hash, _)) = content_hash_of(&SignedKeyRecord { record }) {
+                        push(hash, seq);
+                    }
+                }
+            }
+            EnvelopeKind::IdentityOccurrence => {
+                for row in self
+                    .directory
+                    .list_signed_identity_occurrences_for(subject_key_id)
+                    .await
+                    .unwrap_or_default()
+                {
+                    let seq = Self::ms_seq(row.identity_occurrence.asserted_at);
+                    if let Some((hash, _)) = content_hash_of(&row) {
+                        push(hash, seq);
+                    }
+                }
+            }
+            EnvelopeKind::TransportDestination => {
+                for row in self
+                    .directory
+                    .list_signed_transport_destinations_for(subject_key_id)
+                    .await
+                    .unwrap_or_default()
+                {
+                    let td = &row.transport_destination;
+                    let seq = if td.epoch > 0 {
+                        td.epoch
+                    } else {
+                        Self::ms_seq(td.asserted_at)
+                    };
+                    if let Some((hash, _)) = content_hash_of(&row) {
+                        push(hash, seq);
+                    }
+                }
+            }
+            EnvelopeKind::IdentityOccurrenceRevocation => {
+                for row in self
+                    .directory
+                    .list_signed_identity_occurrence_revocations_for(subject_key_id)
+                    .await
+                    .unwrap_or_default()
+                {
+                    let seq = Self::ms_seq(row.identity_occurrence_revocation.revoked_at);
+                    if let Some((hash, _)) = content_hash_of(&row) {
+                        push(hash, seq);
+                    }
+                }
+            }
+            EnvelopeKind::Attestation => {
+                // DATA-SUBJECT axis — records ABOUT the subject (the 84-family
+                // revocation-reachability set), MINUS the G2 self-non-retainable
+                // scores.
+                for att in self
+                    .directory
+                    .list_attestations_for(subject_key_id)
+                    .await
+                    .unwrap_or_default()
+                {
+                    if Self::is_self_nonretainable_score(&att) {
+                        continue;
+                    }
+                    let seq = Self::ms_seq(att.asserted_at);
+                    if let Some((hash, _)) = content_hash_of(&att) {
+                        push(hash, seq);
+                    }
+                }
+                // SENDER axis — records BY the subject (authorship recovery). No
+                // carve: an attestation I authored is mine to recover, even a
+                // `capacity:*` score I asserted about someone else.
+                for att in self
+                    .directory
+                    .list_attestations_by(subject_key_id)
+                    .await
+                    .unwrap_or_default()
+                {
+                    let seq = Self::ms_seq(att.asserted_at);
+                    if let Some((hash, _)) = content_hash_of(&att) {
+                        push(hash, seq);
+                    }
+                }
+            }
+            // Revocation (key-level), the cohort planes (Family/Community/
+            // LocationProof), the membership-revocation planes, and the
+            // operational trio are not subject-scoped-pullable via this axis.
+            _ => {}
+        }
+        refs
+    }
+
+    /// CIRISEdge#462 — the G2 self-revocation-hole carve. A peer-authored SCORE
+    /// about the subject (`capacity:*` / `capacity_assurance:*` / `moderation:*`
+    /// dimension, CC 2.1 — the dimension lives inside `attestation_envelope`) is
+    /// NEVER served on the data-subject Pull axis: landing a score ABOUT me onto
+    /// the node where I am the sole writer conflates read-copy with
+    /// write-authority — the shape that produced the G2 hole. The subject's OWN
+    /// authored scores (the sender axis) are unaffected.
+    ///
+    /// The prefix set is edge-local pending persist's `is_subject_retainable`
+    /// predicate (CIRISPersist#635) that would own this on the authoritative
+    /// namespace taxonomy; it is fail-closed in spirit — an unclassifiable score
+    /// dimension should be *added* here, never pulled onto self by default.
+    fn is_self_nonretainable_score(att: &Attestation) -> bool {
+        att.attestation_envelope
+            .pointer("/dimension")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|d| {
+                d.starts_with("capacity:")
+                    || d.starts_with("capacity_assurance:")
+                    || d.starts_with("moderation:")
+            })
     }
 
     /// The per-kind apply dispatch behind the #425 choke —
@@ -4187,6 +4367,140 @@ mod tests {
             .put_attestation(SignedAttestation { attestation: att })
             .await
             .expect("seed trust-graph attestation");
+    }
+
+    /// CIRISEdge#462 — build a minimal `Attestation` carrying `dimension` inside
+    /// its envelope (CC 2.1), for the pure G2-carve predicate test. All other
+    /// fields are placeholders — only `attestation_envelope/dimension` is read.
+    fn att_with_dimension(dimension: Option<&str>) -> Attestation {
+        let now = Utc::now();
+        Attestation {
+            attestation_id: "t".into(),
+            attesting_key_id: "a".into(),
+            attested_key_id: "s".into(),
+            attestation_type: "scores".into(),
+            weight: None,
+            asserted_at: now,
+            expires_at: None,
+            attestation_envelope: match dimension {
+                Some(d) => serde_json::json!({ "dimension": d }),
+                None => serde_json::json!({}),
+            },
+            original_content_hash: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
+            scrub_key_id: "a".into(),
+            scrub_timestamp: now,
+            pqc_completed_at: None,
+            persist_row_hash: String::new(),
+            subject_key_ids: vec!["s".into()],
+            withdraws_admission_rule: None,
+            additional_scrubs: Vec::new(),
+            cohort_scope: "federation".into(),
+            tier: "federation".into(),
+            promoted_at: None,
+        }
+    }
+
+    /// CIRISEdge#462 — the G2 self-revocation-hole carve is EXACTLY the
+    /// peer-authored score families (`capacity:*` / `capacity_assurance:*` /
+    /// `moderation:*`); relationship/charter testimony (and trace:*, which is
+    /// E3-gated at fetch, not carved from the refs) is kept.
+    #[test]
+    fn g2_carve_excludes_peer_scores_keeps_testimony() {
+        use FederationDirectoryReplicationBridge as B;
+        for score in [
+            "capacity:core_identity:v1",
+            "capacity_assurance:composite:v1",
+            "moderation:removal:v1",
+        ] {
+            assert!(
+                B::is_self_nonretainable_score(&att_with_dimension(Some(score))),
+                "{score} is a peer-authored score about the subject — carved (G2)"
+            );
+        }
+        assert!(
+            !B::is_self_nonretainable_score(&att_with_dimension(Some("trace:coherence:v1"))),
+            "trace:* is served (E3-gated at fetch), not carved from the pull refs"
+        );
+        assert!(
+            !B::is_self_nonretainable_score(&att_with_dimension(None)),
+            "a charter/relationship attestation (no dimension) is testimony — kept"
+        );
+    }
+
+    /// CIRISEdge#462 — the subject-scoped serve reader answers the SUBJECT with
+    /// its testimony across BOTH axes (ABOUT-me via the data-subject axis +
+    /// authored-BY-me via the sender axis), never leaks another subject's rows,
+    /// and serves NOTHING to a requester that is not the subject (fail-closed).
+    #[tokio::test]
+    async fn subject_pull_serves_both_axes_and_fails_closed() {
+        let subject = "eric-moore-v2-portable";
+        let other = "some-other-subject";
+        let (backend, bridge) = make_bridge(&[subject.to_string()]);
+
+        // Every attester AND attested key must exist in federation_keys to seed
+        // a delegates_to attestation.
+        for kid in [subject, other, "peer-attester"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, "user"),
+                })
+                .await
+                .expect("register attester key");
+        }
+
+        // ABOUT the subject — the data-subject axis.
+        seed_delegates_to(
+            &backend,
+            "peer-attester",
+            subject,
+            &serde_json::json!(["infra:serve"]),
+        )
+        .await;
+        // BY the subject about someone else — the sender axis (authorship recovery).
+        seed_delegates_to(
+            &backend,
+            subject,
+            other,
+            &serde_json::json!(["infra:serve"]),
+        )
+        .await;
+        // About a DIFFERENT subject, by a peer — neither of S's axes; must not leak.
+        seed_delegates_to(
+            &backend,
+            "peer-attester",
+            other,
+            &serde_json::json!(["infra:serve"]),
+        )
+        .await;
+
+        let refs = bridge
+            .subject_holdings(EnvelopeKind::Attestation, subject, Some(subject))
+            .await;
+        assert_eq!(
+            refs.len(),
+            2,
+            "subject pull = {{about-me (data-subject), by-me (sender)}}; the other \
+             subject's peer-authored row never leaks"
+        );
+
+        // Fail-closed entitlement: a requester ≠ subject, or an unattributed one,
+        // gets nothing.
+        assert!(
+            bridge
+                .subject_holdings(EnvelopeKind::Attestation, subject, Some("intruder"))
+                .await
+                .is_empty(),
+            "a Pull for S by a requester ≠ S serves nothing (#462 fail-closed)"
+        );
+        assert!(
+            bridge
+                .subject_holdings(EnvelopeKind::Attestation, subject, None)
+                .await
+                .is_empty(),
+            "an unattributed Pull serves nothing"
+        );
     }
 
     /// Seed a producer's `consent:replication:v1` grant carrying a single

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -4503,6 +4503,55 @@ mod tests {
         );
     }
 
+    /// CIRISEdge#462 — the load-bearing hash-match invariant: every ref
+    /// `subject_holdings` emits resolves through the SAME content-hash fetch path
+    /// a `Deliver` uses (`fetch_envelope_bytes` → persist's `signed_wire_index`).
+    /// If the pull's struct-hashing (`content_hash_of` on the `_for`-read struct)
+    /// ever diverged from what the index keys on, this would surface as
+    /// advertised-then-unfetchable and a Pull would deliver nothing. Proven across
+    /// the Key plane (lookup + `SignedKeyRecord` wrap) and the Attestation plane.
+    #[tokio::test]
+    async fn subject_pull_refs_resolve_through_fetch() {
+        let subject = "eric-moore-v2-portable";
+        let (backend, bridge) = make_bridge(&[subject.to_string()]);
+        // Register the subject's key (also the Key-plane row) + a peer attester,
+        // then seed an attestation ABOUT the subject.
+        for kid in [subject, "peer-attester"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, "user"),
+                })
+                .await
+                .expect("register key");
+        }
+        seed_delegates_to(
+            &backend,
+            "peer-attester",
+            subject,
+            &serde_json::json!(["infra:serve"]),
+        )
+        .await;
+
+        for kind in [EnvelopeKind::Key, EnvelopeKind::Attestation] {
+            let refs = bridge.subject_holdings(kind, subject, Some(subject)).await;
+            assert!(
+                !refs.is_empty(),
+                "{kind:?}: a subject Pull must surface at least one ref"
+            );
+            for r in &refs {
+                assert!(
+                    bridge
+                        .fetch_envelope_bytes(kind, &r.envelope_hash)
+                        .await
+                        .is_some(),
+                    "{kind:?}: pull ref {} must resolve through the content-hash fetch path \
+                     (hash-match with the wire index; else advertised-then-unfetchable)",
+                    hex::encode(r.envelope_hash),
+                );
+            }
+        }
+    }
+
     /// Seed a producer's `consent:replication:v1` grant carrying a single
     /// `recipient_capability` restriction over `prefix`, naming `recipient` as
     /// the consented peer — so persist's E7 projection sources a live row from

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -44,7 +44,7 @@ use tokio::sync::Mutex;
 
 use crate::transport::{Transport, TransportError};
 
-use super::protocol::{EnvelopeKind, ProtocolError, ReplicationMessage};
+use super::protocol::{EnvelopeKind, ProtocolError, PullMessage, ReplicationMessage};
 use super::session::{ReplicationOutcome, Session, SessionRole};
 use super::summary::{StalenessSignal, StateApplier, StateProvider};
 
@@ -370,6 +370,25 @@ impl ReplicationCoordinator {
             .map_err(CoordinatorError::from)
     }
 
+    /// CIRISEdge#462 — INITIATE a subject-scoped RECEIVE-axis pull: send this
+    /// coordinator's peer a `Pull{kind, subject_key_id}`. The peer answers with a
+    /// [`super::protocol::SummaryMessage`] of the subject's refs, which arrives on
+    /// this coordinator's inbound channel and is processed by the NORMAL round
+    /// drive loop (`on_summary` → Diff → Deliver → apply) — so this coordinator
+    /// MUST be an [`SessionRole::Initiator`](super::session::SessionRole::Initiator)
+    /// with a live drive loop (the scheduler's periodic round, installed by
+    /// [`super::runtime::ReplicationRuntime::register_initiator_peer`]). Fire-and-
+    /// forget: the testimony converges over the peer's next round, matching the
+    /// anti-entropy model — sending the Pull carries no session state (only the
+    /// reply does), so there is nothing to await here.
+    pub async fn start_pull(&self, subject_key_id: &str) -> Result<(), CoordinatorError> {
+        let pull = ReplicationMessage::Pull(PullMessage {
+            kind: self.kind,
+            subject_key_id: subject_key_id.to_string(),
+        });
+        self.send_message(&pull).await
+    }
+
     /// Try to parse on-wire bytes as a [`ReplicationMessage`].
     /// Returns:
     ///
@@ -521,6 +540,12 @@ mod tests {
         }
         fn fetch_envelope(&self, _kind: EnvelopeKind, h: &[u8; 32]) -> Option<Vec<u8>> {
             self.envelopes.get(h).cloned()
+        }
+        // CIRISEdge#462 — the mock treats its whole state as the pulled subject's
+        // testimony (a real bridge scopes + gates per subject; here we exercise
+        // the coordinator wiring, not the serve gate).
+        fn subject_refs(&self, kind: EnvelopeKind, _subject_key_id: &str) -> Vec<EnvelopeRef> {
+            self.state.refs_for(kind)
         }
     }
 
@@ -772,6 +797,125 @@ mod tests {
         // ready to begin again on the next scheduler tick).
         assert!(!alice_coord.is_round_complete().await);
         assert!(!bob_coord.is_round_complete().await);
+    }
+
+    /// CIRISEdge#462 — the INITIATION drives the full RECEIVE cycle end-to-end: a
+    /// fresh node's `start_pull` → the responder's subject-scoped Summary → the
+    /// requester's Diff → the responder's Deliver → the requester applies the
+    /// subject's testimony. Proves the Pull reuses the ordinary receive path
+    /// (`on_summary`/`on_diff`/`on_deliver`) with an Initiator requester.
+    #[tokio::test]
+    async fn start_pull_drives_the_full_receive_cycle() {
+        let (alice_t, bob_t) = alice_bob_transports();
+        let alice_t = Arc::new(alice_t);
+        let bob_t = Arc::new(bob_t);
+
+        // Alice is a FRESH node: holds nothing, but knows how to admit the two
+        // rows the subject's testimony consists of.
+        let a_provider = Arc::new(StaticProvider {
+            state: LocalState::new(),
+            envelopes: HashMap::new(),
+        });
+        let a_applier = RecordingApplier::with(
+            HashMap::from([(b"env_3".to_vec(), h(3)), (b"env_4".to_vec(), h(4))]),
+            std::collections::HashSet::new(),
+        );
+
+        // Bob HOLDS the subject's testimony (env_3, env_4); its `subject_refs`
+        // returns them (the mock stands in for the bridge's subject_holdings).
+        let mut b_state = LocalState::new();
+        b_state.insert(EnvelopeKind::Key, h(3), 3);
+        b_state.insert(EnvelopeKind::Key, h(4), 4);
+        let b_provider = Arc::new(StaticProvider {
+            state: b_state,
+            envelopes: HashMap::from([(h(3), b"env_3".to_vec()), (h(4), b"env_4".to_vec())]),
+        });
+        let b_applier = RecordingApplier::with(HashMap::new(), std::collections::HashSet::new());
+
+        let alice_coord = ReplicationCoordinator::new(
+            alice_t.clone(),
+            "bob",
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            a_provider,
+            a_applier,
+        );
+        let bob_coord = ReplicationCoordinator::new(
+            bob_t.clone(),
+            "alice",
+            EnvelopeKind::Key,
+            SessionRole::Responder,
+            b_provider,
+            b_applier,
+        );
+
+        // 1. Alice INITIATES the pull — sends bob a subject-scoped Pull.
+        alice_coord.start_pull("subject-xyz").await.unwrap();
+
+        // 2. Bob receives the Pull → answers with a Summary of the subject's refs.
+        let bob_pull = {
+            let mut inbox = bob_t.my_inbox.lock().await;
+            inbox.recv().await.expect("bob recv pull")
+        };
+        let bob_pull = ReplicationCoordinator::parse_inbound_bytes(&bob_pull).unwrap();
+        assert!(
+            matches!(bob_pull, ReplicationMessage::Pull(ref p) if p.subject_key_id == "subject-xyz"),
+            "bob received a subject-scoped Pull"
+        );
+        let bob_summary = match bob_coord.drive_round_step(Some(bob_pull)).await.unwrap() {
+            DriveStep::SendThenWait(ref msgs) => msgs[0].clone(),
+            o => panic!("expected Summary, got {o:?}"),
+        };
+        bob_coord.send_message(&bob_summary).await.unwrap();
+
+        // 3. Alice receives the Summary → wants both (holds nothing) → Diff.
+        let alice_summary = {
+            let mut inbox = alice_t.my_inbox.lock().await;
+            inbox.recv().await.expect("alice recv summary")
+        };
+        let alice_summary = ReplicationCoordinator::parse_inbound_bytes(&alice_summary).unwrap();
+        let alice_diff = match alice_coord
+            .drive_round_step(Some(alice_summary))
+            .await
+            .unwrap()
+        {
+            DriveStep::SendThenWait(ref msgs) => msgs[0].clone(),
+            o => panic!("expected Diff, got {o:?}"),
+        };
+        alice_coord.send_message(&alice_diff).await.unwrap();
+
+        // 4. Bob receives the Diff → Delivers the subject's bytes.
+        let bob_diff = {
+            let mut inbox = bob_t.my_inbox.lock().await;
+            inbox.recv().await.expect("bob recv diff")
+        };
+        let bob_diff = ReplicationCoordinator::parse_inbound_bytes(&bob_diff).unwrap();
+        let bob_deliver = match bob_coord.drive_round_step(Some(bob_diff)).await.unwrap() {
+            DriveStep::SendThenWait(ref msgs) => msgs[0].clone(),
+            o => panic!("expected Deliver, got {o:?}"),
+        };
+        bob_coord.send_message(&bob_deliver).await.unwrap();
+
+        // 5. Alice receives the Deliver → APPLIES the subject's testimony.
+        let alice_deliver = {
+            let mut inbox = alice_t.my_inbox.lock().await;
+            inbox.recv().await.expect("alice recv deliver")
+        };
+        let alice_deliver = ReplicationCoordinator::parse_inbound_bytes(&alice_deliver).unwrap();
+        match alice_coord
+            .drive_round_step(Some(alice_deliver))
+            .await
+            .unwrap()
+        {
+            DriveStep::Complete(report) => {
+                assert_eq!(
+                    report.admitted, 2,
+                    "the fresh node admitted the subject's 2 rows"
+                );
+                assert_eq!(report.refused, 0);
+            }
+            o => panic!("expected Complete(admitted=2), got {o:?}"),
+        }
     }
 
     /// `try_parse_inbound_bytes` returns `Ok(None)` for non-replication

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -103,6 +103,30 @@ pub trait ReplicationDirectory: Send + Sync {
         self.list_envelope_refs(kind).await
     }
 
+    /// CIRISEdge#462 — the RECEIVE-axis SERVE reader: the refs held for `kind`
+    /// where `subject_key_id` is the data-subject (records ABOUT it) or, on the
+    /// Attestation plane, the sender (records BY it — authorship recovery).
+    /// Answers an inbound subject-scoped Pull, reaching the `SelfOwn` plane the
+    /// advertise projection never offers (a fedID pulling its own testimony onto
+    /// a node no peer would ever *advertise* it to).
+    ///
+    /// `peer_key_id` is the AUTHENTICATED requester. The implementation MUST
+    /// serve only a requester entitled to the subject's rows (this cut:
+    /// requester == subject, fail-closed) and MUST withhold peer-authored
+    /// `capacity:*` scores about the subject (the G2 self-revocation-hole carve).
+    /// The refs it returns hash the SAME struct the wire index keys on, so the
+    /// unchanged Diff/Deliver flow — re-gated per record by
+    /// [`Self::fetch_envelope_bytes_for_peer`] — carries the bytes. Defaults to
+    /// empty: only the production bridge answers a subject pull.
+    async fn subject_holdings(
+        &self,
+        _kind: EnvelopeKind,
+        _subject_key_id: &str,
+        _peer_key_id: Option<&str>,
+    ) -> Vec<EnvelopeRef> {
+        Vec::new()
+    }
+
     /// Return the byte-exact signed envelope for `(kind,
     /// envelope_hash)`, or `None` if the envelope isn't in local state.
     /// Called during the `Deliver`-message construction step.
@@ -226,6 +250,23 @@ impl StateProvider for DirectoryStateAdapter {
             tokio::runtime::Handle::current().block_on(async move {
                 inner
                     .fetch_envelope_bytes_for_peer(kind, &hash, peer.as_deref())
+                    .await
+            })
+        })
+    }
+
+    /// CIRISEdge#462 — answer a subject-scoped Pull. Routes to
+    /// [`ReplicationDirectory::subject_holdings`] with the bound `peer_key_id`
+    /// (the authenticated requester) so the impl's entitlement gate (requester ==
+    /// subject) and the G2 capacity carve both apply.
+    fn subject_refs(&self, kind: EnvelopeKind, subject_key_id: &str) -> Vec<EnvelopeRef> {
+        let inner = Arc::clone(&self.inner);
+        let subject = subject_key_id.to_owned();
+        let peer = self.peer_key_id.clone();
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                inner
+                    .subject_holdings(kind, &subject, peer.as_deref())
                     .await
             })
         })

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -337,6 +337,37 @@ pub struct FetchMessage {
     pub want: Vec<[u8; 32]>,
 }
 
+/// CIRISEdge#462 — the RECEIVE axis's discovery request: a subject-scoped
+/// pull. This is the "third channel" [`FetchMessage`] documents but the wire
+/// never had — a node asks a peer "which `kind` records do you hold where I am
+/// the data-subject or the sender?"
+///
+/// It is NOT anti-entropy. The want-set it seeds is scoped to a SUBJECT (my own
+/// testimony / testimony about me), not to a kind's advertised convergence set —
+/// so it reaches the `SelfOwn` plane that `namespace::projection_for` never
+/// advertises. A fedID that just claimed a fresh node can pull its own testimony
+/// (and a moderation duty conferred on it) that no peer would ever *advertise*.
+///
+/// The responder answers with an ordinary [`SummaryMessage`] of the refs it
+/// holds for the subject — projection-gated exactly as its advertise path would
+/// be, with peer-authored `capacity:*` scores about the subject WITHHELD (the G2
+/// self-revocation-hole carve). The existing Summary → Diff → Deliver flow then
+/// carries the bytes unchanged; the responder's per-record serve gate
+/// (`fetch_envelope`) still backs every byte, so a Pull can only surface rows
+/// the requester was already entitled to receive — it widens nothing.
+///
+/// The requester MUST be admitted as `subject_key_id` (or its owner). Like every
+/// other message, a Pull is scoped to ONE `kind` (one Session/round per kind); a
+/// subject sweep issues one Pull per replicated kind.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PullMessage {
+    /// The kind this pull is scoped to.
+    pub kind: EnvelopeKind,
+    /// The fedID whose testimony is requested — `ci_axes.data_subject` (records
+    /// about it) and `ci_axes.sender` (records by it) both resolve to this id.
+    pub subject_key_id: String,
+}
+
 /// "Here are the bytes." Wraps the requested envelopes' raw signed-
 /// bytes form (the same shape `put_*` admits expect on the receiver's
 /// persist side). Order is unspecified; the receiver MUST validate
@@ -360,6 +391,11 @@ pub enum ReplicationMessage {
     Diff(DiffMessage),
     Fetch(FetchMessage),
     Deliver(DeliverMessage),
+    /// CIRISEdge#462 — subject-scoped RECEIVE-axis discovery. A post-v1 verb: v1
+    /// peers serde-refuse the unknown `type` tag (they do NOT silently ignore
+    /// it), so it is a genuine wire-compat event, coordinated by the
+    /// [`crate::replication::serve_policy::SERVE_ADVERTISE_POLICY_HASH`] re-pin.
+    Pull(PullMessage),
 }
 
 impl ReplicationMessage {
@@ -376,6 +412,7 @@ impl ReplicationMessage {
             Self::Diff(m) => m.kind,
             Self::Fetch(m) => m.kind,
             Self::Deliver(m) => m.kind,
+            Self::Pull(m) => m.kind,
         }
     }
 
@@ -471,6 +508,28 @@ mod tests {
         let bytes = m.to_bytes();
         let parsed = ReplicationMessage::from_bytes(&bytes).expect("parse");
         assert_eq!(parsed, m);
+    }
+
+    /// CIRISEdge#462 — the subject-scoped Pull verb round-trips, and its wire
+    /// tag is the snake_case `pull`.
+    #[test]
+    fn pull_round_trips() {
+        let m = ReplicationMessage::Pull(PullMessage {
+            kind: EnvelopeKind::Attestation,
+            subject_key_id: "eric-moore-v2-portable-f34de31d8c21".to_string(),
+        });
+        let bytes = m.to_bytes();
+        let s = std::str::from_utf8(&bytes).unwrap();
+        assert!(s.contains(r#""type":"pull""#), "pull wire tag: {s}");
+        assert!(
+            s.contains("eric-moore-v2-portable-f34de31d8c21"),
+            "subject: {s}"
+        );
+        let parsed = ReplicationMessage::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed, m);
+        // The verb carries its kind so wire-framing picks the version like any
+        // other message.
+        assert_eq!(parsed.kind(), EnvelopeKind::Attestation);
     }
 
     /// Unknown tag refused — wire-stability guarantee.

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -1,6 +1,6 @@
 //! Wire-stable message types for the anti-entropy protocol.
 //!
-//! Four messages, exchanged pairwise between region peers:
+//! Five messages, exchanged pairwise between region peers:
 //!
 //! ```text
 //!  A → B   Summary  { kind, refs: [(envelope_hash, seq)] }
@@ -17,6 +17,15 @@
 //! reference). The [`SummaryMessage`] / [`DiffMessage`] flow is the
 //! steady-state anti-entropy path; [`FetchMessage`] is the on-demand
 //! path.
+//!
+//! A [`PullMessage`] (CIRISEdge#462) is the RECEIVE axis's discovery verb —
+//! "which `kind` records do you hold where I am the data-subject or the sender?"
+//! It is the SUBJECT-scoped "third channel" `FetchMessage` documents: the
+//! responder answers with a [`SummaryMessage`] of the subject's refs and the
+//! ordinary Diff/Deliver flow carries the bytes. Unlike anti-entropy (which can
+//! only ever converge what a peer *advertises*), a Pull reaches the `SelfOwn`
+//! plane no peer advertises — a fedID pulling its own testimony onto a fresh
+//! node. See [`PullMessage`] for the entitlement + G2 carve.
 //!
 //! ## Wire codec
 //!
@@ -205,6 +214,35 @@ impl EnvelopeKind {
             self,
             Self::Key | Self::IdentityOccurrence | Self::TransportDestination
         )
+    }
+
+    /// CIRISEdge#462 — is this kind answerable by a subject-scoped `Pull` (the
+    /// RECEIVE axis)? EXACTLY the five replicated kinds — the persist
+    /// `ReplicatedKind` set the bridge's `subject_holdings` sweeps. This is the
+    /// single source of truth the initiation loop iterates; it MUST agree with
+    /// the `receive` column of
+    /// [`crate::replication::serve_policy::serve_advertise_manifest`] (asserted in
+    /// that module's `only_the_five_replicated_kinds_answer_a_subject_pull`).
+    #[must_use]
+    pub fn is_subject_pullable(self) -> bool {
+        matches!(
+            self,
+            Self::Key
+                | Self::IdentityOccurrence
+                | Self::TransportDestination
+                | Self::IdentityOccurrenceRevocation
+                | Self::Attestation
+        )
+    }
+
+    /// The kinds a subject sweep issues a `Pull` for — the
+    /// [`Self::is_subject_pullable`] set, in `ALL` order.
+    #[must_use]
+    pub fn subject_pullable() -> Vec<EnvelopeKind> {
+        Self::ALL
+            .into_iter()
+            .filter(|k| k.is_subject_pullable())
+            .collect()
     }
 
     /// Stable snake_case wire name for this kind — the manifest/witness key
@@ -530,6 +568,33 @@ mod tests {
         // The verb carries its kind so wire-framing picks the version like any
         // other message.
         assert_eq!(parsed.kind(), EnvelopeKind::Attestation);
+    }
+
+    /// CIRISEdge#462 — `is_subject_pullable` is EXACTLY the five replicated kinds
+    /// (the persist `ReplicatedKind` set), checked over ALL 14 so a new pullable
+    /// kind must be a deliberate edit here. MUST agree with the serve-policy
+    /// `receive` witness.
+    #[test]
+    fn is_subject_pullable_is_exactly_the_five_replicated_kinds() {
+        for kind in EnvelopeKind::ALL {
+            let expected = matches!(
+                kind,
+                EnvelopeKind::Key
+                    | EnvelopeKind::IdentityOccurrence
+                    | EnvelopeKind::TransportDestination
+                    | EnvelopeKind::IdentityOccurrenceRevocation
+                    | EnvelopeKind::Attestation
+            );
+            assert_eq!(
+                kind.is_subject_pullable(),
+                expected,
+                "{kind:?}: pullable iff it is one of the five replicated kinds"
+            );
+        }
+        assert_eq!(EnvelopeKind::subject_pullable().len(), 5);
+        // The key-level Revocation plane is NOT subject-pullable (not a
+        // ReplicatedKind — it rides the persist_row_hash wire, no subject index).
+        assert!(!EnvelopeKind::Revocation.is_subject_pullable());
     }
 
     /// Unknown tag refused — wire-stability guarantee.

--- a/src/replication/registry.rs
+++ b/src/replication/registry.rs
@@ -239,6 +239,9 @@ impl ReplicationRegistry {
             super::protocol::ReplicationMessage::Diff(m) => m.kind,
             super::protocol::ReplicationMessage::Fetch(m) => m.kind,
             super::protocol::ReplicationMessage::Deliver(m) => m.kind,
+            // CIRISEdge#462 — a subject-scoped Pull routes on its kind like every
+            // other verb; the auto-registered Responder below answers it.
+            super::protocol::ReplicationMessage::Pull(m) => m.kind,
         };
         // CIRISEdge#312 — if no coordinator exists for this (peer, kind), this
         // node doesn't consent-pull from the peer (so no Initiator was built),

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -386,6 +386,13 @@ pub enum ReplicationRuntimeError {
     /// calls will keep failing.
     #[error("replication runtime has shut down; peer mutation is no longer accepted")]
     SchedulerStopped,
+    /// CIRISEdge#462 — one or more subject-`Pull` sends failed to reach the peer.
+    /// The scheduled Initiator was still installed (ordinary anti-entropy runs),
+    /// but anti-entropy CANNOT carry the `SelfOwn` plane a Pull recovers, so the
+    /// caller MUST treat the pull as not-dispatched for the named kinds and retry
+    /// — never a silent `Ok`. Carries `"<Kind>: <error>; …"`.
+    #[error("subject Pull dispatch failed: {0}")]
+    PullDispatch(String),
 }
 
 impl From<SchedulerCommandError> for ReplicationRuntimeError {
@@ -679,15 +686,22 @@ impl ReplicationRuntime {
     /// advertise projection never offers the `SelfOwn` plane, and the graph
     /// already holds the answer, just on another node.
     ///
-    /// FIRE-AND-FORGET, matching the anti-entropy model: `register_initiator_peer`
-    /// failing (scheduler stopped) is the only hard error; a transient Pull-send
-    /// failure for one kind is logged, not propagated, because the peer is now a
-    /// scheduled initiator whose next round re-attempts convergence.
+    /// A failed `Pull` send is NOT swallowed. The scheduled Initiator installed
+    /// here runs ordinary anti-entropy, but anti-entropy is advertise-based and
+    /// CANNOT carry the `SelfOwn` plane a Pull recovers — so a dropped Pull would
+    /// silently lose that kind's subject recovery while the caller believed it was
+    /// dispatched. We attempt every kind (so partial progress lands and register
+    /// stays idempotent for a clean retry), then return [`PullDispatch`] naming
+    /// the kinds whose send failed. `register_initiator_peer` failing (scheduler
+    /// stopped) is a hard error that aborts immediately.
+    ///
+    /// [`PullDispatch`]: ReplicationRuntimeError::PullDispatch
     pub async fn pull_subject_testimony(
         &self,
         peer_key_id: &str,
         subject_key_id: &str,
     ) -> Result<(), ReplicationRuntimeError> {
+        let mut failures: Vec<String> = Vec::new();
         for kind in EnvelopeKind::subject_pullable() {
             // Idempotent — installs (or reuses) the scheduled drive loop that
             // consumes the Pull's Summary reply.
@@ -699,13 +713,17 @@ impl ReplicationRuntime {
                         subject = %subject_key_id,
                         kind = ?kind,
                         error = %e,
-                        "subject Pull send failed for this kind — the scheduled round will \
-                         retry convergence (#462 fire-and-forget)"
+                        "subject Pull send failed — surfacing to the caller for retry (#462)"
                     );
+                    failures.push(format!("{kind:?}: {e}"));
                 }
             }
         }
-        Ok(())
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(ReplicationRuntimeError::PullDispatch(failures.join("; ")))
+        }
     }
 
     /// Hot-remove a `(peer_key_id, kind)` peer — CIRISEdge#173,

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -664,6 +664,50 @@ impl ReplicationRuntime {
         Ok(())
     }
 
+    /// CIRISEdge#462 — INITIATE a subject-scoped RECEIVE-axis pull: recover
+    /// `subject_key_id`'s own testimony (and testimony ABOUT it) from
+    /// `peer_key_id`. For each subject-pullable kind (the five replicated planes)
+    /// this ensures a scheduled Initiator coordinator exists — so the reply's
+    /// drive loop is live — then sends a `Pull`. The peer answers with the
+    /// subject's refs (projection-gated + G2-carved by its `subject_holdings`),
+    /// and the node pulls the gap through the ordinary Diff/Deliver flow.
+    ///
+    /// This is the mechanism the observation in #462 needs: a fedID that claimed
+    /// a fresh node cannot otherwise obtain its own keys / occurrences / routes /
+    /// occurrence-revocations, nor the attestations about-or-by it (so a
+    /// moderation duty conferred on it becomes exercisable) — anti-entropy's
+    /// advertise projection never offers the `SelfOwn` plane, and the graph
+    /// already holds the answer, just on another node.
+    ///
+    /// FIRE-AND-FORGET, matching the anti-entropy model: `register_initiator_peer`
+    /// failing (scheduler stopped) is the only hard error; a transient Pull-send
+    /// failure for one kind is logged, not propagated, because the peer is now a
+    /// scheduled initiator whose next round re-attempts convergence.
+    pub async fn pull_subject_testimony(
+        &self,
+        peer_key_id: &str,
+        subject_key_id: &str,
+    ) -> Result<(), ReplicationRuntimeError> {
+        for kind in EnvelopeKind::subject_pullable() {
+            // Idempotent — installs (or reuses) the scheduled drive loop that
+            // consumes the Pull's Summary reply.
+            self.register_initiator_peer(peer_key_id, kind).await?;
+            if let Some(coord) = self.registry.get(peer_key_id, kind).await {
+                if let Err(e) = coord.start_pull(subject_key_id).await {
+                    tracing::warn!(
+                        peer = %peer_key_id,
+                        subject = %subject_key_id,
+                        kind = ?kind,
+                        error = %e,
+                        "subject Pull send failed for this kind — the scheduled round will \
+                         retry convergence (#462 fire-and-forget)"
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Hot-remove a `(peer_key_id, kind)` peer — CIRISEdge#173,
     /// v5.1.0.
     ///

--- a/src/replication/serve_policy.rs
+++ b/src/replication/serve_policy.rs
@@ -60,7 +60,7 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
         | EnvelopeKind::IdentityOccurrenceRevocation => "subject_pull:data_subject; subject-only",
         EnvelopeKind::Attestation => {
             "subject_pull:data_subject+sender; subject-only; \
-             scores carved (G2: capacity:*/capacity_assurance:*/moderation:*)"
+             consent-gated scores carved on data_subject axis (G2: persist consent_gated_claim)"
         }
         EnvelopeKind::Revocation
         | EnvelopeKind::Family
@@ -110,7 +110,7 @@ pub fn serve_advertise_policy_sha256() -> String {
 /// deliberate, reviewed re-pin, visible to CIRISServer which pins it alongside
 /// persist's `REPLICATION_POLICY_HASH`. See CIRISEdge#393 §4.2/§4.3.
 pub const SERVE_ADVERTISE_POLICY_HASH: &str =
-    "0bf4ce1400014288bc298dd2bf598f333e54d08bba8ce6a8d5a485ca38823ff1";
+    "049e71ef208d24266fe366b8eaed365a467cadd3aadd8856c8ed917c90bced33";
 
 #[cfg(test)]
 mod tests {

--- a/src/replication/serve_policy.rs
+++ b/src/replication/serve_policy.rs
@@ -47,7 +47,37 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
             ("bulk_since", "public")
         }
     };
-    serde_json::json!({ "kind": kind.as_wire_str(), "advertise": advertise, "serve": serve })
+    // CIRISEdge#462 — `receive`: whether this kind answers a subject-scoped Pull
+    // (the RECEIVE axis), and under what rule. The FIVE replicated kinds are
+    // subject-pullable, entitlement FAIL-CLOSED to the subject itself; the
+    // Attestation plane sweeps BOTH testimonial axes with the G2 score carve;
+    // every other kind is NOT subject-pullable (`none`). This column is the
+    // coordinated-cut witness CIRISServer pins alongside `serve`.
+    let receive = match kind {
+        EnvelopeKind::Key
+        | EnvelopeKind::IdentityOccurrence
+        | EnvelopeKind::TransportDestination
+        | EnvelopeKind::IdentityOccurrenceRevocation => "subject_pull:data_subject; subject-only",
+        EnvelopeKind::Attestation => {
+            "subject_pull:data_subject+sender; subject-only; \
+             scores carved (G2: capacity:*/capacity_assurance:*/moderation:*)"
+        }
+        EnvelopeKind::Revocation
+        | EnvelopeKind::Family
+        | EnvelopeKind::Community
+        | EnvelopeKind::LocationProof
+        | EnvelopeKind::FamilyMembershipRevocation
+        | EnvelopeKind::CommunityMembershipRevocation
+        | EnvelopeKind::Organization
+        | EnvelopeKind::OrgMembership
+        | EnvelopeKind::PartnerRecord => "none",
+    };
+    serde_json::json!({
+        "kind": kind.as_wire_str(),
+        "advertise": advertise,
+        "serve": serve,
+        "receive": receive,
+    })
 }
 
 /// The canonical serve/advertise policy manifest (mirrors persist's
@@ -56,8 +86,9 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
 #[must_use]
 pub fn serve_advertise_manifest() -> serde_json::Value {
     serde_json::json!({
+        // CIRISEdge#462 — v2 adds the per-kind `receive` (subject-Pull) axis.
         "contract": "replication_serve_advertise_policy",
-        "version": 1,
+        "version": 2,
         "policies": EnvelopeKind::ALL
             .iter()
             .map(|k| policy_for(*k))
@@ -79,7 +110,7 @@ pub fn serve_advertise_policy_sha256() -> String {
 /// deliberate, reviewed re-pin, visible to CIRISServer which pins it alongside
 /// persist's `REPLICATION_POLICY_HASH`. See CIRISEdge#393 §4.2/§4.3.
 pub const SERVE_ADVERTISE_POLICY_HASH: &str =
-    "79f5c63a4e4945995f9beba6f3746c380e0bee3fe805866ebfaff34ac6d7c9ff";
+    "0bf4ce1400014288bc298dd2bf598f333e54d08bba8ce6a8d5a485ca38823ff1";
 
 #[cfg(test)]
 mod tests {
@@ -94,6 +125,39 @@ mod tests {
              trace:* serve gate), then re-pin deliberately (CIRISEdge#393 §4.2). \
              CIRISServer pins this alongside persist's REPLICATION_POLICY_HASH.",
         );
+    }
+
+    /// CIRISEdge#462 — the RECEIVE axis witness: EXACTLY the five replicated
+    /// kinds answer a subject Pull (`subject_pull:*`), every other kind is `none`,
+    /// and the Attestation plane is the one that names both axes + the G2 carve.
+    #[test]
+    fn only_the_five_replicated_kinds_answer_a_subject_pull() {
+        let manifest = serve_advertise_manifest();
+        let policies = manifest["policies"].as_array().unwrap();
+        let pullable: Vec<&str> = policies
+            .iter()
+            .filter(|p| p["receive"].as_str().unwrap().starts_with("subject_pull"))
+            .map(|p| p["kind"].as_str().unwrap())
+            .collect();
+        assert_eq!(
+            pullable,
+            vec![
+                "key",
+                "attestation",
+                "identity_occurrence",
+                "identity_occurrence_revocation",
+                "transport_destination",
+            ],
+            "exactly the five replicated kinds are subject-pullable (RECEIVE axis)"
+        );
+        // The Attestation plane is the one that sweeps both axes + carves scores.
+        let att = policies
+            .iter()
+            .find(|p| p["kind"] == "attestation")
+            .unwrap();
+        let recv = att["receive"].as_str().unwrap();
+        assert!(recv.contains("data_subject+sender"), "both axes: {recv}");
+        assert!(recv.contains("G2"), "the score carve is witnessed: {recv}");
     }
 
     /// The load-bearing E3 fact must hold in the manifest: exactly ONE kind is

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -36,8 +36,8 @@
 //! Delivers have been applied.
 
 use super::protocol::{
-    DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, ReplicationMessage,
-    SummaryMessage,
+    DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, PullMessage,
+    ReplicationMessage, SummaryMessage,
 };
 use super::summary::{diff_refs, ApplyOutcome, StalenessSignal, StateApplier, StateProvider};
 
@@ -366,7 +366,39 @@ impl Session {
             ReplicationMessage::Diff(diff) => self.on_diff(&diff, provider, source_peer),
             ReplicationMessage::Deliver(deliver) => self.on_deliver(&deliver, applier, source_peer),
             ReplicationMessage::Fetch(fetch) => self.on_fetch(&fetch, provider, source_peer),
+            ReplicationMessage::Pull(pull) => self.on_pull(&pull, provider),
         }
+    }
+
+    /// CIRISEdge#462 — serve a subject-scoped RECEIVE-axis pull. The requester
+    /// asked "which `kind` records do you hold where `subject_key_id` is the
+    /// data-subject or sender?" We answer with an ordinary [`SummaryMessage`] of
+    /// the refs we hold for that subject — sourced from
+    /// [`StateProvider::subject_refs`], which is projection-gated and withholds
+    /// the `capacity:*` scores about the subject (the G2 carve). From here the
+    /// EXISTING flow takes over unchanged: the requester's `on_summary` computes
+    /// `want = subject_refs ∖ its own holdings`, sends a Diff, and our `on_diff`
+    /// serves the bytes through `fetch_envelope` — which RE-APPLIES the full
+    /// per-record serve gate, so the Pull widens nothing.
+    ///
+    /// Reusing Summary here is deliberate: the want-generator the receive axis
+    /// needs (`remote ∖ holdings`) is *exactly* what `on_summary` already is; the
+    /// Pull's only job is to seed that machinery with a SUBJECT-scoped ref set
+    /// instead of the advertise set the `SelfOwn` plane never produces.
+    fn on_pull(&mut self, pull: &PullMessage, provider: &dyn StateProvider) -> ReplicationOutcome {
+        if pull.kind != self.kind {
+            return ReplicationOutcome::UnexpectedMessage;
+        }
+        let refs = provider.subject_refs(self.kind, &pull.subject_key_id);
+        let summary = SummaryMessage {
+            kind: self.kind,
+            refs,
+        };
+        // Record what we offered so a subsequent Diff for these refs is served
+        // (the responder path reads `last_summary_sent` conceptually via
+        // `fetch_envelope`; recording it keeps staleness telemetry honest).
+        self.last_summary_sent = Some(summary.clone());
+        ReplicationOutcome::Send(vec![ReplicationMessage::Summary(summary)])
     }
 
     fn on_summary(

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -119,10 +119,11 @@ pub trait StateProvider: Send + Sync {
     ///
     /// The impl MUST apply the SAME per-record projection gate its advertise path
     /// applies (a Pull can only surface a row the responder would already serve),
-    /// and MUST withhold peer-authored `capacity:*` / `capacity_assurance:*` /
-    /// `moderation:*` scores about the subject (the G2 self-revocation-hole carve:
-    /// a subject pulling a score *about* itself onto the node where it is the sole
-    /// writer conflates read-copy with write-authority). Refs only — the existing
+    /// and MUST withhold the consent-gated peer-authored scores about the subject
+    /// that persist's `consent_gated_claim` classifies (the `capacity:*` family —
+    /// the G2 self-revocation-hole carve: a subject pulling a score *about* itself
+    /// onto the node where it is the sole writer conflates read-copy with
+    /// write-authority). Refs only — the existing
     /// Diff/Deliver flow carries the bytes, re-gated by [`Self::fetch_envelope`].
     ///
     /// Defaults to empty: only the production `DirectoryStateAdapter` (which holds

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -108,6 +108,30 @@ pub trait StateProvider: Send + Sync {
     /// hash, or `None` if the envelope isn't in local state. Called
     /// during the Deliver-message construction step.
     fn fetch_envelope(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> Option<Vec<u8>>;
+
+    /// CIRISEdge#462 — the RECEIVE-axis SERVE reader: the refs this node holds
+    /// for `kind` where `subject_key_id` is the data-subject (`list_signed_records`)
+    /// or, for the Attestation plane, the sender (`list_attestations_by` — the
+    /// subject's own authored testimony, for recovery). Answers an inbound
+    /// [`crate::replication::protocol::PullMessage`]: unlike [`Self::local_refs`]
+    /// (the whole advertised set) this is SUBJECT-scoped, so it reaches the
+    /// `SelfOwn` plane the advertise projection never offers.
+    ///
+    /// The impl MUST apply the SAME per-record projection gate its advertise path
+    /// applies (a Pull can only surface a row the responder would already serve),
+    /// and MUST withhold peer-authored `capacity:*` / `capacity_assurance:*` /
+    /// `moderation:*` scores about the subject (the G2 self-revocation-hole carve:
+    /// a subject pulling a score *about* itself onto the node where it is the sole
+    /// writer conflates read-copy with write-authority). Refs only — the existing
+    /// Diff/Deliver flow carries the bytes, re-gated by [`Self::fetch_envelope`].
+    ///
+    /// Defaults to empty: only the production `DirectoryStateAdapter` (which holds
+    /// the persist `FederationDirectory`) can answer a subject pull. Test/in-memory
+    /// providers that don't override it simply return no refs — a Pull to them is
+    /// a well-formed no-op, never a panic.
+    fn subject_refs(&self, _kind: EnvelopeKind, _subject_key_id: &str) -> Vec<EnvelopeRef> {
+        Vec::new()
+    }
 }
 
 /// CIRISEdge#425 — the typed result of applying ONE delivered envelope.


### PR DESCRIPTION
Closes the **RECEIVE axis** gap (#462): edge had `advertise` (serve out) and `retain` (keep) but no `receive` (what I ask for). The want-set was only ever `remote ∖ holdings`, so a node could learn only what a peer chose to *advertise* — and `namespace::projection_for` never advertises the `SelfOwn` plane. A fedID that claimed a fresh node therefore could not pull its own testimony (keys, occurrences, routes, occurrence-revocations, attestations about-or-by it), nor a moderation duty conferred on it, even though the graph already holds them elsewhere.

## The design: a fifth verb that reuses the whole receive path
`Pull{kind, subject_key_id}` → the responder answers with an ordinary `Summary` of the subject's refs → the requester's existing `on_summary → Diff → Deliver → apply` carries it. The want-generator the receive axis needs (`remote ∖ holdings`) is *exactly* what `on_summary` already is, so the only new code is the request verb, the responder's `on_pull`, a `subject_holdings` serve reader, and the initiation.

**Not anti-entropy** — the want-set is SUBJECT-scoped, reaching the `SelfOwn` plane no peer advertises. This is the "third channel" `FetchMessage` already documents.

## What's here
- **Verb + serve** — `ReplicationMessage::Pull` (post-v1; v1 peers cleanly refuse the unknown tag). Bridge `subject_holdings` sweeps both testimonial axes (`list_attestations_for` about-me + `list_attestations_by` by-me), hashing the same struct the wire index keys on (not `list_signed_records`' `to_value`, which re-orders keys without `preserve_order` and wouldn't resolve through fetch).
- **Initiation (full chain)** — `coordinator.start_pull` → `runtime.pull_subject_testimony` → pyo3 FFI `pull_subject_testimony(peer, subject)`. Fire-and-forget on a scheduled Initiator; the reply converges through the scheduler's round loop (no second drive loop, no race).
- **Serve-policy witness** — a `receive` column (manifest v2) makes the new axis a policy CIRISServer pins; `SERVE_ADVERTISE_POLICY_HASH` re-pinned, so **landing this reds the server's pin conformance until it re-pins — the cut is coordinated by construction.**

## Security
- **Fail-closed entitlement** — a subject's rows serve ONLY to a requester authenticated AS that subject (owner-delegation via `owner_of` is a follow-up). Every byte is re-gated by the per-record serve gate, so a Pull widens nothing.
- **G2 self-revocation-hole carve** — consent-gated peer-authored scores about the subject (persist `admission::consent_gated_claim` — the `capacity:*` reputation family) are withheld on the data-subject axis. **This consumes persist's authoritative CEG taxonomy rather than an edge prefix list** (CEG state resolution is persist's; edge consumes it), so it tracks the closed `ConsentGatedFamily` enum and cannot drift. The subject's own authored scores (sender axis) are recoverable.

Security assumptions are modeled as **store mutations on real admitted data**, not happy paths:
- `g2_carve_holds_on_real_capacity_data_and_is_axis_specific` — seeds the analyze consent so REAL capacity rows admit, then verifies a peer score ABOUT me is carved (pull unchanged) while a score I AUTHORED is recovered (+1).
- `subject_pull_entitlement_discriminates` — two legit subjects; each pulls its own, neither can pull the other's (impersonation blocked, not deny-all).
- `start_pull_drives_the_full_receive_cycle` — fresh node `start_pull` → apply, `admitted=2`.
- `subject_pull_refs_resolve_through_fetch` — the hash-match invariant (every pull ref resolves through the same fetch path a Deliver uses).

## Verification
Full replication suite 176/0, `clippy --all-targets -D warnings` clean across `{transport-http, transport-reticulum, pyo3, lxmf}`, `field_conformance` 5/5, superset compile green. v15.22.0 (minor — wire addition). FSD §3.4.1 documents the verb.

## Cross-repo
- **CIRISServer** must re-pin `SERVE_ADVERTISE_POLICY_HASH` (`049e71ef…`) — the coordinated cut. No dependency filed on the server (edge is substrate; the server rides it).
- **CIRISPersist#634** — a subject-scoped wire-index ref read would retire the compose-and-rehash (non-blocking).
- **CIRISPersist#635** — persist already exposes `consent_gated_claim` (adopted here); open question is whether the pull carve should also cover the role-gated abuse-response families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYwLkbRHuxZCZKUkGw8iEK
