### PR TITLE
v16.3.0 — adopt AccordQuorumEvidence as a cursor-served replication plane (#474)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -577,9 +577,21 @@ tempfile       = { version = "3", optional = true }
 # pre-hashes inbound packets: the reply-side node-wide inbound stall drops from
 # ~32% to ~1% (bench-measured), directly relieving the CIRISEdge#370 reply-stall
 # component — the round-outcome instrument (v13.5.0) observes it in the field.
-# The `+ciris.1` is fork build-metadata; the crate semver is 0.10.
-leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.14.0+ciris.1", version = "0.14", optional = true }
-leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.14.0+ciris.1", version = "0.14", optional = true }
+# v0.15.0+ciris.1 (CIRISEdge#369) — catch-up to upstream 0.8.1+ (LXMF file
+# storage, per-transfer limits, driver-tick CoreProcessor, path-parity fixes) +
+# leviculum#29 stages 2-3: every expensive crypto class now runs OUTSIDE the node
+# mutex — measured lock-holds single-dest datagram 35µs -> 1.2µs (~20x), announce
+# 44µs -> ~21µs. This structurally removes the inbound-crypto-blocks-outbound-sends
+# exclusion CIRISEdge#370 traced (the #29 stage-1 relief above becomes complete).
+# Also carries the envelope-ceiling fix (leviculum#39: Channel::mdu capped at
+# u16::MAX, oversized send -> TooLarge not a lock-holding-thread panic) — the
+# leviculum-side twin of edge's own v16.2.0 frame_fragment cap. SOURCE-COMPAT: the
+# upstream catch-up moved nothing in the API edge consumes (try_send / link_mdu /
+# connect unchanged); the reticulum + reticulum,lxmf feature builds compile with no
+# match-arm or call-site churn. The crate semver is now 0.15; `+ciris.1` is fork
+# build-metadata.
+leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.15.0+ciris.1", version = "0.15", optional = true }
+leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.15.0+ciris.1", version = "0.15", optional = true }
 # v15.20.0 (CIRISEdge#169) — LXMF store-and-forward propagation. The
 # `leviculum-lxmf` workspace member (same pinned tag) ships the whole
 # LXMF wire protocol: propagation-node discovery/upload/`/get` codecs,
@@ -589,7 +601,7 @@ leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.14.0+
 # features keep `pow` on (the stamp/ticket cost we validate at
 # admission). Gated behind the `lxmf` feature — see the `[features]`
 # block. Edge INTEGRATES this crate's protocol; it never reimplements it.
-leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.14.0+ciris.1", version = "0.14", optional = true }
+leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.15.0+ciris.1", version = "0.15", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "16.2.0"
+version = "16.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.2.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.2.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.2.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.2.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.2.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.2.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.2.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.3.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.3.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.3.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.3.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.3.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.3.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.3.0

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2458,6 +2458,10 @@ fn parse_envelope_kind(s: &str) -> PyResult<crate::replication::EnvelopeKind> {
         "family_membership_revocation" => Ok(EnvelopeKind::FamilyMembershipRevocation),
         "community_membership_revocation" => Ok(EnvelopeKind::CommunityMembershipRevocation),
         "location_proof" => Ok(EnvelopeKind::LocationProof),
+        // CIRISEdge#474 — activation surface for the accord-quorum-evidence cursor
+        // plane: without this an operator cannot register a
+        // `(peer, accord_quorum_evidence)` Initiator, so the plane never opens.
+        "accord_quorum_evidence" => Ok(EnvelopeKind::AccordQuorumEvidence),
         other => Err(PyValueError::new_err(format!(
             "unknown EnvelopeKind: {other:?} (valid: key, attestation, revocation, \
              identity_occurrence, family, community, \

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -685,6 +685,42 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         }
     }
 
+    /// CIRISEdge#474 — serve an accord-quorum-evidence cursor pull. The plane has
+    /// no content-hash `signed_wire_index`, so this is its ONLY serve path: read
+    /// persist's `list_signed_accord_quorum_evidence_since` (ordered `(evidence_at,
+    /// proposal_digest)`, bounded by the page limit) and JSON-serialize each bundle
+    /// exactly as the apply side (`apply_accord_quorum_evidence`) deserializes it —
+    /// the byte-for-byte round trip persist's re-tally admit expects. A read error
+    /// is a loud empty (the round re-pulls next pass), never a panic. Non-cursor
+    /// kinds return empty: they converge over Summary/Diff/Fetch, not here.
+    async fn accord_evidence_since(
+        &self,
+        kind: EnvelopeKind,
+        since: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Vec<Vec<u8>> {
+        if kind != EnvelopeKind::AccordQuorumEvidence {
+            return Vec::new();
+        }
+        let limit = self.effective_page_limit().await;
+        match self
+            .directory
+            .list_signed_accord_quorum_evidence_since(since, limit)
+            .await
+        {
+            Ok(bundles) => bundles
+                .iter()
+                .filter_map(|b| serde_json::to_vec(b).ok())
+                .collect(),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "accord-quorum-evidence cursor serve read failed (CIRISEdge#474)"
+                );
+                Vec::new()
+            }
+        }
+    }
+
     /// CIRISEdge#462 — serve a subject-scoped RECEIVE-axis Pull. Entitlement is
     /// FAIL-CLOSED: a Pull for subject `S` is answered only to a requester
     /// authenticated AS `S` (`peer_key_id == Some(S)`). A requester `P ≠ S` — or
@@ -936,6 +972,12 @@ impl FederationDirectoryReplicationBridge {
                 self.list_community_membership_revocations().await
             }
             EnvelopeKind::LocationProof => self.list_location_proofs().await,
+            // CIRISEdge#474 — the accord-quorum-evidence plane is NEVER advertised
+            // by content-hash: it has no `signed_wire_index` entry
+            // (`persist_index_kind` → None), so a ref here would be listed-then-
+            // unfetchable (the LIST-vs-FETCH divergence class). It converges over
+            // the dedicated cursor path (`CursorPull` → `Deliver`) instead.
+            EnvelopeKind::AccordQuorumEvidence => Vec::new(),
         }
     }
 
@@ -1214,6 +1256,9 @@ impl FederationDirectoryReplicationBridge {
             EnvelopeKind::LocationProof => self.apply_location_proof(envelope_bytes).await,
             EnvelopeKind::TransportDestination => {
                 self.apply_transport_destination(envelope_bytes).await
+            }
+            EnvelopeKind::AccordQuorumEvidence => {
+                self.apply_accord_quorum_evidence(envelope_bytes).await
             }
         }
     }
@@ -2643,6 +2688,50 @@ impl FederationDirectoryReplicationBridge {
             SignedLocationProof,
             put_location_proof
         )
+    }
+
+    /// CIRISEdge#474 — RECEIVE half of the accord-quorum-evidence cursor plane.
+    /// This does NOT go through [`apply_signed_plane!`]: there is no `Signed*`
+    /// wrapper and no `put_*`. The delivered bytes are a persist
+    /// [`AccordQuorumEvidence`](ciris_persist::federation::accord_carriage::AccordQuorumEvidence)
+    /// bundle; `apply_replicated_accord_evidence` **re-tallies** it against THIS
+    /// node's own accord roster (never the sender's verdict), fail-closed with
+    /// [`Error::AccordEvidenceUnverified`](ciris_persist::federation::Error), and
+    /// is idempotent on replay. Progress (`Admitted`) iff a new participation
+    /// landed OR a withdrawal tombstone was re-derived locally; a byte-identical
+    /// replay (`participations_admitted == 0`, no new tombstone) is `Duplicate`,
+    /// exactly as the anti-entropy loop counts one — never a silent no-op.
+    async fn apply_accord_quorum_evidence(&self, bytes: &[u8]) -> ApplyOutcome {
+        use ciris_persist::federation::accord_carriage::AccordQuorumEvidence;
+        let evidence: AccordQuorumEvidence = match serde_json::from_slice(bytes) {
+            Ok(e) => e,
+            Err(e) => {
+                return ApplyOutcome::Deserialize(apply_deser_reason(
+                    "AccordQuorumEvidence",
+                    bytes,
+                    &e,
+                ))
+            }
+        };
+        match self
+            .directory
+            .apply_replicated_accord_evidence(&evidence)
+            .await
+        {
+            Ok(admission) => {
+                if admission.participations_admitted > 0
+                    || !admission.withdrawals_projected.is_empty()
+                {
+                    ApplyOutcome::Admitted
+                } else {
+                    ApplyOutcome::Duplicate
+                }
+            }
+            Err(e) => ApplyOutcome::Refused(format!(
+                "AccordQuorumEvidence: admission refused (refusal={}): {e}",
+                e.kind(),
+            )),
+        }
     }
 
     /// CIRISEdge#338 / CIRISPersist#443 (v17.0.0) — admit a replicated route.

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -127,6 +127,21 @@ pub trait ReplicationDirectory: Send + Sync {
         Vec::new()
     }
 
+    /// CIRISEdge#474 — the accord-quorum-evidence CURSOR serve reader: the
+    /// byte-exact bundles held with `evidence_at > since`, JSON-serialized ready to
+    /// wrap in a `Deliver`. Answers an inbound `CursorPull` for a plane that has NO
+    /// content-hash index (so no Diff/Fetch round-trip — the responder delivers
+    /// directly). Bounded by the impl's page limit; the requester re-pulls from its
+    /// new high-water to drain a backlog. Defaults to empty: only the production
+    /// bridge (holding the persist `FederationDirectory`) answers it.
+    async fn accord_evidence_since(
+        &self,
+        _kind: EnvelopeKind,
+        _since: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Vec<Vec<u8>> {
+        Vec::new()
+    }
+
     /// Return the byte-exact signed envelope for `(kind,
     /// envelope_hash)`, or `None` if the envelope isn't in local state.
     /// Called during the `Deliver`-message construction step.
@@ -269,6 +284,21 @@ impl StateProvider for DirectoryStateAdapter {
                     .subject_holdings(kind, &subject, peer.as_deref())
                     .await
             })
