### PR TITLE
v17.6.0 — adopt persist v35.0.0: per-plane projection (#713)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "17.5.1"
+version = "17.6.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v34.0.0", version = "34", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v35.0.0", version = "35", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1250,7 +1250,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v34.0.0", version = "34", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v35.0.0", version = "35", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.5.1
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.5.1
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.5.1
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.5.1
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.5.1
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.5.1
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.5.1
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.6.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.6.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.6.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.6.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.6.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.6.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ classifiers = [
 # an install-time index requirement (so the "unresolvable from PyPI" shape is by
 # design, not a regression).
 dependencies = [
-    "ciris-persist>=34,<35",
+    "ciris-persist>=35,<36",
 ]
 dynamic = ["version"]
 

--- a/src/field_conformance.rs
+++ b/src/field_conformance.rs
@@ -264,34 +264,78 @@ fn check_delivery_mode() -> Result<(), String> {
 
 fn check_cohort_scope_projection() -> Result<(), String> {
     use ciris_persist::federation::namespace::Projection;
-    use ciris_persist::federation::namespace::{projection_for, registry::authority_for};
+    use ciris_persist::federation::namespace::{
+        projection_for, registry::authority_for, tombstone_ceiling, ObjectClass,
+    };
     use ciris_persist::federation::types::cohort_scope;
-    // projection_for must be TOTAL over the 7 closed cohort scopes — edge's
-    // offer/projection filter is a function of this value, so an unhandled scope
-    // would be a routing hole. `authority_for` on a benign dimension gives a
-    // concrete AuthorityClass; the projection must resolve for every scope.
+    // CIRISPersist#713 / v35.0.0 — the projection is per-PLANE. It must be TOTAL
+    // over (plane × the 7 closed cohort scopes) — edge's offer/projection filter
+    // is a function of this value, so an unhandled cell would be a routing hole.
+    // `authority_for` on a benign dimension gives a concrete AuthorityClass.
     let authority = authority_for("trust:example:v1").class;
-    for scope in [
-        cohort_scope::SELF,
-        cohort_scope::FAMILY,
-        cohort_scope::COMMUNITY,
-        cohort_scope::AFFILIATIONS,
-        cohort_scope::SPECIES,
-        cohort_scope::BIOSPHERE,
-        cohort_scope::FEDERATION,
+    for plane in [
+        ObjectClass::Attestation,
+        ObjectClass::KeyRecord,
+        ObjectClass::TransportDestination,
+        ObjectClass::FountainContent,
+        ObjectClass::HardCaseEvent,
     ] {
-        // Both tombstone polarities — a total function over the value domain.
-        let _ = projection_for(scope, authority, false);
-        let _ = projection_for(scope, authority, true);
+        for scope in [
+            cohort_scope::SELF,
+            cohort_scope::FAMILY,
+            cohort_scope::COMMUNITY,
+            cohort_scope::AFFILIATIONS,
+            cohort_scope::SPECIES,
+            cohort_scope::BIOSPHERE,
+            cohort_scope::FEDERATION,
+        ] {
+            // Both tombstone polarities — total over the value domain.
+            let _ = projection_for(plane, scope, authority, false);
+            let _ = projection_for(plane, scope, authority, true);
+        }
     }
-    // The value-semantics witness: self/family are NOT globally advertised
-    // (structural invisibility), federation-tier trust IS — the projection keys
-    // on the VALUE, not on presence.
-    if projection_for(cohort_scope::SELF, authority, false) != Projection::SelfOwn {
+    // Value-semantics witnesses. Structural invisibility holds on every plane:
+    if projection_for(ObjectClass::KeyRecord, cohort_scope::SELF, authority, false)
+        != Projection::SelfOwn
+    {
         return Err("cohort_scope=self must project SelfOwn (structural invisibility)".into());
     }
-    if projection_for(cohort_scope::SELF, authority, true) != Projection::Global {
-        return Err("a tombstone must project Global regardless of scope (anti-rollback)".into());
+    // #713 — the per-plane CEILING replaces unconditional tombstone-Global.
+    // Key-plane tombstones stay Global (verify-relevance is unbounded)…
+    if projection_for(ObjectClass::KeyRecord, cohort_scope::SELF, authority, true)
+        != Projection::Global
+    {
+        return Err("a KeyRecord tombstone must project Global (anti-rollback)".into());
+    }
+    // …while a non-root reachability tombstone projects at the plane ceiling
+    // (Cohort), NOT Global — widening a tombstone would disclose more than the
+    // original fact ("this route was withdrawn" reveals the route existed).
+    // This is the limb-(b) close: reachability no longer inherits the key
+    // plane's audience (CIRISEdge#311 / CIRISPersist#713).
+    if !authority.is_trust_root()
+        && projection_for(
+            ObjectClass::TransportDestination,
+            cohort_scope::SELF,
+            authority,
+            true,
+        ) != Projection::Cohort
+    {
+        return Err(
+            "a non-root reachability tombstone must project at the plane ceiling \
+             (Cohort), not Global (contextual integrity, CIRISPersist#713)"
+                .into(),
+        );
+    }
+    // The ceiling identity the resolver documents: tombstone projection equals
+    // tombstone_ceiling(plane, authority) by construction.
+    if projection_for(
+        ObjectClass::TransportDestination,
+        cohort_scope::FEDERATION,
+        authority,
+        true,
+    ) != tombstone_ceiling(ObjectClass::TransportDestination, authority)
+    {
+        return Err("tombstone projection must equal tombstone_ceiling(plane, authority)".into());
     }
     Ok(())
 }
@@ -303,9 +347,20 @@ fn check_dimension_projection() -> Result<(), String> {
     // dimension resolves DETERMINISTICALLY to the same per-record projection (edge
     // routes each record by its actual dimension, not by presence). A
     // non-deterministic or panicking resolution would be a routing hole.
+    use ciris_persist::federation::namespace::ObjectClass;
     let dimension = "trust:example:v1";
-    let a = projection_for("federation", authority_for(dimension).class, false);
-    let b = projection_for("federation", authority_for(dimension).class, false);
+    let a = projection_for(
+        ObjectClass::Attestation,
+        "federation",
+        authority_for(dimension).class,
+        false,
+    );
+    let b = projection_for(
+        ObjectClass::Attestation,
+        "federation",
+        authority_for(dimension).class,
+        false,
+    );
     if a != b {
         return Err(format!(
             "per-record projection for {dimension:?} is non-deterministic ({a:?} vs {b:?})"

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1623,7 +1623,18 @@ impl FederationDirectoryReplicationBridge {
             .unwrap_or("");
         let authority = namespace::registry::authority_for(dimension).class;
         let is_tombstone = namespace::is_withdraw_or_revocation(attestation_type);
-        match namespace::projection_for(cohort_scope, authority, is_tombstone) {
+        // CIRISPersist#713 / v35.0.0 — the projection is per-PLANE. This dispatch
+        // decides attestation advertisement, so the plane is `Attestation` (whose
+        // row holds documented pre-#713 behavior — the decomposition is the part
+        // #713 stays open for). The per-plane divergence (reachability ceiling)
+        // lands on the TransportDestination/KeyRecord planes wherever THEY are
+        // projected; this call site's behavior is unchanged by construction.
+        match namespace::projection_for(
+            namespace::ObjectClass::Attestation,
+            cohort_scope,
+            authority,
+            is_tombstone,
+        ) {
             Projection::Global | Projection::Cohort => true,
             Projection::SelfOwn => canonical_json
                 .get("attesting_key_id")
@@ -6442,6 +6453,48 @@ mod tests {
 
     fn set_of(keys: &[&str]) -> HashSet<String> {
         keys.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// CIRISPersist#713 macro-acceptance instrument — times the FULL advertise
+    /// decision (JSON field extraction + authority resolution + the per-plane
+    /// `projection_for`) that runs per envelope-ref on the publish loop.
+    /// `#[ignore]` by default: run on demand for the before/after A-B a persist
+    /// re-pin commits edge to reporting:
+    /// `cargo test --release -p ciris-edge --lib advertise_decision_micro_timing --features transport-http -- --ignored --nocapture`
+    #[test]
+    #[ignore = "on-demand hot-path measurement (CIRISPersist#713 acceptance), not a correctness test"]
+    #[allow(clippy::cast_precision_loss)] // ns/call diagnostic print; f64 precision is ample
+    fn advertise_decision_micro_timing() {
+        const N: u32 = 1_000_000;
+        let fixtures = [
+            att_json("trust:reliability:v1", "self", "scores", "node-own"),
+            att_json("trust:reliability:v1", "community", "scores", "peer-a"),
+            att_json(
+                "provenance:build_manifest:linux-x86_64",
+                "federation",
+                "scores",
+                "some-builder",
+            ),
+            att_json("trust:reliability:v1", "family", "withdraw", "node-own"),
+        ];
+        let self_set = set_of(&["node-own"]);
+        // Warm-up pass so allocator/caches settle before the timed window.
+        let mut acc = 0u32;
+        for f in &fixtures {
+            acc += u32::from(Bridge::attestation_is_advertised(f, &self_set));
+        }
+        let start = std::time::Instant::now();
+        for _ in 0..N {
+            for f in &fixtures {
+                acc += u32::from(Bridge::attestation_is_advertised(f, &self_set));
+            }
+        }
+        let elapsed = start.elapsed();
+        let calls = u64::from(N) * fixtures.len() as u64;
+        println!(
+            "advertise_decision_micro_timing: {calls} calls in {elapsed:?} => {:.1} ns/call (acc={acc})",
+            elapsed.as_nanos() as f64 / calls as f64
+        );
     }
 
     /// A trust-root (`provenance:build_manifest:*` → `AccordCoScrub`) attestation


### PR DESCRIPTION
Re-pin persist v34.0.0 → **v35.0.0** and adopt the BREAKING `projection_for(plane: ObjectClass, …)` — the plane→norm table edge arbitrated on CIRISPersist#713, with per-plane tombstone ceilings.

- `bridge.rs` live dispatch → `ObjectClass::Attestation` (row holds pre-#713 behavior — unchanged by construction).
- Conformance witnesses **strengthened**: total over (5 planes × 7 scopes × 2 polarities); pin KeyRecord tombstone→Global, **non-root reachability tombstone→Cohort ceiling** (the limb-(b) close, CIRISEdge#311), and the `tombstone_ceiling` identity.
- `advertise_decision_micro_timing` added (`#[ignore]`, on-demand) — the #713 macro-acceptance instrument.
- **Measured** (the #713 commitment): quiet interleaved A/B, 3×4M calls/side — v34 median 416.4 ns/call, v35 median 401.7 ns/call; distributions overlap → **no measurable macro delta**.
- Pins ×2 + pyproject `>=35,<36`; clippy `-D warnings` + full `--lib` 964/0 green.

Still open with edge on their threads: the #713 Attestation-decomposition shape answer, #704 Ask 3, #716 canonicalizer flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)