### PR TITLE
v17.3.0 — concurrent outbound dispatch (#482 item-1): a dead peer no longer head-of-lines the batch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "17.2.0"
+version = "17.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.2.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.2.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.2.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.2.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.2.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.2.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.2.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.3.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.3.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.3.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.3.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.3.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.3.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.3.0

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -25,6 +25,7 @@ use ciris_persist::outbound::Error as PersistOutboundError;
 use ciris_persist::prelude::{
     OutboundFailureOutcome, OutboundFilter, OutboundQueue, OutboundRow, QueueId,
 };
+use futures::stream::StreamExt as _;
 
 use crate::reachability::{AttemptOutcome, ReachabilityTracker};
 use crate::transport::{Transport, TransportError, TransportSendOutcome};
@@ -462,11 +463,30 @@ pub async fn run_dispatcher(
             continue;
         }
 
-        for row in claimed {
-            dispatch_one(&*queue, &transports, &row, &config, reachability.as_ref()).await;
-        }
+        // CIRISEdge#482 item-1 — dispatch the claimed batch CONCURRENTLY (was a
+        // strictly serial `for` loop through `transports[0]`). Serially, ONE
+        // unreachable peer cost a 30 s establish + up to 120 s transfer and
+        // head-of-lined all the other rows in the batch — including rows for
+        // healthy peers. `for_each_concurrent` lets a slow/dead peer's row time out
+        // in its own slot while the rest proceed; the bound caps concurrent link
+        // establishment so a large batch can't thundering-herd the transport.
+        let queue_ref = &*queue;
+        let transports_ref = &transports;
+        let config_ref = &config;
+        let reach_ref = reachability.as_ref();
+        futures::stream::iter(claimed)
+            .for_each_concurrent(DISPATCH_CONCURRENCY, |row| async move {
+                dispatch_one(queue_ref, transports_ref, &row, config_ref, reach_ref).await;
+            })
+            .await;
     }
 }
+
+/// CIRISEdge#482 — how many claimed outbound rows dispatch concurrently. Bounds
+/// concurrent link establishment (a slow/dead peer occupies at most ONE slot, so
+/// it never head-of-lines the batch) without letting a large claimed batch open an
+/// unbounded number of dials at once.
+const DISPATCH_CONCURRENCY: usize = 16;
 
 #[allow(clippy::too_many_lines)] // CIRISEdge#29 hook insertion crosses the 100-line bound; refactor as
                                  // part of the dispatcher-tier overhaul (FSD §3.4 follow-up)


### PR DESCRIPTION
CIRISEdge#482's highest-leverage transport fix, and the last step of #484's sequence.

## The problem
`run_dispatcher` drained its claimed batch (up to `batch_size`=32 rows) **strictly serially** through one task via `transports[0]`. One unreachable peer cost a 30 s establish + up to 120 s transfer and **head-of-lined all the other rows in the batch** — including rows for healthy peers. A single dead destination stalled the whole durable-outbound plane.

## The fix
`futures::stream::for_each_concurrent(DISPATCH_CONCURRENCY=16, …)` over the claimed batch. A slow/dead peer's row times out in its own slot while the rest proceed; the bound caps concurrent link establishment so a large batch can't thundering-herd the transport.

**Safe to parallelize:** each row is an independent DB row (persist handles concurrent per-row writes), and the Transport was just made concurrency-friendly — leviculum#29 off-lock crypto + the v0.16 awaited variants (v17.1.0/v17.2.0).

## Scope
This completes #484's sequence (pin bump → awaited variants → dispatcher). #482 items 2–7 (inline-DB-per-frame caching, announce-arm worker pool, AV fan-out `join_all`, PoW `spawn_blocking`, …) remain as follow-ups. **#481 (retire the classical-KEX fallback) is next.**

## Verification
`cargo check` + `clippy -D warnings` clean; evidence/version drift green. outbound.rs has no unit-test harness (no mock Transport/queue infra), so the dispatcher is validated by the **network-gauntlet DST soak** on the tag run — the integration lane that already exercises the durable-outbound flow under fault injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GnAcwXX2rrKm244PFKWbBs