### PR TITLE
v17.1.0 — adopt leviculum v0.16.0+ciris.1 (anti-poll API pin bump; #484 step 1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "17.0.0"
+version = "17.1.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -590,8 +590,20 @@ tempfile       = { version = "3", optional = true }
 # connect unchanged); the reticulum + reticulum,lxmf feature builds compile with no
 # match-arm or call-site churn. The crate semver is now 0.15; `+ciris.1` is fork
 # build-metadata.
-leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.15.0+ciris.1", version = "0.15", optional = true }
-leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.15.0+ciris.1", version = "0.15", optional = true }
+# v0.16.0+ciris.1 (CIRISEdge#484, leviculum#42/#44) — the ANTI-POLL API cut, built
+# largely FOR edge: additive completion-futures/await variants (`send_resource_awaited`,
+# `connect_awaited`/`await_link_established`, `send_request_awaited`, `subscribe_events`
+# → bounded `EventTap`) that let edge DELETE all six of its poll loops (reticulum.rs
+# 100ms/50ms/20ms polls). NO wire changes, NO breaking signatures vs v0.15 →
+# SOURCE-COMPAT on the bump (the poll-loop code still compiles; the awaited adoption is
+# a follow-up). FREE on this bump (no code): #44 the periodic storage flush no longer
+# holds the node lock across read+merge+write (the hourly deaf window on SD-card-class
+# HW is gone), + #42 registry hardening (stale-terminal-event race closed pre-tag). The
+# crate semver is now 0.16. CHANGELOG-gotcha lesson from their release: grep for
+# conflict markers before tagging (prose doesn't compile). Adoption sequenced in #484:
+# awaited variants next, then #482 item-1 buffer_unordered dispatcher.
+leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.16.0+ciris.1", version = "0.16", optional = true }
+leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.16.0+ciris.1", version = "0.16", optional = true }
 # v15.20.0 (CIRISEdge#169) — LXMF store-and-forward propagation. The
 # `leviculum-lxmf` workspace member (same pinned tag) ships the whole
 # LXMF wire protocol: propagation-node discovery/upload/`/get` codecs,
@@ -601,7 +613,7 @@ leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.15.0+
 # features keep `pow` on (the stamp/ticket cost we validate at
 # admission). Gated behind the `lxmf` feature — see the `[features]`
 # block. Edge INTEGRATES this crate's protocol; it never reimplements it.
-leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.15.0+ciris.1", version = "0.15", optional = true }
+leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.16.0+ciris.1", version = "0.16", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.0.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.0.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.0.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.0.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.0.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.0.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.0.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.1.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.1.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.1.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.1.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.1.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.1.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.1.0


### PR DESCRIPTION
**#484 step 1: the pin bump.** leviculum v0.15.0 → **v0.16.0+ciris.1** (`f8641c7c`) — the "anti-poll API" release, built largely for edge.

## Source-compat (no code change)
Additive API only — no wire changes, no breaking signatures vs v0.15. The existing poll-loop code still compiles; the awaited-variant adoption (deleting the six poll loops) is the **next cut** per #484's sequencing.

## Free on this bump
- **#44** — the periodic storage flush no longer holds the node lock across its file read+merge+write, so the hourly **deaf window** (scaling with known-destination count × disk speed; SD-card-class hardware felt it) is **gone**.
- **#42** — registry hardening: a stale-terminal-event race found in adversarial review was closed with per-link send accounting before the leviculum tag.

## Sequencing (from #484, confirmed)
1. **This PR** — pin bump (free wins, source-compat).
2. Adopt the 6 awaited variants → delete the poll loops (`send_resource_awaited`, `connect_awaited`/`await_link_established`, `send_request_awaited`, `subscribe_events`→`EventTap`).
3. #482 item-1 — the `outbound.rs` `buffer_unordered` dispatcher (biggest single perf win).
4. #481 — retire the classical-KEX fallback (security follow-up).

## Verification
`cargo check` (`transport-reticulum-auto,lxmf`) clean; reticulum transport **53/53**, drift + version green on v0.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs