### PR TITLE
v17.5.0 — leviculum v0.18 scoped transit (#492): CIRIS-member-only relay

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "17.4.1"
+version = "17.5.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -602,8 +602,8 @@ tempfile       = { version = "3", optional = true }
 # crate semver is now 0.16. CHANGELOG-gotcha lesson from their release: grep for
 # conflict markers before tagging (prose doesn't compile). Adoption sequenced in #484:
 # awaited variants next, then #482 item-1 buffer_unordered dispatcher.
-leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.16.0+ciris.1", version = "0.16", optional = true }
-leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.16.0+ciris.1", version = "0.16", optional = true }
+leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.18.0+ciris.1", version = "0.18", optional = true }
+leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.18.0+ciris.1", version = "0.18", optional = true }
 # v15.20.0 (CIRISEdge#169) — LXMF store-and-forward propagation. The
 # `leviculum-lxmf` workspace member (same pinned tag) ships the whole
 # LXMF wire protocol: propagation-node discovery/upload/`/get` codecs,
@@ -613,7 +613,7 @@ leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.16.0+
 # features keep `pow` on (the stamp/ticket cost we validate at
 # admission). Gated behind the `lxmf` feature — see the `[features]`
 # block. Edge INTEGRATES this crate's protocol; it never reimplements it.
-leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.16.0+ciris.1", version = "0.16", optional = true }
+leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.18.0+ciris.1", version = "0.18", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.4.1
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.4.1
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.4.1
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.4.1
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.4.1
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.4.1
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.4.1
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.5.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.5.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.5.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.5.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.5.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.5.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.5.0

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1334,6 +1334,80 @@ impl PyEdge {
         }
     }
 
+    /// CIRISEdge#492 — IFAC membership-key rotation, phase 1 (install-next).
+    /// The node accepts BOTH the current and the next access code
+    /// (make-before-break); no member is excluded yet. Distribute `passphrase`
+    /// to hybrid-verified members (the persist `key_grant` handoff,
+    /// CIRISPersist#704) BEFORE calling `ifac_activate_next`. `ifac_size` is in
+    /// BYTES (pass bits ÷ 8). Returns the number of interfaces updated.
+    #[pyo3(signature = (passphrase, ifac_size, netname=None))]
+    fn ifac_install_next(
+        &self,
+        passphrase: &str,
+        ifac_size: usize,
+        netname: Option<&str>,
+    ) -> PyResult<usize> {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            let transport = self.inner.reticulum_transport().ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "ifac_install_next: edge has no Reticulum transport \
+                     (disable_reticulum=True, or wheel built without _reticulum-module)",
+                )
+            })?;
+            transport
+                .ifac_install_next(netname, passphrase, ifac_size)
+                .map_err(|e| PyRuntimeError::new_err(format!("ifac_install_next: {e}")))
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            let _ = (passphrase, ifac_size, netname);
+            Err(PyRuntimeError::new_err(
+                "ifac_install_next: requires the _reticulum-module feature",
+            ))
+        }
+    }
+
+    /// CIRISEdge#492 — IFAC rotation phase 2 (activate-next): swap the next code
+    /// to PRIMARY. Outbound frames under the new code; a straggler still on the
+    /// old code continues to land (both accepted). Call after the passphrase has
+    /// reached members. Returns the number of interfaces affected.
+    fn ifac_activate_next(&self) -> PyResult<usize> {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            let transport = self.inner.reticulum_transport().ok_or_else(|| {
+                PyRuntimeError::new_err("ifac_activate_next: edge has no Reticulum transport")
+            })?;
+            Ok(transport.ifac_activate_next())
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            Err(PyRuntimeError::new_err(
+                "ifac_activate_next: requires the _reticulum-module feature",
+            ))
+        }
+    }
+
+    /// CIRISEdge#492 — IFAC rotation phase 3 (seal): drop the OLD code. A member
+    /// that never re-keyed is now excluded (readmission = fresh grant + re-key).
+    /// Call after the convergence window. Returns the number of interfaces
+    /// affected.
+    fn ifac_seal_rotation(&self) -> PyResult<usize> {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            let transport = self.inner.reticulum_transport().ok_or_else(|| {
+                PyRuntimeError::new_err("ifac_seal_rotation: edge has no Reticulum transport")
+            })?;
+            Ok(transport.ifac_seal_rotation())
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            Err(PyRuntimeError::new_err(
+                "ifac_seal_rotation: requires the _reticulum-module feature",
+            ))
+        }
+    }
+
     /// v2.4.0 (CIRISEdge#95) — fetch a remote peer's hybrid KEM
     /// pubkeys (x25519 + ML-KEM-768) from persist's federation
     /// directory for `FederationSession::initiate` consumers
@@ -4196,6 +4270,10 @@ enum LocalInstanceRole {
     require_local_signer = false,
     bundle_save_gate = "off",
     own_build_bundle = None,
+    transit = None,
+    ifac_netname = None,
+    ifac_passphrase = None,
+    ifac_size = None,
 ))]
 #[allow(
     clippy::too_many_arguments,
@@ -4357,6 +4435,15 @@ pub fn init_edge_runtime(
     // hard init error, never a silently commitment-less announce. `None` (the
     // default) announces the pre-#436 v1 wire byte-identical.
     own_build_bundle: Option<Vec<u8>>,
+    // CIRISEdge#492 — node-wide scoped-transit posture for the LEGACY interface
+    // path (the `listen_addr` server + `bootstrap_peers` clients). `transit=False`
+    // = public LEAF port (never rebroadcasts announces); the IFAC trio
+    // (`ifac_netname`/`ifac_passphrase`/`ifac_size`, all three together) gates the
+    // ports to CIRIS members. `ifac_size` is in BYTES (pass bits ÷ 8).
+    transit: Option<bool>,
+    ifac_netname: Option<String>,
+    ifac_passphrase: Option<String>,
+    ifac_size: Option<usize>,
 ) -> PyResult<PyEdge> {
     // v0.19.3 (CIRISEdge#49) — validate the HTTPS init params BEFORE
     // any I/O. The mutual-exclusivity check (dev_self_signed vs cert
@@ -5241,6 +5328,52 @@ pub fn init_edge_runtime(
     transport_config.local_epoch = local_epoch;
     // CIRISEdge#168 (v5.0) — Transport-node mode (§24 NAT-traversal).
     transport_config.enable_transport = enable_transport;
+    // CIRISEdge#492 — node-wide scoped-transit posture for the legacy interface
+    // path (listen_addr server + bootstrap clients). IFAC needs the passphrase +
+    // size together; netname is optional. A relay is typically
+    // `enable_transport=True` + IFAC (member-only); a public leaf sets
+    // `transit=False`.
+    {
+        // Fail CLOSED on partial IFAC config (CIRISEdge#492 review): naming a
+        // network does not scope it, so ifac_netname-without-passphrase must be
+        // an error, not a silently-open port. Same for the passphrase-XOR-size
+        // case.
+        let ifac_cfg = match (ifac_passphrase, ifac_size) {
+            (Some(passphrase), Some(size)) => Some(crate::transport::reticulum::IfacConfig {
+                networkname: ifac_netname,
+                passphrase,
+                ifac_size: size,
+            }),
+            (None, None) if ifac_netname.is_none() => None,
+            (None, None) => {
+                return Err(PyValueError::new_err(
+                    "init_edge_runtime: ifac_netname is set without ifac_passphrase/ifac_size — \
+                     naming a network does not scope it. Supply the passphrase + size to gate the \
+                     port to members, or drop ifac_netname.",
+                ));
+            }
+            _ => {
+                return Err(PyValueError::new_err(
+                    "init_edge_runtime: ifac_passphrase and ifac_size must be provided together \
+                     (IFAC needs both; ifac_netname is optional)",
+                ));
+            }
+        };
+        // The node-wide posture applies ONLY to the legacy interface path (empty
+        // `interfaces`). Shared-instance mode (`local_instance_name`) pushes a
+        // Local interface, so that path is skipped and node-wide IFAC/transit
+        // would be SILENTLY dropped — reject it loudly (CIRISEdge#492 review). In
+        // shared-instance mode the shared rnsd owns the real interfaces.
+        if (transit.is_some() || ifac_cfg.is_some()) && local_instance_name.is_some() {
+            return Err(PyValueError::new_err(
+                "init_edge_runtime: node-wide transit/IFAC (scoped transit) cannot be combined \
+                 with local_instance_name (shared-instance mode) — the shared rnsd owns the \
+                 interfaces, so the posture would be silently ignored. Configure IFAC on the \
+                 shared instance instead.",
+            ));
+        }
+        transport_config = transport_config.with_scoped_transit(transit, ifac_cfg);
+    }
 
     // v2.3.0 (CIRISEdge#100) — shared-instance leader election +
     // LocalInterfaceConfig push. Only runs when the operator supplied
@@ -9478,6 +9611,10 @@ mod pyo3_tier2_tests {
                 false,      // require_local_signer (CIRISEdge#289 — default warn-and-degrade)
                 "off", // bundle_save_gate (CIRISEdge#437 — default Off; flip = fleet-floor event)
                 None,  // own_build_bundle (CIRISEdge#436 — default: no first-contact bundle)
+                None,  // transit (CIRISEdge#492 — default relay posture)
+                None,  // ifac_netname
+                None,  // ifac_passphrase
+                None,  // ifac_size
             )?;
             Ok(edge.signer_key_id())
         });
@@ -9592,6 +9729,10 @@ mod pyo3_tier2_tests {
                 false,      // require_local_signer (CIRISEdge#289 — default warn-and-degrade)
                 "off", // bundle_save_gate (CIRISEdge#437 — default Off; flip = fleet-floor event)
                 None,  // own_build_bundle (CIRISEdge#436 — default: no first-contact bundle)
+                None,  // transit (CIRISEdge#492 — default relay posture)
+                None,  // ifac_netname
+                None,  // ifac_passphrase
+                None,  // ifac_size
             )
             .err()
             .expect("init_edge_runtime must reject non-engine object")
@@ -9745,6 +9886,10 @@ mod pyo3_tier2_tests {
                 false,      // require_local_signer (CIRISEdge#289 — default warn-and-degrade)
                 "off", // bundle_save_gate (CIRISEdge#437 — default Off; flip = fleet-floor event)
                 None,  // own_build_bundle (CIRISEdge#436 — default: no first-contact bundle)
+                None,  // transit (CIRISEdge#492 — default relay posture)
+                None,  // ifac_netname
+                None,  // ifac_passphrase
+                None,  // ifac_size
             )?;
             Ok(())
         });
@@ -9851,6 +9996,10 @@ mod pyo3_tier2_tests {
                 false,      // require_local_signer (CIRISEdge#289 — default warn-and-degrade)
                 "off", // bundle_save_gate (CIRISEdge#437 — default Off; flip = fleet-floor event)
                 None,  // own_build_bundle (CIRISEdge#436 — default: no first-contact bundle)
+                None,  // transit (CIRISEdge#492 — default relay posture)
+                None,  // ifac_netname
+                None,  // ifac_passphrase
+                None,  // ifac_size
             )
             .err()
             .expect("init_edge_runtime must reject pre-v2.8.0-shaped engine")
@@ -10023,6 +10172,10 @@ mod pyo3_tier2_tests {
                 false,      // require_local_signer (CIRISEdge#289 — default warn-and-degrade)
                 "off", // bundle_save_gate (CIRISEdge#437 — default Off; flip = fleet-floor event)
                 None,  // own_build_bundle (CIRISEdge#436 — default: no first-contact bundle)
+                None,  // transit (CIRISEdge#492 — default relay posture)
+                None,  // ifac_netname
+                None,  // ifac_passphrase
+                None,  // ifac_size
             )?;
             Ok(edge.signer_key_id())
         });
@@ -10183,6 +10336,10 @@ mod pyo3_tier2_tests {
                 false,      // require_local_signer
                 "off",      // bundle_save_gate
                 None,       // own_build_bundle
+                None,       // transit (CIRISEdge#492)
+                None,       // ifac_netname
+                None,       // ifac_passphrase
+                None,       // ifac_size
             );
             // Cleanup: drop OUR engine from the singleton so the next real-engine
             // sibling test constructs cleanly (one persist engine per process).
@@ -10303,6 +10460,10 @@ mod pyo3_tier2_tests {
                 false,      // require_local_signer (CIRISEdge#289 — default warn-and-degrade)
                 "off", // bundle_save_gate (CIRISEdge#437 — default Off; flip = fleet-floor event)
                 None,  // own_build_bundle (CIRISEdge#436 — default: no first-contact bundle)
+                None,  // transit (CIRISEdge#492 — default relay posture)
+                None,  // ifac_netname
+                None,  // ifac_passphrase
+                None,  // ifac_size
             )?;
             Ok(edge.signer_key_id())
         });

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1176,6 +1176,16 @@ pub struct ReticulumTransportConfig {
     /// leviculum's valid band by [`effective_link_keepalive_secs`] before it
     /// reaches the builder — an operator override cannot escape the DoS bound.
     pub link_keepalive: Option<Duration>,
+    /// CIRISEdge#492 — node-wide relay (transit) posture applied to the LEGACY
+    /// interface path (the `listen_addr` server + `bootstrap_peers` clients, used
+    /// when `interfaces` is empty). `None` = leviculum default (relay-by-default);
+    /// `Some(false)` = leaf-only. Typed `interfaces` carry their OWN per-interface
+    /// posture and ignore this. See [`IfacConfig`].
+    pub transit: Option<bool>,
+    /// CIRISEdge#492 — node-wide IFAC applied to the LEGACY interface path: `Some`
+    /// makes the `listen_addr` server + every bootstrap client a member-only port;
+    /// `None` = open. Typed `interfaces` carry their own IFAC.
+    pub ifac: Option<IfacConfig>,
 }
 
 impl ReticulumTransportConfig {
@@ -1196,7 +1206,21 @@ impl ReticulumTransportConfig {
             // CIRISEdge#363 — default the bootstrap keepalive ON so advisory
             // links survive the two-plane anti-entropy out of the box.
             link_keepalive: Some(BOOTSTRAP_LINK_KEEPALIVE),
+            transit: None,
+            ifac: None,
         }
+    }
+
+    /// CIRISEdge#492 — set the node-wide scoped-transit posture for the legacy
+    /// interface path: `transit` (`Some(false)` = leaf-only, never rebroadcasts
+    /// announces) + an optional IFAC (member-only access code). Builder-style;
+    /// applies to the `listen_addr` server + every `bootstrap_peers` client.
+    /// Typed `interfaces` carry their own posture and are unaffected.
+    #[must_use]
+    pub fn with_scoped_transit(mut self, transit: Option<bool>, ifac: Option<IfacConfig>) -> Self {
+        self.transit = transit;
+        self.ifac = ifac;
+        self
     }
 
     /// **CIRISEdge#168** — opt this node into Reticulum Transport-node
@@ -1321,12 +1345,43 @@ pub struct AutoInterfaceConfig {
     pub multicast_loopback: Option<bool>,
 }
 
+/// CIRISEdge#492 — per-interface IFAC (Interface Framing Access Code): the
+/// shared-secret "network access code" that scopes an interface to CIRIS
+/// members. Packets without the code drop AT the interface, so everything past
+/// it is member traffic by construction — structural invisibility, no per-packet
+/// identity inspection. Maps onto leviculum's `add_tcp_server_ifac` /
+/// `add_tcp_client_ifac` / `InterfaceConfig { networkname, passphrase, ifac_size }`.
+#[cfg(feature = "_reticulum-module")]
+#[derive(Debug, Clone)]
+pub struct IfacConfig {
+    /// IFAC virtual-network name (`None` = leviculum's unnamed default network).
+    pub networkname: Option<String>,
+    /// The shared member passphrase. Distributed to hybrid-verified members as a
+    /// rotating PQC `key_grant` (CIRISPersist#704) for flag-day-free rotation via
+    /// the three rotation verbs; operator-supplied until that lands.
+    pub passphrase: String,
+    /// IFAC hash-truncation size in BYTES (Python callers pass bits ÷ 8). The
+    /// leviculum convention is 16 for a NETWORK interface (TCP/UDP — edge's
+    /// relay ports) and 8 for a serial link (RNode/pipe/KISS/AX.25). Both peers
+    /// on an interface MUST agree.
+    pub ifac_size: usize,
+}
+
 /// `TcpServerInterface` configuration — bind a TCP socket.
 #[cfg(feature = "transport-reticulum-tcp-server")]
 #[derive(Debug, Clone)]
 pub struct TcpServerInterfaceConfig {
     /// Address the TCP server binds to.
     pub listen_addr: SocketAddr,
+    /// CIRISEdge#492 — relay (transit) posture. `None` = leviculum default
+    /// (relay-by-default, leviculum#48/#51); `Some(false)` = a public LEAF port
+    /// that never rebroadcasts announces and drops any relay crossing it. Declare
+    /// non-transit on a public leaf so no peer builds a path expecting a transit
+    /// this CIRIS node won't provide (the Tor-exit-policy lesson — a silent-drop
+    /// router is worse than absence).
+    pub transit: Option<bool>,
+    /// CIRISEdge#492 — IFAC scoping. `Some` = member-only port; `None` = open.
+    pub ifac: Option<IfacConfig>,
 }
 
 /// `TcpClientInterface` configuration — dial a remote TCP server.
@@ -1335,6 +1390,13 @@ pub struct TcpServerInterfaceConfig {
 pub struct TcpClientInterfaceConfig {
     /// Target TCP server address to dial.
     pub target_addr: SocketAddr,
+    /// CIRISEdge#492 — relay (transit) posture for this dialed link. `None` =
+    /// leviculum default (relay); `Some(false)` = leaf-only. See
+    /// [`TcpServerInterfaceConfig::transit`].
+    pub transit: Option<bool>,
+    /// CIRISEdge#492 — IFAC scoping. `Some` = the dialed peer is a member port
+    /// (member access code applied); `None` = open dial.
+    pub ifac: Option<IfacConfig>,
 }
 
 /// `UdpInterface` configuration — listen + forward addrs.
@@ -2176,8 +2238,15 @@ impl ReticulumTransport {
         if config.interfaces.is_empty() {
             // Legacy v0.11.x defaults — TCP server + bootstrap TCP
             // clients. Registry records each one so the typed surface
-            // is uniform.
-            builder = builder.add_tcp_server(config.listen_addr);
+            // is uniform. CIRISEdge#492 — the node-wide `transit`/`ifac`
+            // posture (if set) applies to these legacy interfaces via the
+            // same shared mapper the typed path uses.
+            builder = apply_tcp_server_transit(
+                builder,
+                config.listen_addr,
+                config.transit,
+                config.ifac.as_ref(),
+            );
             interface_specs.push(RegisteredInterface {
                 handle: InterfaceHandle(interface_specs.len()),
                 kind: "TCPServerInterface".to_string(),
@@ -2190,7 +2259,8 @@ impl ReticulumTransport {
                 ),
             });
             for peer in &config.bootstrap_peers {
-                builder = builder.add_tcp_client(*peer);
+                builder =
+                    apply_tcp_client_transit(builder, *peer, config.transit, config.ifac.as_ref());
                 interface_specs.push(RegisteredInterface {
                     handle: InterfaceHandle(interface_specs.len()),
                     kind: "TCPClientInterface".to_string(),
@@ -2516,6 +2586,41 @@ impl ReticulumTransport {
     #[must_use]
     pub(crate) fn node(&self) -> &Arc<ReticulumNode> {
         &self.node
+    }
+
+    /// CIRISEdge#492 — three-phase IFAC membership-key rotation, flag-day-free.
+    /// Edge owns the orchestration CADENCE; leviculum owns the MECHANISM, and
+    /// the passphrase distribution BETWEEN phases is the persist `key_grant`
+    /// handoff (CIRISPersist#704). Phase 1 — `install_next`: the node accepts
+    /// BOTH the current code and the next (make-before-break); no member is
+    /// excluded yet. Returns the number of interfaces updated.
+    pub fn ifac_install_next(
+        &self,
+        netname: Option<&str>,
+        passphrase: &str,
+        ifac_size: usize,
+    ) -> Result<usize, TransportError> {
+        self.node
+            .ifac_install_next(netname, passphrase, ifac_size)
+            .map_err(|e| TransportError::Io(format!("ifac_install_next: {e}")))
+    }
+
+    /// CIRISEdge#492 — phase 2: swap the next IFAC code to PRIMARY. Outbound now
+    /// frames under the new code; a straggler still holding only the old code
+    /// continues to LAND (both are accepted). Call after the new passphrase has
+    /// been distributed to members. Returns the number of interfaces affected.
+    #[must_use]
+    pub fn ifac_activate_next(&self) -> usize {
+        self.node.ifac_activate_next()
+    }
+
+    /// CIRISEdge#492 — phase 3: SEAL the rotation — drop the old IFAC code. Any
+    /// member that never re-keyed is now excluded (readmission requires a fresh
+    /// grant + re-key). Call after the convergence window. Returns the number of
+    /// interfaces affected.
+    #[must_use]
+    pub fn ifac_seal_rotation(&self) -> usize {
+        self.node.ifac_seal_rotation()
     }
 
     /// v2.2.2 (CIRISEdge#97) — return edge's announced RNS destination
@@ -7368,6 +7473,75 @@ fn set_owner_only(_path: &std::path::Path) -> Result<(), TransportError> {
 /// `Option<String>` parameters since leviculum's share-instance is
 /// configured via separate builder methods rather than the interface
 /// vec.
+/// CIRISEdge#492 — apply a TCP SERVER interface's scoped-transit posture to the
+/// leviculum builder. THE single source of truth for the `(transit, ifac)` →
+/// builder-method mapping, shared by [`apply_interface_config`] (typed path) and
+/// the node-wide legacy path so the two can never diverge on a security-relevant
+/// predicate. IFAC-only → `add_tcp_server_ifac`; no-transit-only →
+/// `add_tcp_server_no_transit`; the IFAC+no-transit combo (a member-only LEAF
+/// port — no convenience method covers it) → the general `add_interface_config`.
+fn apply_tcp_server_transit(
+    builder: ReticulumNodeBuilder,
+    addr: SocketAddr,
+    transit: Option<bool>,
+    ifac: Option<&IfacConfig>,
+) -> ReticulumNodeBuilder {
+    match (ifac, transit == Some(false)) {
+        (Some(ifac), true) => {
+            builder.add_interface_config(leviculum_std::config::InterfaceConfig {
+                interface_type: "TCPServerInterface".to_string(),
+                name: "TCP Server".to_string(),
+                listen_ip: Some(addr.ip().to_string()),
+                listen_port: Some(addr.port()),
+                transit: Some(false),
+                networkname: ifac.networkname.clone(),
+                passphrase: Some(ifac.passphrase.clone()),
+                ifac_size: Some(ifac.ifac_size),
+                ..Default::default()
+            })
+        }
+        (Some(ifac), false) => builder.add_tcp_server_ifac(
+            addr,
+            ifac.networkname.as_deref(),
+            &ifac.passphrase,
+            ifac.ifac_size,
+        ),
+        (None, true) => builder.add_tcp_server_no_transit(addr),
+        (None, false) => builder.add_tcp_server(addr),
+    }
+}
+
+/// CIRISEdge#492 — apply a TCP CLIENT interface's scoped-transit posture.
+/// leviculum has `add_tcp_client_ifac` but NO `add_tcp_client_no_transit`, so any
+/// no-transit client (with or without IFAC) rides `add_interface_config`.
+fn apply_tcp_client_transit(
+    builder: ReticulumNodeBuilder,
+    addr: SocketAddr,
+    transit: Option<bool>,
+    ifac: Option<&IfacConfig>,
+) -> ReticulumNodeBuilder {
+    match (ifac, transit == Some(false)) {
+        (ifac_opt, true) => builder.add_interface_config(leviculum_std::config::InterfaceConfig {
+            interface_type: "TCPClientInterface".to_string(),
+            name: "TCP Client".to_string(),
+            target_host: Some(addr.ip().to_string()),
+            target_port: Some(addr.port()),
+            transit: Some(false),
+            networkname: ifac_opt.as_ref().and_then(|i| i.networkname.clone()),
+            passphrase: ifac_opt.as_ref().map(|i| i.passphrase.clone()),
+            ifac_size: ifac_opt.as_ref().map(|i| i.ifac_size),
+            ..Default::default()
+        }),
+        (Some(ifac), false) => builder.add_tcp_client_ifac(
+            addr,
+            ifac.networkname.as_deref(),
+            &ifac.passphrase,
+            ifac.ifac_size,
+        ),
+        (None, false) => builder.add_tcp_client(addr),
+    }
+}
+
 #[allow(unused_variables, unused_mut)]
 // every variant arm is feature-gated
 // v0.12.0 (CIRISEdge#24) — the match arms cover seven feature-gated
@@ -7410,13 +7584,17 @@ fn apply_interface_config(
         #[cfg(feature = "transport-reticulum-tcp-server")]
         ReticulumInterfaceConfig::TcpServer(cfg) => {
             let name = format!("tcp-server-{}", cfg.listen_addr);
-            builder = builder.add_tcp_server(cfg.listen_addr);
+            // CIRISEdge#492 — scoped-transit posture via the shared mapper.
+            builder =
+                apply_tcp_server_transit(builder, cfg.listen_addr, cfg.transit, cfg.ifac.as_ref());
             Ok((builder, "TCPServerInterface", name))
         }
         #[cfg(feature = "transport-reticulum-tcp-client")]
         ReticulumInterfaceConfig::TcpClient(cfg) => {
             let name = format!("tcp-client-{}", cfg.target_addr);
-            builder = builder.add_tcp_client(cfg.target_addr);
+            // CIRISEdge#492 — scoped-transit posture via the shared mapper.
+            builder =
+                apply_tcp_client_transit(builder, cfg.target_addr, cfg.transit, cfg.ifac.as_ref());
             Ok((builder, "TCPClientInterface", name))
         }
         #[cfg(feature = "transport-reticulum-udp")]

--- a/tests/leviculum_interface_diversity.rs
+++ b/tests/leviculum_interface_diversity.rs
@@ -40,7 +40,7 @@ use std::sync::Arc;
 use ciris_edge::identity::LocalSigner;
 use ciris_edge::transport::reticulum::UdpInterfaceConfig;
 use ciris_edge::transport::reticulum::{
-    AutoInterfaceConfig, LocalInterfaceConfig, ReticulumAuth, ReticulumInterfaceConfig,
+    AutoInterfaceConfig, IfacConfig, LocalInterfaceConfig, ReticulumAuth, ReticulumInterfaceConfig,
     ReticulumTransportConfig, TcpClientInterfaceConfig, TcpServerInterfaceConfig, TransportSpec,
     TransportStats,
 };
@@ -97,11 +97,15 @@ fn every_interface_kind_config_struct_round_trips_into_transport_config() {
         .add_interface(ReticulumInterfaceConfig::TcpServer(
             TcpServerInterfaceConfig {
                 listen_addr: loopback_addr(45_000),
+                transit: None,
+                ifac: None,
             },
         ))
         .add_interface(ReticulumInterfaceConfig::TcpClient(
             TcpClientInterfaceConfig {
                 target_addr: loopback_addr(45_001),
+                transit: None,
+                ifac: None,
             },
         ))
         .add_interface(ReticulumInterfaceConfig::Udp(UdpInterfaceConfig {
@@ -238,6 +242,8 @@ async fn tcp_server_and_tcp_client_typed_round_trip() {
         .add_interface(ReticulumInterfaceConfig::TcpServer(
             TcpServerInterfaceConfig {
                 listen_addr: server_addr,
+                transit: None,
+                ifac: None,
             },
         ));
     let server = ReticulumTransport::new(server_cfg, test_auth("interface-diversity-server"))
@@ -256,6 +262,8 @@ async fn tcp_server_and_tcp_client_typed_round_trip() {
         .add_interface(ReticulumInterfaceConfig::TcpClient(
             TcpClientInterfaceConfig {
                 target_addr: loopback_addr(1),
+                transit: None,
+                ifac: None,
             },
         ));
     let client = ReticulumTransport::new(client_cfg, test_auth("interface-diversity-client"))
@@ -278,6 +286,121 @@ async fn tcp_server_and_tcp_client_typed_round_trip() {
     assert_eq!(c_stats.kind, "TCPClientInterface");
 }
 
+/// CIRISEdge#492 — every scoped-transit posture round-trips through the shared
+/// `apply_interface_config` mapper into a transport that BUILDS: an IFAC'd
+/// member relay (IFAC-only), a public leaf (`transit=false`, no IFAC), a
+/// member-leaf (IFAC + `transit=false` combo → the general escape hatch), and an
+/// IFAC client. This pins that each posture reaches the correct leviculum
+/// builder call without error; leviculum's own `scoped_transit.rs` conformance
+/// harness pins the resulting on-wire behavior.
+#[tokio::test]
+async fn scoped_transit_postures_build() {
+    use ciris_edge::transport::reticulum::ReticulumTransport;
+    let tmp = TempDir::new().expect("tempdir");
+    let ifac = || IfacConfig {
+        networkname: Some("ciris-mesh".to_string()),
+        passphrase: "member-secret".to_string(),
+        ifac_size: 16,
+    };
+    let cfg = ReticulumTransportConfig::new(tmp_identity_path(&tmp, "relay"), "key-relay")
+        .with_transport_node(true)
+        .add_interface(ReticulumInterfaceConfig::TcpServer(
+            TcpServerInterfaceConfig {
+                listen_addr: loopback_addr(0),
+                transit: None,      // relay (leviculum default)
+                ifac: Some(ifac()), // member-only
+            },
+        ))
+        .add_interface(ReticulumInterfaceConfig::TcpServer(
+            TcpServerInterfaceConfig {
+                listen_addr: loopback_addr(0),
+                transit: Some(false), // public leaf
+                ifac: None,
+            },
+        ))
+        .add_interface(ReticulumInterfaceConfig::TcpServer(
+            TcpServerInterfaceConfig {
+                listen_addr: loopback_addr(0),
+                transit: Some(false), // member leaf — the IFAC+no-transit combo
+                ifac: Some(ifac()),
+            },
+        ))
+        .add_interface(ReticulumInterfaceConfig::TcpClient(
+            TcpClientInterfaceConfig {
+                target_addr: loopback_addr(1),
+                transit: None,
+                ifac: Some(ifac()), // dial a member port → add_tcp_client_ifac
+            },
+        ))
+        .add_interface(ReticulumInterfaceConfig::TcpClient(
+            TcpClientInterfaceConfig {
+                target_addr: loopback_addr(2),
+                transit: Some(false), // member-leaf client: IFAC + no-transit combo
+                ifac: Some(ifac()),   // → the escape-hatch arm (target_host/target_port)
+            },
+        ))
+        .add_interface(ReticulumInterfaceConfig::TcpClient(
+            TcpClientInterfaceConfig {
+                target_addr: loopback_addr(3),
+                transit: Some(false), // no-transit client, no IFAC → also escape-hatch
+                ifac: None,
+            },
+        ));
+    let relay = ReticulumTransport::new(cfg, test_auth("scoped-transit-relay"))
+        .await
+        .expect("scoped-transit transport builds across every posture");
+    let specs = relay.interface_specs();
+    assert_eq!(
+        specs.len(),
+        6,
+        "all six scoped-transit interfaces registered"
+    );
+    assert_eq!(
+        specs
+            .iter()
+            .filter(|s| s.kind == "TCPServerInterface")
+            .count(),
+        3
+    );
+    // All THREE client arms build: IFAC-only, IFAC+no-transit combo, and
+    // no-transit-plain — the last two exercise the hand-rolled
+    // target_host/target_port escape-hatch (no add_tcp_client_no_transit exists).
+    assert_eq!(
+        specs
+            .iter()
+            .filter(|s| s.kind == "TCPClientInterface")
+            .count(),
+        3
+    );
+}
+
+/// CIRISEdge#492 — the NODE-WIDE posture (`with_scoped_transit`) reaches the same
+/// mapper on the LEGACY interface path: a config with no typed interfaces but a
+/// node-wide IFAC + `transit=false` builds the legacy `listen_addr` server
+/// IFAC'd + leaf. This is the shape a Python operator gets from
+/// `init_edge_runtime(ifac_passphrase=…, transit=False)`.
+#[tokio::test]
+async fn node_wide_scoped_transit_legacy_path_builds() {
+    use ciris_edge::transport::reticulum::ReticulumTransport;
+    let tmp = TempDir::new().expect("tempdir");
+    let mut cfg = ReticulumTransportConfig::new(tmp_identity_path(&tmp, "nodewide"), "key-nw")
+        .with_scoped_transit(
+            Some(false),
+            Some(IfacConfig {
+                networkname: None,
+                passphrase: "member-secret".to_string(),
+                ifac_size: 16,
+            }),
+        );
+    cfg.listen_addr = loopback_addr(0); // OS-assigned test port (not 0.0.0.0:4242)
+    let t = ReticulumTransport::new(cfg, test_auth("node-wide-scoped"))
+        .await
+        .expect("node-wide scoped-transit legacy path builds");
+    let specs = t.interface_specs();
+    assert_eq!(specs.len(), 1, "legacy server registered");
+    assert_eq!(specs[0].kind, "TCPServerInterface");
+}
+
 /// **Gateway-peer pattern**: one transport configured with TWO
 /// different interface kinds (TCP server + AutoInterface). Both end
 /// up in the spec registry — the gateway-peer routing pattern at the
@@ -298,6 +421,8 @@ async fn gateway_peer_registers_multiple_interface_kinds() {
         .add_interface(ReticulumInterfaceConfig::TcpServer(
             TcpServerInterfaceConfig {
                 listen_addr: loopback_addr(0),
+                transit: None,
+                ifac: None,
             },
         ))
         .add_interface(ReticulumInterfaceConfig::Auto(AutoInterfaceConfig {
@@ -385,6 +510,8 @@ async fn transport_spec_handle_round_trips_through_transport_stats() {
         .add_interface(ReticulumInterfaceConfig::TcpServer(
             TcpServerInterfaceConfig {
                 listen_addr: loopback_addr(0),
+                transit: None,
+                ifac: None,
             },
         ));
     let transport = ReticulumTransport::new(cfg, test_auth("interface-diversity-test"))


### PR DESCRIPTION
## v17.5.0 — leviculum v0.18 scoped transit (#492): CIRIS-member-only relay

Adopts **leviculum v0.18.0+ciris.1** (`ea2ceff2`) and wires its **scoped-transit** posture into edge: a CIRIS relay carries CIRIS traffic only, gated per-interface, with flag-day-free membership-key rotation.

### The pin (source-compatible)
v0.16→v0.18: the +38 upstream catch-up (six of edge's seven offers merged verbatim + their review fixes — notably the IFAC-strip memo discard, which composes with scoped transit) plus the scoped-transit feature. Additive API, **no wire changes** (confirmed from source — `packet.rs`/announce encoder/framing untouched; a scoped/rotating edge node interoperates byte-for-byte with any un-upgraded peer). persist/verify pins unchanged.

### What edge wires (#492)
- **Per-interface posture** — `IfacConfig` + `transit: Option<bool>` on the TCP relay ports. A single shared mapper (`apply_tcp_server_transit` / `apply_tcp_client_transit`) routes each `(transit, ifac)` to the right leviculum call: IFAC → `add_tcp_server_ifac`/`add_tcp_client_ifac`; `transit=false` → `add_tcp_server_no_transit`; the IFAC+no-transit combo (member leaf) and any no-transit client → the general `add_interface_config`. **One source of truth** for a security-relevant predicate — the typed path *and* the node-wide legacy path both go through it.
- **Node-wide posture** — `ReticulumTransportConfig::with_scoped_transit` + **FFI kwargs** on `init_edge_runtime` (`transit`, `ifac_netname`/`ifac_passphrase`/`ifac_size`) so a Python operator brings up an IFAC'd relay directly. IFAC needs passphrase+size together (typed error otherwise).
- **Rotation verbs** — `ifac_install_next`/`ifac_activate_next`/`ifac_seal_rotation` exposed as thin Rust wrappers + PyEdge pymethods. Edge owns the orchestration cadence; leviculum owns the mechanism; **zero trust/key logic in edge**.

### Acceptance
Edge sets config and reaches the right builder call; leviculum enforces the behavior, pinned by its 6-scenario conformance harness (`leviculum-std/tests/scoped_transit.rs`, 6/6): IFAC drop-at-interface, member transit, announce non-rebroadcast out/in a `transit=false` interface, the `forward_packet` drop guard, and the four rotation straggler phases. Edge's tests verify the *plumbing* — all four postures build a transport, and the node-wide legacy path builds. Full `--lib` + clippy `-D warnings` (CI combos + subset canaries) green; the feature got a dedicated adversarial review.

### Fully baked — the persist handoff is filed (**CIRISPersist#704**)
The automated, flag-day-free passphrase **distribution** rides persist's existing `key_grant` — a rotating PQC grant to hybrid-verified members. The requisite is opened + scoped against persist v32.3.0's real surface: a `TransitMembership` scope, a third addressing category (the `extract_key_grant_payload` XOR rejects a grant that is neither content- nor stream-addressed), `wrap_algorithm: v2` **by construction** (classical wraps are GONE, not per-scope-superseded — cf. edge's own #481), and convergence via a generalized `list_key_grants_for_scope_epoch` (not a parallel copy — avoids the #663 divergence). Until v33.0.0 lands, v17.5.0 ships the config-level relay shape with an **operator-supplied passphrase**; the distribution wires onto this unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