+        })
+    }
+
+    /// CIRISEdge#474 — serve an accord-quorum-evidence cursor pull, bridging the
+    /// async persist read into the sync provider surface (same `block_on` pattern
+    /// as [`Self::subject_refs`]). Returns the serialized bundles past `since`.
+    fn accord_evidence_since(
+        &self,
+        kind: EnvelopeKind,
+        since: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Vec<Vec<u8>> {
+        let inner = Arc::clone(&self.inner);
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current()
+                .block_on(async move { inner.accord_evidence_since(kind, since).await })
         })
     }
 }

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -163,14 +163,29 @@ pub enum EnvelopeKind {
     /// REQUIRES `WIRE_PROTOCOL_VERSION_V2` (v1-only peers refuse the unknown
     /// tag at serde-decode — the additive-and-safe transition per FSD §3.7).
     TransportDestination,
+    /// CIRISEdge#474 / CIRISPersist v31.1.0 (#662) — the accord-quorum-evidence
+    /// plane: a `put_accord_proposal` bundle (`proposal` + `participations` +
+    /// `evidence_at`) that carries a steward-quorum decision projecting
+    /// `RoleWithdrawals` across the federation (`WireTier::FederationOnly`).
+    /// UNLIKE every other kind it is **cursor-served, NOT content-hash-indexed**:
+    /// a bundle is an aggregate whose hash moves as each participation lands, so
+    /// persist deliberately keeps it out of the `signed_wire_index`
+    /// ([`Self::persist_index_kind`] returns `None`). It therefore rides the
+    /// dedicated cursor path (`CursorPull` → `Deliver`, resume on `evidence_at`),
+    /// never Summary/Diff/Fetch, and its RECEIVE gate **re-tallies** against the
+    /// receiver's own roster (`apply_replicated_accord_evidence`) rather than
+    /// trusting the sender's verdict. A NEW post-v1 tag: v1-only peers serde-reject
+    /// it (`min_wire_version` → V2). `list_signed_accord_quorum_evidence_since`.
+    AccordQuorumEvidence,
 }
 
 impl EnvelopeKind {
-    /// All 14 replicated wire kinds, in declaration order. Mirrors persist's
-    /// `replication_policy::EnvelopeKind::ALL` (same 14 names/order, pinned by
+    /// All 15 replicated wire kinds, in declaration order. Mirrors persist's
+    /// `replication_policy::EnvelopeKind::ALL` (same 15 names/order, pinned by
     /// `REPLICATION_POLICY_HASH`). Basis for the serve/advertise manifest
-    /// (CIRISEdge#393 item 3).
-    pub const ALL: [EnvelopeKind; 14] = [
+    /// (CIRISEdge#393 item 3). `AccordQuorumEvidence` (CIRISEdge#474) is appended
+    /// last — order is hashed, so it MUST stay at the end.
+    pub const ALL: [EnvelopeKind; 15] = [
         Self::Key,
         Self::Attestation,
         Self::Revocation,
@@ -185,6 +200,7 @@ impl EnvelopeKind {
         Self::OrgMembership,
         Self::PartnerRecord,
         Self::TransportDestination,
+        Self::AccordQuorumEvidence,
     ];
 
     /// CIRISEdge#402/#406 — the finite, self-authenticating **bootstrap** kinds a
@@ -235,6 +251,19 @@ impl EnvelopeKind {
         )
     }
 
+    /// CIRISEdge#474 — is this kind served over the dedicated CURSOR path
+    /// (`CursorPull` → `Deliver`, resume on `evidence_at`) rather than the
+    /// content-hash Summary/Diff/Fetch flow? EXACTLY the kinds with no
+    /// `signed_wire_index` entry ([`Self::persist_index_kind`] → None AND not
+    /// [`Self::Revocation`], which is index-less but rides `persist_row_hash`).
+    /// Currently only [`Self::AccordQuorumEvidence`]; checked over `ALL` in a test
+    /// so a future cursor kind is a deliberate widening, never an accident. An
+    /// Initiator round for such a kind opens with a `CursorPull`, not a Summary.
+    #[must_use]
+    pub fn is_cursor_served(self) -> bool {
+        matches!(self, Self::AccordQuorumEvidence)
+    }
+
     /// The kinds a subject sweep issues a `Pull` for — the
     /// [`Self::is_subject_pullable`] set, in `ALL` order.
     #[must_use]
@@ -265,6 +294,7 @@ impl EnvelopeKind {
             Self::OrgMembership => "org_membership",
             Self::PartnerRecord => "partner_record",
             Self::TransportDestination => "transport_destination",
+            Self::AccordQuorumEvidence => "accord_quorum_evidence",
         }
     }
 
@@ -273,14 +303,20 @@ impl EnvelopeKind {
     /// ([`ciris_persist::federation::FederationDirectory::lookup_signed_record_by_content_hash`]).
     /// This is persist's `replication_policy::EnvelopeKind::as_str` PascalCase
     /// token (`"Key"`, `"Attestation"`, …) — NOT [`Self::as_wire_str`]'s
-    /// snake_case. `None` for [`Self::Revocation`], the ONE kind persist
-    /// deliberately does not index (its fetch stays on the local cache).
+    /// snake_case. `None` for the two kinds persist deliberately does not index:
+    /// [`Self::Revocation`] (its fetch stays on the local cache) and
+    /// [`Self::AccordQuorumEvidence`] (a vote-aggregating bundle whose hash moves
+    /// as participations land — served by cursor, never by content-hash point-read;
+    /// CIRISEdge#474).
     #[must_use]
     pub fn persist_index_kind(self) -> Option<&'static str> {
         Some(match self {
             Self::Key => "Key",
             Self::Attestation => "Attestation",
-            Self::Revocation => return None,
+            // Both are absent from persist's content-hash `signed_wire_index`:
+            // Revocation rides `persist_row_hash`; AccordQuorumEvidence rides the
+            // cursor path (#474). Neither has a content-hash point-read.
+            Self::Revocation | Self::AccordQuorumEvidence => return None,
             Self::IdentityOccurrence => "IdentityOccurrence",
             Self::Family => "Family",
             Self::Community => "Community",
@@ -324,7 +360,10 @@ impl EnvelopeKind {
             | Self::PartnerRecord
             // #311 — a new post-v1 tag; v1-only peers don't know it and
             // would serde-reject the body, so it rides at V2 framing.
-            | Self::TransportDestination => {
+            | Self::TransportDestination
+            // #474 — the accord-quorum-evidence plane is likewise a new post-v1
+            // tag; v1-only peers serde-reject it, so it rides at V2 framing.
+            | Self::AccordQuorumEvidence => {
                 crate::replication::wire_frame::WIRE_PROTOCOL_VERSION_V2
             }
         }
@@ -406,6 +445,32 @@ pub struct PullMessage {
     pub subject_key_id: String,
 }
 
+/// CIRISEdge#474 — the accord-quorum-evidence CURSOR request. The plane has no
+/// content-hash `signed_wire_index` (its bundle hash moves as participations
+/// land), so it CANNOT ride the Summary/Diff/Fetch convergence flow like every
+/// other kind, nor the #462 subject `Pull` (which resolves to a content-hash
+/// `Summary`). Instead the requester names a resume watermark and the responder
+/// answers DIRECTLY with a [`DeliverMessage`] of the bundles past it — ordered
+/// `(evidence_at, proposal_digest)`, served by
+/// [`ciris_persist::federation::FederationDirectory::list_signed_accord_quorum_evidence_since`].
+///
+/// `since` is the requester's high-water `evidence_at`: the responder returns
+/// bundles with `evidence_at > since` (`None` = from the beginning). The receiver
+/// RE-TALLIES each bundle against its own roster on apply, so pulling from `None`
+/// every round is always safe (idempotent) — the cursor is an optimization, not a
+/// trust input. A post-v1 verb, exactly like `Pull`: v1 peers serde-refuse the
+/// unknown `type` tag, coordinated by the `SERVE_ADVERTISE_POLICY_HASH` re-pin.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CursorPullMessage {
+    /// The kind this cursor pull is scoped to — currently only
+    /// [`EnvelopeKind::AccordQuorumEvidence`].
+    pub kind: EnvelopeKind,
+    /// Resume watermark: the responder returns records with `evidence_at`
+    /// strictly greater than this. `None` pulls from the beginning.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub since: Option<chrono::DateTime<chrono::Utc>>,
+}
+
 /// "Here are the bytes." Wraps the requested envelopes' raw signed-
 /// bytes form (the same shape `put_*` admits expect on the receiver's
 /// persist side). Order is unspecified; the receiver MUST validate
@@ -434,6 +499,10 @@ pub enum ReplicationMessage {
     /// it), so it is a genuine wire-compat event, coordinated by the
     /// [`crate::replication::serve_policy::SERVE_ADVERTISE_POLICY_HASH`] re-pin.
     Pull(PullMessage),
+    /// CIRISEdge#474 — the accord-quorum-evidence CURSOR request (resume on
+    /// `evidence_at`). Like `Pull`, a post-v1 verb v1 peers serde-refuse; the
+    /// responder answers with a `Deliver` of the bundles past the watermark.
+    CursorPull(CursorPullMessage),
 }
 
 impl ReplicationMessage {
@@ -451,6 +520,7 @@ impl ReplicationMessage {
             Self::Fetch(m) => m.kind,
             Self::Deliver(m) => m.kind,
             Self::Pull(m) => m.kind,
+            Self::CursorPull(m) => m.kind,
         }
     }
 
@@ -568,6 +638,63 @@ mod tests {
         // The verb carries its kind so wire-framing picks the version like any
         // other message.
         assert_eq!(parsed.kind(), EnvelopeKind::Attestation);
+    }
+
+    /// CIRISEdge#474 — the `CursorPull` verb round-trips on the wire (snake_case
+    /// `cursor_pull` tag), carries its kind for framing, and omits `since` when
+    /// `None` (the stateless pull-all case) so the wire stays compact.
+    #[test]
+    fn cursor_pull_round_trips() {
+        let m = ReplicationMessage::CursorPull(CursorPullMessage {
+            kind: EnvelopeKind::AccordQuorumEvidence,
+            since: None,
+        });
+        let bytes = m.to_bytes();
+        let s = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            s.contains(r#""type":"cursor_pull""#),
+            "cursor_pull wire tag: {s}"
+        );
+        assert!(
+            !s.contains("since"),
+            "None `since` is skipped on the wire: {s}"
+        );
+        let parsed = ReplicationMessage::from_bytes(&bytes).expect("parse");
+        assert_eq!(parsed, m);
+        assert_eq!(parsed.kind(), EnvelopeKind::AccordQuorumEvidence);
+        // A v2-framed kind — v1-only peers serde-refuse the tag.
+        assert_eq!(
+            parsed.kind().min_wire_version(),
+            crate::replication::wire_frame::WIRE_PROTOCOL_VERSION_V2
+        );
+    }
+
+    /// CIRISEdge#474 — `is_cursor_served` is EXACTLY `AccordQuorumEvidence`,
+    /// checked over ALL so a future cursor kind is a deliberate widening. It agrees
+    /// with `persist_index_kind() == None` (no content-hash index) — but NOT with
+    /// `Revocation`, which is also index-less yet rides `persist_row_hash`, not the
+    /// cursor path.
+    #[test]
+    fn is_cursor_served_is_exactly_accord_quorum_evidence() {
+        for kind in EnvelopeKind::ALL {
+            assert_eq!(
+                kind.is_cursor_served(),
+                matches!(kind, EnvelopeKind::AccordQuorumEvidence),
+                "{kind:?}: cursor-served iff it is AccordQuorumEvidence"
+            );
+        }
+        // The one cursor kind is unindexed, v2-framed, and NOT subject-pullable.
+        assert!(EnvelopeKind::AccordQuorumEvidence
+            .persist_index_kind()
+            .is_none());
+        assert!(!EnvelopeKind::AccordQuorumEvidence.is_subject_pullable());
+        assert_eq!(
+            EnvelopeKind::AccordQuorumEvidence.as_wire_str(),
+            "accord_quorum_evidence"
+        );
+        // Revocation is index-less but is NOT cursor-served (different wire).
+        assert!(EnvelopeKind::Revocation.persist_index_kind().is_none());
+        assert!(!EnvelopeKind::Revocation.is_cursor_served());
     }
 
     /// CIRISEdge#462 — `is_subject_pullable` is EXACTLY the five replicated kinds

--- a/src/replication/registry.rs
+++ b/src/replication/registry.rs
@@ -242,6 +242,9 @@ impl ReplicationRegistry {
             // CIRISEdge#462 — a subject-scoped Pull routes on its kind like every
             // other verb; the auto-registered Responder below answers it.
             super::protocol::ReplicationMessage::Pull(m) => m.kind,
+            // CIRISEdge#474 — a cursor pull routes on its kind too; the
+            // auto-registered Responder serves it via `on_cursor_pull`.
+            super::protocol::ReplicationMessage::CursorPull(m) => m.kind,
         };
         // CIRISEdge#312 — if no coordinator exists for this (peer, kind), this
         // node doesn't consent-pull from the peer (so no Initiator was built),

--- a/src/replication/serve_policy.rs
+++ b/src/replication/serve_policy.rs
@@ -1,7 +1,7 @@
 //! CIRISEdge#393 (E3, item 3) — the SERVE/ADVERTISE policy manifest: edge's
 //! responder half of the Registry-of-Record contract.
 //!
-//! persist owns the APPLY policy for all 14 replicated kinds and exports it as
+//! persist owns the APPLY policy for all 15 replicated kinds and exports it as
 //! `ciris_persist::federation::replication_policy::REPLICATION_POLICY_HASH`
 //! (pinned by edge in `lib.rs`). Edge owns the **serve/advertise** half — for
 //! each kind, WHICH peers it advertises to (the projection scope) and WHETHER
@@ -46,6 +46,11 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
         EnvelopeKind::Organization | EnvelopeKind::OrgMembership | EnvelopeKind::PartnerRecord => {
             ("bulk_since", "public")
         }
+        // CIRISEdge#474 — the accord-quorum-evidence plane rides the dedicated
+        // CURSOR path (`CursorPull` → `Deliver`, resume on `evidence_at`), NOT the
+        // content-hash Summary/Diff/Fetch flow (`persist_index_kind` → None). The
+        // bundle is a public `FederationOnly`-tier record — no capability gate.
+        EnvelopeKind::AccordQuorumEvidence => ("cursor:evidence_at", "public"),
     };
     // CIRISEdge#462 — `receive`: whether this kind answers a subject-scoped Pull
     // (the RECEIVE axis), and under what rule. The FIVE replicated kinds are
@@ -72,6 +77,13 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
         | EnvelopeKind::Organization
         | EnvelopeKind::OrgMembership
         | EnvelopeKind::PartnerRecord => "none",
+        // CIRISEdge#474 — NOT a subject-scoped Pull. It is received over the
+        // dedicated cursor path and its RECEIVE gate re-tallies against the
+        // receiver's own roster rather than trusting the sender's verdict; the
+        // value stays out of the `subject_pull:*` namespace by construction.
+        EnvelopeKind::AccordQuorumEvidence => {
+            "cursor_pull:evidence_at; re-tally admit (apply_replicated_accord_evidence)"
+        }
     };
     serde_json::json!({
         "kind": kind.as_wire_str(),
@@ -107,15 +119,19 @@ pub fn serve_advertise_policy_sha256() -> String {
 }
 
 /// The pinned serve/advertise policy hash. A change to edge's responder policy
-/// (advertise scope or serve gate for ANY of the 14 kinds) flips this — a
+/// (advertise scope or serve gate for ANY of the 15 kinds) flips this — a
 /// deliberate, reviewed re-pin, visible to CIRISServer which pins it alongside
 /// persist's `REPLICATION_POLICY_HASH`. See CIRISEdge#393 §4.2/§4.3.
 // v16.0.0 — re-pinned: the Attestation `receive` carve text now describes the
 // retainability-allowlist rule (scores-plane, `!is_subject_retainable(dimension)`),
 // replacing the stale `consent_gated_claim` prose the #635 carve had left behind
 // (Codex on #470). CIRISServer re-pins from 049e71ef… to this value.
+// v16.3.0 (CIRISEdge#474) — re-pinned: the 15th kind `accord_quorum_evidence` is
+// appended (advertise `cursor:evidence_at`, serve `public`, receive
+// `cursor_pull:evidence_at` — the cursor plane, NOT a subject Pull). CIRISServer
+// re-pins from 6f683311… to this value alongside persist's v31 REPLICATION_POLICY_HASH.
 pub const SERVE_ADVERTISE_POLICY_HASH: &str =
-    "6f683311627689221d886f4245ac7b9fa6715e6f1e135855f52fa7800fb7cda5";
+    "328d73b0a6a5c7e2d1272b81e245ecceeca1d837dd08b0415105e1661ff4a699";
 
 #[cfg(test)]
 mod tests {
@@ -163,6 +179,35 @@ mod tests {
         let recv = att["receive"].as_str().unwrap();
         assert!(recv.contains("data_subject+sender"), "both axes: {recv}");
         assert!(recv.contains("G2"), "the score carve is witnessed: {recv}");
+    }
+
+    /// CIRISEdge#474 — the accord-quorum-evidence plane appears in the manifest as
+    /// a CURSOR plane: advertise `cursor:evidence_at`, serve `public`, receive
+    /// `cursor_pull:*` (NOT `subject_pull:*`, so it stays out of the five
+    /// subject-pullable kinds), and never capability-gated.
+    #[test]
+    fn accord_quorum_evidence_is_a_public_cursor_plane() {
+        let manifest = serve_advertise_manifest();
+        let policies = manifest["policies"].as_array().unwrap();
+        let aqe = policies
+            .iter()
+            .find(|p| p["kind"] == "accord_quorum_evidence")
+            .expect("accord_quorum_evidence is in the 15-kind manifest");
+        assert_eq!(aqe["advertise"], "cursor:evidence_at");
+        assert_eq!(aqe["serve"], "public");
+        let recv = aqe["receive"].as_str().unwrap();
+        assert!(
+            recv.starts_with("cursor_pull:"),
+            "cursor receive axis: {recv}"
+        );
+        assert!(
+            !recv.starts_with("subject_pull"),
+            "NOT a subject pull — stays out of the five: {recv}"
+        );
+        assert!(
+            !aqe["serve"].as_str().unwrap().contains("capability:"),
+            "the accord plane is public, never capability-gated"
+        );
     }
 
     /// The load-bearing E3 fact must hold in the manifest: exactly ONE kind is

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -36,8 +36,8 @@
 //! Delivers have been applied.
 
 use super::protocol::{
-    DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, PullMessage,
-    ReplicationMessage, SummaryMessage,
+    CursorPullMessage, DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage,
+    PullMessage, ReplicationMessage, SummaryMessage,
 };
 use super::summary::{diff_refs, ApplyOutcome, StalenessSignal, StateApplier, StateProvider};
 
@@ -170,6 +170,12 @@ pub struct Session {
     /// CIRISEdge#380 — monotonic count of initiator rounds this session has
     /// started. Basis for the `proactive_sent` refresh window.
     round_counter: u64,
+    /// CIRISEdge#474 — set when this Initiator opened a CURSOR round (emitted a
+    /// `CursorPull` instead of a Summary). The answering `Deliver` is then a
+    /// SOLICITED reply, not an unsolicited push — so [`Self::on_deliver`] applies
+    /// it without the per-round unsolicited-WARN, and an empty cursor result still
+    /// completes the round cleanly. Per-round state, cleared by [`Self::reset`].
+    awaiting_cursor_deliver: bool,
 }
 
 /// CIRISEdge#380 — per-round byte budget for the proactive Deliver. The
@@ -198,6 +204,7 @@ impl Session {
             proactive_publish: false,
             proactive_sent: std::collections::BTreeMap::new(),
             round_counter: 0,
+            awaiting_cursor_deliver: false,
         }
     }
 
@@ -224,6 +231,7 @@ impl Session {
         self.last_summary_sent = None;
         self.diff_want_count = None;
         self.completed = false;
+        self.awaiting_cursor_deliver = false;
     }
 
     pub fn role(&self) -> SessionRole {
@@ -241,6 +249,22 @@ impl Session {
             matches!(self.role, SessionRole::Initiator),
             "start_round() is initiator-only"
         );
+        // CIRISEdge#474 — the accord-quorum-evidence plane has no content-hash
+        // index, so its round opens with a CURSOR pull, not a Summary. `since:
+        // None` pulls all (bounded by the responder's page limit); the receiver's
+        // re-tally admit is idempotent on replay, so a stateless-from-None puller
+        // is correct — edge's uniform per-round read model. The answering Deliver
+        // is marked solicited (`awaiting_cursor_deliver`) so `on_deliver` applies
+        // it as a reply, and an evidence-free peer completes the round cleanly.
+        if self.kind.is_cursor_served() {
+            self.awaiting_cursor_deliver = true;
+            return ReplicationOutcome::Send(vec![ReplicationMessage::CursorPull(
+                CursorPullMessage {
+                    kind: self.kind,
+                    since: None,
+                },
+            )]);
+        }
         let refs = provider.local_refs(self.kind);
         let summary = SummaryMessage {
             kind: self.kind,
@@ -367,7 +391,35 @@ impl Session {
             ReplicationMessage::Deliver(deliver) => self.on_deliver(&deliver, applier, source_peer),
             ReplicationMessage::Fetch(fetch) => self.on_fetch(&fetch, provider, source_peer),
             ReplicationMessage::Pull(pull) => self.on_pull(&pull, provider),
+            ReplicationMessage::CursorPull(cp) => self.on_cursor_pull(&cp, provider),
         }
+    }
+
+    /// CIRISEdge#474 — serve an accord-quorum-evidence CURSOR pull. Unlike
+    /// [`Self::on_pull`] (which seeds the content-hash Summary→Diff→Deliver
+    /// machinery), this plane has NO content-hash index, so we answer DIRECTLY
+    /// with a [`DeliverMessage`] of the serialized bundles past the requester's
+    /// `since` watermark — sourced from [`StateProvider::accord_evidence_since`],
+    /// which reads persist's cursor-ordered `list_signed_accord_quorum_evidence_since`
+    /// and applies the same page limit as every other plane. The requester
+    /// re-tallies each bundle on apply (`apply_accord_quorum_evidence`), so serving
+    /// from `since` (or the beginning) can only converge — a byte-identical replay
+    /// is a `Duplicate`, never a double-count. An empty result is a well-formed
+    /// empty `Deliver`: the round still completes (the reply is solicited via the
+    /// requester's `awaiting_cursor_deliver`), no timeout, no unsolicited WARN.
+    fn on_cursor_pull(
+        &mut self,
+        pull: &CursorPullMessage,
+        provider: &dyn StateProvider,
+    ) -> ReplicationOutcome {
+        if pull.kind != self.kind {
+            return ReplicationOutcome::UnexpectedMessage;
+        }
+        let envelopes = provider.accord_evidence_since(self.kind, pull.since);
+        ReplicationOutcome::Send(vec![ReplicationMessage::Deliver(DeliverMessage {
+            kind: self.kind,
+            envelopes,
+        })])
     }
 
     /// CIRISEdge#462 — serve a subject-scoped RECEIVE-axis pull. The requester
@@ -563,7 +615,11 @@ impl Session {
         // quota. Instead we make the phase + peer VISIBLE (a bare unsolicited push on
         // a non-bootstrap plane from a peer is the row to watch), and the threaded
         // `source_peer` lets the applier/persist make the per-peer call.
-        let solicited = self.diff_want_count.is_some();
+        // CIRISEdge#474 — a cursor round's Deliver answers the `CursorPull` this
+        // Initiator sent (no `Diff` phase exists for the index-less accord plane),
+        // so `awaiting_cursor_deliver` marks it solicited exactly as `diff_want_count`
+        // does for the content-hash planes.
+        let solicited = self.diff_want_count.is_some() || self.awaiting_cursor_deliver;
         if !solicited && !deliver.envelopes.is_empty() {
             let bootstrap_plane = matches!(
                 self.kind,
@@ -756,6 +812,141 @@ mod tests {
             local_state: std::sync::Mutex::new(LocalState::new()),
             hash_lookup,
         }
+    }
+
+    /// CIRISEdge#474 — a provider that answers an accord cursor pull with canned
+    /// serialized bundles (the bytes the apply path would `from_slice`). Every
+    /// content-hash method is empty: the cursor plane never advertises refs.
+    struct CursorProvider {
+        bundles: Vec<Vec<u8>>,
+    }
+    impl StateProvider for CursorProvider {
+        fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+            Vec::new()
+        }
+        fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+            None
+        }
+        fn accord_evidence_since(
+            &self,
+            _kind: EnvelopeKind,
+            _since: Option<chrono::DateTime<chrono::Utc>>,
+        ) -> Vec<Vec<u8>> {
+            self.bundles.clone()
+        }
+    }
+
+    /// CIRISEdge#474 — an Initiator round for the cursor plane opens with a
+    /// `CursorPull` (`since: None`), NEVER a Summary: the plane has no content-hash
+    /// index, so the Summary/Diff/Fetch flow does not apply to it.
+    #[test]
+    fn cursor_round_initiator_opens_with_cursor_pull_not_summary() {
+        let provider = CursorProvider { bundles: vec![] };
+        let mut init = Session::new(SessionRole::Initiator, EnvelopeKind::AccordQuorumEvidence);
+        match init.start_round(&provider) {
+            ReplicationOutcome::Send(msgs) => {
+                assert_eq!(msgs.len(), 1, "one CursorPull, no Summary");
+                match &msgs[0] {
+                    ReplicationMessage::CursorPull(cp) => {
+                        assert_eq!(cp.kind, EnvelopeKind::AccordQuorumEvidence);
+                        assert!(cp.since.is_none(), "stateless pull-all (#474)");
+                    }
+                    other => panic!("expected CursorPull, got {other:?}"),
+                }
+            }
+            other => panic!("expected Send, got {other:?}"),
+        }
+    }
+
+    /// CIRISEdge#474 — a Responder answers a `CursorPull` DIRECTLY with a `Deliver`
+    /// of the provider's bundles (no Summary/Diff round-trip for an index-less plane).
+    #[test]
+    fn cursor_round_responder_serves_bundles_as_a_deliver() {
+        let b1 = b"{\"proposal\":1}".to_vec();
+        let b2 = b"{\"proposal\":2}".to_vec();
+        let provider = CursorProvider {
+            bundles: vec![b1.clone(), b2.clone()],
+        };
+        let applier = applier_for(&[]);
+        let mut resp = Session::new(SessionRole::Responder, EnvelopeKind::AccordQuorumEvidence);
+        let pull = ReplicationMessage::CursorPull(CursorPullMessage {
+            kind: EnvelopeKind::AccordQuorumEvidence,
+            since: None,
+        });
+        match resp.on_message(pull, &provider, &applier, Some("peer")) {
+            ReplicationOutcome::Send(msgs) => {
+                assert_eq!(msgs.len(), 1);
+                match &msgs[0] {
+                    ReplicationMessage::Deliver(d) => {
+                        assert_eq!(d.kind, EnvelopeKind::AccordQuorumEvidence);
+                        assert_eq!(
+                            d.envelopes,
+                            vec![b1, b2],
+                            "serves the cursor bytes verbatim"
+                        );
+                    }
+                    other => panic!("expected Deliver, got {other:?}"),
+                }
+            }
+            other => panic!("expected Send, got {other:?}"),
+        }
+    }
+
+    /// CIRISEdge#474 — the full 2-message exchange: Initiator CursorPull → Deliver
+    /// → the Initiator applies the delivered bundles (solicited via
+    /// `awaiting_cursor_deliver`) and completes.
+    #[test]
+    fn cursor_round_initiator_applies_delivered_bundles_and_completes() {
+        let b1 = b"{\"proposal\":\"a\"}".to_vec();
+        let h1 = h(7);
+        let provider = CursorProvider {
+            bundles: vec![b1.clone()],
+        };
+        let applier = applier_for(&[(h1, b1.clone())]);
+        let mut init = Session::new(SessionRole::Initiator, EnvelopeKind::AccordQuorumEvidence);
+        let ReplicationOutcome::Send(open) = init.start_round(&provider) else {
+            panic!("expected Send")
+        };
+        assert!(matches!(open[0], ReplicationMessage::CursorPull(_)));
+        let deliver = ReplicationMessage::Deliver(DeliverMessage {
+            kind: EnvelopeKind::AccordQuorumEvidence,
+            envelopes: vec![b1],
+        });
+        match init.on_message(deliver, &provider, &applier, Some("peer")) {
+            ReplicationOutcome::Applied { admitted, .. } => assert_eq!(admitted, 1),
+            other => panic!("expected Applied, got {other:?}"),
+        }
+        assert_eq!(applier.admitted_count(), 1);
+        assert!(
+            init.is_complete(),
+            "the cursor round completes after the Deliver"
+        );
+    }
+
+    /// CIRISEdge#474 — an evidence-free peer answers with an EMPTY Deliver; the
+    /// Initiator's round still completes cleanly (no timeout, no unsolicited WARN —
+    /// the reply is solicited via `awaiting_cursor_deliver`).
+    #[test]
+    fn empty_cursor_pull_completes_the_round() {
+        let provider = CursorProvider { bundles: vec![] };
+        let applier = applier_for(&[]);
+        let mut init = Session::new(SessionRole::Initiator, EnvelopeKind::AccordQuorumEvidence);
+        let _ = init.start_round(&provider);
+        assert!(!init.is_complete());
+        let empty = ReplicationMessage::Deliver(DeliverMessage {
+            kind: EnvelopeKind::AccordQuorumEvidence,
+            envelopes: vec![],
+        });
+        match init.on_message(empty, &provider, &applier, Some("peer")) {
+            ReplicationOutcome::Applied {
+                admitted, refused, ..
+            } => {
+                assert_eq!(admitted, 0);
+                assert_eq!(refused, 0);
+            }
+            other => panic!("expected Applied, got {other:?}"),
+        }
+        assert!(init.is_complete(), "an empty cursor round still completes");
     }
 
     /// Two peers with disjoint state converge in one round.

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -133,6 +133,27 @@ pub trait StateProvider: Send + Sync {
     fn subject_refs(&self, _kind: EnvelopeKind, _subject_key_id: &str) -> Vec<EnvelopeRef> {
         Vec::new()
     }
+
+    /// CIRISEdge#474 — the accord-quorum-evidence CURSOR serve reader. Answers an
+    /// inbound [`crate::replication::protocol::CursorPullMessage`]: the byte-exact
+    /// [`AccordQuorumEvidence`](ciris_persist::federation::accord_carriage::AccordQuorumEvidence)
+    /// bundles this node holds with `evidence_at > since`, JSON-serialized ready to
+    /// wrap in a [`crate::replication::protocol::DeliverMessage`]. UNLIKE
+    /// [`Self::local_refs`] / [`Self::subject_refs`] this returns BYTES, not refs —
+    /// the plane has no content-hash index, so there is no Diff/Fetch round-trip;
+    /// the responder delivers directly. Bounded by the impl's page limit; the
+    /// requester re-pulls from its new high-water next round to drain a backlog.
+    ///
+    /// Defaults to empty: only the production `DirectoryStateAdapter` (holding the
+    /// persist `FederationDirectory`) and the DST store answer it. A cursor pull to
+    /// a provider that doesn't override it is a well-formed no-op, never a panic.
+    fn accord_evidence_since(
+        &self,
+        _kind: EnvelopeKind,
+        _since: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Vec<Vec<u8>> {
+        Vec::new()
+    }
 }
 
 /// CIRISEdge#425 — the typed result of applying ONE delivered envelope.


### PR DESCRIPTION
Closes #474 — the persist-major adoption (v31.1.0's `AccordQuorumEvidence`, persist #662).

## What this is
`AccordQuorumEvidence` is the 15th replication kind: a steward-quorum decision projecting `RoleWithdrawals` across the federation. It is **cursor-served, not content-hash-indexed** — a bundle's hash moves as each participation lands, so persist deliberately keeps it out of the `signed_wire_index`. It therefore cannot ride the Summary/Diff/Fetch flow every other kind uses. This PR adds the dedicated cursor sub-protocol **end to end** (wire verb → round state machine → serve/apply → activation).

## Design (follows the #462 `Pull` precedent)
- **New wire verb** `CursorPull{kind, since}` → responder answers DIRECTLY with a `Deliver` of bundles past `since`. A post-v1 verb: v1 peers serde-refuse the unknown tag (additive-safe), coordinated by the `SERVE_ADVERTISE_POLICY_HASH` re-pin — exactly as #462 established.
- **Stateless `since:None` pull-all.** The receiver **re-tallies** each bundle against its own roster (`apply_replicated_accord_evidence` — never the sender's verdict; fail-closed; idempotent), so pulling from the start every round can only converge. This matches edge's uniform per-round read model (`list_signed_*_since(None)` everywhere). The `since` field is on the wire for a future in-memory high-water — no re-pin needed to add it.
- **Round completion.** `awaiting_cursor_deliver` marks the answering `Deliver` solicited, so an evidence-free peer completes the round cleanly (no timeout, no unsolicited-WARN).
- **Apply mapping.** Admitted iff a new participation landed OR a withdrawal tombstone was re-derived; a byte-identical replay → `Duplicate`; `AccordEvidenceUnverified` → `Refused`; parse-fail → `Deserialize` (never a silent drop).
- **No LIST-vs-FETCH hazard.** `list_envelope_refs_inner` returns empty for the kind — it is never content-hash advertised (a ref would be listed-then-unfetchable).

## Coordination — none required beyond the mirror
`SERVE_ADVERTISE_POLICY_HASH` (re-pinned `6f683311`→`328d73b0`) is a **local governance pin** (a drift test, never exchanged on the wire). A mixed fleet is safe: a 14-kind peer serde-rejects the 15th kind cleanly. CIRISServer rides edge's `pub const`, so it picks up the new value on its next edge bump — **CIRISServer landed v31 (0.5.172)**, so the blocker is clear.

## Files
`protocol.rs` (kind + verb + `is_cursor_served`), `session.rs` (state machine + 4 tests), `bridge.rs` (serve + apply), `directory.rs` / `summary.rs` (provider plumbing), `registry.rs` (routing), `serve_policy.rs` (policy + hash), `pyo3.rs` (activation).

## Known follow-up (documented, not a gap)
`since:None` converges any realistic governance-volume backlog under the page limit; a backlog exceeding one page wants the in-memory high-water (wire field already present). The cursor `Deliver` relies on transport fragmentation — hardened in v16.2.0 (leviculum#39) — for a large page.

## Verification
`cargo check` (default + `pyo3`) + `clippy -D warnings` clean. New tests: protocol (`cursor_pull_round_trips`, `is_cursor_served` exactness), session (open-with-CursorPull / serve-as-Deliver / apply+complete / empty-completes), serve_policy (manifest entry + re-pinned drift). Suites: replication **187**, frame_fragment 17 — all green. The apply→persist re-tally is exercised end-to-end by the cohab conformance + network-gauntlet CI lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs