### PR TITLE
v17.4.0 — all of Tracks A+B (#481/#489/#482 items 2,3,5,7): security hardening & hot-path perf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "17.3.0"
+version = "17.4.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.3.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.3.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.3.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.3.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.3.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.3.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.3.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.4.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.4.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.4.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.4.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.4.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.4.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.4.0

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -6368,10 +6368,12 @@ fn seal_av_outer(
 
 /// Hybrid X25519 + ML-KEM-768 KEX — initiator side (CIRISEdge#54).
 ///
-/// `algorithm` is one of `"hybrid"`, `"hybrid-required"`, or `"classical"`.
-/// HNDL-strict callers (realtime A/V, key_grant DEK distribution) should
-/// pass `"hybrid-required"`: classical fallback is REJECTED rather than
-/// silently negotiated down.
+/// `algorithm` is one of `"hybrid"` or `"hybrid-required"`. Post-CIRISEdge#481
+/// the two are identical on the initiate side (both require the peer's
+/// ML-KEM-768 half and reject a classical-only peer); `"hybrid-required"`
+/// remains as an explicit HNDL-strict marker for realtime A/V + key_grant DEK
+/// distribution. `"classical"` is REJECTED with `PyValueError` — the classical
+/// X25519-only KEX is retired (there is no negotiable quantum-vulnerable path).
 ///
 /// Returns `(handshake_msg_json_bytes, session_key, negotiated_algorithm_wire_id)`.
 /// The handshake JSON round-trips through
@@ -6395,10 +6397,18 @@ fn federation_session_initiate(
     let requested = match algorithm {
         "hybrid" => KexAlgorithm::Hybrid,
         "hybrid-required" => KexAlgorithm::HybridRequired,
-        "classical" => KexAlgorithm::Classical,
+        // CIRISEdge#481 — the classical KEX is retired. Refuse the request
+        // explicitly (rather than routing it to `initiate`, which would also
+        // reject it) so the caller gets a clear, actionable error.
+        "classical" => {
+            return Err(PyValueError::new_err(
+                "algorithm 'classical': the classical X25519-only KEX is retired \
+                 (CIRISEdge#481, HNDL discipline) — use 'hybrid' or 'hybrid-required'",
+            ));
+        }
         other => {
             return Err(PyValueError::new_err(format!(
-                "algorithm: expected 'hybrid' | 'hybrid-required' | 'classical', got {other:?}"
+                "algorithm: expected 'hybrid' | 'hybrid-required', got {other:?}"
             )));
         }
     };

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -7379,9 +7379,15 @@ impl PyLxmfPropagationNode {
         unstamped_lxmf: &[u8],
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
         let stamp = fixed_bytes::<32>("propagation_stamp", propagation_stamp)?;
-        let id = self
-            .inner
-            .validate_and_store(&stamp, unstamped_lxmf)
+        // CIRISEdge#482 item 7 — the proof-of-work VALIDATION (workblock
+        // expansion rounds) is CPU-heavy and previously ran holding the GIL,
+        // freezing every other Python thread for its whole duration. Copy the
+        // Python-borrowed ciphertext to an owned buffer, then RELEASE the GIL
+        // (`py.detach`) for the stamp check so Python threads keep running.
+        let unstamped = unstamped_lxmf.to_vec();
+        let node = &self.inner;
+        let id = py
+            .detach(|| node.validate_and_store(&stamp, &unstamped))
             .map_err(|e| lxmf_err(&e))?;
         Ok(pyo3::types::PyBytes::new(py, &id))
     }
@@ -7576,9 +7582,14 @@ impl PyLxmfPropagationClient {
         unstamped_lxmf: &[u8],
         cost: u8,
     ) -> PyResult<Bound<'py, pyo3::types::PyBytes>> {
-        let stamp = self
-            .inner
-            .generate_propagation_stamp(unstamped_lxmf, cost)
+        // CIRISEdge#482 item 7 — PoW GENERATION is the heaviest CPU path here
+        // (searching for a stamp at `cost` leading-zero bits over the workblock
+        // rounds). Copy the borrowed input, then release the GIL so Python
+        // threads run during the search instead of freezing behind it.
+        let unstamped = unstamped_lxmf.to_vec();
+        let node = &self.inner;
+        let stamp = py
+            .detach(|| node.generate_propagation_stamp(&unstamped, cost))
             .map_err(|e| lxmf_err(&e))?;
         Ok(pyo3::types::PyBytes::new(py, &stamp))
     }

--- a/src/transport/federation_session.rs
+++ b/src/transport/federation_session.rs
@@ -34,17 +34,30 @@
 //!
 //! ## Negotiation rules
 //!
-//! - Hybrid is the default.
-//! - Classical fallback is admitted iff the peer's advertised KEX pubkeys
-//!   lack the ML-KEM-768 half.
-//! - **ML-KEM-only is rejected at v1** — both peers MUST support X25519
-//!   for fallback safety. A peer advertising ML-KEM-768 without X25519 is
-//!   out-of-spec; honoring it would create a degraded ciphersuite an
-//!   attacker could force by stripping the X25519 advertisement.
+//! - Hybrid X25519+ML-KEM-768 is MANDATORY. Both peers MUST advertise the
+//!   ML-KEM-768 half; a peer that lacks it is REJECTED, not degraded.
+//! - **The classical X25519-only KEX is RETIRED (CIRISEdge#481).** There is
+//!   no negotiable classical path: [`FederationSession::initiate`] refuses a
+//!   classical request (or a classical-only peer) and
+//!   [`FederationSession::respond`] refuses a classical handshake, both with
+//!   [`SessionError::ClassicalKexRetired`]. Fed TM §3.3 Gap C is only closed
+//!   if an active attacker cannot force EITHER side down to a
+//!   quantum-vulnerable session by stripping the ML-KEM advertisement —
+//!   which requires the classical path to be gone, not merely deprioritized.
+//!   `Hybrid` and `HybridRequired` are consequently identical on the
+//!   initiate side; the `Classical` enum/wire variants are retained ONLY so
+//!   a downgrade attempt parses to a typed, logged refusal.
+//! - **ML-KEM-only is rejected** — both peers MUST support X25519 as the
+//!   classical half of the hybrid construction. A peer advertising ML-KEM-768
+//!   without X25519 is out-of-spec; honoring it would create a degraded
+//!   ciphersuite an attacker could force by stripping the X25519 half.
 //!
-//! These rules are encoded structurally in [`PeerKexPubkeys`]
-//! (`x25519_pub` is required; `mlkem768_pub` is `Option`) and enforced
-//! in [`FederationSession::initiate`].
+//! `PeerKexPubkeys.mlkem768_pub` remains `Option` (rather than being made
+//! non-optional) because directory-sourced advertisements are represented
+//! with `None` and rejected at their CONSTRUCTION boundary — the FFI Member
+//! conversion and the A/V-MLS bridge both HNDL-pre-check `mlkem768_pub` is
+//! present. The retirement above enforces the same invariant at the two KEX
+//! verbs, so a classical-only peer is refused wherever it enters.
 
 use ciris_crypto::hybrid_kex::{
     self, ClassicalHandshakeMsg, HybridHandshakeMsg, KEX_ALGORITHM_CLASSICAL_V1,
@@ -62,20 +75,24 @@ pub const ALGORITHM_CLASSICAL_V1: &str = KEX_ALGORITHM_CLASSICAL_V1;
 /// representable — see module docs.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KexAlgorithm {
-    /// Hybrid X25519 + ML-KEM-768. Default whenever the peer advertises
-    /// both halves; falls back to [`Self::Classical`] silently when the
-    /// peer is classical-only.
+    /// Hybrid X25519 + ML-KEM-768. The peer MUST advertise both halves; a
+    /// classical-only peer is REJECTED with
+    /// [`SessionError::HybridRequiredButPeerLacksMlkem`]. Since CIRISEdge#481
+    /// retired the classical fallback, this is now IDENTICAL to
+    /// [`Self::HybridRequired`] on the initiate side (there is no longer a
+    /// weaker mode to fall back to).
     Hybrid,
-    /// Hybrid X25519 + ML-KEM-768 with NO classical fallback. Caller
-    /// asserts the channel content is HNDL-sensitive (CEG §10.5.5;
-    /// realtime A/V; key_grant DEK distribution) — a peer that hasn't
-    /// advertised ML-KEM-768 is REJECTED with
-    /// [`SessionError::HybridRequiredButPeerLacksMlkem`] rather than
-    /// silently degraded.
+    /// Hybrid X25519 + ML-KEM-768, HNDL-strict. Retained as a distinct name
+    /// for callers that assert the channel content is HNDL-sensitive
+    /// (CEG §10.5.5; realtime A/V; key_grant DEK distribution). Post-#481 its
+    /// negotiation is the same as [`Self::Hybrid`] — a classical-only peer is
+    /// REJECTED with [`SessionError::HybridRequiredButPeerLacksMlkem`].
     HybridRequired,
-    /// Classical X25519 only. Admitted when the peer hasn't published
-    /// an ML-KEM-768 pubkey AND the caller opted in to fallback via
-    /// [`Self::Hybrid`] (NOT [`Self::HybridRequired`]).
+    /// Classical X25519 only — **RETIRED (CIRISEdge#481)**. No longer a
+    /// negotiable outcome: requesting it makes [`FederationSession::initiate`]
+    /// return [`SessionError::ClassicalKexRetired`]. The variant is retained
+    /// so a classical wire message parses to a typed, logged refusal (see
+    /// [`SessionHandshakeMsg::Classical`]) rather than a blind parse failure.
     Classical,
 }
 
@@ -224,6 +241,18 @@ pub enum SessionError {
     /// post-quantum era, and a classical-only outcome would violate that.
     #[error("HybridRequired mode rejects classical-fallback peer (HNDL discipline)")]
     HybridRequiredButPeerLacksMlkem,
+    /// CIRISEdge#481 — the classical X25519-only KEX is RETIRED. Fed TM
+    /// §3.3 Gap C (harvest-now-decrypt-later) is only closed if there is
+    /// NO negotiable classical path at all: an active attacker who strips a
+    /// peer's ML-KEM-768 advertisement must not be able to force either side
+    /// down to a quantum-vulnerable session key. This error fires when
+    /// `initiate` is asked for classical (explicitly, or via a peer that
+    /// lacks ML-KEM-768) OR when `respond` receives a classical handshake.
+    /// The `Classical` wire/enum variants are RETAINED so the refusal is a
+    /// typed, observable rejection (a downgrade attempt is logged as itself)
+    /// rather than a parse failure an attacker could probe blindly.
+    #[error("classical KEX is retired (CIRISEdge#481, HNDL discipline) — hybrid X25519+ML-KEM-768 is mandatory")]
+    ClassicalKexRetired,
 }
 
 impl From<hybrid_kex::KexError> for SessionError {
@@ -263,18 +292,23 @@ impl FederationSession {
         if peer.x25519_pub == [0u8; 32] && peer.mlkem768_pub.is_some() {
             return Err(SessionError::MlKemOnlyRejected);
         }
-        // Negotiation:
-        // - HybridRequired + peer has ML-KEM → hybrid
-        // - HybridRequired + peer lacks ML-KEM → REJECT (HNDL discipline)
-        // - Hybrid + peer has ML-KEM → hybrid
-        // - Hybrid + peer lacks ML-KEM → classical fallback
-        // - Classical (requested) → classical
+        // CIRISEdge#481 — negotiation AFTER classical retirement. `Hybrid` and
+        // `HybridRequired` are now IDENTICAL on the initiate side: both REQUIRE
+        // the peer to advertise ML-KEM-768, and there is NO classical fallback.
+        // - Hybrid | HybridRequired + peer has ML-KEM → hybrid
+        // - Hybrid | HybridRequired + peer lacks ML-KEM → REJECT (no downgrade)
+        // - Classical (explicitly requested) → REJECT (retired)
+        //
+        // The silent `Hybrid + peer-lacks-ML-KEM → classical` fallback that used
+        // to live here was PRECISELY the downgrade an active attacker forces by
+        // stripping a peer's ML-KEM advertisement; Fed TM §3.3 Gap C is only
+        // closed once that path is gone.
         let actual = match (requested, peer.mlkem768_pub.is_some()) {
-            (KexAlgorithm::HybridRequired, false) => {
+            (KexAlgorithm::HybridRequired | KexAlgorithm::Hybrid, true) => KexAlgorithm::Hybrid,
+            (KexAlgorithm::HybridRequired | KexAlgorithm::Hybrid, false) => {
                 return Err(SessionError::HybridRequiredButPeerLacksMlkem);
             }
-            (KexAlgorithm::HybridRequired | KexAlgorithm::Hybrid, true) => KexAlgorithm::Hybrid,
-            (KexAlgorithm::Hybrid, false) | (KexAlgorithm::Classical, _) => KexAlgorithm::Classical,
+            (KexAlgorithm::Classical, _) => return Err(SessionError::ClassicalKexRetired),
         };
         match actual {
             KexAlgorithm::Hybrid => {
@@ -282,16 +316,14 @@ impl FederationSession {
                 let (msg, k) = hybrid_kex::initiate_hybrid(&peer.x25519_pub, mlkem_pub)?;
                 Ok((SessionHandshakeMsg::Hybrid(msg), SessionKey(k)))
             }
-            KexAlgorithm::Classical => {
-                let (msg, k) = hybrid_kex::initiate_classical(&peer.x25519_pub)?;
-                Ok((SessionHandshakeMsg::Classical(msg), SessionKey(k)))
-            }
-            // `actual` is the post-negotiation outcome — the negotiation
-            // arm above either returns Err for `HybridRequired` against
-            // a classical peer or collapses to `Hybrid` against a
-            // hybrid one, so `HybridRequired` never reaches here.
-            KexAlgorithm::HybridRequired => unreachable!(
-                "post-negotiation actual is Hybrid or Classical; HybridRequired never escapes"
+            // #481 — `actual` is `Hybrid` by construction: the explicit
+            // `Classical` request and the classical-peer case both returned
+            // `Err` above, and `HybridRequired` collapsed to `Hybrid`. The
+            // classical initiate path (`hybrid_kex::initiate_classical`) is
+            // retired and no longer reachable from this verb.
+            KexAlgorithm::Classical | KexAlgorithm::HybridRequired => unreachable!(
+                "post-#481 negotiation yields only Hybrid; classical is retired \
+                 and HybridRequired collapses to Hybrid"
             ),
         }
     }
@@ -322,10 +354,14 @@ impl FederationSession {
                 let k = hybrid_kex::respond_hybrid_with_public(&own.x25519_priv, priv_, pub_, m)?;
                 Ok(SessionKey(k))
             }
-            SessionHandshakeMsg::Classical(m) => {
-                let k = hybrid_kex::respond_classical(&own.x25519_priv, m)?;
-                Ok(SessionKey(k))
-            }
+            // CIRISEdge#481 — a responder MUST NOT derive a key from a classical
+            // handshake. This is the ACTIVE-attacker close: an attacker who
+            // strips the initiator's ML-KEM advertisement (or hand-crafts a
+            // classical handshake) must not establish a quantum-vulnerable
+            // session with us. The `Classical` variant is still PARSED so the
+            // refusal is typed and observable (a downgrade attempt is logged as
+            // itself), but no key is ever computed from it.
+            SessionHandshakeMsg::Classical(_m) => Err(SessionError::ClassicalKexRetired),
         }
     }
 }
@@ -381,34 +417,54 @@ mod tests {
         assert_eq!(initiator_key.as_bytes().len(), 32);
     }
 
-    /// Same as above, classical mode (X25519 only).
+    /// CIRISEdge#481 — an explicit `Classical` request is RETIRED. `initiate`
+    /// refuses it with [`SessionError::ClassicalKexRetired`] rather than
+    /// producing a classical session key (was: `classical_round_trip`).
     #[test]
-    fn classical_round_trip_yields_matching_session_keys() {
+    fn classical_initiate_is_retired() {
         let responder = fresh_recipient();
         let peer_view = advertise(&responder);
-        let (msg, initiator_key) =
-            FederationSession::initiate(&peer_view, KexAlgorithm::Classical).expect("initiate");
-        assert_eq!(msg.algorithm(), ALGORITHM_CLASSICAL_V1);
-        let responder_key = FederationSession::respond(&responder, &msg).expect("respond");
-        assert_eq!(initiator_key.as_bytes(), responder_key.as_bytes());
+        let r = FederationSession::initiate(&peer_view, KexAlgorithm::Classical);
+        assert!(
+            matches!(r, Err(SessionError::ClassicalKexRetired)),
+            "classical initiate must be retired, got {r:?}"
+        );
     }
 
-    /// Acceptance criterion 3 — classical fallback when peer hasn't
-    /// advertised ML-KEM-768. Requesting hybrid against such a peer
-    /// negotiates DOWN to classical, NOT failing.
+    /// CIRISEdge#481 — requesting `Hybrid` against a classical-only peer no
+    /// longer falls back to classical; it is REJECTED. This is the exact
+    /// active-downgrade an attacker forces by stripping the ML-KEM
+    /// advertisement (was: `..._falls_back`, which asserted the now-retired
+    /// fallback).
     #[test]
-    fn hybrid_requested_against_classical_only_peer_falls_back() {
+    fn hybrid_requested_against_classical_only_peer_is_rejected() {
         let responder = fresh_recipient();
         let peer_view = advertise_classical_only(&responder);
-        let (msg, initiator_key) =
-            FederationSession::initiate(&peer_view, KexAlgorithm::Hybrid).expect("initiate");
-        assert_eq!(
-            msg.algorithm(),
-            ALGORITHM_CLASSICAL_V1,
-            "fallback should pick classical"
+        let r = FederationSession::initiate(&peer_view, KexAlgorithm::Hybrid);
+        assert!(
+            matches!(r, Err(SessionError::HybridRequiredButPeerLacksMlkem)),
+            "hybrid vs classical-only peer must reject (no fallback), got {r:?}"
         );
-        let responder_key = FederationSession::respond(&responder, &msg).expect("respond");
-        assert_eq!(initiator_key.as_bytes(), responder_key.as_bytes());
+    }
+
+    /// CIRISEdge#481 — the ACTIVE-attacker close: even a WELL-FORMED classical
+    /// handshake (what an attacker who stripped the initiator's ML-KEM
+    /// advertisement would present) is REFUSED by the responder, never
+    /// completed into a session key.
+    #[test]
+    fn respond_rejects_classical_handshake() {
+        let responder = fresh_recipient();
+        let peer_view = advertise(&responder);
+        // Produce a genuine classical handshake via the crypto layer directly
+        // — `initiate` itself will no longer emit one.
+        let (classical_msg, _initiator_key) = hybrid_kex::initiate_classical(&peer_view.x25519_pub)
+            .expect("classical initiate (crypto layer)");
+        let wire = SessionHandshakeMsg::Classical(classical_msg);
+        let r = FederationSession::respond(&responder, &wire);
+        assert!(
+            matches!(r, Err(SessionError::ClassicalKexRetired)),
+            "responder must refuse a classical handshake, got {r:?}"
+        );
     }
 
     /// Acceptance criterion 4 — ML-KEM-only mode rejected. A peer view

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -362,6 +362,15 @@ fn reverse_path_wait_step(
 /// announce storm can't be driven by rapid link churn.
 const EVENT_ANNOUNCE_MIN_INTERVAL: Duration = Duration::from_secs(10);
 
+/// CIRISEdge#482 item 3 — bound on the announce cold-start hand-off queue. The
+/// EventReceiver task `try_send`s each inbound announce here and a dedicated
+/// worker drains it, so a slow/contended rooting directory can no longer
+/// head-of-line every other node event behind an announce's DB round-trips.
+/// At the cap, the oldest-losing policy is a LOUD drop (RNS announces are
+/// periodic + idempotent, so a dropped one self-heals on the next re-announce),
+/// never a silent one (CIRISEdge#425).
+const ANNOUNCE_QUEUE_DEPTH: usize = 256;
+
 /// CIRISEdge#482 item 5 — window a `check_blackhole` deny-list snapshot stays
 /// valid before the next dial re-reads `blackhole_list()` from persist. Short
 /// enough that operator add/remove takes effect near-immediately; long enough
@@ -4503,6 +4512,33 @@ impl Transport for ReticulumTransport {
         // announce immediately.
         let mut last_event_announce: Option<std::time::Instant> = None;
 
+        // CIRISEdge#482 item 3 — offload announce cold-start onto a dedicated
+        // worker so a slow / contended rooting directory can no longer
+        // head-of-line every other node event behind an announce's DB
+        // round-trips. The EventReceiver select arm below `try_send`s each
+        // inbound announce here; this single worker drains them FIFO (the same
+        // serial processing order as the old inline path, just decoupled from
+        // the hot event task — so it introduces no new concurrency). The worker
+        // exits when `announce_tx` drops on listener shutdown.
+        let announce_ctx = AnnounceCtx {
+            peers: Arc::clone(&self.peers),
+            rooting: self.rooting.clone(),
+            event_bus: self.event_bus.clone(),
+            reachability: self.reachability.clone(),
+            peer_bundles: Arc::clone(&self.peer_bundles),
+            hybrid_policy: self.hybrid_policy,
+            transport_binding_enforcement: self.transport_binding_enforcement,
+            bundle_save_gate: self.bundle_save_gate,
+        };
+        let (announce_tx, mut announce_rx) =
+            mpsc::channel::<leviculum_core::ReceivedAnnounce>(ANNOUNCE_QUEUE_DEPTH);
+        tokio::spawn(async move {
+            while let Some(announce) = announce_rx.recv().await {
+                resolve_announce_cold_start(announce, &announce_ctx).await;
+            }
+            tracing::debug!("announce cold-start worker exiting (channel closed)");
+        });
+
         loop {
             tokio::select! {
                 _ = announce_tick.tick() => {
@@ -4552,13 +4588,11 @@ impl Transport for ReticulumTransport {
                         sink: &sink,
                         rooting: self.rooting.as_deref(),
                         binding_cache: &self.binding_cache,
-                        hybrid_policy: self.hybrid_policy,
-                        transport_binding_enforcement: self.transport_binding_enforcement,
+                        announce_tx: &announce_tx,
                         bundle_save_gate: self.bundle_save_gate,
                         peer_bundles: &self.peer_bundles,
                         own_bundle: self.own_bundle.as_ref(),
                         event_bus: self.event_bus.as_deref(),
-                        reachability: self.reachability.as_ref(),
                         link_established_at: &self.link_established_at,
                         link_to_peer_key_id: &self.link_to_peer_key_id,
                         link_last_inbound_at: &self.link_last_inbound_at,
@@ -4607,6 +4641,25 @@ impl Transport for ReticulumTransport {
     }
 }
 
+/// CIRISEdge#482 item 3 — the OWNED subset of transport state that
+/// [`resolve_announce_cold_start`] needs, so it can run on a dedicated worker
+/// task (fed from [`EventCtx::announce_tx`]) instead of inline on the single
+/// EventReceiver task. Every field is `Arc`/`Copy` so the whole struct clones
+/// cheaply; it mirrors exactly the 8 `EventCtx` fields the cold-start path
+/// touches (verified: it delegates `ctx` to no other helper). Built once in
+/// [`ReticulumTransport::listen`] and moved into the worker.
+#[derive(Clone)]
+struct AnnounceCtx {
+    peers: Arc<Mutex<HashMap<String, RootedPeer>>>,
+    rooting: Option<Arc<dyn RootingDirectory>>,
+    event_bus: Option<Arc<crate::events::EventBus>>,
+    reachability: Option<Arc<ReachabilityTracker>>,
+    peer_bundles: Arc<crate::bundle_gate::PeerBundleStore>,
+    hybrid_policy: HybridPolicy,
+    transport_binding_enforcement: TransportBindingEnforcement,
+    bundle_save_gate: crate::bundle_gate::BundleSaveGateMode,
+}
+
 /// Shared handles the event loop hands to [`handle_event`].
 struct EventCtx<'a> {
     node: &'a ReticulumNode,
@@ -4622,11 +4675,10 @@ struct EventCtx<'a> {
     /// CIRISEdge#482 item 2 — per-`(peer, dest)` hybrid-binding memo, borrowed
     /// from the owning transport; see [`binding_exists_cached`].
     binding_cache: &'a BindingCache,
-    /// Consumer hybrid PQC policy applied to a rooted chain.
-    hybrid_policy: HybridPolicy,
-    /// CIRISEdge#205 (AV-42 Phase 4) — RNS destination-hash binding
-    /// enforcement posture applied in [`resolve_announce_cold_start`].
-    transport_binding_enforcement: TransportBindingEnforcement,
+    /// CIRISEdge#482 item 3 — hand-off channel to the announce cold-start
+    /// worker. The `AnnounceReceived` arm `try_send`s here instead of running
+    /// [`resolve_announce_cold_start`] inline on the EventReceiver task.
+    announce_tx: &'a mpsc::Sender<leviculum_core::ReceivedAnnounce>,
     /// CIRISEdge#437 — bundle-gate posture on the DURABLE Rooted save,
     /// applied to the write-through in [`resolve_announce_cold_start`].
     bundle_save_gate: crate::bundle_gate::BundleSaveGateMode,
@@ -4640,11 +4692,6 @@ struct EventCtx<'a> {
     /// emissions. `None` → no events emitted (the transport was
     /// constructed without `ReticulumAuth::event_bus`).
     event_bus: Option<&'a crate::events::EventBus>,
-    /// CIRISEdge#29 — per-medium reachability tracker. `Some` →
-    /// every successfully-rooted announce records an
-    /// `AttemptOutcome::AnnounceReceived` against `(peer_key_id,
-    /// TransportId::RETICULUM_RS)`.
-    reachability: Option<&'a Arc<ReachabilityTracker>>,
     /// CIRISEdge#32 (v0.14.0) — link establishment timestamps,
     /// populated on `LinkEstablished` / cleared on `LinkClosed` /
     /// `LinkStale`.
@@ -5072,13 +5119,23 @@ fn select_reply_link(
 async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
     match event {
         NodeEvent::AnnounceReceived { announce, .. } => {
-            // The announce app-data carries the peer's signed
-            // attestation. Run the authenticated cold-start path —
-            // root the federation key, verify the attestation
-            // signature, apply the hybrid policy — before the peer
-            // is recorded as resolvable. This replaces v0.3.1's
-            // trust-on-first-use (CIRISEdge#15, AV-42).
-            resolve_announce_cold_start(&announce, ctx).await;
+            // The announce app-data carries the peer's signed attestation; the
+            // authenticated cold-start path roots the federation key, verifies
+            // the attestation signature, and applies the hybrid policy before
+            // the peer is recorded as resolvable (replaces v0.3.1 TOFU —
+            // CIRISEdge#15, AV-42). CIRISEdge#482 item 3 — that work is now
+            // handed to a dedicated worker (non-blocking `try_send`) so its DB
+            // round-trips don't head-of-line every other node event. A full
+            // queue drops the announce LOUDLY (never silently — CIRISEdge#425);
+            // RNS announces are periodic + idempotent, so the peer's next
+            // re-announce retries.
+            if let Err(e) = ctx.announce_tx.try_send(announce) {
+                tracing::warn!(
+                    error = %e,
+                    "announce DROPPED — cold-start worker queue full or closed \
+                     (CIRISEdge#482 item 3; RNS re-announce will retry)"
+                );
+            }
         }
         // v7.2.0: Leviculum v0.8.x upstream auto-accepts inbound link
         // requests internally — the v0.7.x `NodeEvent::LinkRequest` +
@@ -6387,14 +6444,14 @@ async fn handle_peer_bundle_frame(
 
 #[allow(clippy::too_many_lines)]
 async fn resolve_announce_cold_start(
-    announce: &leviculum_core::ReceivedAnnounce,
-    ctx: &EventCtx<'_>,
+    announce: leviculum_core::ReceivedAnnounce,
+    ctx: &AnnounceCtx,
 ) {
     use ciris_persist::federation::self_at_login::BindingProvenance;
     // Step 0 — the cold-start path needs the persist directory. With
     // no rooting backend the announce cannot be authenticated; drop
     // it (fail-honest — never fall back to TOFU).
-    let Some(rooting) = ctx.rooting else {
+    let Some(rooting) = ctx.rooting.as_deref() else {
         // CIRISEdge#425 — no rooting directory means EVERY announce is dropped, so
         // no peer can ever root: the mesh silently never forms. A floored WARN
         // (fixed discriminant — one config condition) so a misconfigured node says
@@ -6437,7 +6494,7 @@ async fn resolve_announce_cold_start(
             // CIRISEdge#34 — still surface on the announce stream for operators
             // who subscribe, but at INFO severity: ambient non-CIRIS traffic is
             // informational, not a warning (CIRISEdge#357).
-            if let Some(bus) = ctx.event_bus {
+            if let Some(bus) = ctx.event_bus.as_deref() {
                 bus.emit_announce(crate::events::NetworkEvent::announce(
                     None,
                     announce.destination_hash().as_bytes().to_vec(),
@@ -6473,7 +6530,7 @@ async fn resolve_announce_cold_start(
                      the announce identity pubkeys (RNS §5.6.8.8.1.1 mismatch — \
                      spoofed transport-identity binding)",
                 );
-                if let Some(bus) = ctx.event_bus {
+                if let Some(bus) = ctx.event_bus.as_deref() {
                     bus.emit_announce(crate::events::NetworkEvent::announce(
                         Some(key_id.clone()),
                         announce.destination_hash().as_bytes().to_vec(),
@@ -6773,7 +6830,7 @@ async fn resolve_announce_cold_start(
                 // tracker / event / peer-map writes are logically
                 // independent (the tracker is observability, the peer
                 // map is routing).
-                if let Some(tracker) = ctx.reachability {
+                if let Some(tracker) = ctx.reachability.as_ref() {
                     tracker.record_attempt(
                         &key_id,
                         TransportId::RETICULUM_RS,
@@ -6784,7 +6841,7 @@ async fn resolve_announce_cold_start(
                 // event with info severity. The peer key_id is now known
                 // to be authentic; surface it on the announce stream so
                 // the UI can render "peer X joined".
-                if let Some(bus) = ctx.event_bus {
+                if let Some(bus) = ctx.event_bus.as_deref() {
                     bus.emit_announce(crate::events::NetworkEvent::announce(
                         Some(key_id.clone()),
                         announce.destination_hash().as_bytes().to_vec(),
@@ -6903,7 +6960,7 @@ async fn resolve_announce_cold_start(
             ctx.bundle_save_gate,
             persist_provenance,
             &persisted_key,
-            ctx.peer_bundles,
+            &ctx.peer_bundles,
             rooting,
         )
         .await;

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -362,6 +362,27 @@ fn reverse_path_wait_step(
 /// announce storm can't be driven by rapid link churn.
 const EVENT_ANNOUNCE_MIN_INTERVAL: Duration = Duration::from_secs(10);
 
+/// CIRISEdge#482 item 5 — window a `check_blackhole` deny-list snapshot stays
+/// valid before the next dial re-reads `blackhole_list()` from persist. Short
+/// enough that operator add/remove takes effect near-immediately; long enough
+/// that a dial FLOOD (the hot path this optimizes) collapses to one DB read.
+/// See the `blackhole_cache` field docblock for the staleness argument.
+const BLACKHOLE_CACHE_TTL: Duration = Duration::from_secs(2);
+
+/// CIRISEdge#482 item 2 — window a `hybrid_transport_binding_exists` verdict
+/// stays valid before the next inbound frame re-queries the rooting directory.
+/// The inbound attribution path checked this per frame (an uncached directory
+/// lookup); caching collapses a burst from one peer to a single query. Kept
+/// tight because caching a stale `true` past a binding *revocation* is the
+/// security-relevant direction — see the `binding_cache` field docblock.
+const BINDING_CACHE_TTL: Duration = Duration::from_secs(3);
+
+/// CIRISEdge#482 item 2 — the memo backing [`binding_exists_cached`]. Keyed by
+/// the COMPLETE input to `hybrid_transport_binding_exists` — `(key_id, dest)` —
+/// mapping to `(verdict, fetched_at)`. A plain `std::sync::Mutex` (guard never
+/// held across an `.await`, keeping the inbound path #217-safe).
+type BindingCache = std::sync::Mutex<HashMap<(String, [u8; 16]), (bool, std::time::Instant)>>;
+
 /// CIRISEdge#318 — cap on the in-memory `peers` (rooted + advisory bindings)
 /// map. Bounds advisory-admit pollution: at cap, an Advisory binding is evicted
 /// before a new key is inserted (Rooted bindings are never evicted for advisory
@@ -1725,6 +1746,32 @@ pub struct ReticulumTransport {
     /// `routing_blackhole_*` returns `TransportError::Config` in that
     /// case, and the send-path enforcement check is a no-op.
     blackhole: Option<Arc<dyn ciris_persist::federation::BlackholeRules>>,
+    /// CIRISEdge#482 item 5 — short-TTL snapshot of the deny-list so a
+    /// dial FLOOD collapses to one `blackhole_list()` DB round-trip per
+    /// [`BLACKHOLE_CACHE_TTL`] window instead of one read per dial (the
+    /// hot send-path was an uncached full-table read). Holds
+    /// `(fetched_at, rows)`; a lookup within the window scans the cached
+    /// `Arc<Vec<_>>` with zero DB traffic. The lock is a plain
+    /// `std::sync::Mutex` held only across the snapshot swap — never
+    /// across the `.await` refresh — so this stays #217-safe (no tokio
+    /// timing primitive on a path that can run on persist's runtime
+    /// thread). **Staleness bound**: a newly-`add`ed rule takes effect,
+    /// and a `remove`d rule stops blocking, within one TTL window; the
+    /// deny-list is operator-intent (see the #120 docblock — low-dozens,
+    /// human-curated), so a ≤TTL enforcement lag on a peer that was
+    /// reachable a moment ago is immaterial, and both directions
+    /// fail-safe (over-block briefly on removal, under-block briefly on
+    /// add). `None`-backend transports never populate this.
+    blackhole_cache: std::sync::Mutex<
+        Option<(
+            std::time::Instant,
+            Arc<Vec<ciris_persist::federation::BlackholeRecord>>,
+        )>,
+    >,
+    /// CIRISEdge#482 item 2 — per-`(peer, dest)` hybrid-binding memo consulted
+    /// on the inbound attribution path (once-per-frame directory lookup → one
+    /// query per TTL window). See [`binding_exists_cached`].
+    binding_cache: BindingCache,
     /// CIRISEdge#33 (v0.15.0) — process-wall-clock instant the
     /// transport was constructed. Backs `routing_transport_uptime`.
     /// Monotonic via `std::time::Instant`; transport replacement
@@ -2330,6 +2377,8 @@ impl ReticulumTransport {
             )),
             dialed_link_dest: Arc::new(Mutex::new(HashMap::new())),
             blackhole: blackhole_rules,
+            blackhole_cache: std::sync::Mutex::new(None),
+            binding_cache: std::sync::Mutex::new(HashMap::new()),
             started_at: std::time::Instant::now(),
             store_and_forward: None,
             delivery: crate::transport::PendingDelivery::LiveOnly,
@@ -3245,7 +3294,9 @@ impl ReticulumTransport {
         store
             .blackhole_upsert(identity_hash, until_parsed, reason)
             .await
-            .map_err(|e| TransportError::Io(format!("blackhole_upsert: {e}")))
+            .map_err(|e| TransportError::Io(format!("blackhole_upsert: {e}")))?;
+        self.invalidate_blackhole_cache();
+        Ok(())
     }
 
     /// Remove a blackhole rule. Idempotent: returns `Ok(())` whether
@@ -3268,7 +3319,22 @@ impl ReticulumTransport {
         store
             .blackhole_remove(identity_hash)
             .await
-            .map_err(|e| TransportError::Io(format!("blackhole_remove: {e}")))
+            .map_err(|e| TransportError::Io(format!("blackhole_remove: {e}")))?;
+        self.invalidate_blackhole_cache();
+        Ok(())
+    }
+
+    /// #482 item 5 — drop the cached deny-list snapshot so a LOCAL rule
+    /// mutation (`add`/`remove`) is visible to the very next dial instead
+    /// of waiting out [`BLACKHOLE_CACHE_TTL`]. The TTL then only bounds
+    /// staleness against rules written by OTHER processes sharing the
+    /// persist-backed `cirislens.blackhole_rules` table (which this
+    /// process cannot observe without a read).
+    fn invalidate_blackhole_cache(&self) {
+        *self
+            .blackhole_cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
     }
 
     /// v0.18.0 (CIRISEdge#33 background-pruner wiring) — expose the
@@ -3435,18 +3501,48 @@ impl ReticulumTransport {
         let Some(store) = self.blackhole.as_ref() else {
             return Ok(());
         };
-        // Pull the full row set; v0.16.1 cohabitation deployments have
-        // operator-curated deny-lists in the low-dozens range. A
-        // future cut can pivot to a single-row lookup primitive if
-        // persist exposes one (the trait surface today is
-        // `blackhole_list` only — see #120 docblock for the rationale
-        // of batched-flush over per-row lookup).
-        let rows = store
-            .blackhole_list()
-            .await
-            .map_err(|e| TransportError::Io(format!("blackhole_list (check): {e}")))?;
+        // #482 item 5 — serve the full deny-list from a short-TTL snapshot
+        // so a dial FLOOD collapses to one `blackhole_list()` round-trip per
+        // window instead of one per dial. v0.16.1 cohabitation deployments
+        // have operator-curated deny-lists in the low-dozens range, so the
+        // snapshot is cheap to hold. The `std::sync::Mutex` guard is dropped
+        // before the `.await` refresh (never held across it) — keeping this
+        // #217-safe on a send-path that can run on persist's runtime thread.
+        // A future cut can pivot to a single-row lookup primitive if persist
+        // exposes one (the trait surface today is `blackhole_list` only —
+        // see #120 docblock for the rationale of batched-flush).
+        let cached = {
+            let guard = self
+                .blackhole_cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match guard.as_ref() {
+                Some((fetched_at, rows)) if fetched_at.elapsed() < BLACKHOLE_CACHE_TTL => {
+                    Some(Arc::clone(rows))
+                }
+                _ => None,
+            }
+        };
+        let rows = match cached {
+            Some(rows) => rows,
+            None => {
+                let fetched = store
+                    .blackhole_list()
+                    .await
+                    .map_err(|e| TransportError::Io(format!("blackhole_list (check): {e}")))?;
+                let rows = Arc::new(fetched);
+                // Benign race: two concurrent stale-misses may both refresh;
+                // last-writer-wins with no correctness impact (identical data).
+                *self
+                    .blackhole_cache
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                    Some((std::time::Instant::now(), Arc::clone(&rows)));
+                rows
+            }
+        };
         let now = chrono::Utc::now();
-        for rec in rows {
+        for rec in rows.iter() {
             if rec.identity_hash != identity_hash {
                 continue;
             }
@@ -3477,8 +3573,8 @@ impl ReticulumTransport {
                 }
             });
             return Err(TransportError::PeerBlackholed {
-                identity_hash: rec.identity_hash,
-                reason: rec.reason,
+                identity_hash: rec.identity_hash.clone(),
+                reason: rec.reason.clone(),
                 until: rec.until.map(|t| t.to_rfc3339()),
             });
         }
@@ -4369,6 +4465,7 @@ impl Transport for ReticulumTransport {
                         sent_resource_progress: &self.sent_resource_progress,
                         sink: &sink,
                         rooting: self.rooting.as_deref(),
+                        binding_cache: &self.binding_cache,
                         hybrid_policy: self.hybrid_policy,
                         transport_binding_enforcement: self.transport_binding_enforcement,
                         bundle_save_gate: self.bundle_save_gate,
@@ -4436,6 +4533,9 @@ struct EventCtx<'a> {
     /// Persist directory adapter for the authenticated cold-start
     /// path; `None` → announces are dropped (no rooting possible).
     rooting: Option<&'a dyn RootingDirectory>,
+    /// CIRISEdge#482 item 2 — per-`(peer, dest)` hybrid-binding memo, borrowed
+    /// from the owning transport; see [`binding_exists_cached`].
+    binding_cache: &'a BindingCache,
     /// Consumer hybrid PQC policy applied to a rooted chain.
     hybrid_policy: HybridPolicy,
     /// CIRISEdge#205 (AV-42 Phase 4) — RNS destination-hash binding
@@ -4546,6 +4646,56 @@ fn resolve_link_attribution(
 /// the `LinkIdentified`-fed table first (a peer dialed us), then the link's
 /// DESTINATION (a link WE dialed — the reverse path), then `None`
 /// (SkippedNoSourceKeyId downstream, never a silent drop).
+/// CIRISEdge#482 item 2 — consult a per-`(peer, dest)` TTL memo before querying
+/// the rooting directory for a hybrid transport binding. The inbound attribution
+/// path calls `hybrid_transport_binding_exists` once PER FRAME; a peer that is
+/// actively sending re-proves the SAME `(key_id, dest)` binding on every frame,
+/// so a short-TTL memo collapses that to one directory query per
+/// [`BINDING_CACHE_TTL`] window (the hot receive path this optimizes).
+///
+/// `(key_id, dest)` is the COMPLETE input to `hybrid_transport_binding_exists`,
+/// so the cache key is exact: a re-key (new `key_id`) or re-home (new `dest`)
+/// changes the key and misses, re-querying live. **Staleness bound**: a binding
+/// *revocation* (persist supports subject-revoked bindings) propagates to this
+/// gate within one TTL window — bounded, and additive to the rooting
+/// directory's own federation-propagation latency, not the sole delay. The
+/// window is deliberately tight (seconds) because a stale `true` is the
+/// security-relevant direction on this load-bearing E3 attribution gate; a
+/// stale `false` is fail-closed (a just-rooted peer is briefly not attributed,
+/// then self-heals on the next window).
+async fn binding_exists_cached(
+    cache: &BindingCache,
+    rooting: &dyn RootingDirectory,
+    key_id: &str,
+    dest: [u8; 16],
+) -> bool {
+    {
+        let guard = cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some((verdict, at)) = guard.get(&(key_id.to_string(), dest)) {
+            if at.elapsed() < BINDING_CACHE_TTL {
+                return *verdict;
+            }
+        }
+    }
+    let verdict = rooting.hybrid_transport_binding_exists(key_id, dest).await;
+    {
+        let mut guard = cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Bound memory: prune expired entries before inserting. The live set is
+        // naturally bounded by the rooted-peer population (item 1 gates entry to
+        // this check), but departed peers must not accumulate.
+        guard.retain(|_, (_, at)| at.elapsed() < BINDING_CACHE_TTL);
+        guard.insert(
+            (key_id.to_string(), dest),
+            (verdict, std::time::Instant::now()),
+        );
+    }
+    verdict
+}
+
 async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8>) {
     // CIRISEdge#353 — stamp last-inbound for the reverse-path link selector
     // (RNS `last_inbound`). This frame proves the peer is ALIVE on THIS link
@@ -4716,7 +4866,7 @@ async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8
             // directory (can't prove the hybrid route ⇒ not attributable).
             let gated = match (item1, dest, ctx.rooting) {
                 (Some(sid), Some(d), Some(rooting)) => {
-                    if rooting.hybrid_transport_binding_exists(&key_id, d).await {
+                    if binding_exists_cached(ctx.binding_cache, rooting, &key_id, d).await {
                         Some(sid)
                     } else if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
                         link_attribution_miss_log().check(key_id.as_str())
@@ -5603,7 +5753,7 @@ async fn heal_or_report_attribution_miss(
                 );
                 // Item 2 still applies — the heal upgrades item 1 only.
                 if let (Some(d), Some(rooting)) = (dest16, ctx.rooting) {
-                    if rooting.hybrid_transport_binding_exists(key_id, d).await {
+                    if binding_exists_cached(ctx.binding_cache, rooting, key_id, d).await {
                         return crate::transport::SourceKeyId::from_rooted_binding(
                             key_id.to_string(),
                             Rooted,

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -383,6 +383,18 @@ const BINDING_CACHE_TTL: Duration = Duration::from_secs(3);
 /// held across an `.await`, keeping the inbound path #217-safe).
 type BindingCache = std::sync::Mutex<HashMap<(String, [u8; 16]), (bool, std::time::Instant)>>;
 
+/// CIRISEdge#482 item 5 — the deny-list snapshot cache: `(generation,
+/// Option<(fetched_at, rows)>)`. The generation is bumped on local
+/// invalidation so a concurrent refresh can't clobber it. See the
+/// `blackhole_cache` field docblock.
+type BlackholeCache = std::sync::Mutex<(
+    u64,
+    Option<(
+        std::time::Instant,
+        Arc<Vec<ciris_persist::federation::BlackholeRecord>>,
+    )>,
+)>;
+
 /// CIRISEdge#318 — cap on the in-memory `peers` (rooted + advisory bindings)
 /// map. Bounds advisory-admit pollution: at cap, an Advisory binding is evicted
 /// before a new key is inserted (Rooted bindings are never evicted for advisory
@@ -1768,12 +1780,16 @@ pub struct ReticulumTransport {
     /// reachable a moment ago is immaterial, and both directions
     /// fail-safe (over-block briefly on removal, under-block briefly on
     /// add). `None`-backend transports never populate this.
-    blackhole_cache: std::sync::Mutex<
-        Option<(
-            std::time::Instant,
-            Arc<Vec<ciris_persist::federation::BlackholeRecord>>,
-        )>,
-    >,
+    ///
+    /// The leading `u64` is a GENERATION counter bumped by
+    /// [`Self::invalidate_blackhole_cache`] under this same lock:
+    /// `check_blackhole` snapshots it before its DB read and only commits
+    /// the fetched snapshot if the generation is UNCHANGED, so a local
+    /// `add`/`remove` that lands DURING an in-flight dial's read is never
+    /// clobbered by that dial's stale pre-mutation snapshot re-armed with a
+    /// fresh timestamp (CIRISEdge#482 review finding) — the "visible to the
+    /// very next dial" invalidation guarantee holds against that race.
+    blackhole_cache: BlackholeCache,
     /// CIRISEdge#482 item 2 — per-`(peer, dest)` hybrid-binding memo consulted
     /// on the inbound attribution path (once-per-frame directory lookup → one
     /// query per TTL window). See [`binding_exists_cached`].
@@ -2410,7 +2426,7 @@ impl ReticulumTransport {
             )),
             dialed_link_dest: Arc::new(Mutex::new(HashMap::new())),
             blackhole: blackhole_rules,
-            blackhole_cache: std::sync::Mutex::new(None),
+            blackhole_cache: std::sync::Mutex::new((0, None)),
             binding_cache: std::sync::Mutex::new(HashMap::new()),
             started_at: std::time::Instant::now(),
             store_and_forward: None,
@@ -3385,10 +3401,15 @@ impl ReticulumTransport {
     /// persist-backed `cirislens.blackhole_rules` table (which this
     /// process cannot observe without a read).
     fn invalidate_blackhole_cache(&self) {
-        *self
+        let mut guard = self
             .blackhole_cache
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Bump the generation so any dial with an in-flight `blackhole_list()`
+        // read (snapshotted the OLD generation before its `.await`) declines to
+        // commit its now-stale snapshot, and drop the current snapshot.
+        guard.0 = guard.0.wrapping_add(1);
+        guard.1 = None;
     }
 
     /// v0.18.0 (CIRISEdge#33 background-pruner wiring) — expose the
@@ -3565,35 +3586,46 @@ impl ReticulumTransport {
         // A future cut can pivot to a single-row lookup primitive if persist
         // exposes one (the trait surface today is `blackhole_list` only —
         // see #120 docblock for the rationale of batched-flush).
-        let cached = {
+        let (cached, gen_at_miss) = {
             let guard = self
                 .blackhole_cache
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            match guard.as_ref() {
+            let cached = match guard.1.as_ref() {
                 Some((fetched_at, rows)) if fetched_at.elapsed() < BLACKHOLE_CACHE_TTL => {
                     Some(Arc::clone(rows))
                 }
                 _ => None,
-            }
+            };
+            // Snapshot the generation WITH the miss check so a concurrent
+            // invalidation during the `.await` below is detected at commit.
+            (cached, guard.0)
         };
-        let rows = match cached {
-            Some(rows) => rows,
-            None => {
-                let fetched = store
-                    .blackhole_list()
-                    .await
-                    .map_err(|e| TransportError::Io(format!("blackhole_list (check): {e}")))?;
-                let rows = Arc::new(fetched);
-                // Benign race: two concurrent stale-misses may both refresh;
-                // last-writer-wins with no correctness impact (identical data).
-                *self
+        let rows = if let Some(rows) = cached {
+            rows
+        } else {
+            let fetched = store
+                .blackhole_list()
+                .await
+                .map_err(|e| TransportError::Io(format!("blackhole_list (check): {e}")))?;
+            let rows = Arc::new(fetched);
+            // Commit the fresh snapshot ONLY if no invalidation raced our read
+            // (generation unchanged since the miss). If a LOCAL add/remove bumped
+            // the generation during our `.await`, drop this now-stale snapshot and
+            // let the next dial re-read — so the explicit invalidation is never
+            // clobbered by a pre-mutation snapshot re-armed with a fresh timestamp
+            // (CIRISEdge#482 review finding). Two concurrent stale-misses WITHOUT
+            // an interleaved mutation still race benignly (identical data).
+            {
+                let mut guard = self
                     .blackhole_cache
                     .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
-                    Some((std::time::Instant::now(), Arc::clone(&rows)));
-                rows
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if guard.0 == gen_at_miss {
+                    guard.1 = Some((std::time::Instant::now(), Arc::clone(&rows)));
+                }
             }
+            rows
         };
         let now = chrono::Utc::now();
         for rec in rows.iter() {
@@ -4681,25 +4713,6 @@ fn resolve_link_attribution(
     }
 }
 
-/// Handle one [`NodeEvent`]. Announce events populate the peer map;
-/// link requests are accepted with auto-resource-accept; established
-/// links + completed sender-side resources unblock [`Transport::send`];
-/// completed receiver-side resources become [`InboundFrame`]s.
-// v0.14.0 (CIRISEdge#32 + #34 link-half) — grew past clippy's 100-line
-// cap once the LinkIdentified / LinkStale / ResponseReceived /
-// RequestTimedOut arms + the link-event emissions on existing arms
-// landed. Each new arm is a small typed routing of one NodeEvent
-// variant onto a side-effect (record / emit); extracting would
-// fragment the event-loop verdict across multiple helpers.
-#[allow(clippy::too_many_lines)]
-/// CIRISEdge#353/#365 — attribute an inbound link frame to its source peer and
-/// hand it to the inbound sink. Shared by BOTH the resource path
-/// (`ResourceCompleted`) and the packet path (`LinkDataReceived`, the #353 ask #2
-/// non-contending reverse-path reply) so the two can NEVER diverge in how they
-/// attribute or route a frame (the #348 two-loops lesson). Attribution order:
-/// the `LinkIdentified`-fed table first (a peer dialed us), then the link's
-/// DESTINATION (a link WE dialed — the reverse path), then `None`
-/// (SkippedNoSourceKeyId downstream, never a silent drop).
 /// CIRISEdge#482 item 2 — consult a per-`(peer, dest)` TTL memo before querying
 /// the rooting directory for a hybrid transport binding. The inbound attribution
 /// path calls `hybrid_transport_binding_exists` once PER FRAME; a peer that is
@@ -4750,6 +4763,25 @@ async fn binding_exists_cached(
     verdict
 }
 
+/// Handle one [`NodeEvent`]. Announce events populate the peer map;
+/// link requests are accepted with auto-resource-accept; established
+/// links + completed sender-side resources unblock [`Transport::send`];
+/// completed receiver-side resources become [`InboundFrame`]s.
+// v0.14.0 (CIRISEdge#32 + #34 link-half) — grew past clippy's 100-line
+// cap once the LinkIdentified / LinkStale / ResponseReceived /
+// RequestTimedOut arms + the link-event emissions on existing arms
+// landed. Each new arm is a small typed routing of one NodeEvent
+// variant onto a side-effect (record / emit); extracting would
+// fragment the event-loop verdict across multiple helpers.
+#[allow(clippy::too_many_lines)]
+/// CIRISEdge#353/#365 — attribute an inbound link frame to its source peer and
+/// hand it to the inbound sink. Shared by BOTH the resource path
+/// (`ResourceCompleted`) and the packet path (`LinkDataReceived`, the #353 ask #2
+/// non-contending reverse-path reply) so the two can NEVER diverge in how they
+/// attribute or route a frame (the #348 two-loops lesson). Attribution order:
+/// the `LinkIdentified`-fed table first (a peer dialed us), then the link's
+/// DESTINATION (a link WE dialed — the reverse path), then `None`
+/// (SkippedNoSourceKeyId downstream, never a silent drop).
 async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8>) {
     // CIRISEdge#353 — stamp last-inbound for the reverse-path link selector
     // (RNS `last_inbound`). This frame proves the peer is ALIVE on THIS link

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -366,9 +366,10 @@ const EVENT_ANNOUNCE_MIN_INTERVAL: Duration = Duration::from_secs(10);
 /// EventReceiver task `try_send`s each inbound announce here and a dedicated
 /// worker drains it, so a slow/contended rooting directory can no longer
 /// head-of-line every other node event behind an announce's DB round-trips.
-/// At the cap, the oldest-losing policy is a LOUD drop (RNS announces are
-/// periodic + idempotent, so a dropped one self-heals on the next re-announce),
-/// never a silent one (CIRISEdge#425).
+/// At the cap, `try_send` TAIL-drops — it rejects the NEWEST announce and keeps
+/// the 256 already queued — with a LOUD warn, never a silent drop
+/// (CIRISEdge#425). RNS announces are periodic + idempotent, so a dropped one
+/// self-heals on the peer's next re-announce.
 const ANNOUNCE_QUEUE_DEPTH: usize = 256;
 
 /// CIRISEdge#482 item 5 — window a `check_blackhole` deny-list snapshot stays
@@ -5125,16 +5126,28 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             // the peer is recorded as resolvable (replaces v0.3.1 TOFU —
             // CIRISEdge#15, AV-42). CIRISEdge#482 item 3 — that work is now
             // handed to a dedicated worker (non-blocking `try_send`) so its DB
-            // round-trips don't head-of-line every other node event. A full
-            // queue drops the announce LOUDLY (never silently — CIRISEdge#425);
-            // RNS announces are periodic + idempotent, so the peer's next
-            // re-announce retries.
-            if let Err(e) = ctx.announce_tx.try_send(announce) {
-                tracing::warn!(
-                    error = %e,
-                    "announce DROPPED — cold-start worker queue full or closed \
-                     (CIRISEdge#482 item 3; RNS re-announce will retry)"
-                );
+            // round-trips don't head-of-line every other node event. Both drop
+            // paths are LOUD (never silent — CIRISEdge#425), but split so a DEAD
+            // worker (channel Closed) is diagnosable rather than masked as
+            // ordinary backpressure (queue Full).
+            match ctx.announce_tx.try_send(announce) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_)) => {
+                    tracing::warn!(
+                        "announce DROPPED — cold-start worker queue FULL \
+                         (backpressure); RNS re-announce will retry (CIRISEdge#482 item 3)"
+                    );
+                }
+                Err(mpsc::error::TrySendError::Closed(_)) => {
+                    // The worker task is gone (exited or panicked). This is NOT
+                    // routine backpressure — every subsequent announce will be
+                    // dropped until the transport is rebuilt, so it is an ERROR.
+                    tracing::error!(
+                        "announce DROPPED — cold-start worker is GONE (channel \
+                         closed: the worker task exited); announces are no longer \
+                         being processed (CIRISEdge#482 item 3)"
+                    );
+                }
             }
         }
         // v7.2.0: Leviculum v0.8.x upstream auto-accepts inbound link

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1546,6 +1546,12 @@ pub struct ReticulumTransport {
     /// listening on ... (dest <explicit_hash>) (named-dest
     /// <named_hash>)` on the `transport_up` interface event.
     local_named_dest_hash: DestinationHash,
+    /// CIRISEdge#489 — the announce-suppression policy installed on `node`
+    /// via `set_announce_control`. Retained here (Arc-backed inner shares
+    /// state with the node's boxed clone) so a future scoped destination can
+    /// be registered via `register_destination_scope` and the node's
+    /// auto-announce loops immediately honour its cohort scope.
+    announce_policy: crate::announce_suppression::ScopePrivacyAnnouncePolicy,
     /// v2.1.0 (CIRISPersist `LocalIdentityAggregate` RET-transport
     /// role) — the 64-byte Reticulum dual-key public material edge
     /// minted at startup: `x25519_pub (32) ‖ ed25519_pub (32)`. The
@@ -2305,6 +2311,32 @@ impl ReticulumTransport {
         // `register_destination` (native) registers it at `local_named_dest_hash`.
         node.register_destination(named_dest);
 
+        // CIRISEdge#489 — INSTALL the announce-suppression policy onto the node.
+        // Until this call `ScopePrivacyAnnouncePolicy` was dead code:
+        // `set_announce_control` was never invoked anywhere in `src/`, so
+        // leviculum's own local-destination auto-announce loops (the periodic
+        // management re-announce + the local re-gossip pass) gossiped every
+        // local destination unconditionally — a group-scoped destination could
+        // be announced in breach of CC 5.4 (§5.4: group-scoped destinations
+        // MUST NOT announce). The policy default-SUPPRESSES every UNregistered
+        // destination, so the ONE destination that must keep auto-announcing —
+        // this node's NAMED discovery address, the Commons-scoped public mesh
+        // address peers resolve us by — is registered `Public` here so its
+        // auto-re-announce survives. The explicit-hash dest needs no
+        // registration: leviculum skips explicit-hash announces structurally,
+        // and default-suppress is the belt. Edge's own explicit interval
+        // announce of the named dest (`announce_destination`, below) is a
+        // SEPARATE path that does not consult the policy, so mesh discovery is
+        // preserved on both the explicit and the auto paths; the policy only
+        // adds suppression for scoped destinations (register future ones via
+        // the retained `announce_policy` handle).
+        let announce_policy = crate::announce_suppression::ScopePrivacyAnnouncePolicy::new();
+        announce_policy.register_destination_scope(
+            local_named_dest_hash.into_bytes(),
+            crate::cohort_scope::CohortScope::Public,
+        );
+        node.set_announce_control(Some(Box::new(announce_policy.clone())));
+
         // Take the single event receiver before starting, then start
         // the event loop. `listen` claims the stashed receiver.
         let events = node
@@ -2349,6 +2381,7 @@ impl ReticulumTransport {
             node: Arc::new(node),
             local_dest_hash,
             local_named_dest_hash,
+            announce_policy,
             local_transport_pubkey,
             local_identity: identity.clone(),
             local_attestation,
@@ -2499,6 +2532,27 @@ impl ReticulumTransport {
         let mut out = [0u8; 16];
         out.copy_from_slice(bytes);
         out
+    }
+
+    /// CIRISEdge#489 — register (or update) the cohort scope of a destination
+    /// with the installed announce-suppression policy. The node's own
+    /// auto-announce loops (management re-announce + local re-gossip) consult
+    /// this on their very next pass: a group-scoped destination
+    /// (`SelfOnly` / `Family` / `Cohort`) is thereafter SUPPRESSED (CC 5.4 —
+    /// group-scoped destinations must not announce), a `Public` (Commons)
+    /// destination stays announceable. Idempotent; re-registration overwrites
+    /// the prior scope. This is the "register as edge admits each scoped
+    /// destination" half of the policy contract — the node's own named
+    /// discovery address is registered `Public` at construction; any scoped
+    /// destination edge later registers with the node MUST also be scoped here
+    /// (a missing registration default-suppresses, which is safer-than-leak).
+    pub fn register_announce_scope(
+        &self,
+        dest_hash: [u8; 16],
+        scope: crate::cohort_scope::CohortScope,
+    ) {
+        self.announce_policy
+            .register_destination_scope(dest_hash, scope);
     }
 
     /// spec. Returns a `Vec<TransportSpec>` of `(handle, kind)` pairs.


### PR DESCRIPTION
## v17.4.0 — all of Tracks A + B (+ Track C prep): security hardening & hot-path perf

One coordinated cut (no interim PRs) driven with subagents + an adversarial review/verify gate. **All of Track A and Track B** land; two structural extras and the Track C integration are deliberately deferred (below), each with the review gate confirming what shipped.

### Track A — security / conformance
- **#481 — retire the classical KEX fallback** (Fed TM §3.3 Gap C, harvest-now-decrypt-later). Three closures, all typed via new `SessionError::ClassicalKexRetired`:
  1. `respond()` refuses **every** classical handshake (the active-attacker close — even a well-formed classical handshake never derives a key).
  2. `initiate()` no longer silently falls back to classical: `Hybrid` ≡ `HybridRequired` (a classical-only peer is rejected); an explicit `Classical` request errors.
  3. FFI `federation_session_initiate` rejects `algorithm="classical"` explicitly.
  The `Classical` enum/wire variants are **retained** so a downgrade attempt parses to a typed, logged refusal. Tests: two classical-success tests became retirement assertions + a new `respond_rejects_classical_handshake` (13/13 green).
- **#489 — actually install the announce-suppression policy.** `ScopePrivacyAnnouncePolicy` was dead code — `set_announce_control` was never called, so leviculum's own local-dest auto-announce loops gossiped group-scoped destinations in breach of CC 5.4. Now installed on the node; the node's own **named** Commons-scoped discovery dest is registered `Public` so auto-re-announce survives (verified: edge's explicit interval announce is a separate path that bypasses the policy, and the explicit-hash dest is skipped structurally — discovery cannot regress). `register_announce_scope()` added for future scoped dests.

### Track B — hot-path perf (#482)
- **item 2 — `hybrid_transport_binding_exists` TTL cache** (3s). Was an uncached rooting-directory lookup **per inbound frame** at both attribution call sites; a peer actively sending now costs one query per window. `(key_id, dest)` is the complete input so the key is exact; tight TTL because a stale `true` past a binding revocation is the security-relevant direction on this E3 gate.
- **item 5 — `check_blackhole` deny-list TTL cache** (2s). Was a full `blackhole_list()` DB read **per dial**; a dial flood now collapses to one read per window. Local add/remove invalidate via a **generation counter** (review-hardened) so an operator change is visible to the very next dial even under a concurrent in-flight refresh.
- **item 7 — release the GIL for LXMF proof-of-work.** Both PoW FFI paths ran the CPU-heavy workblock rounds holding the GIL, freezing every other Python thread. Now wrapped in `py.detach()` (owned-copy first) so Python threads keep running during the compute.
- **item 3 — offload announce cold-start off the event loop.** `resolve_announce_cold_start` ran inline on the single EventReceiver task, so an announce's rooting-directory DB round-trips head-of-lined every other node event (`LinkEstablished`/`LinkIdentified`/inbound frames). Now the `AnnounceReceived` arm `try_send`s the announce to a bounded (256) channel and a dedicated worker drains it **FIFO — the same serial order as before, just decoupled from the hot task, so it introduces no new concurrency**. `resolve` takes an owned `AnnounceCtx` (the 8 Arc/Copy fields it uses); the 3 `EventCtx` fields it was the sole reader of are removed. A full queue drops the announce **loudly** (never silent — #425; RNS re-announce retries). Ordering-safe by construction: supersession is one atomic `peers.lock` critical section, persist writes are epoch-guarded, and attribution is order-independent (per-frame re-attribution + divergence heal).

All cache/timing work is **#217-safe** (`std::time::Instant` only, guards never held across `.await`).

### No-regression gate
- Adversarial review workflow (4 dimension reviewers → per-finding verification). Result: KEX-security, announce-wiring, and GIL dimensions **clean**; one **low-sev** cache-invalidation race found and **fixed** (generation counter).
- `cargo clippy --all-targets -D warnings` green on the CI combos; subset canaries (`transport-reticulum`, `transport-http`, mobile `pyo3-sqlite extension-module`) green (union-coverage-blindness checked); full `--lib` suite 964/0; item 3 got its own dedicated adversarial review.

### Deferred (each warrants its own focused PR + soak — NOT dropped)
- **#481 item 4** (`PeerKexPubkeys.mlkem768_pub` `Option`→`Vec`): redundant with the existing construction-boundary HNDL enforcement (FFI Member conversion + A/V-MLS bridge already reject `None`); would ripple through the whole A/V subsystem against a deliberate design.
- **#169** (LXMF propagation host serve-path): a real event-loop serve-path integration (gated `all(_reticulum-module, lxmf)`), needing DST/soak — and the direct precursor to lev#45, which is out of scope for this cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
