### PR TITLE
feat(v16.0.2): adopt persist v31.1.0 — the baked ceremony trust root

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "16.0.1"
+version = "16.0.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.0.0", version = "31", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.1.0", version = "31", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1216,7 +1216,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.0.0", version = "31", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.1.0", version = "31", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.0.1
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.1
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.1
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.0.1
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.0.1
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.1
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.1
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.0.2
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.2
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.2
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.0.2
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.0.2
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.2
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,13 @@ mod wire_vocabulary_hash_tests {
 /// re-pin is a deliberate, reviewed act across the triple (the same posture as
 /// [`WIRE_VOCABULARY_HASH`], now for the admission surface rather than the wire
 /// vocabulary).
+// v31.1.0 re-pin: persist's replication policy moved with the ceremony trust-root
+// bake (#665, "install the plane it confers") + the exclusion-plane rebuild
+// (#655/#662). Edge's serve/advertise half is UNCHANGED — its own
+// SERVE_ADVERTISE_POLICY_HASH test + all 815 behavioral tests still pass — so this
+// is a clean witness re-pin of the persist-internal apply policy (CIRISEdge#393).
 pub const PERSIST_REPLICATION_POLICY_HASH: &str =
-    "351912ead0aab4847f40d2b54a7a326546c37d43507deb38ea24d6094d29d63b";
+    "3af30bccf437679ecccba325e2db055824b4721eeac069fc30a38d7a0723bbef";
 
 #[cfg(test)]
 mod replication_policy_hash_tests {
@@ -174,8 +179,11 @@ mod replication_policy_hash_tests {
 /// `recipient_capability` enforcement (#396 item 6), the op vocabulary is drawn
 /// from a manifest whose drift is a BUILD failure first, a behavior change
 /// second — the same posture as [`PERSIST_REPLICATION_POLICY_HASH`].
+// v31.1.0 re-pin: the closed consent grammar moved with the baked plane the
+// ceremony trust root confers (#665). Edge's consent handling is UNCHANGED (no
+// consent test regressed), so this is a clean witness re-pin (CIRISEdge#397 §5).
 pub const PERSIST_CONSENT_GRAMMAR_HASH: &str =
-    "2064b567c60062fe9583ea983224d977db7440c8d240d6902a2db50e3e157d05";
+    "b66870da9639c8560538a26c566168fea9759139eaa67ad4116ff8a5f290d69f";
 
 #[cfg(test)]
 mod consent_grammar_hash_tests {


### PR DESCRIPTION
Re-pin `ciris-persist` v31.0.0 → **v31.1.0** (both sites). v31.1.0 **bakes the re-genesis ceremony's trust root** (persist#665, "install the plane it confers"), rebuilds the two exclusion planes (#655/#662), and fixes the revocation-id UUID skew (#622).

**Source-compat, zero edge .rs behavior change.** Edge reads persist's baked genesis bundle at RUNTIME (`baked_canonical_genesis_ids` / `canonical_genesis_bundle`), so the new production root flows through on the re-pin — edge pins no genesis value. `seed_revocation` already mints `Uuid` ids (#622-safe); the spoofing tests hit the binding gate directly.

**Two deliberate witness re-pins** — edge asserts persist's authoritative hashes; both moved with the baked plane, and **edge's own half is unchanged** (its `SERVE_ADVERTISE_POLICY_HASH` + all 817 behavioral tests still pass), so persist's change is apply-side internal, not a serve/consent contract edge must mirror:
- `PERSIST_REPLICATION_POLICY_HASH` `351912ea… → 3af30bcc…`
- `PERSIST_CONSENT_GRAMMAR_HASH` `2064b567… → b66870da…`

Carries the merged **#473 security fixes** (route hijack, reassembly DoS, first-party fetch + 3), so v16.0.2 ships the **hardened base with the production trust root**, in that order.

Green: full test-anchor lib **817/0**; clippy `-D warnings` clean; fmt clean; evidence drift green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs