### PR TITLE
v17.8.0 — leviculum v0.19.0+ciris.1: explicit-hash addressing absorbed upstream (#497)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "17.7.0"
+version = "17.8.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -602,8 +602,8 @@ tempfile       = { version = "3", optional = true }
 # crate semver is now 0.16. CHANGELOG-gotcha lesson from their release: grep for
 # conflict markers before tagging (prose doesn't compile). Adoption sequenced in #484:
 # awaited variants next, then #482 item-1 buffer_unordered dispatcher.
-leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.18.0+ciris.1", version = "0.18", optional = true }
-leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.18.0+ciris.1", version = "0.18", optional = true }
+leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.19.0+ciris.1", version = "0.19", optional = true }
+leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.19.0+ciris.1", version = "0.19", optional = true }
 # v15.20.0 (CIRISEdge#169) — LXMF store-and-forward propagation. The
 # `leviculum-lxmf` workspace member (same pinned tag) ships the whole
 # LXMF wire protocol: propagation-node discovery/upload/`/get` codecs,
@@ -613,7 +613,7 @@ leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.18.0+
 # features keep `pow` on (the stamp/ticket cost we validate at
 # admission). Gated behind the `lxmf` feature — see the `[features]`
 # block. Edge INTEGRATES this crate's protocol; it never reimplements it.
-leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.18.0+ciris.1", version = "0.18", optional = true }
+leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.19.0+ciris.1", version = "0.19", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.7.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.7.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.7.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.7.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.7.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.7.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.7.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.8.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.8.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.8.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.8.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.8.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.8.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.8.0


### PR DESCRIPTION
Adopts **leviculum v0.19.0+ciris.1** (`6ce13f76`) — the +11 catch-up in which upstream absorbed the **seventh and last** CIRIS code offer (explicit-hash listen, fork-carried since v0.10.1) and hardened it in review.

Why it matters here: the mesh promise that *"joining needs no domain names anywhere in the chain"* is, at the transport layer, exactly this primitive — the routable address **is** `sha256(fed_pubkey)[..16]`, derived independently by every peer, with nothing to resolve and no registry to trust. It's now upstream code with reference-verified behavior rather than a capability this fork carries alone.

**Source-compat: clean.** Pin-only bump, no API migration — edge already registers its federation destination through `with_explicit_hash` (CIRISEdge#371).

### Both post-adoption checks from #497, run and clean
- **`register_destination` displacement warning — not observed** in edge's reticulum lanes. Edge derives that hash in exactly one place (`identity.rs` → `reticulum_destination_for_pubkey`), so a hit would have meant a rotation race or a derivation bug. There isn't one.
- **Announce-refusal warn flood — 0 occurrences.** Path requests for explicit-hash destinations are now silently skipped instead of driving that warn on every poll.

### CC 5.4: a future application, not pending work
The structural closure v0.19 enables — registering group-scoped destinations via `with_explicit_hash`, so never-announce is enforced by `ExplicitHashCannotAnnounce` rather than by the `AnnounceControl` hook — **applies the moment group-scoped destinations land**. Edge registers exactly two destinations today: the federation explicit-hash one (already structural) and the named discovery dest (which must announce). Until then #489's installed hook + `register_announce_scope()` is the live mechanism and is already wired. Flagging so this isn't carried as an open task it isn't.

### Verified
`clippy --all-targets -D warnings` · full `--lib` · `links_ffi` (the lane whose ~50% flake was fixed in v17.7.0) · `leviculum_interface_diversity` (scoped transit) · `explicit_hash_addressing` (the v0.19 surface itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)