### PR TITLE
v17.0.0 — adopt persist v32.1.0 + verify v13.3.1 (Key-plane admission cursor #682)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "16.3.0"
+version = "17.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.5.0", version = "31", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v32.1.0", version = "32", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.5.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.2.0", version = "13", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.2.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.3.1", version = "13", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.3.1", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.2.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.2.0", version = "13" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.3.1", version = "13" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1228,7 +1228,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v31.5.0", version = "31", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v32.1.0", version = "32", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v16.3.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.3.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v16.3.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v16.3.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v16.3.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.3.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v16.3.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.0.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.0.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.0.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.0.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.0.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.0.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ classifiers = [
 # an install-time index requirement (so the "unresolvable from PyPI" shape is by
 # design, not a regression).
 dependencies = [
-    "ciris-persist>=31,<32",
+    "ciris-persist>=32,<33",
 ]
 dynamic = ["version"]
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -70,9 +70,10 @@ use ciris_persist::federation::register::{KeyRefusalReason, ReplicatedKeyOutcome
 use ciris_persist::federation::trust_root::capability_roots_to_trusted_root;
 use ciris_persist::federation::types::delegation_scope;
 use ciris_persist::federation::types::{
-    Attestation, SignedAttestation, SignedCommunity, SignedCommunityMembershipRevocation,
-    SignedFamily, SignedFamilyMembershipRevocation, SignedIdentityOccurrence,
-    SignedIdentityOccurrenceRevocation, SignedKeyRecord, SignedLocationProof, SignedRevocation,
+    Attestation, KeyRecord, SignedAttestation, SignedCommunity,
+    SignedCommunityMembershipRevocation, SignedFamily, SignedFamilyMembershipRevocation,
+    SignedIdentityOccurrence, SignedIdentityOccurrenceRevocation, SignedKeyRecord,
+    SignedLocationProof, SignedRevocation,
 };
 use ciris_persist::federation::FederationDirectory;
 use ciris_verify_core::threshold::ThresholdMember;
@@ -1353,22 +1354,45 @@ impl FederationDirectoryReplicationBridge {
         refs
     }
 
-    /// Key plane — `SelfOwn` (publish-own): the node's OWN establishment
-    /// records. Scope filter is the `SelfOwn` publish set; seq is `valid_from`.
+    /// Key plane — `SelfOwn` (publish-own): the node's OWN establishment records.
+    /// Scope filter is the `SelfOwn` publish set.
+    ///
+    /// persist v32 (CIRISPersist#682) wraps each served key in
+    /// `ServedKeyRecord { record, admitted_at }` — `admitted_at` is the node-local
+    /// admission instant (monotonic, out of the content hash) that fixes the
+    /// late-replication cursor bug (a record signed in January, admitted here in
+    /// February, must not sort under January and become permanently invisible).
+    /// Two consequences edge MUST honor, both invisible to the compiler:
+    ///   1. the wire content hash is over the SIGNED record ONLY — the v31
+    ///      `SignedKeyRecord{record}` shape — so `admitted_at` must stay OUT of it.
+    ///      [`KeyAdvertiseRow`]'s `#[serde(skip)]` reproduces that exact byte shape
+    ///      (pinned by `key_advertise_row_hashes_identically_to_signed_key_record`),
+    ///      so the advertised hash still resolves through the content-hash fetch —
+    ///      hashing the bare `ServedKeyRecord` would fold `admitted_at` in and make
+    ///      every ref listed-then-unfetchable (the LIST-vs-FETCH class);
+    ///   2. the resume `seq` moves from the producer's `valid_from` to the
+    ///      node-local `admitted_at` — the #682 fix, so a late-admitted key sorts
+    ///      by when THIS node saw it, not by a stale producer clock.
     async fn list_keys(&self) -> Vec<EnvelopeRef> {
         let subjects: HashSet<String> = self
             .subjects_for_projection(Projection::SelfOwn)
             .into_iter()
             .collect();
-        let rows = self
+        let rows: Vec<KeyAdvertiseRow> = self
             .directory
             .list_signed_key_records_since(None, self.effective_page_limit().await)
             .await
-            .unwrap_or_default();
+            .unwrap_or_default()
+            .into_iter()
+            .map(|served| KeyAdvertiseRow {
+                record: served.record,
+                admitted_at: served.admitted_at,
+            })
+            .collect();
         self.advertise_since(
             &rows,
             |row| subjects.contains(&row.record.key_id),
-            |row| Self::ms_seq(row.record.valid_from),
+            |row| Self::ms_seq(row.admitted_at),
         )
     }
 
@@ -2932,6 +2956,24 @@ fn content_hash_of<T: serde::Serialize>(value: &T) -> Option<([u8; 32], Vec<u8>)
     Some((hash, bytes))
 }
 
+/// CIRISEdge#474-adjacent (persist v32/#682) — the Key plane's advertise row.
+///
+/// persist v32's `list_signed_key_records_since` returns
+/// `ServedKeyRecord { record, admitted_at }`; edge advertises the content hash of
+/// the SIGNED record only (the v31 `SignedKeyRecord { record }` shape). This
+/// carries `admitted_at` for the resume seq but `#[serde(skip)]`s it, so
+/// [`content_hash_of`] of this row is byte-identical to
+/// `content_hash_of(&SignedKeyRecord { record })` — the exact hash persist's
+/// `signed_wire_index` keys on. The identity is pinned by a test
+/// (`key_advertise_row_hashes_identically_to_signed_key_record`); if serde field
+/// order or naming ever drifted, that test reds before the wire does.
+#[derive(serde::Serialize)]
+struct KeyAdvertiseRow {
+    record: KeyRecord,
+    #[serde(skip)]
+    admitted_at: chrono::DateTime<chrono::Utc>,
+}
+
 // ─── Tests ──────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -3054,6 +3096,43 @@ mod tests {
             consent_role: None,
             additional_scrubs: Vec::new(),
         }
+    }
+
+    /// persist v32/#682 belt: the Key-plane advertise row must hash byte-identically
+    /// to the v31 `SignedKeyRecord { record }` shape (persist's `signed_wire_index`
+    /// basis), and the node-local `admitted_at` must NOT enter that hash. If serde
+    /// field order/naming ever drifted, this reds BEFORE the wire does — the silent
+    /// LIST-vs-FETCH break `cargo check` cannot see.
+    #[test]
+    fn key_advertise_row_hashes_identically_to_signed_key_record() {
+        let record = fixture_key_record("agent-alice", identity_type::AGENT);
+        // The exact wire hash edge must reproduce.
+        let (want, _) = content_hash_of(&SignedKeyRecord {
+            record: record.clone(),
+        })
+        .expect("signed key hashes");
+        // Two DIFFERENT admission instants → the advertise hash is unchanged.
+        let t1 = chrono::DateTime::<chrono::Utc>::from_timestamp(1_700_000_000, 0).unwrap();
+        let t2 = chrono::DateTime::<chrono::Utc>::from_timestamp(1_800_000_123, 456).unwrap();
+        let (h1, _) = content_hash_of(&KeyAdvertiseRow {
+            record: record.clone(),
+            admitted_at: t1,
+        })
+        .expect("advertise row hashes");
+        let (h2, _) = content_hash_of(&KeyAdvertiseRow {
+            record,
+            admitted_at: t2,
+        })
+        .expect("advertise row hashes");
+        assert_eq!(
+            h1, want,
+            "KeyAdvertiseRow must hash as SignedKeyRecord{{record}} — the content-hash \
+             fetch keys on it; folding admitted_at in makes every ref unfetchable"
+        );
+        assert_eq!(
+            h1, h2,
+            "the wire hash is INVARIANT to admitted_at (node-local, never serialized)"
+        );
     }
 
     // ── Construction smoke ───────────────────────────────────────────


### PR DESCRIPTION
Adopts **persist v32.1.0** ("a cursor on the producer's clock" — #682/#668/#690) + **verify v13.2.0 → v13.3.1** lockstep.

## Not a wire break
persist v32 is a MAJOR **API/ABI** break, **not** a wire break: `admitted_at` is node-local and stays out of the content hash ("one record hashes identically on every node"), so **v16.x and v17.x nodes still federate**. The major bump is because the co-install pin floor breaks (`ciris-persist>=32,<33`).

## The one break that reaches edge — and it's compiler-green
`FederationDirectory::list_signed_key_records_since` now returns `Vec<ServedKeyRecord { record, admitted_at }>` (was `Vec<SignedKeyRecord { record }>`). Because `advertise_since` is generic over `Serialize` and the closures read `row.record.*`, **it compiles clean** — but `content_hash_of` serializes the *whole* row, so the advertised Key-plane hash would silently fold in `admitted_at` and stop matching persist's `signed_wire_index` (keyed over `{record}`). Result: every Key ref **listed-then-unfetchable** (the LIST-vs-FETCH class). A green build, a broken wire.

**Fix** (`bridge.rs::list_keys`): map each `ServedKeyRecord` into a `KeyAdvertiseRow` with `#[serde(skip)] admitted_at` — byte-identical hash to `SignedKeyRecord { record }` (the exact v31 wire hash), `admitted_at` carried un-hashed for the seq. The seq moves `valid_from` → `admitted_at` (the #682 late-replication fix: a key sorts by when *this* node admitted it, not a stale producer clock).

## The other three breaks don't touch edge
- `DIRECTORY_ABI_VERSION` 1→2 — edge crosses no directory capsule; its executor-capsule ABI is still 1.
- `Scrubber::scrub_batch → ScrubOutcome` and the Python scrubber 4-tuple — edge calls neither (the `scrubbers` in bridge.rs are the co-scrub *holder* array, not the PII `Scrubber`).
- Every other `list_*` method edge calls is unchanged v31→v32 (diffed all ten).

## Belt — the silent class needs a test the compiler can't be
- `key_advertise_row_hashes_identically_to_signed_key_record` pins `KeyAdvertiseRow == SignedKeyRecord{record}` and invariance to `admitted_at`.
- `key_round_trips_through_bridge` (existing) is the end-to-end acceptance: list → hash → fetch-by-hash through persist's v32 index → decode — **passes**, proving the wire hash resolves.

## Verification
`cargo check` (default + `pyo3`) + `clippy -D warnings` clean; replication **188**, key belt + round-trip, version/evidence/`touch_claim` (verify v13.3.1 canary) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs