### PR TITLE
feat(v16.0.0): adopt persist v31.0.0 + verify v13.1.0 — the subject-binding mesh reset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "15.22.0"
+version = "16.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.11.0", version = "30", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.0.0", version = "31", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.11
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.0.0", version = "13", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.0.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.1.0", version = "13", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.1.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.0.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.0.0", version = "13" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.1.0", version = "13" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1216,7 +1216,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v30.11.0", version = "30", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.0.0", version = "31", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v15.22.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.22.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v15.22.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v15.22.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v15.22.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.22.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v15.22.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.0.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.0.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.0.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ classifiers = [
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
 dependencies = [
-    "ciris-persist>=30.3.0,<31",
+    "ciris-persist>=31,<32",
 ]
 dynamic = ["version"]
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -7475,16 +7475,25 @@ mod delegation_gate_tests {
     /// v6.5.0 `self_at_login` shape: scope as JSON array.
     #[allow(clippy::similar_names)] // granter/grantee mirrors persist's column names
     fn delegates_to_row(granter: &str, grantee: &str, scope: &[&str]) -> Attestation {
-        let now = Utc::now();
-        let envelope = serde_json::json!({
+        // v31.0.0 (CIRISPersist#598): µs-truncate the instant so the signed
+        // `asserted_at` and its typed column agree at postgres resolution.
+        let now =
+            ciris_persist::federation::admission::truncate_to_substrate_resolution(Utc::now());
+        let mut envelope = serde_json::json!({
             "kind": "delegates_to",
             "dimension": "self:delegates_to:agent_occurrence:v1",
             "agent_occurrence_key_id": grantee,
             "bilateral_pair_id": format!("pair-{granter}-{grantee}"),
             "scope": scope,
         });
-        let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(granter, &envelope);
-        Attestation {
+        // #598: bind the signed `asserted_at` into the envelope BEFORE signing.
+        if let Some(obj) = envelope.as_object_mut() {
+            obj.insert(
+                "asserted_at".to_owned(),
+                serde_json::json!(now.to_rfc3339()),
+            );
+        }
+        let mut att = Attestation {
             attestation_id: format!("att-{granter}-{grantee}"),
             attesting_key_id: granter.into(),
             attested_key_id: grantee.into(),
@@ -7493,9 +7502,9 @@ mod delegation_gate_tests {
             asserted_at: now,
             expires_at: None,
             attestation_envelope: envelope,
-            original_content_hash: hash,
-            scrub_signature_classical: ed_sig,
-            scrub_signature_pqc: pqc_sig,
+            original_content_hash: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
             scrub_key_id: granter.into(),
             scrub_timestamp: now,
             pqc_completed_at: None,
@@ -7506,18 +7515,36 @@ mod delegation_gate_tests {
             cohort_scope: "federation".into(),
             tier: "federation".into(),
             promoted_at: None,
-        }
+        };
+        // #643: stamp the `row` mirror of the typed columns into the envelope
+        // AFTER the struct fields are set, BEFORE we canonicalize/sign.
+        ciris_persist::federation::envelope::RowMirror::stamp_row(&mut att)
+            .expect("stamp v31 row mirror");
+        let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(granter, &att.attestation_envelope);
+        att.original_content_hash = hash;
+        att.scrub_signature_classical = ed_sig;
+        att.scrub_signature_pqc = pqc_sig;
+        att
     }
 
     fn withdraws_row(granter: &str, target: &str) -> Attestation {
-        let now = Utc::now();
-        let envelope = serde_json::json!({
+        // v31.0.0 (CIRISPersist#598): µs-truncate so the signed `asserted_at`
+        // and its typed column agree at postgres resolution.
+        let now =
+            ciris_persist::federation::admission::truncate_to_substrate_resolution(Utc::now());
+        let mut envelope = serde_json::json!({
             "kind": "withdraws",
             "dimension": "withdraws:self:delegates_to:agent_occurrence:v1",
             "target_attestation_id": format!("att-{granter}-{target}"),
         });
-        let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(granter, &envelope);
-        Attestation {
+        // #598: bind the signed `asserted_at` into the envelope BEFORE signing.
+        if let Some(obj) = envelope.as_object_mut() {
+            obj.insert(
+                "asserted_at".to_owned(),
+                serde_json::json!(now.to_rfc3339()),
+            );
+        }
+        let mut att = Attestation {
             attestation_id: format!("withdraws-{granter}-{target}"),
             attesting_key_id: granter.into(),
             attested_key_id: target.into(),
@@ -7526,9 +7553,9 @@ mod delegation_gate_tests {
             asserted_at: now,
             expires_at: None,
             attestation_envelope: envelope,
-            original_content_hash: hash,
-            scrub_signature_classical: ed_sig,
-            scrub_signature_pqc: pqc_sig,
+            original_content_hash: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
             scrub_key_id: granter.into(),
             scrub_timestamp: now,
             pqc_completed_at: None,
@@ -7539,7 +7566,16 @@ mod delegation_gate_tests {
             cohort_scope: "federation".into(),
             tier: "federation".into(),
             promoted_at: None,
-        }
+        };
+        // #643: stamp the `row` mirror of the typed columns into the envelope
+        // AFTER the struct fields are set, BEFORE we canonicalize/sign.
+        ciris_persist::federation::envelope::RowMirror::stamp_row(&mut att)
+            .expect("stamp v31 row mirror");
+        let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(granter, &att.attestation_envelope);
+        att.original_content_hash = hash;
+        att.scrub_signature_classical = ed_sig;
+        att.scrub_signature_pqc = pqc_sig;
+        att
     }
 
     async fn seed_keys(backend: &Arc<MemoryBackend>, keys: &[(&str, &str)]) {

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1136,14 +1136,18 @@ impl FederationDirectoryReplicationBridge {
         // which is NOT in persist's retainable allowlist. Gating on the dimension
         // alone would carve that delegation OUT of the pull the receive axis exists
         // to recover (Codex on #470).
+        //
+        // FAIL-CLOSED on the scores axis: a scores row is carved UNLESS it carries a
+        // dimension that is EXPLICITLY retainable. A scores row with an absent or
+        // non-string `/dimension` (legacy / malformed) is therefore carved, not
+        // served — the earlier `!is_subject_retainable(dim)` form fell OPEN on a
+        // missing dimension, reopening G2 for that input (Codex on #470, round 2).
         att.attestation_type == ciris_persist::federation::types::attestation_type::SCORES
-            && att
+            && !att
                 .attestation_envelope
                 .pointer("/dimension")
                 .and_then(serde_json::Value::as_str)
-                .is_some_and(|dim| {
-                    !ciris_persist::federation::namespace::is_subject_retainable(dim)
-                })
+                .is_some_and(ciris_persist::federation::namespace::is_subject_retainable)
     }
 
     /// The per-kind apply dispatch behind the #425 choke —
@@ -4589,15 +4593,17 @@ mod tests {
             );
         }
         // Self-authored (allowlisted) scores are kept here (trace:* is separately
-        // E3-gated at fetch); a dimensionless conferral (delegates_to — the
-        // moderation-duty shape) is never a score, so it is kept.
+        // E3-gated at fetch).
         assert!(
             !B::is_non_retainable_score(&att_with_dimension(Some("trace:coherence:v1"))),
             "trace:* is self-emission-mandatory (retainable); kept here, E3-gated at fetch"
         );
+        // FAIL-CLOSED: a SCORES row with NO dimension is carved, not served — a
+        // missing/malformed dimension must never fall open on the data-subject axis
+        // (Codex on #470 round 2). `att_with_dimension` builds attestation_type=scores.
         assert!(
-            !B::is_non_retainable_score(&att_with_dimension(None)),
-            "a dimensionless conferral (delegates_to) carries no score — kept (unforgeable)"
+            B::is_non_retainable_score(&att_with_dimension(None)),
+            "a scores row with no dimension is carved (fail-closed); it is NOT a conferral"
         );
     }
 
@@ -4621,6 +4627,14 @@ mod tests {
         assert!(
             B::is_non_retainable_score(&att_with_dimension(Some(dim))),
             "the same non-retainable dimension on a scores-type row is still carved (fail-closed)"
+        );
+        // A DIMENSIONLESS conferral is kept by TYPE — NOT because it lacks a
+        // dimension (a dimensionless SCORES row is carved, fail-closed).
+        let mut dimensionless_conferral = att_with_dimension(None);
+        dimensionless_conferral.attestation_type = "delegates_to".into();
+        assert!(
+            !B::is_non_retainable_score(&dimensionless_conferral),
+            "a dimensionless conferral is kept by TYPE (the moderation-duty shape)"
         );
     }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1108,26 +1108,42 @@ impl FederationDirectoryReplicationBridge {
     /// shrinks the pull SILENTLY; that is a persist ask — tell them to add it, do
     /// not assume persist knows.)
     ///
-    /// DIMENSIONLESS attestations carry no score and are NOT carved: a `delegates_to`
-    /// conferral (the moderation-duty shape #462 exists to recover) is signed by the
-    /// conferring authority — the subject cannot forge it, so a retained copy grants
-    /// no write authority. The subject's OWN authored scores (the sender axis) are
-    /// likewise untouched — a score I authored is mine to recover.
+    /// CONFERRALS ARE RETAINED BY TYPE, not by dimension: a `delegates_to` (the
+    /// moderation-duty shape #462 exists to recover) is signed by the conferring
+    /// authority — the subject cannot forge it, so a retained copy grants no write
+    /// authority. This holds EVEN when the conferral is dimension-bearing: the
+    /// `self_at_login` shape carries `dimension:
+    /// "self:delegates_to:agent_occurrence:v1"` (src/edge.rs), which is NOT in
+    /// persist's retainable allowlist. The subject's OWN authored scores (the sender
+    /// axis) are likewise untouched — a score I authored is mine to recover.
     ///
-    /// INVARIANT this carve depends on (shared with persist's taxonomy, not a
-    /// per-family lookup): **scores are dimension-bearing, conferrals are
-    /// dimensionless.** The G2 hazard is "sole-writer of a row about me"; CC binds
-    /// authority to the SIGNATURE, never to custody, so an authority-signed
-    /// conferral is safe to retain regardless of dimension. The `has-dimension`
-    /// gate therefore lands the authorship hazard exactly — *given* that invariant.
-    /// If persist ever made a peer-authored score dimensionless, or a conferral
-    /// dimension-bearing, the gate would misfire; that is the one thing to keep
-    /// true across both repos.
+    /// INVARIANT (corrected — Codex on #470): key the carve on the SCORES PLANE, not
+    /// on has-a-dimension. The earlier "scores are dimension-bearing, conferrals are
+    /// dimensionless" reading was FALSE — `self_at_login` is a dimension-bearing
+    /// conferral — and the has-dimension gate would carve that delegation out of the
+    /// very pull the receive axis exists to serve. The reliable discriminator is
+    /// `attestation_type`: every peer-authored claim (reputation / capacity /
+    /// moderation) rides `attestation_type == "scores"` with a distinguishing
+    /// dimension; conferrals ride `delegates_to` / `trust:confers`. So the carve is
+    /// `type == scores AND !is_subject_retainable(dimension)`. The one thing to keep
+    /// true across both repos: persist keeps peer-authored claims on the scores
+    /// plane and conferrals off it.
     fn is_non_retainable_score(att: &Attestation) -> bool {
-        att.attestation_envelope
-            .pointer("/dimension")
-            .and_then(serde_json::Value::as_str)
-            .is_some_and(|dim| !ciris_persist::federation::namespace::is_subject_retainable(dim))
+        // Only the SCORES plane is carveable. A conferral (delegates_to /
+        // trust:confers) is authority-signed — unforgeable by the subject — so it is
+        // retained by TYPE regardless of dimension, INCLUDING the dimension-bearing
+        // self_at_login shape (`self:delegates_to:agent_occurrence:v1`, src/edge.rs),
+        // which is NOT in persist's retainable allowlist. Gating on the dimension
+        // alone would carve that delegation OUT of the pull the receive axis exists
+        // to recover (Codex on #470).
+        att.attestation_type == ciris_persist::federation::types::attestation_type::SCORES
+            && att
+                .attestation_envelope
+                .pointer("/dimension")
+                .and_then(serde_json::Value::as_str)
+                .is_some_and(|dim| {
+                    !ciris_persist::federation::namespace::is_subject_retainable(dim)
+                })
     }
 
     /// The per-kind apply dispatch behind the #425 choke —
@@ -4582,6 +4598,29 @@ mod tests {
         assert!(
             !B::is_non_retainable_score(&att_with_dimension(None)),
             "a dimensionless conferral (delegates_to) carries no score — kept (unforgeable)"
+        );
+    }
+
+    /// Codex on #470 — the carve keys on the SCORES PLANE, not on has-a-dimension.
+    /// `self_at_login` proves conferrals CAN be dimension-bearing
+    /// (`self:delegates_to:agent_occurrence:v1`, src/edge.rs), and that dimension is
+    /// NOT in persist's retainable allowlist — so a has-dimension gate would carve
+    /// the delegation OUT of the very pull the receive axis exists to recover. The
+    /// control proves the discriminator is `attestation_type`, not the dimension.
+    #[test]
+    fn g2_carve_keeps_dimension_bearing_conferrals() {
+        use FederationDirectoryReplicationBridge as B;
+        let dim = "self:delegates_to:agent_occurrence:v1";
+        let mut conferral = att_with_dimension(Some(dim));
+        conferral.attestation_type = "delegates_to".into();
+        assert!(
+            !B::is_non_retainable_score(&conferral),
+            "a dimension-bearing delegates_to conferral is retained by TYPE, never carved"
+        );
+        // Control: the SAME non-retainable dimension on a SCORES-type row IS carved.
+        assert!(
+            B::is_non_retainable_score(&att_with_dimension(Some(dim))),
+            "the same non-retainable dimension on a scores-type row is still carved (fail-closed)"
         );
     }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -936,7 +936,7 @@ impl FederationDirectoryReplicationBridge {
     ///
     /// The Attestation plane sweeps BOTH testimonial axes: `list_attestations_for`
     /// (records ABOUT the subject — the revocation-reachability set, with the G2
-    /// [`Self::is_consent_gated_score`] carve) and `list_attestations_by`
+    /// [`Self::is_non_retainable_score`] carve) and `list_attestations_by`
     /// (records BY the subject — authorship recovery, no carve: mine to recover).
     /// Non-replicated / cohort kinds are not subject-pullable and return empty.
     async fn subject_holdings_inner(
@@ -1017,7 +1017,7 @@ impl FederationDirectoryReplicationBridge {
                     .await
                     .unwrap_or_default()
                 {
-                    if Self::is_consent_gated_score(&att) {
+                    if Self::is_non_retainable_score(&att) {
                         continue;
                     }
                     let seq = Self::ms_seq(att.asserted_at);
@@ -1091,27 +1091,43 @@ impl FederationDirectoryReplicationBridge {
     }
 
     /// CIRISEdge#462 — the G2 self-revocation-hole carve, resolved by CONSUMING
-    /// persist's authoritative CEG taxonomy rather than an edge prefix list: an
-    /// attestation whose dimension is a consent-gated peer-authored SCORE (persist
-    /// [`consent_gated_claim`](ciris_persist::federation::admission::consent_gated_claim)
-    /// — the `capacity:*` reputation family, CC 3.4.5 / AV-79) is NEVER served on
-    /// the data-subject Pull axis. Landing a score ABOUT me onto the node where I
-    /// am the sole writer conflates read-copy with write-authority — the shape
-    /// that produced the G2 hole. The subject's OWN authored scores (the sender
-    /// axis) are unaffected: `consent_gated_claim` classifies by dimension and
-    /// edge consults it ONLY on the data-subject axis.
+    /// persist's authoritative retainability ALLOWLIST (CIRISPersist#635,
+    /// [`is_subject_retainable`](ciris_persist::federation::namespace::is_subject_retainable)):
+    /// a data-subject-axis attestation whose DIMENSION is a score is withheld
+    /// UNLESS persist affirms the subject is necessarily its author (`emit_authority`
+    /// — trace:*, transport:{kind}, the substrate self-reports, …). Landing a score
+    /// ABOUT me onto the node where I am the sole writer is safe only when I am its
+    /// author; otherwise it conflates read-copy with write-authority (the G2 hole).
     ///
-    /// Deliberately persist's decision, not an edge prefix list — the gated set is
-    /// CEG state resolution persist owns (the closed `ConsentGatedFamily` enum
-    /// grows there), so edge tracks new consent-gated score families for free and
-    /// cannot drift. This matches the issue's exact scope (`capacity:*`);
-    /// `moderation:*` / `slashing:*` are role-gated, NOT consent-gated, and are
-    /// community-cohort — they follow the duty, not the individual identity, so
-    /// they do not ride the data-subject axis. CIRISPersist#635 tracks the open
-    /// question of whether the pull carve should ALSO cover the role-gated
-    /// abuse-response families.
-    fn is_consent_gated_score(att: &Attestation) -> bool {
-        ciris_persist::federation::admission::consent_gated_claim(att).is_some()
+    /// This REPLACES the earlier `consent_gated_claim` (capacity-only) carve, which
+    /// UNDER-carved: it withheld only the consent-gated family and let every other
+    /// peer-authored score through. `is_subject_retainable` is an allowlist, so it
+    /// is FAIL-CLOSED — an unknown / new / renamed scored family reads
+    /// non-retainable and is carved, not silently pulled. (Consequence per #635: a
+    /// family edge legitimately needs to pull that is missing from the allowlist
+    /// shrinks the pull SILENTLY; that is a persist ask — tell them to add it, do
+    /// not assume persist knows.)
+    ///
+    /// DIMENSIONLESS attestations carry no score and are NOT carved: a `delegates_to`
+    /// conferral (the moderation-duty shape #462 exists to recover) is signed by the
+    /// conferring authority — the subject cannot forge it, so a retained copy grants
+    /// no write authority. The subject's OWN authored scores (the sender axis) are
+    /// likewise untouched — a score I authored is mine to recover.
+    ///
+    /// INVARIANT this carve depends on (shared with persist's taxonomy, not a
+    /// per-family lookup): **scores are dimension-bearing, conferrals are
+    /// dimensionless.** The G2 hazard is "sole-writer of a row about me"; CC binds
+    /// authority to the SIGNATURE, never to custody, so an authority-signed
+    /// conferral is safe to retain regardless of dimension. The `has-dimension`
+    /// gate therefore lands the authorship hazard exactly — *given* that invariant.
+    /// If persist ever made a peer-authored score dimensionless, or a conferral
+    /// dimension-bearing, the gate would misfire; that is the one thing to keep
+    /// true across both repos.
+    fn is_non_retainable_score(att: &Attestation) -> bool {
+        att.attestation_envelope
+            .pointer("/dimension")
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|dim| !ciris_persist::federation::namespace::is_subject_retainable(dim))
     }
 
     /// The per-kind apply dispatch behind the #425 choke —
@@ -2776,6 +2792,7 @@ mod tests {
     use super::*;
     use base64::engine::general_purpose::STANDARD as B64;
     use base64::Engine as _;
+    use chrono::SubsecRound as _;
     use chrono::Utc;
     use ciris_crypto::{ClassicalSigner as _, Ed25519Signer, MlDsa65Signer, PqcSigner as _};
     use ciris_persist::federation::types::{
@@ -3046,17 +3063,28 @@ mod tests {
         // AV-62 anti-Goodhart gate forbids a SELF-attested `capacity:*` row (you
         // can't rate your own reputation), which the old `capacity:example:v1`
         // fixture tripped — but self-attesting one's own identity is legitimate.
-        let now = Utc::now();
-        let envelope = serde_json::json!({
+        let now = Utc::now().trunc_subsecs(6);
+        let attestation_id = uuid::Uuid::new_v4().to_string();
+        let mut envelope = serde_json::json!({
             "attesting_key_id": other_producer,
             "attested_key_id": other_producer,
             "attestation_type": "scores",
             "dimension": "identity:example:v1",
             "cohort_scope": "self",
         });
+        bind_attestation_envelope(
+            &mut envelope,
+            now,
+            &attestation_id,
+            other_producer,
+            "scores",
+            other_producer,
+            &[other_producer],
+            "self",
+        );
         let (hash_hex, ed_sig, pqc_sig) = sign_attestation_envelope(other_producer, &envelope);
         let att = Attestation {
-            attestation_id: uuid::Uuid::new_v4().to_string(),
+            attestation_id,
             attesting_key_id: other_producer.to_string(),
             attested_key_id: other_producer.to_string(),
             attestation_type: "scores".to_string(),
@@ -3348,31 +3376,31 @@ mod tests {
             sink.lock().expect("observer sink").push(k.to_string());
         })));
 
-        let now = Utc::now();
-        let envelope = serde_json::json!({
-            "revocation_id": "rev-1",
-            "revoked_key_id": target,
-            "revoking_key_id": revoker,
-        });
-        let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(revoker, &envelope);
-        let rev = ciris_persist::federation::types::Revocation {
+        let now = Utc::now().trunc_subsecs(6);
+        let mut rev = ciris_persist::federation::types::Revocation {
             revocation_id: "rev-1".to_string(),
             revoked_key_id: target.to_string(),
             revoking_key_id: revoker.to_string(),
             reason: None,
             revoked_at: now,
             effective_at: now,
-            revocation_envelope: envelope,
-            original_content_hash: hash,
-            scrub_signature_classical: ed_sig,
-            scrub_signature_pqc: pqc_sig,
+            revocation_envelope: serde_json::json!({}),
+            original_content_hash: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
             scrub_key_id: revoker.to_string(),
             scrub_timestamp: now,
             pqc_completed_at: None,
             persist_row_hash: String::new(),
-            observed_region: String::new(),
+            observed_region: "us".to_string(),
             revoked_after: None,
         };
+        ciris_persist::federation::admission::bind_revocation_into_envelope(&mut rev)
+            .expect("bind revocation envelope");
+        let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(revoker, &rev.revocation_envelope);
+        rev.original_content_hash = hash;
+        rev.scrub_signature_classical = ed_sig;
+        rev.scrub_signature_pqc = pqc_sig;
         let bytes =
             serde_json::to_vec(&SignedRevocation { revocation: rev }).expect("serialize rev");
         let outcome = bridge
@@ -4092,15 +4120,26 @@ mod tests {
         // Build a federation-tier attestation with real hybrid sigs
         // (v6.3.2 / CIRISEdge#166 — passes persist v9.0.0's
         // verify_federation_tier_ingest).
-        let now = Utc::now();
-        let envelope = serde_json::json!({
+        let now = Utc::now().trunc_subsecs(6);
+        let attestation_id = uuid::Uuid::new_v4().to_string();
+        let mut envelope = serde_json::json!({
             "attesting_key_id": attesting_id,
             "attested_key_id": attested_id,
             "attestation_type": "delegates_to",
         });
+        bind_attestation_envelope(
+            &mut envelope,
+            now,
+            &attestation_id,
+            attesting_id,
+            "delegates_to",
+            attested_id,
+            &[],
+            "federation",
+        );
         let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(attesting_id, &envelope);
         let att = Attestation {
-            attestation_id: uuid::Uuid::new_v4().to_string(),
+            attestation_id,
             attesting_key_id: attesting_id.to_string(),
             attested_key_id: attested_id.to_string(),
             attestation_type: "delegates_to".to_string(),
@@ -4164,17 +4203,28 @@ mod tests {
 
         // A federation-tier (tier="federation") Attestation via put_attestation
         // (indexes under "Attestation"; cohort_scope="federation" → advertised).
-        let now = Utc::now();
-        let envelope = serde_json::json!({
+        let now = Utc::now().trunc_subsecs(6);
+        let attestation_id = uuid::Uuid::new_v4().to_string();
+        let mut envelope = serde_json::json!({
             "attesting_key_id": attester,
             "attested_key_id": key_id,
             "attestation_type": "delegates_to",
         });
+        bind_attestation_envelope(
+            &mut envelope,
+            now,
+            &attestation_id,
+            attester,
+            "delegates_to",
+            key_id,
+            &[],
+            "federation",
+        );
         let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(attester, &envelope);
         backend
             .put_attestation(SignedAttestation {
                 attestation: Attestation {
-                    attestation_id: uuid::Uuid::new_v4().to_string(),
+                    attestation_id,
                     attesting_key_id: attester.to_string(),
                     attested_key_id: key_id.to_string(),
                     attestation_type: "delegates_to".to_string(),
@@ -4372,6 +4422,42 @@ mod tests {
     /// membership-free scopes MemoryBackend's write gate admits without
     /// family/community rows (`family`/`community` require seeded
     /// membership).
+    /// CIRISPersist#598 + #643 (v31.0.0) — stamp the SIGNED bindings an attestation
+    /// envelope must now carry before signing, so the scrub signature covers them:
+    /// the `asserted_at` instant (the fold orders on it) and the `row` mirror of the
+    /// typed columns (else a relay rewrites attestation_id/attester/type/subject/
+    /// cohort while the signature still verifies — the subject-blindness class).
+    /// `subject_key_ids` omitted ⇔ the column is empty; `weight` omitted ⇔ NULL.
+    /// The single sink every attestation fixture routes through.
+    #[allow(clippy::too_many_arguments)] // mirrors the attestation's typed-column set
+    fn bind_attestation_envelope(
+        envelope: &mut serde_json::Value,
+        asserted_at: chrono::DateTime<chrono::Utc>,
+        attestation_id: &str,
+        attesting_key_id: &str,
+        attestation_type: &str,
+        attested_key_id: &str,
+        subject_key_ids: &[&str],
+        cohort_scope: &str,
+    ) {
+        let Some(obj) = envelope.as_object_mut() else {
+            return;
+        };
+        obj.entry("asserted_at")
+            .or_insert_with(|| serde_json::json!(asserted_at.to_rfc3339()));
+        let mut row = serde_json::json!({
+            "attestation_id": attestation_id,
+            "attesting_key_id": attesting_key_id,
+            "attestation_type": attestation_type,
+            "attested_key_id": attested_key_id,
+            "cohort_scope": cohort_scope,
+        });
+        if !subject_key_ids.is_empty() {
+            row["subject_key_ids"] = serde_json::json!(subject_key_ids);
+        }
+        obj.entry("row").or_insert(row);
+    }
+
     async fn seed_scoped_attestation(
         backend: &MemoryBackend,
         id: &str,
@@ -4379,9 +4465,27 @@ mod tests {
         subject: &str,
         attestation_type: &str,
         cohort_scope: &str,
-        envelope: serde_json::Value,
+        mut envelope: serde_json::Value,
     ) {
-        let now = Utc::now();
+        // CIRISPersist#598 (v31.0.0): truncate to MICROSECONDS — postgres TIMESTAMPTZ
+        // can't store sub-µs, so a producer that mints ns precision makes an op
+        // sequence a strict order on sqlite/memory but a TIE on postgres. The fold
+        // refuses ns rows outright.
+        let now = Utc::now().trunc_subsecs(6);
+        // #598: the fold orders on the `asserted_at` COLUMN, so that instant must be
+        // SIGNED — stamp it into the envelope (matching the column) before signing,
+        // or the row is REFUSED as an unbound replay. RFC3339, the shape persist's
+        // own fixtures bind.
+        bind_attestation_envelope(
+            &mut envelope,
+            now,
+            id,
+            attester,
+            attestation_type,
+            subject,
+            &[subject],
+            cohort_scope,
+        );
         let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(attester, &envelope);
         let att = Attestation {
             attestation_id: id.to_string(),
@@ -4445,37 +4549,39 @@ mod tests {
         }
     }
 
-    /// CIRISEdge#462 — the G2 carve is persist's authoritative consent-gated-score
-    /// classification (`consent_gated_claim`), NOT an edge prefix list. That is
-    /// EXACTLY the `capacity:*` reputation family (CC 3.4.5): the peer-authored
-    /// score whose landing on the subject's own node is the self-revocation hole.
-    /// `moderation:*` / `slashing:*` are role-gated (not consent-gated) and
-    /// community-cohort — persist deliberately does not gate them, and they follow
-    /// the duty not the identity, so they are NOT carved here; relationship/charter
-    /// testimony and trace:* (E3-gated at fetch) are kept.
+    /// CIRISEdge#462 — the G2 carve is persist's authoritative retainability
+    /// ALLOWLIST (`is_subject_retainable`, CIRISPersist#635), keyed on authorship.
+    /// A scored dimension is carved UNLESS persist affirms the subject is its
+    /// author. This is FAIL-CLOSED: unlike the earlier capacity-only carve, ANY
+    /// peer-authored score — capacity, capacity_assurance, moderation, or an
+    /// unknown/new family — is withheld. Self-authored scores (trace:*) and
+    /// dimensionless conferrals (delegates_to) are kept.
     #[test]
-    fn g2_carve_is_persist_consent_gated_score_taxonomy() {
+    fn g2_carve_is_persist_retainability_allowlist() {
         use FederationDirectoryReplicationBridge as B;
-        assert!(
-            B::is_consent_gated_score(&att_with_dimension(Some("capacity:core_identity:v1"))),
-            "capacity:* is the consent-gated reputation family — carved (G2)"
-        );
-        // Consuming persist's taxonomy: these are NOT consent-gated scores, so the
-        // pull does not carve them (persist owns this call — edge cannot drift).
-        for kept in [
-            "capacity_assurance:composite:v1", // not the `capacity:` prefix
-            "moderation:removal:v1",           // role-gated, community-cohort
-            "trace:coherence:v1",              // E3-gated at fetch, not here
+        // Peer-authored scores about the subject — ALL carved (fail-closed
+        // allowlist), including families the old capacity-only carve missed.
+        for carved in [
+            "capacity:core_identity:v1",       // the canonical G2 reputation score
+            "capacity_assurance:composite:v1", // the old carve LET THIS THROUGH
+            "moderation:removal:v1",           // ditto — now correctly carved
+            "some_future:score:v9",            // unknown family → fail-closed → carved
         ] {
             assert!(
-                !B::is_consent_gated_score(&att_with_dimension(Some(kept))),
-                "{kept} is not a consent-gated score — persist does not gate it, so the pull \
-                 does not carve it (role-gated/other families are handled elsewhere)"
+                B::is_non_retainable_score(&att_with_dimension(Some(carved))),
+                "{carved} is not in persist's retainable allowlist — carved (G2, fail-closed)"
             );
         }
+        // Self-authored (allowlisted) scores are kept here (trace:* is separately
+        // E3-gated at fetch); a dimensionless conferral (delegates_to — the
+        // moderation-duty shape) is never a score, so it is kept.
         assert!(
-            !B::is_consent_gated_score(&att_with_dimension(None)),
-            "a charter/relationship attestation (no dimension) is testimony — kept"
+            !B::is_non_retainable_score(&att_with_dimension(Some("trace:coherence:v1"))),
+            "trace:* is self-emission-mandatory (retainable); kept here, E3-gated at fetch"
+        );
+        assert!(
+            !B::is_non_retainable_score(&att_with_dimension(None)),
+            "a dimensionless conferral (delegates_to) carries no score — kept (unforgeable)"
         );
     }
 
@@ -4759,6 +4865,182 @@ mod tests {
         );
     }
 
+    /// CIRISPersist#659 (v31.0.0) — SPOOFING PROOF (the Revocation plane).
+    ///
+    /// A signed revocation now binds `revoked_key_id` (and its sibling typed
+    /// columns) INTO the signed envelope. Pre-v31 that column was UNSIGNED, so a
+    /// single genuine revocation could be re-pointed at ANY key: a relay repaints
+    /// the column, the scrub signature still verifies over the (now-mismatched)
+    /// envelope, and the row de-admits whatever the column names — one signature,
+    /// unbounded reach (the subject-blindness class: possession of a signed blob
+    /// conferred authority over a key the signer never named). This exercises the
+    /// binding gate directly — `check_revocation_envelope_binding`, which EVERY
+    /// store's admit path (memory / sqlite / postgres / tier_ingest) runs — proving
+    /// the honestly bound row passes while the paste is refused, and isolating the
+    /// subject-binding fix from the ORTHOGONAL slash-authority gate (a third-party
+    /// `put_revocation` also requires the revoker hold `slash` from a trusted root:
+    /// defense in depth, but not what #659 closes). Authority is bound to the
+    /// SIGNATURE, never to custody of the row.
+    #[test]
+    fn v31_revocation_paste_cannot_deadmit_an_unintended_key() {
+        // Build a well-formed, signed revocation of `revoked`, tagged `id`.
+        let build = |id: &str, revoked: &str| {
+            let now = Utc::now().trunc_subsecs(6);
+            let mut rev = Revocation {
+                revocation_id: id.to_string(),
+                revoked_key_id: revoked.to_string(),
+                revoking_key_id: "revoker".to_string(),
+                reason: None,
+                revoked_at: now,
+                effective_at: now,
+                revocation_envelope: serde_json::json!({}),
+                original_content_hash: String::new(),
+                scrub_signature_classical: String::new(),
+                scrub_signature_pqc: None,
+                scrub_key_id: "revoker".to_string(),
+                scrub_timestamp: now,
+                pqc_completed_at: None,
+                observed_region: "us".to_string(),
+                persist_row_hash: String::new(),
+                revoked_after: None,
+            };
+            // persist's OWN binder stamps the typed columns into the envelope, so
+            // the member set can never drift from the verifier.
+            ciris_persist::federation::admission::bind_revocation_into_envelope(&mut rev)
+                .expect("bind revocation envelope");
+            let (hash, ed_sig, pqc_sig) =
+                sign_attestation_envelope("revoker", &rev.revocation_envelope);
+            rev.original_content_hash = hash;
+            rev.scrub_signature_classical = ed_sig;
+            rev.scrub_signature_pqc = pqc_sig;
+            rev
+        };
+
+        // CONTROL: the honestly-bound revocation PASSES the binding gate. Every
+        // store's admit path (memory / sqlite / postgres / tier_ingest) runs
+        // exactly this check, so it is the real gate, not a stand-in.
+        let honest = build("rev-honest", "victim-A");
+        ciris_persist::federation::admission::check_revocation_envelope_binding(&honest)
+            .expect("an honestly-bound revocation satisfies the column-to-envelope binding");
+
+        // ATTACK: sign a revocation of victim-A, then repaint the target column to
+        // victim-B. The signed envelope still pins victim-A.
+        let mut pasted = build("rev-spoof", "victim-A");
+        pasted.revoked_key_id = "victim-B".to_string();
+
+        let err = ciris_persist::federation::admission::check_revocation_envelope_binding(&pasted)
+            .expect_err(
+                "a revocation signed to de-admit victim-A must NOT de-admit victim-B once its \
+                 column is repainted — pre-v31 the unsigned column pasted onto ANY key (#659)",
+            );
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("RevocationEnvelopeUnbound") || msg.contains("revoked_key_id"),
+            "refused for the RIGHT reason (revoked_key_id column ≠ signed envelope), got: {msg}"
+        );
+    }
+
+    /// CIRISPersist#643 (v31.0.0) — SPOOFING PROOF (the Attestation/conferral plane).
+    ///
+    /// A `delegates_to` conferral now binds `attested_key_id` + `subject_key_ids`
+    /// into the signed `row` mirror. Pre-v31 those columns were UNSIGNED, so a
+    /// single genuine conferral (say `infra:serve` granted to grantee-A) could be
+    /// lifted onto ANY key — repaint the target column and the authority the signer
+    /// never granted rides the same signature. persist's own doc flags
+    /// `subject_key_ids` as the column that "grants revocation authority", so
+    /// lifting it is the highest-value forgery; this proves v31 refuses the lift
+    /// while the honest conferral admits.
+    #[tokio::test]
+    async fn v31_conferral_paste_cannot_lift_authority_onto_another_key() {
+        let (backend, _bridge) = make_bridge(&[]);
+        for kid in ["root", "grantee-A", "grantee-B"] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, "user"),
+                })
+                .await
+                .expect("register key");
+        }
+
+        // Build a signed delegates_to(root → attested, scope infra:serve).
+        let build = |id: &str, attested: &str| {
+            let now = Utc::now().trunc_subsecs(6);
+            let mut envelope = serde_json::json!({
+                "id": id,
+                "attesting_key_id": "root",
+                "attested_key_id": attested,
+                "attestation_type": "delegates_to",
+                "scope": ["infra:serve"],
+            });
+            bind_attestation_envelope(
+                &mut envelope,
+                now,
+                id,
+                "root",
+                "delegates_to",
+                attested,
+                &[attested],
+                "federation",
+            );
+            let (hash, ed_sig, pqc_sig) = sign_attestation_envelope("root", &envelope);
+            Attestation {
+                attestation_id: id.to_string(),
+                attesting_key_id: "root".to_string(),
+                attested_key_id: attested.to_string(),
+                attestation_type: "delegates_to".to_string(),
+                weight: None,
+                asserted_at: now,
+                expires_at: None,
+                attestation_envelope: envelope,
+                original_content_hash: hash,
+                scrub_signature_classical: ed_sig,
+                scrub_signature_pqc: pqc_sig,
+                scrub_key_id: "root".to_string(),
+                scrub_timestamp: now,
+                pqc_completed_at: None,
+                persist_row_hash: String::new(),
+                subject_key_ids: vec![attested.to_string()],
+                withdraws_admission_rule: None,
+                additional_scrubs: Vec::new(),
+                cohort_scope: "federation".to_string(),
+                tier: "federation".to_string(),
+                promoted_at: None,
+            }
+        };
+
+        // CONTROL: the honest conferral onto grantee-A ADMITS.
+        backend
+            .put_attestation(SignedAttestation {
+                attestation: build("att-honest", "grantee-A"),
+            })
+            .await
+            .expect("an honestly-bound conferral admits");
+
+        // ATTACK: sign a conferral onto grantee-A, then repaint BOTH target columns
+        // to grantee-B. The signed `row` mirror still pins grantee-A.
+        let mut pasted = build("att-spoof", "grantee-A");
+        pasted.attested_key_id = "grantee-B".to_string();
+        pasted.subject_key_ids = vec!["grantee-B".to_string()];
+
+        let err = backend
+            .put_attestation(SignedAttestation {
+                attestation: pasted,
+            })
+            .await
+            .expect_err(
+                "a delegates_to signed to grant grantee-A must NOT grant grantee-B once its \
+                 target columns are repainted — pre-v31 the unsigned columns lifted authority \
+                 onto ANY key (#643)",
+            );
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("subject_key_ids")
+                || msg.contains("attested_key_id")
+                || msg.contains("InvalidArgument"),
+            "refused for the RIGHT reason (signed row mirror ≠ typed columns), got: {msg}"
+        );
+    }
+
     /// CIRISEdge#462 — the load-bearing hash-match invariant: every ref
     /// `subject_holdings` emits resolves through the SAME content-hash fetch path
     /// a `Deliver` uses (`fetch_envelope_bytes` → persist's `signed_wire_index`).
@@ -4861,32 +5143,37 @@ mod tests {
     /// be registered keys). persist computes `persist_row_hash` on put — the
     /// value the Revocation plane advertises + the cache-free fetch scan matches.
     async fn seed_revocation(backend: &MemoryBackend, revoking: &str, revoked: &str) {
-        let now = Utc::now();
+        let now = Utc::now().trunc_subsecs(6); // #598 microsecond floor
         let id = uuid::Uuid::new_v4().to_string();
-        let envelope = serde_json::json!({
-            "revocation_id": id,
-            "revoked_key_id": revoked,
-            "revoking_key_id": revoking,
-        });
-        let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(revoking, &envelope);
-        let revocation = Revocation {
+        let mut revocation = Revocation {
             revocation_id: id,
             revoked_key_id: revoked.to_string(),
             revoking_key_id: revoking.to_string(),
             reason: None,
             revoked_at: now,
             effective_at: now,
-            revocation_envelope: envelope,
-            original_content_hash: hash,
-            scrub_signature_classical: ed_sig,
-            scrub_signature_pqc: pqc_sig,
+            revocation_envelope: serde_json::json!({}),
+            original_content_hash: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
             scrub_key_id: revoking.to_string(),
             scrub_timestamp: now,
             pqc_completed_at: None,
-            observed_region: String::new(),
+            observed_region: "us".to_string(), // #598-era: must be {us,eu,apac}, not empty
             persist_row_hash: String::new(),
             revoked_after: None,
         };
+        // CIRISPersist#659 (v31.0.0): bind the typed columns (revoked_key_id, reason,
+        // revoked_at, …) into the signed envelope — else a relay could paste one
+        // signed revocation onto ANY key. Use persist's OWN binder so the member set
+        // never drifts, then sign the now-bound envelope.
+        ciris_persist::federation::admission::bind_revocation_into_envelope(&mut revocation)
+            .expect("bind revocation envelope");
+        let (hash, ed_sig, pqc_sig) =
+            sign_attestation_envelope(revoking, &revocation.revocation_envelope);
+        revocation.original_content_hash = hash;
+        revocation.scrub_signature_classical = ed_sig;
+        revocation.scrub_signature_pqc = pqc_sig;
         backend
             .put_revocation(SignedRevocation { revocation })
             .await
@@ -5344,7 +5631,7 @@ mod tests {
 
         // A trace scores-attestation (self-subject, federation tier =
         // promoted) + a NON-trace attestation for the control.
-        let now = Utc::now();
+        let now = Utc::now().trunc_subsecs(6);
         for (attestation_type, dimension) in [
             ("scores", Some("trace:complete:v1")),
             ("delegates_to", None),
@@ -5363,9 +5650,20 @@ mod tests {
                 envelope["agent_id_hash"] = serde_json::json!("ah-fixture-1");
                 envelope["trace"] = serde_json::json!({ "steps": [] });
             }
+            let attestation_id = uuid::Uuid::new_v4().to_string();
+            bind_attestation_envelope(
+                &mut envelope,
+                now,
+                &attestation_id,
+                producer,
+                attestation_type,
+                producer,
+                &[producer],
+                "federation",
+            );
             let (hash, ed_sig, pqc_sig) = sign_attestation_envelope(producer, &envelope);
             let att = Attestation {
-                attestation_id: uuid::Uuid::new_v4().to_string(),
+                attestation_id,
                 attesting_key_id: producer.to_string(),
                 attested_key_id: producer.to_string(),
                 attestation_type: attestation_type.to_string(),
@@ -5457,6 +5755,11 @@ mod tests {
         use ciris_persist::federation::accord_test_support::{
             register_accord_holder, signed_canonical_record_with_roles, Identity,
         };
+        // CIRISPersist v31.0.0 (#467): the helper now stamps the SUBJECT BINDING
+        // (pubkeys) into the envelope before signing, so a signature can no longer
+        // be lifted onto a different key_id. This fixture doesn't spoof, so the
+        // placeholder subject + no-PQC is the byte-preserving update.
+        use ciris_persist::federation::operational::test_support::PLACEHOLDER_SUBJECT_ED25519_BASE64;
         // The roster key_ids `has_accord_conferred_role` resolves against. Persist's
         // own `accord_holder_roster_key_ids` is private, but it is derived from
         // this public genesis accessor — so we mint identities under exactly
@@ -5532,6 +5835,8 @@ mod tests {
             let rec = signed_canonical_record_with_roles(
                 peer,
                 identity_type::NODE,
+                PLACEHOLDER_SUBJECT_ED25519_BASE64,
+                None,
                 vec![FederationDirectoryReplicationBridge::SERVE_CAPABILITY.to_string()],
                 serde_json::json!({ "key_id": peer }),
                 &scrubbers,

--- a/src/replication/mesh_config.rs
+++ b/src/replication/mesh_config.rs
@@ -343,16 +343,64 @@ mod tests {
             .expect("seed key record");
     }
 
+    /// #598 (v31.0.0) + #643: bind the `asserted_at` instant the fold orders on
+    /// (RFC3339, MICROSECOND precision — ns is REFUSED) and the `row` mirror of
+    /// the typed columns INTO the envelope BEFORE signing, else the row is
+    /// refused as an unbound replay. Duplicated verbatim from `bridge.rs`'s test
+    /// module (cfg(test) items cannot cross module boundaries).
+    #[allow(clippy::too_many_arguments)] // mirrors the attestation's typed-column set
+    fn bind_attestation_envelope(
+        envelope: &mut serde_json::Value,
+        asserted_at: chrono::DateTime<chrono::Utc>,
+        attestation_id: &str,
+        attesting_key_id: &str,
+        attestation_type: &str,
+        attested_key_id: &str,
+        subject_key_ids: &[&str],
+        cohort_scope: &str,
+    ) {
+        let Some(obj) = envelope.as_object_mut() else {
+            return;
+        };
+        obj.entry("asserted_at")
+            .or_insert_with(|| serde_json::json!(asserted_at.to_rfc3339()));
+        let mut row = serde_json::json!({
+            "attestation_id": attestation_id,
+            "attesting_key_id": attesting_key_id,
+            "attestation_type": attestation_type,
+            "attested_key_id": attested_key_id,
+            "cohort_scope": cohort_scope,
+        });
+        if !subject_key_ids.is_empty() {
+            row["subject_key_ids"] = serde_json::json!(subject_key_ids);
+        }
+        obj.entry("row").or_insert(row);
+    }
+
     fn attestation(
         attester: &str,
         subject: &str,
         attestation_type: &str,
-        envelope: serde_json::Value,
+        mut envelope: serde_json::Value,
     ) -> Attestation {
-        let now = Utc::now();
+        use chrono::SubsecRound as _;
+        // #598: the fold orders on the `asserted_at` COLUMN, so bind that instant
+        // (µs-truncated) + the #643 `row` mirror into the envelope before signing.
+        let now = Utc::now().trunc_subsecs(6);
+        let attestation_id = uuid::Uuid::new_v4().to_string();
+        bind_attestation_envelope(
+            &mut envelope,
+            now,
+            &attestation_id,
+            attester,
+            attestation_type,
+            subject,
+            &[subject],
+            "federation",
+        );
         let (hash, ed_sig, pqc_sig) = sign_envelope(attester, &envelope);
         Attestation {
-            attestation_id: uuid::Uuid::new_v4().to_string(),
+            attestation_id,
             attesting_key_id: attester.to_string(),
             attested_key_id: subject.to_string(),
             attestation_type: attestation_type.to_string(),

--- a/src/replication/serve_policy.rs
+++ b/src/replication/serve_policy.rs
@@ -60,7 +60,8 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
         | EnvelopeKind::IdentityOccurrenceRevocation => "subject_pull:data_subject; subject-only",
         EnvelopeKind::Attestation => {
             "subject_pull:data_subject+sender; subject-only; \
-             consent-gated scores carved on data_subject axis (G2: persist consent_gated_claim)"
+             non-retainable scores-plane rows carved on data_subject axis \
+             (G2: attestation_type==scores AND !persist::is_subject_retainable(dimension))"
         }
         EnvelopeKind::Revocation
         | EnvelopeKind::Family
@@ -109,8 +110,12 @@ pub fn serve_advertise_policy_sha256() -> String {
 /// (advertise scope or serve gate for ANY of the 14 kinds) flips this — a
 /// deliberate, reviewed re-pin, visible to CIRISServer which pins it alongside
 /// persist's `REPLICATION_POLICY_HASH`. See CIRISEdge#393 §4.2/§4.3.
+// v16.0.0 — re-pinned: the Attestation `receive` carve text now describes the
+// retainability-allowlist rule (scores-plane, `!is_subject_retainable(dimension)`),
+// replacing the stale `consent_gated_claim` prose the #635 carve had left behind
+// (Codex on #470). CIRISServer re-pins from 049e71ef… to this value.
 pub const SERVE_ADVERTISE_POLICY_HASH: &str =
-    "049e71ef208d24266fe366b8eaed365a467cadd3aadd8856c8ed917c90bced33";
+    "6f683311627689221d886f4245ac7b9fa6715e6f1e135855f52fa7800fb7cda5";
 
 #[cfg(test)]
 mod tests {

--- a/src/transport/realtime_av_alm/delivered.rs
+++ b/src/transport/realtime_av_alm/delivered.rs
@@ -423,6 +423,8 @@ pub enum DeliveryEmitError {
     /// The directory refused or failed the submission.
     #[error("delivery emission submit failed: {0}")]
     Submit(String),
+    #[error("delivery row v31 envelope binding failed: {0}")]
+    Bind(String),
 }
 
 /// Emit one [`DeliveredObservation`] as a scores-plane row about the relay
@@ -540,10 +542,65 @@ async fn build_delivery_row(
         .pqc
         .as_ref()
         .ok_or(DeliveryEmitError::SignerLacksPqc)?;
-    let envelope = delivery_envelope(observation);
-    let canonical = ceg_produce_canonicalize(&envelope)
+    // #598: the fold orders on the `asserted_at` COLUMN, so it must be SIGNED and
+    // microsecond-truncated (postgres TIMESTAMPTZ can't hold sub-µs). Truncate
+    // through persist's own helper so the resolution can never drift.
+    let now = ciris_persist::federation::admission::truncate_to_substrate_resolution(now);
+
+    // Content-address the row id off the STABLE (pre-binding) envelope so identical
+    // window contents still dedupe to one row — the id must be derived BEFORE the
+    // asserted_at/row bindings (#643 requires the id INSIDE the signed bytes, so the
+    // hash of the bound envelope cannot in turn define the id).
+    let mut envelope = delivery_envelope(observation);
+    let stable_hash = hex::encode(Sha256::digest(
+        &ceg_produce_canonicalize(&envelope)
+            .map_err(|e| DeliveryEmitError::Canonicalize(e.to_string()))?,
+    ));
+    let attestation_id = format!("capacity-delivery-{}", &stable_hash[..16]);
+
+    // #598: bind the signed `asserted_at` into the envelope before it is signed.
+    if let Some(obj) = envelope.as_object_mut() {
+        obj.insert(
+            "asserted_at".to_owned(),
+            serde_json::json!(now.to_rfc3339()),
+        );
+    }
+
+    // Assemble the row, then #643: stamp the typed-column `row` mirror into the
+    // envelope via persist's canonical binder (keyed on `attestation_id`), so the
+    // scrub signature below covers it — else v31's admit gate refuses the score and
+    // delivery measurements silently stop persisting (Codex on #470).
+    let mut attestation = Attestation {
+        attestation_id,
+        attesting_key_id: signer.key_id.clone(),
+        attested_key_id: observation.key.advertiser_key_id.clone(),
+        attestation_type: attestation_type::SCORES.to_owned(),
+        weight: None,
+        asserted_at: now,
+        expires_at: None,
+        attestation_envelope: envelope,
+        original_content_hash: String::new(),
+        scrub_signature_classical: String::new(),
+        scrub_signature_pqc: None,
+        scrub_key_id: signer.key_id.clone(),
+        scrub_timestamp: now,
+        pqc_completed_at: None,
+        persist_row_hash: String::new(),
+        subject_key_ids: Vec::new(),
+        withdraws_admission_rule: None,
+        cohort_scope: cohort_scope::FEDERATION.to_owned(),
+        tier: attestation_tier::FEDERATION.to_owned(),
+        promoted_at: None,
+        additional_scrubs: Vec::new(),
+    };
+    ciris_persist::federation::envelope::RowMirror::stamp_row(&mut attestation)
+        .map_err(|e| DeliveryEmitError::Bind(e.to_string()))?;
+
+    // Sign the NOW-BOUND envelope (asserted_at + row present) — AV-33 bound-PQC
+    // (ML-DSA-65 over `canonical ‖ ed25519_sig`).
+    let canonical = ceg_produce_canonicalize(&attestation.attestation_envelope)
         .map_err(|e| DeliveryEmitError::Canonicalize(e.to_string()))?;
-    let original_content_hash = hex::encode(Sha256::digest(&canonical));
+    attestation.original_content_hash = hex::encode(Sha256::digest(&canonical));
     let ed_sig = signer
         .classical
         .sign(&canonical)
@@ -555,31 +612,9 @@ async fn build_delivery_row(
         .sign(&bound)
         .await
         .map_err(|e| DeliveryEmitError::Sign(format!("ml_dsa_65 sign: {e}")))?;
-
-    let attestation_id = format!("capacity-delivery-{}", &original_content_hash[..16]);
-    Ok(Attestation {
-        attestation_id,
-        attesting_key_id: signer.key_id.clone(),
-        attested_key_id: observation.key.advertiser_key_id.clone(),
-        attestation_type: attestation_type::SCORES.to_owned(),
-        weight: None,
-        asserted_at: now,
-        expires_at: None,
-        attestation_envelope: envelope,
-        original_content_hash,
-        scrub_signature_classical: B64.encode(&ed_sig),
-        scrub_signature_pqc: Some(B64.encode(&pqc_sig)),
-        scrub_key_id: signer.key_id.clone(),
-        scrub_timestamp: now,
-        pqc_completed_at: None,
-        persist_row_hash: String::new(),
-        subject_key_ids: Vec::new(),
-        withdraws_admission_rule: None,
-        cohort_scope: cohort_scope::FEDERATION.to_owned(),
-        tier: attestation_tier::FEDERATION.to_owned(),
-        promoted_at: None,
-        additional_scrubs: Vec::new(),
-    })
+    attestation.scrub_signature_classical = B64.encode(&ed_sig);
+    attestation.scrub_signature_pqc = Some(B64.encode(&pqc_sig));
+    Ok(attestation)
 }
 
 #[cfg(test)]
@@ -994,12 +1029,15 @@ mod tests {
         stance_dimension: &str,
         asserted_at: DateTime<Utc>,
     ) -> Attestation {
+        // #598 µs floor — the fold orders on the signed `asserted_at` column.
+        let asserted_at =
+            ciris_persist::federation::admission::truncate_to_substrate_resolution(asserted_at);
         let envelope = serde_json::json!({
             "dimension": stance_dimension,
             "scope": [ANALYZE_CONSENT_SCOPE],
+            "asserted_at": asserted_at.to_rfc3339(),
         });
-        let (och, sc, sp) = sign_attestation_envelope(subject, &envelope);
-        Attestation {
+        let mut attestation = Attestation {
             attestation_id: id.to_owned(),
             attesting_key_id: subject.to_owned(),
             attested_key_id: covers.to_owned(),
@@ -1008,9 +1046,9 @@ mod tests {
             asserted_at,
             expires_at: None,
             attestation_envelope: envelope,
-            original_content_hash: och,
-            scrub_signature_classical: sc,
-            scrub_signature_pqc: sp,
+            original_content_hash: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
             scrub_key_id: subject.to_owned(),
             scrub_timestamp: asserted_at,
             pqc_completed_at: None,
@@ -1021,7 +1059,15 @@ mod tests {
             tier: attestation_tier::FEDERATION.to_owned(),
             promoted_at: None,
             additional_scrubs: Vec::new(),
-        }
+        };
+        // #643: stamp the typed-column row mirror in, then sign the bound envelope.
+        ciris_persist::federation::envelope::RowMirror::stamp_row(&mut attestation)
+            .expect("stamp v31 row mirror");
+        let (och, sc, sp) = sign_attestation_envelope(subject, &attestation.attestation_envelope);
+        attestation.original_content_hash = och;
+        attestation.scrub_signature_classical = sc;
+        attestation.scrub_signature_pqc = sp;
+        attestation
     }
 
     /// A [`LocalSigner`] whose hybrid keys derive from the SAME

--- a/src/transport/realtime_av_alm/transit_gate.rs
+++ b/src/transport/realtime_av_alm/transit_gate.rs
@@ -449,14 +449,24 @@ mod tests {
         // (envelope + Attestation field layout copied from operational.rs
         // test_support; the signature is persist's own sign_envelope).
         let id = "gate-restore-user-edge";
-        let envelope = serde_json::json!({
+        // v31.0.0 (CIRISPersist#598): µs-truncate so the signed `asserted_at`
+        // and its typed column agree at postgres resolution. `now` stays in
+        // function scope — the gate/planner assertions below reuse it.
+        let now =
+            ciris_persist::federation::admission::truncate_to_substrate_resolution(Utc::now());
+        let mut envelope = serde_json::json!({
             "references_attestation_id": id,
             "dimension": TRUST_ACCEPTS_DIMENSION,
             "scope": [INFRA_SERVE_SCOPE],
         });
-        let (och, sc, sp) = sign_envelope_like_persist("gate-user", &envelope);
-        let now = Utc::now();
-        let edge = ciris_persist::federation::Attestation {
+        // #598: bind the signed `asserted_at` into the envelope BEFORE signing.
+        if let Some(obj) = envelope.as_object_mut() {
+            obj.insert(
+                "asserted_at".to_owned(),
+                serde_json::json!(now.to_rfc3339()),
+            );
+        }
+        let mut edge = ciris_persist::federation::Attestation {
             attestation_id: id.to_owned(),
             attesting_key_id: "gate-user".to_owned(),
             attested_key_id: "gate-root".to_owned(),
@@ -466,9 +476,9 @@ mod tests {
             asserted_at: now,
             expires_at: None,
             attestation_envelope: envelope,
-            original_content_hash: och,
-            scrub_signature_classical: sc,
-            scrub_signature_pqc: sp,
+            original_content_hash: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
             scrub_key_id: "gate-user".to_owned(),
             scrub_timestamp: now,
             pqc_completed_at: None,
@@ -480,6 +490,14 @@ mod tests {
             promoted_at: None,
             additional_scrubs: Vec::new(),
         };
+        // #643: stamp the `row` mirror of the typed columns into the envelope
+        // AFTER the struct fields are set, BEFORE we canonicalize/sign.
+        ciris_persist::federation::envelope::RowMirror::stamp_row(&mut edge)
+            .expect("stamp v31 row mirror");
+        let (och, sc, sp) = sign_envelope_like_persist("gate-user", &edge.attestation_envelope);
+        edge.original_content_hash = och;
+        edge.scrub_signature_classical = sc;
+        edge.scrub_signature_pqc = sp;
         FederationDirectory::put_attestation(
             &*backend,
             ciris_persist::federation::SignedAttestation { attestation: edge },

--- a/src/transport/self_route.rs
+++ b/src/transport/self_route.rs
@@ -311,7 +311,15 @@ async fn build_and_sign_self_route(
         occurrence_key_id: signer.key_id.clone(),
         transport_kind: RETICULUM_TRANSPORT_KIND.to_string(),
         destination,
-        asserted_at: Utc::now(),
+        // #598/v31: this `asserted_at` is BOTH signed into the envelope AND the
+        // supersession-ordering key (persist's self_at_login fold reads it). It must
+        // be microsecond-truncated before signing — postgres TIMESTAMPTZ cannot hold
+        // sub-µs, so a raw ns `Utc::now()` would sign a byte the stored column can't
+        // reproduce, diverging the row after storage (Codex on #470). Memory/sqlite
+        // tolerate ns, so only a postgres node exposes this — hence untested locally.
+        asserted_at: ciris_persist::federation::admission::truncate_to_substrate_resolution(
+            Utc::now(),
+        ),
         last_seen_at: None,
         // `[x25519 ‖ ed25519]` — same split as the #299 write-through.
         transport_ed25519_pubkey_base64: Some(B64.encode(&transport_pubkey[32..64])),

--- a/tests/test_anchor_e2e.rs
+++ b/tests/test_anchor_e2e.rs
@@ -25,7 +25,9 @@ use sha2::{Digest, Sha256};
 
 use ciris_crypto::{ClassicalSigner, Ed25519Signer, HybridSigner, MlDsa65Signer, PqcSigner};
 use ciris_edge::verify::{RootingDirectory, RootingVerdict};
-use ciris_persist::federation::genesis::test_anchor_genesis_records;
+use ciris_persist::federation::genesis::{
+    test_anchor_genesis_records, test_anchor_registration_envelope,
+};
 use ciris_persist::federation::{FederationDirectory, KeyRecord, SignedKeyRecord};
 use ciris_persist::prelude::FederationDirectorySqlite;
 use ciris_persist::verify::canonical::ceg_produce_canonicalize;
@@ -52,7 +54,17 @@ async fn test_anchor_peer_roots_through_edge_root_binding() {
 
     // ── 2. The root's VERIFIABLE self-scrub over test-accord-holder-0's own
     //       CANONICAL envelope (CIRISPersist#451 CIRIS_TEST_TRUST_ROOT_SCRUB*). ─
-    let holder_env = serde_json::json!({ "key_id": "test-accord-holder-0", "test_anchor": true });
+    // v31.0.0 (CIRISVerify 13.1.0): the test-anchor preimage moved — the holder's
+    // signed registration envelope now binds `identity_type` (accord_holder) and
+    // both pubkeys for the provenance-link subject binding. Build it via persist's
+    // exported pinned helper (not a hand-rolled literal) so the scrub covers the
+    // EXACT bytes genesis stores as the holder's registration_envelope; the holder
+    // IS the SW root, so its pubkeys are the root's.
+    let holder_env = test_anchor_registration_envelope(
+        "test-accord-holder-0",
+        &B64.encode(&root_ed_pub),
+        Some(&B64.encode(&root_pqc_pub)),
+    );
     let holder_canonical = canonical_bytes(&holder_env);
     let holder_scrub = root_signer
         .sign(&holder_canonical)
@@ -90,7 +102,18 @@ async fn test_anchor_peer_roots_through_edge_root_binding() {
     let peer_pqc = MlDsa65Signer::from_seed(&[0x0b; 32]).expect("peer ml-dsa");
     let peer_ed_pub = peer_ed.public_key().expect("peer ed pub");
     let peer_pqc_pub = PqcSigner::public_key(&peer_pqc).expect("peer pqc pub");
-    let peer_env = serde_json::json!({ "key_id": "edge-key-peer" });
+    // v31.0.0: the provenance link's subject binding now REFUSES a registration
+    // whose SIGNED bytes omit any of `identity_type`/`pubkey_ed25519_base64`/
+    // `pubkey_ml_dsa_65_base64` (an absent binding is skippable-by-omission: a
+    // relay could rewrite the identity/keys while the scrub still verifies).
+    // Bind the full subject set into the envelope the scrub covers so it matches
+    // the columns below.
+    let peer_env = serde_json::json!({
+        "key_id": "edge-key-peer",
+        "identity_type": "agent",
+        "pubkey_ed25519_base64": B64.encode(&peer_ed_pub),
+        "pubkey_ml_dsa_65_base64": B64.encode(&peer_pqc_pub),
+    });
     let peer_canonical = canonical_bytes(&peer_env);
     let peer_scrub = root_signer
         .sign(&peer_canonical)


### PR DESCRIPTION
## v16.0.0 — adopt persist v31.0.0 + verify v13.1.0 (the subject-binding mesh reset)

**Wire-breaking federation cut.** persist v31.0.0 binds the typed columns of every signed federation record **into the signed envelope**, so a v15.x node and a v16.x node cannot federate: an old client emits unbound records the new admit path refuses (and vice-versa). Hence the **major** bump.

### The four subject-binding planes ("so many claims were outside the envelope")

Each closes a *subject-blindness* hole where possession of a signed blob conferred authority over a key the signer never named:

| # | Plane | What v31 now binds |
|---|-------|--------------------|
| #598 | ordering | `asserted_at` must be **signed** and microsecond-truncated (postgres `TIMESTAMPTZ` can't store sub-µs; the fold orders on that column) |
| #643 | attestation | the `row` object is a **signed mirror** of the 7 typed columns |
| #659 | revocation | columns bound via persist's `bind_revocation_into_envelope`; `observed_region ∈ {us,eu,apac}` |
| #467 | provenance-link | `key_id + identity_type + both pubkeys` bound into the registration bytes |

Edge production **hand-builds no signed records** — it emits through persist (which binds), and its rooting delegates `root_binding`/`provenance_chain` to persist, so the tightened chain-walk (#467) is reached **by construction** (the other two `RootingDirectory` impls are `unreachable!()` no-op stubs). The break surfaced only in **test fixtures**, migrated through the single `bind_attestation_envelope` sink (`bridge` + `mesh_config`) and `bind_revocation_into_envelope`; `test_anchor_e2e` now signs through persist's pinned `test_anchor_registration_envelope` helper rather than a transcribed literal (the preimage relocated in v31).

Carries the **v30.12.0 #635 carve** forward unchanged: the G2 self-revocation carve is `att has /dimension && !is_subject_retainable(dim)` — a fail-closed allowlist keyed on authorship. Dimensionless conferrals (`delegates_to`) bypass it, so a conferred moderation duty survives a Pull; peer-authored scores do not.

### Spoofing / impersonation proofs (prove the holes are closed)

Build the exact paste attack against the pre-v31 shape, prove v31 refuses it, each paired with an **honest-twin control** so the mutation is *provably* the cause of the refusal:

- **`v31_revocation_paste_cannot_deadmit_an_unintended_key`** — a revocation signed to de-admit `victim-A`, its column repainted onto `victim-B`, is refused by `check_revocation_envelope_binding` (the gate **every** store's admit path runs: memory / sqlite / postgres / tier_ingest) — isolated from the orthogonal slash-authority gate (defense in depth, not what #659 closes).
- **`v31_conferral_paste_cannot_lift_authority_onto_another_key`** — a `delegates_to` conferral signed for `grantee-A`, its `attested_key_id` + `subject_key_ids` repainted onto `grantee-B`, is refused by `check_row_column_binding` (`subject_key_ids` is the column CC flags as *granting revocation authority* — the highest-value forgery).

The invariant both prove: **authority is bound to the SIGNATURE, never to custody of the row.**

### Verification

- Tests: replication **179/0**, mesh_config **6/0**, field_conformance **5/5**, test_anchor_e2e **1/0**
- `clippy -D warnings` clean across `{reticulum, reticulum+test-anchor, http, default}` **and** the pre-push canonical set (`http+reticulum+pyo3+lxmf --all-targets`)
- `fmt` clean; evidence stamps bumped to v16.0.0 (drift test green)

### Pins

`ciris-persist v31.0.0` (`version = "31"`), `ciris-verify v13.1.0`; `pyproject ciris-persist>=31,<32`.

---

Supersedes #466 (v15.23.0 / v30.12.0 adopt — folded into this cut). No wire-format hashes changed edge-side beyond #462's already-re-pinned `SERVE_ADVERTISE_POLICY_HASH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs
