### PR TITLE
fix(security): close v16 review findings — route hijack, reassembly DoS, first-party fetch + 3 more

### DIFF
--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -765,23 +765,43 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                 }
             }
             if let Some(peer) = peer_key_id {
-                // CIRISEdge#396 item 1 — the same consent-membership bound the
-                // listing applies, so a peer excluded from the advertise cannot
-                // obtain an attestation by fetching a hash it learned
-                // out-of-band. Fail-closed: no `ResolvedRecipient`, no bytes.
-                // (#433: `resolve_attestation_recipient` books its OWN branch's
-                // reason — this call site must not re-count, or a single withhold
-                // would show up twice under two different reasons.)
-                let recipient = self.resolve_attestation_recipient(peer).await?;
-                // #379 `infra:serve` + #396 item 6 `recipient_capability`, over
-                // the WIRE bytes — the direct-fetch twins of the listing gates,
-                // so the fetch path narrows exactly as the advertise path did.
-                // The wire is the BARE `Attestation` (§3); tolerate the legacy
-                // `{"attestation": …}` wrap for a peer still on the old wire.
+                // v16 review: FIRST-PARTY right overrides #396 producer-advertise-
+                // consent. If `peer` is this attestation's AUTHOR or DATA-SUBJECT it is
+                // fetching its OWN testimony — the same first-party carve the subject-
+                // Pull LIST gate (`pull_ref_is_serveable`) applies — so list and fetch
+                // AGREE (no advertised-then-unfetchable, no ref disclosed-then-withheld).
+                // For a first-party fetch the recipient IS the peer; #396 item-1
+                // consent-membership and item-6 recipient_capability do not apply. The
+                // E3 trace serve-cap gate below STILL does (a subject pulling its own
+                // `trace:*` row needs `infra:serve`, exactly as the list requires).
+                let first_party = serde_json::from_slice::<serde_json::Value>(&bytes)
+                    .ok()
+                    .is_some_and(|v| {
+                        Self::attestation_is_first_party_to(
+                            v.get("attestation").unwrap_or(&v),
+                            peer,
+                        )
+                    });
+                // #396 item 1 — the same consent-membership bound the listing applies,
+                // so a THIRD-party peer excluded from the advertise cannot obtain an
+                // attestation by fetching a hash it learned out-of-band. Fail-closed:
+                // no `ResolvedRecipient`, no bytes. (#433: `resolve_attestation_recipient`
+                // books its OWN branch's reason — no re-count here.)
+                let recipient: String = if first_party {
+                    peer.to_owned()
+                } else {
+                    self.resolve_attestation_recipient(peer)
+                        .await?
+                        .as_str()
+                        .to_owned()
+                };
+                // #379 `infra:serve` + #396 item 6 `recipient_capability`, over the WIRE
+                // bytes — the direct-fetch twins of the listing gates. The wire is the
+                // BARE `Attestation` (§3); tolerate the legacy `{"attestation": …}` wrap.
                 if let Ok(value) = serde_json::from_slice::<serde_json::Value>(&bytes) {
                     let inner = value.get("attestation").unwrap_or(&value);
                     if Self::attestation_requires_serve(inner)
-                        && !self.peer_has_serve_capability(recipient.as_str()).await
+                        && !self.peer_has_serve_capability(&recipient).await
                     {
                         // #433: `peer_has_serve_capability` books the specific leg
                         // (no-role / read-error / not-rooted / walk-error) — its
@@ -795,20 +815,17 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                         );
                         return None;
                     }
-                    if self
-                        .recipient_capability_withholds(
-                            inner,
-                            recipient.as_str(),
-                            &mut HashMap::new(),
-                        )
-                        .await
+                    // #396 item 6 — recipient_capability gates a THIRD-party recipient
+                    // (an author-chosen audience). A first-party subject/author is not
+                    // such a recipient, so it does not apply (matches the list gate).
+                    if !first_party
+                        && self
+                            .recipient_capability_withholds(inner, &recipient, &mut HashMap::new())
+                            .await
                     {
-                        // #433 — item 6 was the purest silent withhold on this
-                        // path: a bare `return None` with only a `trace!`. It is
-                        // countable now, booked inside
-                        // `recipient_capability_withholds` at the branch that
-                        // decided (which knows the offending dimension), so this
-                        // site does not re-count.
+                        // #433 — item 6 was the purest silent withhold on this path.
+                        // Countable now, booked inside `recipient_capability_withholds`
+                        // at the deciding branch, so this site does not re-count.
                         return None;
                     }
                 }
@@ -1964,6 +1981,27 @@ impl FederationDirectoryReplicationBridge {
     /// ([`Self::fetch_envelope_bytes_for_peer`] and [`Self::list_attestations`])
     /// because only here is the branch visible — and so a withhold is counted
     /// exactly once.
+    /// Whether the authenticated `peer` is FIRST-PARTY to this attestation `inner`
+    /// (the BARE wire value): its author (`attesting_key_id`), its primary subject
+    /// (`attested_key_id`), or in its data-subject set (`subject_key_ids`). All three
+    /// are bound into the SIGNED envelope (#643), and the link authenticates `peer`,
+    /// so a match means the peer genuinely authored-or-is-the-subject-of the row.
+    ///
+    /// v16 review: first-party right overrides #396 producer-advertise-consent. The
+    /// subject-Pull LIST gate (`pull_ref_is_serveable`) already drops #396 (a subject
+    /// pulls its own testimony from a node no peer would ever advertise it to); the
+    /// FETCH must AGREE, else the ref is listed-then-withheld (advertised-then-
+    /// unfetchable + a disclosed ref the subject can't obtain).
+    fn attestation_is_first_party_to(inner: &serde_json::Value, peer: &str) -> bool {
+        let is = |field: &str| inner.get(field).and_then(serde_json::Value::as_str) == Some(peer);
+        is("attesting_key_id")
+            || is("attested_key_id")
+            || inner
+                .get("subject_key_ids")
+                .and_then(serde_json::Value::as_array)
+                .is_some_and(|arr| arr.iter().any(|s| s.as_str() == Some(peer)))
+    }
+
     async fn resolve_attestation_recipient(&self, peer: &str) -> Option<ResolvedRecipient> {
         use crate::observability::WithholdReason;
         let Some(local) = self.local_key_id.as_deref() else {
@@ -4638,6 +4676,89 @@ mod tests {
         );
     }
 
+    /// v16 review (#3): the FETCH first-party classifier. Author (sender axis),
+    /// primary subject, and any co-subject are first-party; an unrelated peer is not.
+    #[test]
+    fn attestation_is_first_party_to_matches_author_and_subject() {
+        use FederationDirectoryReplicationBridge as B;
+        let att = serde_json::json!({
+            "attesting_key_id": "author-A",
+            "attested_key_id": "subject-S",
+            "subject_key_ids": ["subject-S", "co-subject-C"],
+            "dimension": "x",
+        });
+        assert!(B::attestation_is_first_party_to(&att, "author-A")); // sender axis
+        assert!(B::attestation_is_first_party_to(&att, "subject-S")); // primary subject
+        assert!(B::attestation_is_first_party_to(&att, "co-subject-C")); // data-subject set
+        assert!(!B::attestation_is_first_party_to(&att, "stranger-X")); // still #396-gated
+                                                                        // Missing fields must not false-positive into a first-party bypass.
+        assert!(!B::attestation_is_first_party_to(
+            &serde_json::json!({}),
+            "anyone"
+        ));
+    }
+
+    /// v16 review (#3): the FETCH honors first-party right, matching the Pull LIST
+    /// gate. A subject fetching a `delegates_to` ABOUT itself gets the bytes even
+    /// though the node granted it NO #396 consent-membership — while a third party
+    /// with no consent is still withheld. Closes the list-wider-than-fetch gap (a
+    /// ref listed then unfetchable).
+    #[tokio::test]
+    async fn first_party_fetch_overrides_producer_advertise_consent() {
+        let local = "this-node";
+        let producer = "author-A";
+        let subject = "subject-S";
+        let stranger = "stranger-X";
+        let (backend, bridge) = make_bridge(&[
+            local.to_string(),
+            producer.to_string(),
+            subject.to_string(),
+            stranger.to_string(),
+        ]);
+        let bridge = bridge.with_local_key_id(Some(local.to_string()));
+        for kid in [local, producer, subject, stranger] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+        }
+        // A delegates_to ABOUT the subject, authored by the producer, with NO consent
+        // grant/membership for anyone → #396 withholds every THIRD party.
+        seed_delegates_to(
+            &backend,
+            producer,
+            subject,
+            &serde_json::json!(["infra:serve"]),
+        )
+        .await;
+
+        // The subject's own Pull LISTS the ref (entitlement fail-closed to the subject).
+        let refs = bridge
+            .subject_holdings(EnvelopeKind::Attestation, subject, Some(subject))
+            .await;
+        assert!(!refs.is_empty(), "the subject lists its own delegates_to");
+        let hash = refs[0].envelope_hash;
+
+        // FIRST-PARTY: the subject fetches its own testimony despite no #396 consent.
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(EnvelopeKind::Attestation, &hash, Some(subject))
+                .await
+                .is_some(),
+            "the data-subject fetches its own row — first-party overrides #396"
+        );
+        // THIRD-PARTY: a stranger with no consent-membership is still withheld.
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(EnvelopeKind::Attestation, &hash, Some(stranger))
+                .await
+                .is_none(),
+            "a third party without #396 consent still cannot fetch it (the gate holds)"
+        );
+    }
+
     /// CIRISEdge#462 — the subject-scoped serve reader answers the SUBJECT with
     /// its testimony across BOTH axes (ABOUT-me via the data-subject axis +
     /// authored-BY-me via the sender axis), never leaks another subject's rows,
@@ -5086,11 +5207,16 @@ mod tests {
                  onto ANY key (#643)",
             );
         let msg = format!("{err:?}");
+        // v16 review: assert the #643 row-column binding gate refused it SPECIFICALLY
+        // — check_row_column_binding names the divergent member. A bare
+        // "InvalidArgument" is NOT enough: many other put_attestation gates
+        // (cohort-scope, #510 consent-grammar, canonicalize) Debug-format the same,
+        // so accepting it would let this test stay green even if the paste were
+        // refused by an unrelated gate (false confidence).
         assert!(
-            msg.contains("subject_key_ids")
-                || msg.contains("attested_key_id")
-                || msg.contains("InvalidArgument"),
-            "refused for the RIGHT reason (signed row mirror ≠ typed columns), got: {msg}"
+            msg.contains("subject_key_ids") || msg.contains("attested_key_id"),
+            "must be refused by the #643 row-column binding (naming the divergent \
+             attested_key_id/subject_key_ids), not an incidental InvalidArgument, got: {msg}"
         );
     }
 

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -717,6 +717,23 @@ impl ReplicationRuntime {
                     );
                     failures.push(format!("{kind:?}: {e}"));
                 }
+            } else {
+                // SECURITY/correctness (v16 review): register_initiator_peer just
+                // installed this coordinator, so a None means a concurrent
+                // deregister/reconcile raced it away before we could send. That is a
+                // NOT-SENT Pull for this kind — record it, never a silent Ok (the
+                // PullDispatch contract; anti-entropy cannot carry SelfOwn, so a
+                // swallowed Pull is silent subject-recovery loss).
+                tracing::warn!(
+                    peer = %peer_key_id,
+                    subject = %subject_key_id,
+                    kind = ?kind,
+                    "subject Pull coordinator absent immediately after register \
+                     (raced by a concurrent deregister) — surfacing, not swallowing"
+                );
+                failures.push(format!(
+                    "{kind:?}: coordinator absent after register (raced)"
+                ));
             }
         }
         if failures.is_empty() {

--- a/src/transport/frame_fragment.rs
+++ b/src/transport/frame_fragment.rs
@@ -88,6 +88,17 @@ pub const MIN_FRAGMENTABLE_MDU: usize = FRAGMENT_HEADER_LEN + 16;
 /// reject ceiling — so every admissible frame fragments.
 const MAX_FRAGMENTS: usize = u16::MAX as usize;
 
+/// SECURITY (v16 review, pre-attribution reassembly OOM): the receive side bounded
+/// only the COUNT of in-flight partials (`max_in_flight`), never their bytes — so
+/// a peer declaring `total = u16::MAX` and streaming fragments (withholding one so
+/// the frame never completes) could pin ~27 MB in a SINGLE partial, and
+/// `max_in_flight` of them ~7 GB, all before the link is even attributed. These
+/// cap a single frame's accumulated payload (matching the transport `MAX_BODY_BYTES`
+/// admissibility ceiling), and the TOTAL resident reassembly memory across all
+/// partials — the hard bound regardless of partial count.
+const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024; // == transport MAX_BODY_BYTES
+const MAX_IN_FLIGHT_BYTES: usize = 4 * MAX_FRAME_BYTES; // 32 MiB global budget
+
 /// CIRISEdge#422 — fragment-ARQ NAK magic. A third, distinct 4-byte tag so a
 /// receiver tells a NAK (`CNAK`) from a whole frame (`CRPL`) or a data fragment
 /// (`CFRG`) at a glance — a NAK is a TRANSPORT-level control packet, never a
@@ -249,6 +260,9 @@ pub fn parse_nak(bytes: &[u8]) -> Option<([u8; 8], Vec<u16>)> {
 struct Partial {
     total: u16,
     chunks: HashMap<u16, Vec<u8>>,
+    /// Accumulated payload bytes across `chunks` (maintained by delta so a resent
+    /// index never double-counts) — the per-frame ceiling is enforced against this.
+    bytes: usize,
 }
 
 /// Reassembles fragments (of possibly-interleaved frames) back into whole frames.
@@ -259,6 +273,9 @@ pub struct Reassembler {
     partials: HashMap<[u8; 8], Partial>,
     order: VecDeque<[u8; 8]>,
     max_in_flight: usize,
+    /// Sum of every partial's `bytes` — the global reassembly budget is enforced
+    /// against this so total resident memory is bounded regardless of partial count.
+    in_flight_bytes: usize,
 }
 
 impl Reassembler {
@@ -276,6 +293,7 @@ impl Reassembler {
             partials: HashMap::new(),
             order: VecDeque::new(),
             max_in_flight: max_in_flight.max(1),
+            in_flight_bytes: 0,
         }
     }
 
@@ -295,24 +313,58 @@ impl Reassembler {
             return None; // malformed
         }
         let chunk = packet[FRAGMENT_HEADER_LEN..].to_vec();
+        let chunk_len = chunk.len();
 
-        let entry = self.partials.entry(msg_id).or_insert_with(|| {
-            self.order.push_back(msg_id);
-            Partial {
-                total,
-                chunks: HashMap::new(),
+        // Ensure the partial exists. A total mismatch across fragments of the "same"
+        // id (collision / attack) drops this frame's partial rather than reassemble
+        // corrupt bytes. (Copy the existing `total` out so no borrow is held across
+        // the removal below.)
+        match self.partials.get(&msg_id).map(|p| p.total) {
+            Some(t) if t != total => {
+                let dropped = self.partials.remove(&msg_id).map_or(0, |p| p.bytes);
+                self.in_flight_bytes = self.in_flight_bytes.saturating_sub(dropped);
+                self.order.retain(|id| *id != msg_id);
+                return None;
             }
-        });
-        // A total mismatch across fragments of the "same" id (collision / attack)
-        // — drop this frame's partial rather than reassemble corrupt bytes.
-        if entry.total != total {
+            None => {
+                self.order.push_back(msg_id);
+                self.partials.insert(
+                    msg_id,
+                    Partial {
+                        total,
+                        chunks: HashMap::new(),
+                        bytes: 0,
+                    },
+                );
+            }
+            Some(_) => {}
+        }
+
+        // Insert the chunk, maintaining byte accounting by DELTA (a resent index
+        // replaces its previous bytes, never double-counts). Copy out what the
+        // post-checks need, then the &mut is released before any removal.
+        let entry = self
+            .partials
+            .get_mut(&msg_id)
+            .expect("ensured present above");
+        let prev_len = entry.chunks.insert(index, chunk).map_or(0, |v| v.len());
+        entry.bytes = entry.bytes + chunk_len - prev_len;
+        let entry_bytes = entry.bytes;
+        let complete = entry.chunks.len() == entry.total as usize;
+        self.in_flight_bytes = self.in_flight_bytes + chunk_len - prev_len;
+
+        // SECURITY (v16 review): a single frame cannot exceed MAX_FRAME_BYTES — drop
+        // the partial if a peer streams past it (e.g. total=u16::MAX, never completes).
+        if entry_bytes > MAX_FRAME_BYTES {
             self.partials.remove(&msg_id);
+            self.in_flight_bytes = self.in_flight_bytes.saturating_sub(entry_bytes);
             self.order.retain(|id| *id != msg_id);
             return None;
         }
-        entry.chunks.insert(index, chunk);
-        if entry.chunks.len() == entry.total as usize {
+
+        if complete {
             let mut partial = self.partials.remove(&msg_id).expect("just inserted");
+            self.in_flight_bytes = self.in_flight_bytes.saturating_sub(partial.bytes);
             self.order.retain(|id| *id != msg_id);
             let mut frame = Vec::new();
             for i in 0..partial.total {
@@ -327,9 +379,16 @@ impl Reassembler {
     }
 
     fn evict_if_over_cap(&mut self) {
-        while self.order.len() > self.max_in_flight {
-            if let Some(oldest) = self.order.pop_front() {
-                self.partials.remove(&oldest);
+        // Evict oldest partials until BOTH the count cap AND the global byte budget
+        // hold — MAX_IN_FLIGHT_BYTES is the hard bound on total resident reassembly
+        // memory regardless of how bytes are distributed across partials.
+        while self.order.len() > self.max_in_flight || self.in_flight_bytes > MAX_IN_FLIGHT_BYTES {
+            match self.order.pop_front() {
+                Some(oldest) => {
+                    let freed = self.partials.remove(&oldest).map_or(0, |p| p.bytes);
+                    self.in_flight_bytes = self.in_flight_bytes.saturating_sub(freed);
+                }
+                None => break,
             }
         }
     }
@@ -591,6 +650,42 @@ mod tests {
         assert!(
             r.in_flight() <= 4,
             "LRU cap bounds memory under lost fragments"
+        );
+    }
+
+    #[test]
+    fn accept_bounds_a_single_frame_at_max_frame_bytes() {
+        // SECURITY (v16 review): a peer declares total=u16::MAX and streams
+        // full-payload fragments while WITHHOLDING index 0, so the frame never
+        // completes. The receive side must cap accumulated bytes at MAX_FRAME_BYTES
+        // (dropping the partial) instead of pinning ~27 MB — the old path had NO
+        // receive-side byte ceiling.
+        fn frag(msg_id: [u8; 8], total: u16, index: u16, payload: &[u8]) -> Vec<u8> {
+            let mut p = Vec::with_capacity(FRAGMENT_HEADER_LEN + payload.len());
+            p.extend_from_slice(&FRAGMENT_MAGIC);
+            p.extend_from_slice(&msg_id);
+            p.extend_from_slice(&total.to_be_bytes());
+            p.extend_from_slice(&index.to_be_bytes());
+            p.extend_from_slice(payload);
+            p
+        }
+        let mut r = Reassembler::new();
+        let msg_id = [7u8; 8];
+        let payload = vec![0xABu8; 4096];
+        let mut peak = 0usize;
+        // ~16 MiB streamed into ONE never-completing frame (index 0 withheld).
+        for index in 1u16..=4096 {
+            let out = r.accept(&frag(msg_id, u16::MAX, index, &payload));
+            assert!(out.is_none(), "the frame never completes");
+            peak = peak.max(r.in_flight_bytes);
+        }
+        assert!(
+            peak <= MAX_FRAME_BYTES + payload.len(),
+            "a single frame's reassembly is bounded at MAX_FRAME_BYTES (peak {peak})"
+        );
+        assert!(
+            r.in_flight_bytes <= MAX_IN_FLIGHT_BYTES,
+            "the global reassembly budget holds"
         );
     }
 

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -1141,6 +1141,8 @@ pub enum HttpsInitError {
     /// `None`). Cert + key always travel together.
     #[error("https_tls_cert_path and https_tls_key_path must both be set (got only one)")]
     CertKeyPair,
+    #[error("https_listen_addr is set in non-dev mode but https_tls_cert_path and https_tls_key_path are both unset — a production HTTPS listener needs a cert+key pair (or enable https_dev_self_signed)")]
+    MissingCertKey,
 
     /// `https_listen_addr` did not parse as a SocketAddr.
     #[error("https_listen_addr parse: {0}")]
@@ -1225,6 +1227,13 @@ impl HttpsInitParams {
         // Cert + key always travel together.
         match (tls_cert_path, tls_key_path) {
             (Some(_), None) | (None, Some(_)) => return Err(HttpsInitError::CertKeyPair),
+            // SECURITY/correctness (v16 review): a non-dev HTTPS transport REQUIRES a
+            // cert+key pair. Reject the both-absent case with a typed error here —
+            // otherwise init_edge_runtime's `.expect("validated by
+            // HttpsInitParams::parse")` on `tls_cert_path` panics ACROSS the FFI on a
+            // plausible operator misconfig (listen addr set, forgot the cert paths,
+            // didn't enable dev mode).
+            (None, None) if !dev_self_signed => return Err(HttpsInitError::MissingCertKey),
             _ => {}
         }
 
@@ -1427,6 +1436,17 @@ mod v0_19_3_init_tests {
             false,
         );
         assert!(matches!(r, Err(HttpsInitError::CertKeyPair)));
+    }
+
+    #[test]
+    fn parse_both_paths_absent_in_non_dev_is_missing_cert_key() {
+        // SECURITY/correctness (v16 review): listen addr set, non-dev mode, NO
+        // cert/key must be a TYPED error — not a downstream `.expect(...)` FFI panic.
+        let r = HttpsInitParams::parse(Some("0.0.0.0:4242"), None, None, false, None, false);
+        assert!(matches!(r, Err(HttpsInitError::MissingCertKey)));
+        // Control: the SAME both-absent inputs in DEV mode are fine (mints a pair).
+        let ok = HttpsInitParams::parse(Some("0.0.0.0:4242"), None, None, false, None, true);
+        assert!(matches!(ok, Ok(Some(_))));
     }
 
     #[test]

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -5426,13 +5426,42 @@ enum RouteSupersession {
     HijackRefused,
 }
 
+/// Whether an Advisory announce's `rejection` proves the announcer OWNS the
+/// federation key — i.e. its claimed pubkey MATCHED the directory row. Only
+/// rejections raised AFTER the pubkey comparison qualify, so this is an
+/// **allowlist** of post-match variants; everything else (including any
+/// future-added variant) is fail-CLOSED.
+///
+/// SECURITY (v16 review, `owns_key` route-hijack): a former denylist
+/// `!matches!(UnknownKeyId | PubkeyMismatch)` FAILED OPEN on `DirectoryError`.
+/// persist's `root_binding` returns `DirectoryError` when a `lookup_public_key`
+/// call errors — and the FIRST such lookup happens BEFORE any pubkey comparison,
+/// so a first-lookup error proves NO match. It is also indistinguishable from a
+/// mid-walk error by variant alone, so ALL `DirectoryError` must be fail-closed.
+/// The old denylist mapped it to `owns_key=true`, letting a transient directory
+/// error during a hostile announce defeat the CRITICAL-1 verified-only
+/// supersession gate and hijack a Rooted peer's route.
+fn owns_key_from_rooting_rejection(rejection: &RootingRejection) -> bool {
+    matches!(
+        rejection,
+        RootingRejection::BrokenProvenanceLink { .. }
+            | RootingRejection::UnsignedProvenanceLink { .. }
+            | RootingRejection::NotRootedAtSteward { .. }
+            | RootingRejection::TerminusNotInAnchor { .. }
+            | RootingRejection::CycleDetected { .. }
+            | RootingRejection::OverDepth { .. }
+    )
+}
+
 /// Decide whether an incoming announce supersedes the cached route for its
 /// key_id. `existing` is `(provenance, epoch, dest16)` of the cached entry (if
 /// any). `incoming_owns_key` is whether the announcer PROVED control of the key
 /// the directory binds to this `key_id` (Confirmed, or an Advisory whose
-/// rejection was neither `UnknownKeyId` nor `PubkeyMismatch` — i.e. the pubkey
-/// matched and the announce self-verified). This is the load-bearing signal
-/// that separates the OWNER rerouting its own dest from a SPOOF.
+/// rejection is a POST-pubkey-match variant per
+/// [`owns_key_from_rooting_rejection`] — i.e. the pubkey matched and the announce
+/// self-verified; a pre-match rejection or a lookup `DirectoryError` is
+/// fail-closed to `false`). This is the load-bearing signal that separates the
+/// OWNER rerouting its own dest from a SPOOF.
 ///
 /// Order is load-bearing: the hijack gate is checked FIRST, before any epoch
 /// comparison, so a `u64::MAX`-epoch spoof cannot poison a rooted route.
@@ -6361,10 +6390,10 @@ async fn resolve_announce_cold_start(
             // the owner from healing its OWN routing dest — which is exactly the
             // boot-prime (#238 Rooted, epoch 0, explicit dest) → genuine-announce
             // (Advisory, named dest) heal that #336 depends on.
-            let owns_key = !matches!(
-                rejection,
-                RootingRejection::UnknownKeyId { .. } | RootingRejection::PubkeyMismatch { .. }
-            );
+            // SECURITY (v16 review): owns_key is an ALLOWLIST of post-pubkey-match
+            // rejections — a lookup `DirectoryError` (or any pre-match rejection)
+            // does NOT prove the announcer owns the key, so it is fail-closed here.
+            let owns_key = owns_key_from_rooting_rejection(&rejection);
             // CIRISEdge#337 §4 — advisory admits are attacker-floodable (mint
             // unlimited self-signed keypairs). DEBUG, not INFO: the always-on
             // admit signal is the THROTTLED `peer_admitted_log` point-1 line
@@ -7738,6 +7767,61 @@ mod tests {
                 route_supersession_decision(Some((Rooted, 0, EXPLICIT)), Advisory, false, 0, NAMED),
                 RouteSupersession::HijackRefused,
             );
+        }
+
+        /// SECURITY (v16 review): `owns_key` is fail-CLOSED on every rejection that
+        /// does NOT prove a pubkey match. The route-hijack bug was `DirectoryError`
+        /// (a first-lookup error, raised BEFORE any pubkey comparison) reading as
+        /// owns_key=true under the old denylist. Exhaustive over all 9 variants.
+        #[test]
+        fn owns_key_is_a_post_pubkey_match_allowlist() {
+            use super::RootingRejection as R;
+            let s = String::new;
+            // Fail-CLOSED — these prove NO pubkey match (pre-match or the mismatch itself):
+            for r in [
+                R::UnknownKeyId { key_id: s() },
+                R::PubkeyMismatch {
+                    key_id: s(),
+                    claimed_pubkey_ed25519_base64: s(),
+                    directory_pubkey_ed25519_base64: s(),
+                },
+                // THE FIX: a lookup DirectoryError is indistinguishable from a
+                // first-lookup (no-match) error, so it can never imply ownership.
+                R::DirectoryError { detail: s() },
+            ] {
+                assert!(
+                    !owns_key_from_rooting_rejection(&r),
+                    "must be fail-closed (no proven pubkey match): {r:?}"
+                );
+            }
+            // ALLOWED — the pubkey matched; only the trust chain fell short. This is
+            // the OWNER healing its own route (the #336 boot-prime→genuine-announce).
+            for r in [
+                R::BrokenProvenanceLink {
+                    key_id: s(),
+                    missing_parent_key_id: s(),
+                },
+                R::UnsignedProvenanceLink {
+                    key_id: s(),
+                    signed_by_key_id: s(),
+                    detail: s(),
+                },
+                R::NotRootedAtSteward {
+                    key_id: s(),
+                    identity_type: s(),
+                },
+                R::TerminusNotInAnchor {
+                    key_id: s(),
+                    terminus_pubkey_ed25519_base64: s(),
+                },
+                R::CycleDetected { key_id: s() },
+                R::OverDepth { max_depth: 8 },
+            ] {
+                assert!(
+                    owns_key_from_rooting_rejection(&r),
+                    "a post-pubkey-match rejection is the owner healing its route: {r:?}"
+                );
+            }
         }
 
         /// A Confirmed (Rooted, owns_key) reroute at equal epoch also heals — the


### PR DESCRIPTION
An adversarially-verified security review (find → refute → confirm) of the v16 mesh-reset surfaces surfaced **6 real defects (2 HIGH)**. All fixed with tests; the verify pass refuted 3 false positives (delivery id, carve scope, heal hash-compare).

## 🔴 HIGH
- **owns_key route hijack** (`reticulum.rs`) — `owns_key` was a denylist `!matches!(UnknownKeyId | PubkeyMismatch)`, but persist's `root_binding` returns `DirectoryError` from its **first** `lookup_public_key`, *before* any pubkey comparison. A transient DB error during a hostile announce → `owns_key=true` with no match → the CRITICAL-1 verified-only supersession gate is bypassed → a Rooted peer's route is durably hijacked (outbound seals to the attacker). Now an **allowlist** of the 6 post-pubkey-match rejections; `DirectoryError`/`UnknownKeyId`/`PubkeyMismatch` fail-**closed**. Exhaustive unit test.
- **pre-attribution reassembly OOM** (`frame_fragment.rs`) — `accept` bounded only the *count* of in-flight partials, never bytes; a peer declaring `total=u16::MAX` and streaming fragments could pin ~27 MB/partial, ~7 GB total, before attribution. Added a per-frame + a global byte budget with delta-accurate accounting. Test.

## 🟡 MEDIUM
- **first-party fetch vs #396** (`bridge.rs`) — the subject-Pull *list* gate drops #396, but the *fetch* applied it, so a ref was listed-then-unfetchable. `fetch_envelope_bytes_for_peer` now honors first-party (author/data-subject), matching the list. Behavioral test (subject fetches own row; third party still gated).
- **`pull_subject_testimony` silent-skip** (`runtime.rs`) — a `registry.get()==None` race skipped a Pull with no failure recorded → silent Ok, violating the PullDispatch contract. Now surfaced.
- **HTTPS-init FFI panic** (`http.rs`) — non-dev + no cert/key passed `parse()` then hit `.expect(...)` across the FFI. Now a typed `MissingCertKey`. Test.

## 🔵 LOW
- **spoofing-test false confidence** (`bridge.rs`) — the conferral paste test accepted a bare `InvalidArgument`; tightened to the #643 named-member refusal.

**Green:** full test-anchor lib **817/0**; clippy `-D warnings` clean; fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs