### PR TITLE
ci: drop PyPI publish + consume cohab siblings from git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2476,6 +2476,11 @@ jobs:
             echo "::error::expected 4 per-platform signed manifests, got $MCOUNT"
             exit 1
           fi
+          # Flatten beside the wheels/tarballs — gh release upload/download use a
+          # FLAT asset namespace, so SHA256SUMS must reference basenames or
+          # `sha256sum -c` fails for a consumer who downloads them side-by-side
+          # (CIRISEdge#471, Codex).
+          mv dist/manifests/*.manifest.json dist/
       # v0.13.0 (CIRISEdge#36 GO) — bundle the UniFFI-generated Kotlin
       # and Swift bindings as release tarballs. Mobile / native
       # consumers (CIRISAgent KMP UI, future iOS shell) consume them
@@ -2515,8 +2520,10 @@ jobs:
         run: |
           cd dist
           # Include the desktop wheels + their per-platform signed manifests so all
-          # integrity metadata travels with the Release (CIRISEdge#471).
-          sha256sum ciris-edge-v*.tar.gz *.whl manifests/*.manifest.json > SHA256SUMS
+          # integrity metadata travels with the Release (CIRISEdge#471). All by
+          # BASENAME — release assets are a flat namespace, so `sha256sum -c` works
+          # when a consumer downloads them beside SHA256SUMS.
+          sha256sum ciris-edge-v*.tar.gz *.whl *.manifest.json > SHA256SUMS
           cat SHA256SUMS
       - name: create GitHub Release + upload assets
         env:
@@ -2554,7 +2561,7 @@ jobs:
             "dist/ciris-edge-v${VERSION}-kotlin-bindings.tar.gz" \
             "dist/ciris-edge-v${VERSION}-swift-bindings.tar.gz" \
             dist/*.whl \
-            dist/manifests/*.manifest.json \
+            dist/*.manifest.json \
             "dist/SHA256SUMS"
 
           # Promote draft → published. Idempotent on already-published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1923,13 +1923,23 @@ jobs:
               echo "::error::no wheel found for ${label} (dist/wheels/ciris_edge-wheel-${label}/)"
               exit 1
             fi
+            # EdgeExtras is a linux-x86_64 SOURCE/build-input snapshot — its dep-tree
+            # hash is `cargo tree --target x86_64-unknown-linux-gnu` and
+            # enabled_transports reflects the emit binary — so it is accurate ONLY for
+            # the canonical manifest. The other platforms sign binary hash + target +
+            # signature WITHOUT it, rather than stamp a linux source snapshot onto a
+            # non-linux wheel (Codex on #471). `--extras` is optional to ciris-build-sign.
+            local extras_args=()
+            if [ "$label" = "linux-x86_64" ]; then
+              extras_args=(--extras "dist/edge-extras-${VERSION}.json")
+            fi
             ciris-build-sign sign \
               --primitive edge \
               --build-id "$VERSION" \
               --target "$target" \
               --binary "$wheel" \
               --binary-version "$VERSION" \
-              --extras "dist/edge-extras-${VERSION}.json" \
+              "${extras_args[@]}" \
               --ed25519-seed "$ED_KEY_PATH" \
               --mldsa-secret "$MLDSA_KEY_PATH" \
               --key-id ciris-edge-build-v1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2184,14 +2184,28 @@ jobs:
                   raise SystemExit(f'no tag found for {crate} in Cargo.toml')
               return m.group(1)
           persist = find_tag('ciris-persist')
+          # ciris-verify-core / ciris-keyring / ciris-crypto all ship from the
+          # CIRISVerify monorepo under ONE tag. Assert that parity before pinning
+          # the Python `ciris-verify` package to it (Codex #471) — else cohab could
+          # test a `ciris-verify` wheel from a different repo revision than the
+          # keyring/crypto crates actually linked into edge, and pass on a shape that
+          # was never built.
           verify  = find_tag('ciris-verify-core')
+          keyring = find_tag('ciris-keyring')
+          crypto  = find_tag('ciris-crypto')
+          assert verify == keyring == crypto, (
+              f'CIRISVerify crates disagree on tag (verify-core {verify}, keyring '
+              f'{keyring}, crypto {crypto}) — they share one monorepo tag by design'
+          )
           pins = {
-              # CIRISEdge: neither persist (stopped at v30.4.0) nor verify publishes
-              # to PyPI — everyone consumes them via git tag now. A version pin
-              # (ciris-persist==X / ciris-verify==X) resolves against PyPI and fails
-              # "No matching distribution". Build BOTH from the git tags edge pins in
-              # Cargo.toml (the reusable workflow's documented git-source override) —
-              # off the assets we build, not PyPI.
+              # CIRISEdge is git-tag-only, and so are its substrate siblings: NEITHER
+              # persist (stopped at v30.4.0) NOR verify publishes to PyPI, and NO ONE
+              # consumes them off PyPI — every consumer pins the Cargo git tag (Rust)
+              # or rides the ciris-server one-wheel (Python). A version pin
+              # (ciris-persist==X / ciris-verify==X) would resolve against PyPI and
+              # fail "No matching distribution", so build BOTH from the git tags edge
+              # pins in Cargo.toml (the reusable workflow's documented git-source
+              # override) — off the assets we build, not PyPI.
               'ciris-persist': f'git+https://github.com/CIRISAI/CIRISPersist.git@v{persist}',
               'ciris-verify':  f'git+https://github.com/CIRISAI/CIRISVerify.git@v{verify}',
           }
@@ -2357,6 +2371,39 @@ jobs:
             echo "::warning::XCFramework download attempt $attempt failed; retrying in $((attempt * 10))s"
             sleep $((attempt * 10))
           done
+      - name: download desktop abi3 wheels for durable Release attach (with retry)
+        # CIRISEdge#471 — publish-pypi was the desktop wheels' ONLY durable home;
+        # with it removed, attach them to the GitHub Release so build-manifest's
+        # registered (hybrid-signed) hashes stay obtainable. NOT PyPI — no one
+        # consumes these off PyPI; the Release is the durable, hash-matching source.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if gh run download "$GITHUB_RUN_ID" \
+                --repo "$GITHUB_REPOSITORY" \
+                --pattern 'ciris_edge-wheel-*' \
+                --dir dist/wheels; then
+              echo "✓ desktop wheels download succeeded on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" = "5" ]; then
+              echo "::error::desktop wheels download failed 5 times"
+              exit 1
+            fi
+            echo "::warning::desktop wheels download attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          # gh run download nests each artifact in its own dir; flatten beside the
+          # tarballs so SHA256SUMS + the upload pick them up.
+          find dist/wheels -name '*.whl' -exec mv {} dist/ \;
+          echo "=== desktop wheels ==="
+          ls -la dist/*.whl
+          COUNT=$(ls dist/*.whl 2>/dev/null | wc -l)
+          if [ "$COUNT" -lt 3 ]; then
+            echo "::error::expected >=3 desktop abi3 wheels (linux x86_64 + aarch64, darwin arm64), got $COUNT"
+            exit 1
+          fi
       # v0.13.0 (CIRISEdge#36 GO) — bundle the UniFFI-generated Kotlin
       # and Swift bindings as release tarballs. Mobile / native
       # consumers (CIRISAgent KMP UI, future iOS shell) consume them
@@ -2395,7 +2442,9 @@ jobs:
       - name: generate SHA256SUMS
         run: |
           cd dist
-          sha256sum ciris-edge-v*.tar.gz > SHA256SUMS
+          # Include the desktop abi3 wheels so their hashes travel with the Release
+          # (they match build-manifest's registered hashes — CIRISEdge#471).
+          sha256sum ciris-edge-v*.tar.gz *.whl > SHA256SUMS
           cat SHA256SUMS
       - name: create GitHub Release + upload assets
         env:
@@ -2432,6 +2481,7 @@ jobs:
             "dist/ciris-edge-v${VERSION}-xcframework.tar.gz" \
             "dist/ciris-edge-v${VERSION}-kotlin-bindings.tar.gz" \
             "dist/ciris-edge-v${VERSION}-swift-bindings.tar.gz" \
+            dist/*.whl \
             "dist/SHA256SUMS"
 
           # Promote draft → published. Idempotent on already-published

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2184,19 +2184,16 @@ jobs:
                   raise SystemExit(f'no tag found for {crate} in Cargo.toml')
               return m.group(1)
           persist = find_tag('ciris-persist')
-          keyring = find_tag('ciris-keyring')
-          crypto  = find_tag('ciris-crypto')
-          assert keyring == crypto, f'ciris-keyring ({keyring}) and ciris-crypto ({crypto}) must share a tag — both come from CIRISVerify'
+          verify  = find_tag('ciris-verify-core')
           pins = {
-              # CIRISEdge: persist stopped PyPI-publishing at v30.4.0, so a version
-              # pin (ciris-persist==X) resolves against PyPI and fails with "No
-              # matching distribution" — cohab was permanently benign-red. Build it
-              # from its git tag instead (the reusable workflow's documented
-              # git-source override): the same tag edge pins in Cargo.toml, off the
-              # assets we build, not PyPI. (verify is still a version pin — flip it
-              # to git-source the same way if a tag-run shows it also left PyPI.)
+              # CIRISEdge: neither persist (stopped at v30.4.0) nor verify publishes
+              # to PyPI — everyone consumes them via git tag now. A version pin
+              # (ciris-persist==X / ciris-verify==X) resolves against PyPI and fails
+              # "No matching distribution". Build BOTH from the git tags edge pins in
+              # Cargo.toml (the reusable workflow's documented git-source override) —
+              # off the assets we build, not PyPI.
               'ciris-persist': f'git+https://github.com/CIRISAI/CIRISPersist.git@v{persist}',
-              'ciris-verify':  f'ciris-verify=={keyring}',
+              'ciris-verify':  f'git+https://github.com/CIRISAI/CIRISVerify.git@v{verify}',
           }
           print(f'json={json.dumps(pins)}')
           PYEOF
@@ -2224,117 +2221,6 @@ jobs:
       under-test-wheel-artifact: ciris_edge-wheel-${{ matrix.platform }}
       under-test-package: ciris-edge
       pin-overrides: ${{ needs.extract-substrate-pins.outputs.pin-overrides }}
-
-  # ─── publish-pypi: tag-gated wheel upload via OIDC ──────────────────
-  #
-  # Trust posture: the BuildManifest round-trip (build-manifest job
-  # above) is the cryptographic root of trust. PyPI is the fast
-  # distribution channel — peers verifying authenticity check the
-  # registry-side hybrid Ed25519 + ML-DSA-65 signature on the
-  # manifest, not the PyPI artifact itself. PEP 740 attestations
-  # compound the two.
-  #
-  # Auth: OIDC trusted publishing. NO API token in CI secrets — PyPI
-  # validates the workflow's GitHub identity directly. One-time setup
-  # on PyPI side is required (project owner reserves the name +
-  # configures the trusted publisher); see docs/PYPI_PUBLISH.md.
-  publish-pypi:
-    name: Publish wheels to PyPI (tag-gated)
-    runs-on: ubuntu-latest
-    # Gate publish on every quality job — presence-of-wheel alone is
-    # not a quality gate. Same v0.3.3 closure persist applied after
-    # v0.3.2 shipped wheels through a fmt-failure tag run.
-    #
-    # v0.7.0 (CIRISEdge#17) — added the four mobile lanes to the gate.
-    # publish-pypi still only ships the three desktop abi3 wheels
-    # (linux x86_64 + linux aarch64 + darwin aarch64) — Chaquopy wheels
-    # and iOS PyO3 tarballs go to GitHub Release via `mobile-release`,
-    # not PyPI. Mirrors persist's discipline exactly (persist's
-    # publish-pypi also gates on ios-build + android-package without
-    # consuming their artifacts). Rationale: a tag that builds a green
-    # desktop wheel but breaks the iOS/Android cohabitation paths
-    # should not ship to PyPI either — the cohabiting agent expects
-    # version-aligned substrate across all platforms.
-    needs:
-      - pyo3-wheel
-      - build-manifest
-      - lint
-      - license-audit
-      - linux-x86_64-test
-      - darwin-aarch64-test
-      - android-package
-      - ios-pyo3-package
-      - xcframework
-      # v3.0.1 — `cohabitation-conformance` dropped from publish-pypi
-      # gating. During family-wide major-version transitions (v3.0.0
-      # pyo3 0.28→0.29 + persist 5→6 + verify 5.1→5.2 was the trigger)
-      # the harness can't pass: it installs the latest PyPI siblings
-      # alongside the under-test wheel, but those siblings haven't
-      # co-bumped yet — pip resolution hits `ResolutionImpossible` and
-      # the gate becomes a structural blocker for the lockstep itself
-      # (no member of the family can publish until all members have
-      # already published, classic chicken-and-egg).
-      #
-      # Cohabitation still runs as an INFORMATIONAL job — operators see
-      # the failures in PR reviews and can choose to wait for downstream
-      # consumers to co-bump before merging. It just no longer blocks
-      # the OIDC publish.
-      #
-      # When `ciris-lens-core` (and any other siblings) ship their
-      # co-bump to the new persist/edge/verify floor, re-enable this by
-      # adding `- cohabitation-conformance` back to the `needs` list.
-      # Tracked in CIRISLensCore#53 for the immediate lens-core
-      # co-bump.
-    if: startsWith(github.ref, 'refs/tags/v')
-    environment:
-      name: pypi
-      url: https://pypi.org/project/ciris-edge/
-    permissions:
-      # OIDC token-issuance permission. Required for PyPI's trusted
-      # publishing. Scope is the workflow's GitHub-issued JWT only;
-      # no long-lived secret.
-      id-token: write
-    steps:
-      - name: download all multi-arch wheels
-        # `merge-multiple: true` flattens the per-artifact subdirs;
-        # the .whl filenames already encode the target tag (e.g.
-        # `-manylinux_2_34_aarch64`) so there's no collision.
-        uses: actions/download-artifact@v4
-        with:
-          pattern: ciris_edge-wheel-*
-          merge-multiple: true
-          path: dist
-      - name: sanity-check wheel shapes before publish
-        run: |
-          ls -la dist/
-          COUNT=$(ls dist/*.whl 2>/dev/null | wc -l)
-          if [ "${COUNT}" -lt 3 ]; then
-            echo "::error::Expected 3 wheels (linux x86_64 + aarch64, darwin arm64); got ${COUNT}"
-            ls dist/*.whl 2>/dev/null || echo "  (no .whl files at all)"
-            exit 1
-          fi
-          for wheel in dist/*.whl; do
-            # v0.7.0 (CIRISEdge#17) — abi3-py310 floor (Chaquopy compat).
-            if ! [[ "${wheel}" =~ -cp310-abi3- ]]; then
-              echo "::error::Non-abi3 wheel detected: ${wheel}"
-              exit 1
-            fi
-            echo "✓ ${wheel}"
-          done
-          echo "✓ All ${COUNT} wheels conform to cp310-abi3."
-      - name: publish to PyPI via OIDC trusted publishing
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          # No `password:` — OIDC trusted publishing handles auth.
-          packages-dir: dist
-          # skip-existing makes tag re-runs idempotent. PyPI rejects
-          # same-version re-uploads anyway; failing softly here keeps
-          # re-runs from blowing up.
-          skip-existing: true
-          # PEP 740 — sigstore-attested upload. Consumers verifying
-          # the manifest can also verify the PyPI artifact ties to
-          # this exact GH workflow identity.
-          attestations: true
 
   # ─── mobile-release: GitHub Release tarball publish (CIRISEdge#17) ──
   #
@@ -2518,10 +2404,11 @@ jobs:
           TAG="${GITHUB_REF_NAME}"
           VERSION="${{ steps.version.outputs.version }}"
 
-          # publish-pypi creates the GitHub Release in some flows; create
-          # here if it doesn't exist yet, otherwise just upload. --verify-tag
-          # ensures we don't accidentally create a release for a tag that
-          # doesn't exist (e.g. workflow_dispatch on main).
+          # mobile-release is the SOLE creator of the GitHub Release (edge is
+          # git-tag-only; there is no PyPI publish job). Create here if it does
+          # not exist yet, otherwise just upload. --verify-tag ensures we don't
+          # accidentally create a release for a tag that doesn't exist (e.g.
+          # workflow_dispatch on main).
           if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create "$TAG" \
               --repo "$GITHUB_REPOSITORY" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: CI
 on:
   push:
     branches: [main]
-    # Fire on v-prefixed release tags so the publish-pypi job (gated on
-    # `refs/tags/v*`) actually runs. Mirrors persist's v0.1.12 closure.
+    # Fire on v-prefixed release tags so the tag-gated release jobs (gated on
+    # `refs/tags/v*`) run — mobile-release, cohab, build-ios, xcframework, etc.
     tags: ['v*']
   pull_request:
 
@@ -1791,7 +1791,7 @@ jobs:
   # OQ-12 closure: every released CIRISEdge artifact publishes
   # `EdgeExtras` JSON signed via `ciris-build-sign` (Ed25519 +
   # ML-DSA-65 hybrid) and registers with CIRISRegistry. Round-trip
-  # verified before publish-pypi runs.
+  # verified as part of the tag-gated release.
   #
   # Trust posture: this manifest is the cryptographic root of trust.
   # PyPI is just a fast distribution channel — peers verifying
@@ -1804,8 +1804,8 @@ jobs:
   # otherwise both POST `version=X` to the registry — and because
   # maturin wheels aren't byte-reproducible, the two runs register
   # different hashes and the loser's round-trip GET fails on a hash
-  # mismatch. Matching `publish-pypi`'s gate keeps registration to
-  # the tag run only (CIRISEdge#11; v0.2.3 main-run hit the race).
+  # mismatch. The tag-gate keeps registration to the tag run only
+  # (CIRISEdge#11; v0.2.3 main-run hit the race).
   build-manifest:
     name: Generate + sign build manifest (hybrid Ed25519 + ML-DSA-65)
     runs-on: ubuntu-latest
@@ -1908,21 +1908,54 @@ jobs:
           MLDSA_KEY_PATH=$(mktemp)
           printf '%s' "${CIRIS_BUILD_ED25519_SECRET}" | base64 -d > "$ED_KEY_PATH"
           printf '%s' "${CIRIS_BUILD_MLDSA_SECRET}" | base64 -d > "$MLDSA_KEY_PATH"
-          BINARY="$(ls dist/wheel/*.whl | head -1)"
-          ciris-build-sign sign \
-            --primitive edge \
-            --build-id "${{ steps.version.outputs.version }}" \
-            --target x86_64-unknown-linux-gnu \
-            --binary "$BINARY" \
-            --binary-version "${{ steps.version.outputs.version }}" \
-            --extras "dist/edge-extras-${{ steps.version.outputs.version }}.json" \
-            --ed25519-seed "$ED_KEY_PATH" \
-            --mldsa-secret "$MLDSA_KEY_PATH" \
-            --key-id ciris-edge-build-v1 \
-            --output "dist/ciris-edge-${{ steps.version.outputs.version }}.manifest.json"
+          VERSION="${{ steps.version.outputs.version }}"
+          mkdir -p dist/manifests
+          # CIRISEdge#471 — EVERY desktop platform gets its own hybrid-signed
+          # manifest, not just linux-x86_64. Each wheel sits under
+          # dist/wheels/ciris_edge-wheel-<label>/ (the multi-arch download above).
+          # `--target` is metadata and ciris-build-sign HASHES the wheel file (never
+          # runs it), so signing the windows/darwin/aarch64 wheels on this linux
+          # runner is correct.
+          sign_platform() {
+            local label="$1" target="$2" wheel
+            wheel="$(ls "dist/wheels/ciris_edge-wheel-${label}"/*.whl 2>/dev/null | head -1)"
+            if [ -z "$wheel" ]; then
+              echo "::error::no wheel found for ${label} (dist/wheels/ciris_edge-wheel-${label}/)"
+              exit 1
+            fi
+            ciris-build-sign sign \
+              --primitive edge \
+              --build-id "$VERSION" \
+              --target "$target" \
+              --binary "$wheel" \
+              --binary-version "$VERSION" \
+              --extras "dist/edge-extras-${VERSION}.json" \
+              --ed25519-seed "$ED_KEY_PATH" \
+              --mldsa-secret "$MLDSA_KEY_PATH" \
+              --key-id ciris-edge-build-v1 \
+              --output "dist/manifests/ciris-edge-${VERSION}-${label}.manifest.json"
+            echo "✓ signed ${label} (${target})"
+          }
+          sign_platform linux-x86_64   x86_64-unknown-linux-gnu
+          sign_platform linux-aarch64  aarch64-unknown-linux-gnu
+          sign_platform darwin-aarch64 aarch64-apple-darwin
+          sign_platform windows-x86_64 x86_64-pc-windows-msvc
           shred -uz "$ED_KEY_PATH" "$MLDSA_KEY_PATH" 2>/dev/null || rm -f "$ED_KEY_PATH" "$MLDSA_KEY_PATH"
-          echo "Signed manifest:"
-          cat "dist/ciris-edge-${{ steps.version.outputs.version }}.manifest.json"
+          # The linux-x86_64 manifest is the CANONICAL one registered with
+          # CIRISRegistry (its round-trip below); the other three ride the GitHub
+          # Release attached beside their wheels.
+          cp "dist/manifests/ciris-edge-${VERSION}-linux-x86_64.manifest.json" \
+             "dist/ciris-edge-${VERSION}.manifest.json"
+          echo "=== per-platform signed manifests ==="
+          ls -la dist/manifests/
+          echo "=== canonical (linux-x86_64) manifest ==="
+          cat "dist/ciris-edge-${VERSION}.manifest.json"
+      - name: upload per-platform signed manifests
+        uses: actions/upload-artifact@v4
+        with:
+          name: ciris-edge-manifests
+          path: dist/manifests/*.manifest.json
+          if-no-files-found: error
       - name: pre-flight registry steward-key check
         # Surfaces the registry's active steward key_id to the step
         # summary. Persist + lens log this for human-visible
@@ -2012,7 +2045,7 @@ jobs:
               'version': '${{ steps.version.outputs.version }}',
               'binaries': binaries,
               'generated_at': '${GENERATED_AT}',
-              'notes': 'CIRIS federation transport substrate; manifest signed via ciris-build-sign --primitive edge (CIRISVerify v1.9.0). Multi-arch publish: linux x86_64 + aarch64, darwin arm64.',
+              'notes': 'CIRIS federation transport substrate; manifest signed via ciris-build-sign --primitive edge (CIRISVerify v1.9.0). Per-platform hybrid-signed manifests for linux x86_64 + aarch64, darwin arm64, windows x64 (this registry holds the linux-x86_64 canonical; all four are attached to the GitHub Release beside their wheels). Git-tag-only; not published to PyPI.',
           }))
           " "${BINARIES_JSON}")
           echo "POST ${REGISTRY_URL}/v1/verify/binary-manifest"
@@ -2122,8 +2155,8 @@ jobs:
   # problem only surfaces when persist and edge are TWO wheels. This
   # job loads exactly that deployment shape — pinned siblings from
   # CIRISConformance's matrix + the just-built under-test wheel — and
-  # runs the conformance suite. A regression here BLOCKS publish-pypi
-  # (added to its `needs:` graph below).
+  # runs the conformance suite. Tag-only release-quality signal; it does not
+  # gate any publisher (edge is git-tag-only).
   #
   # Matrix: 3 platforms × 2 backends = 6 cells. Each platform exercises
   # its own native wheel; each backend (sqlite, postgres) exercises
@@ -2255,17 +2288,18 @@ jobs:
   #   - `SHA256SUMS`                                — release-attestable
   #     hashes over all of the above
   #
-  # `publish-pypi` ships the THREE desktop wheels to PyPI separately
-  # (linux-x86_64, linux-aarch64, darwin-aarch64). The two channels
-  # are complementary — PyPI for `pip install ciris-edge` on desktop,
-  # GitHub Release for `gh release download` on mobile/native.
+  # v16.0.1 (CIRISEdge#471) — the GitHub Release is the SOLE desktop-wheel
+  # channel too: mobile-release attaches the four desktop wheels
+  # (linux-x86_64, linux-aarch64, darwin-aarch64, windows-x86_64) + their
+  # per-platform hybrid-signed manifests here. There is no PyPI publish; edge is
+  # git-tag-only.
   #
   # Persist's job: CIRISPersist ci.yml lines 1293-1426. Mirrored shape:
   #   - Tag-gate: `if: startsWith(github.ref, 'refs/tags/v')`
   #   - `gh run download` with 5-attempt retry (absorbs ListArtifacts
   #     transient 403s — persist hit this on v1.5.24 tag run).
   #   - `gh release create --verify-tag` if release doesn't exist yet
-  #     (publish-pypi may have created it).
+  #     (mobile-release is the sole creator now — CIRISEdge#471).
   #   - `gh release upload --clobber` for idempotent tag re-runs.
   #
   # Edge-specific additions: XCFramework asset (verify ships one too;
@@ -2280,6 +2314,15 @@ jobs:
       - xcframework
       - lint
       - license-audit
+      # CIRISEdge#471 — mobile-release is now the SOLE publisher of the desktop
+      # wheels + their per-platform signed manifests, so it inherits publish-pypi's
+      # desktop quality gates: never ship a wheel whose platform tests failed, or
+      # before the full wheel matrix + signed manifests exist (no partial-download
+      # race). `pyo3-wheel` gates on ALL four desktop cells (incl. windows).
+      - pyo3-wheel
+      - build-manifest
+      - linux-x86_64-test
+      - darwin-aarch64-test
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
@@ -2400,8 +2443,37 @@ jobs:
           echo "=== desktop wheels ==="
           ls -la dist/*.whl
           COUNT=$(ls dist/*.whl 2>/dev/null | wc -l)
-          if [ "$COUNT" -lt 3 ]; then
-            echo "::error::expected >=3 desktop abi3 wheels (linux x86_64 + aarch64, darwin arm64), got $COUNT"
+          if [ "$COUNT" -ne 4 ]; then
+            echo "::error::expected 4 desktop wheels (linux x86_64+aarch64, darwin arm64, windows x64), got $COUNT"
+            exit 1
+          fi
+      - name: download per-platform signed manifests (with retry)
+        # CIRISEdge#471 — the hybrid-signed manifest for EACH desktop wheel
+        # (build-manifest signs all four). Attached to the Release beside its wheel
+        # so EVERY platform's binary is verifiable against a signed manifest.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if gh run download "$GITHUB_RUN_ID" \
+                --repo "$GITHUB_REPOSITORY" \
+                --name ciris-edge-manifests \
+                --dir dist/manifests; then
+              echo "✓ signed manifests download succeeded on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" = "5" ]; then
+              echo "::error::signed manifests download failed 5 times"
+              exit 1
+            fi
+            echo "::warning::signed manifests download attempt $attempt failed; retrying in $((attempt * 10))s"
+            sleep $((attempt * 10))
+          done
+          echo "=== per-platform signed manifests ==="
+          ls -la dist/manifests/*.manifest.json
+          MCOUNT=$(ls dist/manifests/*.manifest.json 2>/dev/null | wc -l)
+          if [ "$MCOUNT" -ne 4 ]; then
+            echo "::error::expected 4 per-platform signed manifests, got $MCOUNT"
             exit 1
           fi
       # v0.13.0 (CIRISEdge#36 GO) — bundle the UniFFI-generated Kotlin
@@ -2442,9 +2514,9 @@ jobs:
       - name: generate SHA256SUMS
         run: |
           cd dist
-          # Include the desktop abi3 wheels so their hashes travel with the Release
-          # (they match build-manifest's registered hashes — CIRISEdge#471).
-          sha256sum ciris-edge-v*.tar.gz *.whl > SHA256SUMS
+          # Include the desktop wheels + their per-platform signed manifests so all
+          # integrity metadata travels with the Release (CIRISEdge#471).
+          sha256sum ciris-edge-v*.tar.gz *.whl manifests/*.manifest.json > SHA256SUMS
           cat SHA256SUMS
       - name: create GitHub Release + upload assets
         env:
@@ -2482,6 +2554,7 @@ jobs:
             "dist/ciris-edge-v${VERSION}-kotlin-bindings.tar.gz" \
             "dist/ciris-edge-v${VERSION}-swift-bindings.tar.gz" \
             dist/*.whl \
+            dist/manifests/*.manifest.json \
             "dist/SHA256SUMS"
 
           # Promote draft → published. Idempotent on already-published

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "16.0.0"
+version = "16.0.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/docs/PYPI_PUBLISH.md
+++ b/docs/PYPI_PUBLISH.md
@@ -1,187 +1,62 @@
-# PyPI publishing — operator runbook
+# Distribution runbook — CIRISEdge is git-tag-only (PyPI publishing REMOVED)
 
-CIRISEdge publishes `ciris-edge` wheels to PyPI on every tag push via
-OIDC trusted publishing (no long-lived API token in CI). Mirrors
-the pattern CIRISPersist + CIRISVerify use.
+> **Status: PyPI publishing was removed in v16.0.1 (CIRISEdge#471).**
+> There is no `publish-pypi` job, no OIDC trusted-publisher setup, and
+> `pip install ciris-edge` is **not** a supported path. This file used to be
+> the PyPI operator runbook; it now documents the actual distribution model so
+> anyone who lands here (e.g. from `docs/RELEASE_NOTES.md`) gets the truth.
 
-This doc covers the **one-time setup** needed on the PyPI side before
-the first tag push triggers a successful publish.
+## Why no PyPI
 
----
+- **`ciris-edge` exceeds the PyPI project-size quota** — the publish always
+  failed `400 Project size too large`, so PyPI was never a working channel.
+- **The substrate siblings aren't on PyPI either** — `ciris-persist` stopped
+  publishing at v30.4.0, and `ciris-verify` is git-tag-only. A PyPI
+  `Requires-Dist` on them would resolve to "No matching distribution".
+- So **no one consumes edge (or its wheels) off PyPI.** Keeping a permanently
+  red `publish-pypi` job on every release tag only hid real failures.
 
-## TL;DR — checklist
+## How CIRISEdge is actually consumed
 
-1. Reserve the project name on PyPI.
-2. Configure trusted publisher pointing at this repo + the `ci.yml`
-   workflow + the `pypi` environment.
-3. Push a v-prefixed tag. Wheels publish; `pip install ciris-edge`
-   works.
+| Consumer | Mechanism |
+|----------|-----------|
+| Rust crates (CIRISServer, …) | pin the **Cargo git tag**: `ciris-edge = { git = "…/CIRISEdge", tag = "v16.0.1" }` |
+| Python (CIRISAgent) | rides the **`ciris-server` one-wheel** (#896), which bundles edge + resolves ONE process-wide `ciris-persist` by construction |
+| Mobile / native | the **GitHub Release** tarballs (android, ios, xcframework, kotlin/swift bindings) |
+| Desktop Python wheels | the **GitHub Release** — the four abi3 wheels (linux x86_64 + aarch64, darwin arm64, windows x64), each beside its hybrid-signed manifest |
 
-Total time: ~5 minutes if you have a PyPI account already.
+`pyproject.toml`'s `ciris-persist>=31,<32` is a **source-build major-tracker +
+co-resident version-agreement declaration**, not an install-time index
+requirement — it is unresolvable from PyPI by design.
 
----
+## What ships on a release tag
 
-## Why OIDC trusted publishing (no API token)
+Pushing a `v*` tag runs `ci.yml`. On green edge-side, `mobile-release` creates
+the GitHub Release (it is the **sole** publisher) and attaches:
 
-Older PyPI publish flows used long-lived API tokens uploaded as GitHub
-repo secrets. Tokens leak; rotation is manual; revocation is reactive.
+- the mobile/native tarballs + `SHA256SUMS`;
+- the **four desktop abi3 wheels**;
+- **one hybrid-signed manifest per desktop platform** (`ciris-edge-<version>-<label>.manifest.json`),
+  produced by `build-manifest` via `ciris-build-sign` (Ed25519 + ML-DSA-65). The
+  linux-x86_64 manifest is additionally registered with CIRISRegistry as the
+  canonical; all four ride the Release so **every platform's binary is verifiable
+  against a signed manifest**.
 
-PyPI's trusted publishing (PEP 740 / OIDC) replaces that:
+`mobile-release` gates on the desktop quality jobs (`pyo3-wheel`,
+`build-manifest`, `linux-x86_64-test`, `darwin-aarch64-test`) so a wheel whose
+platform tests or manifest build failed is never distributed.
 
-- GitHub Actions issues a short-lived JWT identifying the workflow run.
-- PyPI verifies the JWT against a pre-configured trust policy
-  ("only allow uploads from `CIRISAI/CIRISEdge`'s `ci.yml` workflow
-  running in the `pypi` environment").
-- No persistent credential stored anywhere.
+## Verifying a downloaded wheel
 
-Recommended pattern across the OSS ecosystem (sigstore cosign, npm
-provenance, etc.). What the
-[PyPI docs themselves recommend](https://docs.pypi.org/trusted-publishers/).
+1. Download the wheel + its `ciris-edge-<version>-<label>.manifest.json` from the
+   Release (or check its line in `SHA256SUMS`).
+2. Verify the manifest signature with `ciris-build-verify` (from the CIRISVerify
+   build-tool tarball) against the edge build steward key `ciris-edge-build-v1`.
+3. Confirm the manifest's `binary_hash` matches `sha256` of the wheel.
 
----
+## Known-benign red on release tags
 
-## Setup steps
-
-### 1. Reserve `ciris-edge` on PyPI
-
-If you've never published to PyPI before, you'll need an account
-first. Once logged in:
-
-- Go to <https://pypi.org/manage/account/publishing/>
-- Click "Add a new pending publisher" (this works *before* the project
-  exists — you reserve the name + configure trust in one step)
-- Fill in:
-  - **PyPI Project Name**: `ciris-edge`
-  - **Owner**: `CIRISAI`
-  - **Repository name**: `CIRISEdge`
-  - **Workflow name**: `ci.yml`
-  - **Environment name**: `pypi`
-
-The "Pending Publisher" form publishes the trust policy *before* the
-first upload. After the first successful upload, PyPI promotes it to
-an active "trusted publisher" on the now-created project.
-
-### 2. (Optional) Tag-pattern restrictions
-
-If you want to restrict who can trigger publishes (e.g., only release
-tags from `main`, not arbitrary tags from any branch), add a tag-
-pattern filter in the publisher config. Skip for v0.1.0; can add later.
-
-### 3. Confirm the GitHub environment exists
-
-GitHub Actions environments are created on demand — the first
-workflow run referencing `environment: pypi` creates it. Or
-preemptively:
-
-- <https://github.com/CIRISAI/CIRISEdge/settings/environments>
-- "New environment" → name `pypi`
-- (Optional) Add deployment protection rules. **Recommended:
-  "Required reviewers"** with the repo maintainer(s) — adds a manual
-  approval step before each PyPI publish.
-
-### 4. Push the tag
-
-After steps 1-3, the next `git tag v0.1.0 && git push origin v0.1.0`
-triggers `.github/workflows/ci.yml::publish-pypi`. The job:
-
-1. Waits for `pyo3-wheel` (matrix of 3 entries) + `lint` +
-   `license-audit` + `linux-x86_64-test` + `darwin-aarch64-test` to
-   succeed.
-2. Downloads all three wheel artifacts (linux x86_64 + aarch64, darwin
-   arm64) via the `ciris_edge-wheel-*` glob.
-3. Sanity-checks count + shape (rejects anything that isn't exactly
-   3 cp310-abi3 wheels — prevents v0.1.10-class regressions reaching
-   consumers).
-4. Calls `pypa/gh-action-pypi-publish@release/v1` with
-   `attestations: true`. One sigstore attestation bundle covers all
-   three wheels.
-5. PyPI accepts the upload via OIDC trusted publishing.
-6. `pip install ciris-edge==0.1.0` works within ~30 seconds of the
-   workflow finishing on every supported `(os, arch)`.
-
-### Wheel matrix
-
-| Target triple                | Wheel tag                  | Runner             | Phase |
-|------------------------------|----------------------------|--------------------|-------|
-| `x86_64-unknown-linux-gnu`   | `manylinux_2_34_x86_64`    | `ubuntu-latest`    | 1     |
-| `aarch64-unknown-linux-gnu`  | `manylinux_2_34_aarch64`   | `ubuntu-24.04-arm` | 1     |
-| `aarch64-apple-darwin`       | `macosx_11_0_arm64`        | `macos-14`         | 1     |
-
-`darwin-x86_64` (macos-13) intentionally omitted: GitHub Actions Intel
-macOS runners queue indefinitely due to capacity issues. CIRISPersist's
-matrix dropped it for the same reason; CIRISAgent's `build.yml`
-explicitly notes "macOS Intel: built and uploaded manually". Add back
-via manual upload if a real consumer asks.
-
-iOS / Android out of scope here — they ship via swift-bridge / uniffi
-native packaging at Phase 3, not PyPI.
-
----
-
-## How this compounds with the BuildManifest signature
-
-The `build-manifest` CI job (OQ-12 closure) signs every release with
-hybrid Ed25519 + ML-DSA-65 via `ciris-build-sign --primitive edge`
-and registers with CIRISRegistry. The edge build pipeline has
-**three layers** of provenance:
-
-| Layer | What it proves | Where it lives |
-|---|---|---|
-| Source-of-truth git tag | "This commit is what CIRISAI's repo says" | GitHub repo |
-| BuildManifest hybrid signature (Ed25519 + ML-DSA-65) | "This binary was built from that commit by CIRISAI's signing key" | CIRISRegistry, fetchable via `GET /v1/verify/binary-manifest/<version>?project=ciris-edge` |
-| PEP 740 attestation | "This PyPI artifact was uploaded by CIRISAI's GHA workflow running on that commit" | PyPI, fetchable via `pip install --attestations ...` |
-
-A consumer pinning `pip install ciris-edge==0.1.0` gets:
-
-- Fast install from PyPI's CDN.
-- `ciris-persist >= 0.4.0` and `ciris-verify >= 1.8.6` pulled
-  transitively (matches the install graph the lens / agent / registry
-  already use).
-- Optional attestation-verify (defense-in-depth on the PyPI
-  distribution channel).
-- Cross-check via CIRISRegistry — the wheel's sha256 in PyPI must
-  match `binaries["x86_64-unknown-linux-gnu"]` in the registered
-  BuildManifest (once `build-manifest` lands).
-
-The cryptographic root remains the BuildManifest. PyPI is the fast
-delivery channel; verifiable but not load-bearing on its own.
-
----
-
-## Failure modes
-
-- **First tag push after setup, publish fails with "trusted publisher
-  not found".** PyPI's pending-publisher took longer than expected to
-  propagate, or the workflow filename doesn't match. Check the values
-  entered in step 1 against `.github/workflows/ci.yml`. Re-run the
-  failed job once trust propagates.
-
-- **`skip-existing: true` swallowing a real failure.** If the wheel
-  for the tagged version *already exists* on PyPI, the action skips
-  silently. That's intentional for re-runs. To actually re-publish,
-  bump to a fresh version.
-
-- **Non-cp310-abi3 wheel.** Sanity check rejects it before publish.
-  This is the v0.1.10-class regression — silently shipping a wrong
-  shape would be worse than failing.
-
-- **Registry round-trip 404 on first attempt** (when `build-manifest`
-  lands). `api.registry.ciris-services-1.ai` has a read-after-write
-  window between registration POST and the immediately-following GET.
-  Persist v0.4.0's tag CI hit this and the second attempt was clean.
-  Mitigation in `build-manifest` job: sleep + retry on the round-trip
-  step (3-5 second initial sleep, exponential backoff to ~30s). See
-  `~/.claude/projects/-home-emoore-CIRISEdge/memory/reference_registry_race.md`
-  for context.
-
----
-
-## Rotation
-
-Trusted publisher config doesn't rotate — there's no key material to
-expire. To revoke (e.g., if the workflow is compromised):
-
-- PyPI project settings → "Trusted publishers" → remove the entry.
-- Re-add with the corrected config.
-
-PyPI keeps an audit log of publisher-config changes per project.
+Two tag-only jobs are expected to be red and do **not** gate the release:
+the historical PyPI publish (now removed) and — until every substrate sibling
+re-pins — cohabitation conformance. Verify a release by **edge-side jobs green +
+the GitHub Release artifacts**, not an all-green board.

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.0.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.0.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.0.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.0.1
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.1
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.1
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.0.1
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.0.1
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.1
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,15 @@ classifiers = [
 # alignment). The bundled cdylib links persist 19; a `<19` ceiling here would
 # republish the exact v2.0.2 failure above (Requires-Dist asking for a version
 # the cdylib does not expect → ResolutionImpossible for co-resident consumers).
+# CIRISEdge#471 / git-tag-only: edge is NOT consumed standalone off PyPI —
+# `pip install ciris-edge` is not a supported path (the PyPI publish job is gone,
+# and edge's own wheel exceeds the PyPI project-size quota). Rust consumers pin the
+# Cargo git tag; Python consumers ride the ciris-server one-wheel, which resolves
+# ONE process-wide ciris-persist by construction. persist itself stopped
+# PyPI-publishing at v30.4.0, so this `>=31,<32` never resolves from PyPI: it is a
+# source-build major-tracker + the co-resident version-agreement declaration, NOT
+# an install-time index requirement (so the "unresolvable from PyPI" shape is by
+# design, not a regression).
 dependencies = [
     "ciris-persist>=31,<32",
 ]


### PR DESCRIPTION
Makes release tags read TRUE instead of a permanent red board (which hides real failures).

**Edge is git-tag-only** — persist stopped PyPI-publishing at v30.4.0, verify likewise, and edge's own PyPI publish fails the project-size quota. Every release tag was red on 7 permanent-benign jobs (6 cohab + publish-pypi).

- **Remove the `publish-pypi` job.** `mobile-release` is already the sole creator of the GitHub Release — proven by v16.0.0, which published all 7 artifacts *despite* publish-pypi failing. Nothing `needs` publish-pypi, so no dangling gate.
- **Flip cohab's verify pin to git-source** (`git+https://github.com/CIRISAI/CIRISVerify.git@v{verify}`), matching the persist git-source override from #465. Both substrate siblings now build from the exact tags edge pins in Cargo.toml, off the assets we build — not PyPI. Drops two dead keyring/crypto extractions.

actionlint clean (only the pre-existing ciriscache false-positive). Cohab is tag-only, so the verify git-source is first exercised on the next release tag. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs