### PR TITLE
feat(v15.23.0): adopt persist v30.12.0 — G2 carve → is_subject_retainable allowlist (#635)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "15.22.0"
+version = "15.23.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.11.0", version = "30", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.12.0", version = "30", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1216,7 +1216,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.11.0", version = "30", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.12.0", version = "30", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.22.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.22.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.22.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.22.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.22.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.22.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.22.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.23.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.23.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.23.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.23.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.23.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.23.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.23.0

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -936,7 +936,7 @@ impl FederationDirectoryReplicationBridge {
     ///
     /// The Attestation plane sweeps BOTH testimonial axes: `list_attestations_for`
     /// (records ABOUT the subject — the revocation-reachability set, with the G2
-    /// [`Self::is_consent_gated_score`] carve) and `list_attestations_by`
+    /// [`Self::is_non_retainable_score`] carve) and `list_attestations_by`
     /// (records BY the subject — authorship recovery, no carve: mine to recover).
     /// Non-replicated / cohort kinds are not subject-pullable and return empty.
     async fn subject_holdings_inner(
@@ -1017,7 +1017,7 @@ impl FederationDirectoryReplicationBridge {
                     .await
                     .unwrap_or_default()
                 {
-                    if Self::is_consent_gated_score(&att) {
+                    if Self::is_non_retainable_score(&att) {
                         continue;
                     }
                     let seq = Self::ms_seq(att.asserted_at);
@@ -1091,27 +1091,33 @@ impl FederationDirectoryReplicationBridge {
     }
 
     /// CIRISEdge#462 — the G2 self-revocation-hole carve, resolved by CONSUMING
-    /// persist's authoritative CEG taxonomy rather than an edge prefix list: an
-    /// attestation whose dimension is a consent-gated peer-authored SCORE (persist
-    /// [`consent_gated_claim`](ciris_persist::federation::admission::consent_gated_claim)
-    /// — the `capacity:*` reputation family, CC 3.4.5 / AV-79) is NEVER served on
-    /// the data-subject Pull axis. Landing a score ABOUT me onto the node where I
-    /// am the sole writer conflates read-copy with write-authority — the shape
-    /// that produced the G2 hole. The subject's OWN authored scores (the sender
-    /// axis) are unaffected: `consent_gated_claim` classifies by dimension and
-    /// edge consults it ONLY on the data-subject axis.
+    /// persist's authoritative retainability ALLOWLIST (CIRISPersist#635,
+    /// [`is_subject_retainable`](ciris_persist::federation::namespace::is_subject_retainable)):
+    /// a data-subject-axis attestation whose DIMENSION is a score is withheld
+    /// UNLESS persist affirms the subject is necessarily its author (`emit_authority`
+    /// — trace:*, transport:{kind}, the substrate self-reports, …). Landing a score
+    /// ABOUT me onto the node where I am the sole writer is safe only when I am its
+    /// author; otherwise it conflates read-copy with write-authority (the G2 hole).
     ///
-    /// Deliberately persist's decision, not an edge prefix list — the gated set is
-    /// CEG state resolution persist owns (the closed `ConsentGatedFamily` enum
-    /// grows there), so edge tracks new consent-gated score families for free and
-    /// cannot drift. This matches the issue's exact scope (`capacity:*`);
-    /// `moderation:*` / `slashing:*` are role-gated, NOT consent-gated, and are
-    /// community-cohort — they follow the duty, not the individual identity, so
-    /// they do not ride the data-subject axis. CIRISPersist#635 tracks the open
-    /// question of whether the pull carve should ALSO cover the role-gated
-    /// abuse-response families.
-    fn is_consent_gated_score(att: &Attestation) -> bool {
-        ciris_persist::federation::admission::consent_gated_claim(att).is_some()
+    /// This REPLACES the earlier `consent_gated_claim` (capacity-only) carve, which
+    /// UNDER-carved: it withheld only the consent-gated family and let every other
+    /// peer-authored score through. `is_subject_retainable` is an allowlist, so it
+    /// is FAIL-CLOSED — an unknown / new / renamed scored family reads
+    /// non-retainable and is carved, not silently pulled. (Consequence per #635: a
+    /// family edge legitimately needs to pull that is missing from the allowlist
+    /// shrinks the pull SILENTLY; that is a persist ask — tell them to add it, do
+    /// not assume persist knows.)
+    ///
+    /// DIMENSIONLESS attestations carry no score and are NOT carved: a `delegates_to`
+    /// conferral (the moderation-duty shape #462 exists to recover) is signed by the
+    /// conferring authority — the subject cannot forge it, so a retained copy grants
+    /// no write authority. The subject's OWN authored scores (the sender axis) are
+    /// likewise untouched — a score I authored is mine to recover.
+    fn is_non_retainable_score(att: &Attestation) -> bool {
+        att.attestation_envelope
+            .pointer("/dimension")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|dim| !ciris_persist::federation::namespace::is_subject_retainable(dim))
     }
 
     /// The per-kind apply dispatch behind the #425 choke —
@@ -4445,37 +4451,39 @@ mod tests {
         }
     }
 
-    /// CIRISEdge#462 — the G2 carve is persist's authoritative consent-gated-score
-    /// classification (`consent_gated_claim`), NOT an edge prefix list. That is
-    /// EXACTLY the `capacity:*` reputation family (CC 3.4.5): the peer-authored
-    /// score whose landing on the subject's own node is the self-revocation hole.
-    /// `moderation:*` / `slashing:*` are role-gated (not consent-gated) and
-    /// community-cohort — persist deliberately does not gate them, and they follow
-    /// the duty not the identity, so they are NOT carved here; relationship/charter
-    /// testimony and trace:* (E3-gated at fetch) are kept.
+    /// CIRISEdge#462 — the G2 carve is persist's authoritative retainability
+    /// ALLOWLIST (`is_subject_retainable`, CIRISPersist#635), keyed on authorship.
+    /// A scored dimension is carved UNLESS persist affirms the subject is its
+    /// author. This is FAIL-CLOSED: unlike the earlier capacity-only carve, ANY
+    /// peer-authored score — capacity, capacity_assurance, moderation, or an
+    /// unknown/new family — is withheld. Self-authored scores (trace:*) and
+    /// dimensionless conferrals (delegates_to) are kept.
     #[test]
-    fn g2_carve_is_persist_consent_gated_score_taxonomy() {
+    fn g2_carve_is_persist_retainability_allowlist() {
         use FederationDirectoryReplicationBridge as B;
-        assert!(
-            B::is_consent_gated_score(&att_with_dimension(Some("capacity:core_identity:v1"))),
-            "capacity:* is the consent-gated reputation family — carved (G2)"
-        );
-        // Consuming persist's taxonomy: these are NOT consent-gated scores, so the
-        // pull does not carve them (persist owns this call — edge cannot drift).
-        for kept in [
-            "capacity_assurance:composite:v1", // not the `capacity:` prefix
-            "moderation:removal:v1",           // role-gated, community-cohort
-            "trace:coherence:v1",              // E3-gated at fetch, not here
+        // Peer-authored scores about the subject — ALL carved (fail-closed
+        // allowlist), including families the old capacity-only carve missed.
+        for carved in [
+            "capacity:core_identity:v1",       // the canonical G2 reputation score
+            "capacity_assurance:composite:v1", // the old carve LET THIS THROUGH
+            "moderation:removal:v1",           // ditto — now correctly carved
+            "some_future:score:v9",            // unknown family → fail-closed → carved
         ] {
             assert!(
-                !B::is_consent_gated_score(&att_with_dimension(Some(kept))),
-                "{kept} is not a consent-gated score — persist does not gate it, so the pull \
-                 does not carve it (role-gated/other families are handled elsewhere)"
+                B::is_non_retainable_score(&att_with_dimension(Some(carved))),
+                "{carved} is not in persist's retainable allowlist — carved (G2, fail-closed)"
             );
         }
+        // Self-authored (allowlisted) scores are kept here (trace:* is separately
+        // E3-gated at fetch); a dimensionless conferral (delegates_to — the
+        // moderation-duty shape) is never a score, so it is kept.
         assert!(
-            !B::is_consent_gated_score(&att_with_dimension(None)),
-            "a charter/relationship attestation (no dimension) is testimony — kept"
+            !B::is_non_retainable_score(&att_with_dimension(Some("trace:coherence:v1"))),
+            "trace:* is self-emission-mandatory (retainable); kept here, E3-gated at fetch"
+        );
+        assert!(
+            !B::is_non_retainable_score(&att_with_dimension(None)),
+            "a dimensionless conferral (delegates_to) carries no score — kept (unforgeable)"
         );
     }
 


### PR DESCRIPTION
Re-pin v30.11.0 → v30.12.0 + adopt **CIRISPersist#635**. The #462 receive-axis G2 carve now consumes persist's authoritative retainability **allowlist** (`is_subject_retainable`) instead of the capacity-only `consent_gated_claim`.

## What changed
```
carve(att) = att has a /dimension  AND  !is_subject_retainable(dimension)
```
**Stricter + fail-closed**, fixing a real under-carve: the old carve withheld only `capacity:*` and let every *other* peer-authored score through (capacity_assurance, moderation, any new/unknown family). The allowlist is keyed on **authorship** (`emit_authority`) — a score about me is retainable only when I'm necessarily its author (trace:*, transport:{kind}, substrate self-reports). Unknown family → non-retainable → carved.

## #462's purpose preserved
Dimensionless attestations are never carved — a `delegates_to` conferral (the moderation-duty shape, an attestation *type* on the `trust:confers:v1` plane, no envelope dimension) is signed by the conferring authority and unforgeable by the subject, so a retained copy grants no write authority. The delegates_to-based pull tests confirm conferral recovery is intact.

## Not adopted here (deliberate)
- **#634 `wire_refs_for_subject`**: relocates the byte-exactness guarantee into persist (its 3-backend witness caught a real postgres TIMESTAMPTZ skew) but doesn't change edge's skew profile — the actual local-mint Key fix is the open **#640**. Edge's compose-and-rehash unchanged pending #640.
- **#639 bench ciriscache removal**: separate CI change (follow-up), pairs with the #464/#465 runner cut.

## Per #635's caveat
A family edge legitimately needs to pull that's missing from the allowlist shrinks the pull **silently** (fail-closed) — flagging the residual question to persist rather than assuming.

field_conformance 5/5, replication suite 177/0, clippy -D warnings clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYwLkbRHuxZCZKUkGw8iEK