### PR TITLE
v16.2.0 — catch up to persist v31.5.0 + verify v13.2.0; harden edge for leviculum#39

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "16.1.0"
+version = "16.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.2.0", version = "31", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.5.0", version = "31", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.2.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.1.0", version = "13", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.1.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.2.0", version = "13", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.2.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.1.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.1.0", version = "13" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.2.0", version = "13" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1216,7 +1216,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.2.0", version = "31", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.5.0", version = "31", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.1.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.1.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.1.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.1.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.1.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.1.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.1.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.2.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.2.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.2.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.2.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.2.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.2.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.2.0

--- a/src/transport/frame_fragment.rs
+++ b/src/transport/frame_fragment.rs
@@ -88,6 +88,25 @@ pub const MIN_FRAGMENTABLE_MDU: usize = FRAGMENT_HEADER_LEN + 16;
 /// reject ceiling — so every admissible frame fragments.
 const MAX_FRAGMENTS: usize = u16::MAX as usize;
 
+/// SECURITY / robustness (leviculum#39): the HARD per-piece byte ceiling on the
+/// link Channel send path. Each fragment (and the whole-frame fast path) rides a
+/// single `LinkHandle::try_send`, whose payload becomes the leviculum Channel
+/// `Envelope`'s `data` — and that envelope's wire length field is a `u16`, so
+/// `data.len()` can never exceed `u16::MAX`, **regardless of how large an MTU the
+/// link negotiated**. `node.link_mdu()` reports the RAW negotiated MDU, which MTU
+/// discovery can push far above this (a live node saw ~200 KB). Without this cap
+/// the `frame.len() <= mdu` fast path handed a 113 KiB frame to a single
+/// `try_send`, and leviculum's `Envelope` length assert panicked the delivery
+/// thread ("envelope data length 115764 exceeds maximum 65535") — a `Result`-shaped
+/// condition surfacing as a crash in a lock-holding thread, deafening the node.
+/// [`fragment`] caps its effective MDU at this value so an oversized frame
+/// FRAGMENTS (each piece `<= u16::MAX`) instead of going whole. This mirrors
+/// leviculum#39's own `Channel::mdu(..).min(u16::MAX)` on the send guard, and
+/// hardens edge against BOTH the pre-#39 panic and any future stricter refusal.
+/// The 6-byte `CHANNEL_ENVELOPE_HEADER_SIZE` leviculum prepends is separate framing
+/// not counted in the `u16` `data` length, so this ceiling is exact.
+const WIRE_ENVELOPE_MAX_BYTES: usize = u16::MAX as usize;
+
 /// SECURITY (v16 review, pre-attribution reassembly OOM): the receive side bounded
 /// only the COUNT of in-flight partials (`max_in_flight`), never their bytes — so
 /// a peer declaring `total = u16::MAX` and streaming fragments (withholding one so
@@ -167,8 +186,16 @@ fn msg_id_of(frame: &[u8]) -> [u8; 8] {
 /// for a degenerate `mdu < MIN_FRAGMENTABLE_MDU` or a frame that would need more
 /// than [`MAX_FRAGMENTS`] pieces (the caller then keeps its existing
 /// oversized-drop path, now loud + counted).
+///
+/// The effective MDU is capped at [`WIRE_ENVELOPE_MAX_BYTES`] (leviculum#39): no
+/// single link Channel send can carry more than `u16::MAX` bytes of payload no
+/// matter how large the link MDU, so a frame above that ceiling FRAGMENTS rather
+/// than riding the whole-frame fast path into a length-assert panic.
 #[must_use]
 pub fn fragment(frame: &[u8], mdu: usize) -> Option<Vec<Vec<u8>>> {
+    // leviculum#39: never let the whole-frame fast path (or a fragment) exceed the
+    // Channel Envelope's u16 wire ceiling, even on a large-MTU link.
+    let mdu = mdu.min(WIRE_ENVELOPE_MAX_BYTES);
     if frame.len() <= mdu {
         return Some(vec![frame.to_vec()]);
     }
@@ -582,6 +609,54 @@ mod tests {
             got = r.accept(f).or(got);
         }
         assert_eq!(got, Some(frame));
+    }
+
+    #[test]
+    fn large_mtu_link_fragments_below_the_u16_envelope_ceiling() {
+        // leviculum#39 field regression: on a link whose negotiated MDU exceeds the
+        // Channel Envelope's u16 wire ceiling, an oversized frame MUST fragment —
+        // never ride the whole-frame fast path into a single `try_send` that panics
+        // leviculum's `Envelope` length assert. Reproduces the live failure exactly:
+        // a 115_764-byte frame on a ~200 KB-MDU link ("envelope data length 115764
+        // exceeds maximum 65535").
+        let link_mdu = 200_000usize; // MTU discovery can negotiate this
+        let frame: Vec<u8> = (0..115_764u32).map(|i| (i % 239) as u8).collect();
+        let frags = fragment(&frame, link_mdu).unwrap();
+        assert!(
+            frags.len() > 1,
+            "the frame must fragment, not go whole — {} piece(s)",
+            frags.len()
+        );
+        for f in &frags {
+            assert!(
+                f.len() <= WIRE_ENVELOPE_MAX_BYTES,
+                "every piece fits the u16 Channel Envelope ceiling ({} <= {})",
+                f.len(),
+                WIRE_ENVELOPE_MAX_BYTES
+            );
+            assert!(is_fragment(f));
+        }
+        // And it still reassembles byte-exact through the CFRG path.
+        let mut r = Reassembler::new();
+        let mut got = None;
+        for f in &frags {
+            got = r.accept(f).or(got);
+        }
+        assert_eq!(got.as_ref(), Some(&frame), "reassembles byte-exact");
+        assert_eq!(r.in_flight(), 0, "completed frame is freed");
+    }
+
+    #[test]
+    fn frame_at_the_u16_ceiling_rides_whole_even_on_a_huge_link() {
+        // A frame exactly at the envelope ceiling is still one deliverable unit; the
+        // cap only bites ABOVE u16::MAX. (u16::MAX itself is an admissible data len.)
+        let frame: Vec<u8> = (0..WIRE_ENVELOPE_MAX_BYTES as u32)
+            .map(|i| (i % 233) as u8)
+            .collect();
+        let frags = fragment(&frame, 1_000_000).unwrap();
+        assert_eq!(frags.len(), 1, "a ==ceiling frame is one whole piece");
+        assert!(!is_fragment(&frags[0]));
+        assert_eq!(frags[0].len(), WIRE_ENVELOPE_MAX_BYTES);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three-part catch-up. Low-risk, source-compat verified, ships one **security** fix and one **live-node crash** hardening.

### 1. Persist v31.2.0 → v31.5.0
- **v31.3.0** (#670/#673) — backend-parity enforced invariant. Persist-internal; no edge surface.
- **v31.4.0** (#664/#603/#604) — consumer unblock: `tier_ingest::test_support` widened to `pub`, `FaultInjectingDirectory`, and `resolve_mesh_config` now carries `unreadable_roots`. Edge already logs `unreadable_roots` (`mesh_config.rs:219`); no break.
- **v31.5.0** (#685/#689) — **SECURITY**: a quorum-**withdrawn** trust root kept projecting Global, because `namespace::is_trust_root` called the bare `is_canonical` / `is_infra_attest` instead of the tombstone-aware `_effective` variants. Edge consumes persist's projection through the pinned crate, so **the bump is the fix** on edge's substrate.

### 2. Verify v13.1.0 → v13.2.0 (lockstep)
persist v31.5.0 moved its own verify pin to **v13.2.0** (#254). Edge pins verify **directly** (`ciris-keyring` / `ciris-crypto` / `ciris-verify-core`), so those had to move in lockstep — otherwise two `ciris_verify_core` copies split the graph and `TransportBindingSignature` in `touch_claim.rs` fails to type-check (the cross-repo duplication class). v13.2.0 is additive; no edge source change beyond the pin.

### 3. leviculum#39 — edge-side fragmentation ceiling (`frame_fragment.rs`)
The leviculum Channel `Envelope` wire length field is `u16`, so no single `LinkHandle::try_send` payload can exceed `u16::MAX`. But `node.link_mdu()` reports the **raw** negotiated MDU, which MTU discovery can push far above that (a live node saw ~200 KB). `fragment()`'s `frame.len() <= mdu` fast path then handed a 113 KiB frame to one `try_send`, and leviculum's `Envelope` length assert **panicked the delivery thread** (`envelope data length 115764 exceeds maximum 65535`) — a `Result`-shaped condition surfacing as a crash in a lock-holding thread, deafening the node.

`fragment()` now caps its effective MDU at `WIRE_ENVELOPE_MAX_BYTES` (`u16::MAX`) so an oversized frame **fragments** instead of going whole — mirroring leviculum#39's own `Channel::mdu(..).min(u16::MAX)` on the send guard. This hardens edge against **both** the current pinned leviculum (v0.14.0, still panics) and any future stricter refusal, **independent of a leviculum re-tag**.

> Note: leviculum#39's fix (`c4ec96c4`) is on `master` but **not yet tagged** — the leviculum pin bump waits on a tag. This PR is the edge half of the same chain (issue #39 explicitly names "edge fragments against the same wrong ceiling").

## Verification
`cargo check` + `clippy -D warnings` (default) clean; `frame_fragment` 17/17, `replication` 180, `transport` 228, `version` 4, `evidence_tsv_matches_emitted` 1, `touch_claim` 6 — all green.

## Explicitly NOT in this cut
**CIRISEdge#474** (adopt the `AccordQuorumEvidence` replication kind) — a *cursor-served + re-tally-admit* plane that does **not** fit edge's content-hash Summary/Diff/Fetch flow, and appending it moves the self-computed `SERVE_ADVERTISE_POLICY_HASH` (a coordinated re-pin with CIRISServer#398). That's a distinct design cut. Edge stays **sound** without it: an unknown 15th-kind frame serde-rejects cleanly (additive-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs