### PR TITLE
ci: give release-tag runs their own concurrency group (never cancel the release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,17 @@ on:
   pull_request:
 
 concurrency:
-  # CIRISEdge#293 / CIRISPersist#397 — one full matrix per released commit.
-  # Push events key on the SHA so a merge (refs/heads/main) and its release
-  # tag (refs/tags/v*) — the SAME commit — share a group; cancel-in-progress
-  # lets the tag run (the superset that also publishes) cancel the redundant
-  # main run. PRs key on the ref so a new push cancels the stale PR run.
-  group: ci-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  # CIRISEdge#293 — dedup redundant runs, but NEVER cancel a release tag's run.
+  # A merge (refs/heads/main) and its release tag (refs/tags/v*) are the SAME
+  # commit. The old SHA-shared group + cancel-in-progress was a RACE — whichever
+  # push REGISTERED LAST won — and on v16.0.2 the main-push run cancelled the TAG
+  # run, losing the full release matrix + mobile-release (no Release, no signed
+  # manifests). Fix: give TAGS their own ref-based group so a same-SHA main-push
+  # can never cancel the release run. PRs key on the ref (a new push cancels the
+  # stale PR run); branch pushes key on the SHA (main-push self-dedup preserved).
+  # Trade: a released commit's non-tag matrix runs on both the main AND tag runs —
+  # a bounded, infrequent cost, in exchange for a release that always publishes.
+  group: ci-${{ github.event_name == 'pull_request' && github.ref || (startsWith(github.ref, 'refs/tags/v') && github.ref || github.sha) }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
**Root cause of v16.0.2's missing Release.** The push concurrency group was SHA-based, so a merge (`refs/heads/main`) and its release tag (`refs/tags/v*`) — the *same* commit — shared a group, and `cancel-in-progress` **raced**: whichever push registered last won. On v16.0.2 the main-push run cancelled the **tag** run, so the full release matrix + `mobile-release` never ran — no Release, no signed manifests (I had to re-run the tag run by hand to publish v16.0.2).

**Fix:** tags now key on the **ref** (their own group), so a same-SHA main-push can never cancel the release run. PRs still key on the ref; branch pushes on the SHA (main-push self-dedup preserved).

**Trade:** a released commit's non-tag matrix runs on both the main *and* tag runs — a bounded, infrequent cost, in exchange for a release that always publishes. Config-only; actionlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs