### PR TITLE
feat(v16.1.0): adopt persist v31.2.0 — the re-genesised mesh

### DIFF
--- a/.github/scripts/check_cargo_pyproject_skew.py
+++ b/.github/scripts/check_cargo_pyproject_skew.py
@@ -43,11 +43,15 @@ def cargo_pinned_tag(crate: str, text: str) -> str:
     line. Edge pins persist twice (main deps + dev-deps) but on the same
     tag — taking the first is fine.
     """
-    pattern = rf'^\s*{re.escape(crate)}\s*=\s*\{{[^}}]*tag\s*=\s*"v(\d+\.\d+\.\d+)"'
+    # Accept a release tag `vX.Y.Z` AND a pre-release/build tag `vX.Y.Z-rc.N`
+    # (RC staging adopts, e.g. `v31.2.0-rc.1`) — the suffix is captured so the
+    # PEP 440 comparison below sees the real pre-release version.
+    pattern = rf'^\s*{re.escape(crate)}\s*=\s*\{{[^}}]*tag\s*=\s*"v(\d+\.\d+\.\d+(?:[-.+][0-9A-Za-z.+-]*)?)"'
     match = re.search(pattern, text, re.M)
     if not match:
         raise SystemExit(
-            f"check_cargo_pyproject_skew: no `tag = \"vX.Y.Z\"` entry for {crate} in Cargo.toml"
+            f"check_cargo_pyproject_skew: no `tag = \"vX.Y.Z\"` (or `vX.Y.Z-rc.N`) "
+            f"entry for {crate} in Cargo.toml"
         )
     return match.group(1)
 
@@ -79,7 +83,11 @@ def main() -> int:
         constraint = pyproject_constraint(package, pyproject_text)
         spec = SpecifierSet(constraint)
         v = Version(cargo_version)
-        if v in spec:
+        # prereleases=True: this guard checks MAJOR/range consistency (would a pip
+        # resolve skew like the v2.0.1 cascade), and an RC pin like 31.2.0rc1 is
+        # consistent with `>=31,<32`. packaging excludes pre-releases from a
+        # release-only spec by default, so ask explicitly.
+        if spec.contains(v, prereleases=True):
             successes.append(
                 f"  OK   {crate}: Cargo v{cargo_version} satisfies pyproject {constraint!r}"
             )

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "16.0.2"
+version = "16.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.1.0", version = "31", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.2.0", version = "31", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1216,7 +1216,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.1.0", version = "31", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.2.0", version = "31", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.0.2
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.2
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.0.2
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.0.2
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.0.2
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.2
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.0.2
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.1.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.1.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.1.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.1.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.1.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.1.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.1.0


### PR DESCRIPTION
Re-pin `ciris-persist` v31.1.0 → **v31.2.0** (both sites) — the **final cut of the mesh re-genesis**.

`authorization_digest` now binds the **whole record** (not key_id alone — #660), returns a **32-byte SHA-256** (signable on a token — CIRISServer#398), and **excludes the scrub set** the ceremony mutates between holder signatures (so a 2-of-3 is structurally possible — #683). `mesh_genesis` re-exports it. Carries persist's fixture fixes (#490 constitutional family, #557 `trust:accepts` seal_row_in_place, #554 doc/gate).

**Source- and behavior-compat:** full test-anchor lib **817/0** including `edge::baked_genesis_tests`, which now read persist's **newly-baked seed** (the re-genesis product) — edge reads the baked bundle at runtime, so the new trust root flows through on the re-pin. No witness re-pins (the digest change is persist-internal; edge doesn't compute it).

Also brings the **pin-skew hook fix** (accept RC/pre-release tags) from the RC staging branch, so future RC adopts aren't blocked. Supersedes the `v16.1.0-rc.*` staging tags.

Green: test-anchor lib 817/0; clippy `-D warnings` clean; fmt; drift + pin-skew green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs