### PR TITLE
v17.9.0 — scope-native addressing (#499) + persist v36.2.0 / verify v13.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "17.8.0"
+version = "17.9.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.1.0", version = "36", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.2.0", version = "36", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.1.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.3.1", version = "13", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.3.1", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.4.0", version = "13", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.4.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.3.1
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.3.1", version = "13" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.4.0", version = "13" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1250,7 +1250,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.1.0", version = "36", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.2.0", version = "36", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.8.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.8.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.8.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.8.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.8.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.8.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.8.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.9.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.9.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.9.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.9.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.9.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.9.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.9.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,12 @@ pub mod reachability;
 pub mod replication;
 pub mod sas;
 mod sas_wordlist;
+// CIRISEdge#499 (workstream B) — scope-native derived-address table.
+// `(scope, group_id, epoch, member)` -> 16-byte Reticulum destination
+// hash, derived on membership/epoch change and read (never derived) on
+// the packet path, with the three-phase epoch rotation that keeps the
+// receive accept-set a superset of the send-set (CIRISEdge#492 shape).
+pub mod scope_addressing;
 // v6.0.0 (CIRISEdge#175) — CC 1.13.3.4 substrate.
 pub mod scope_privacy;
 pub mod swarm;

--- a/src/mls/cohort_group.rs
+++ b/src/mls/cohort_group.rs
@@ -1,0 +1,1968 @@
+//! Persistent per-cohort MLS group (CIRISEdge#499, workstream E).
+//!
+//! The `community` / `affiliations` scopes need a **real**
+//! `exporter_secret` — an RFC 9420 §8.5 epoch secret produced by an
+//! actual MLS group with an actual roster — so
+//! [`crate::scope_privacy`]'s `k_record_id` / `k_symbol` subkeys are
+//! bound to group membership rather than to a placeholder. Unlike the
+//! per-stream A/V group ([`crate::transport::realtime_av_mls`]), a
+//! cohort group must **outlive the process**: a node that restarts
+//! and cannot reload its cohort group has silently lost the ability
+//! to read its own community's records.
+//!
+//! # Why a snapshot, and NOT `StorageProvider` (CIRISEdge#217)
+//!
+//! The obvious design is to implement openmls's
+//! [`openmls_traits::storage::StorageProvider`] over the sealed KV so
+//! openmls persists incrementally. We deliberately do **not**:
+//!
+//! - `StorageProvider` is ~45 **synchronous** methods.
+//! - The sealed KV ([`ciris_persist::encrypted_kv::XChaChaKvStore`],
+//!   surfaced here via [`ScopeStateProvider`]) is **async**.
+//! - Bridging sync-over-async means `block_on` inside an async
+//!   context, which is this repo's documented *"no reactor running"*
+//!   panic class (CIRISEdge#217 — the same failure mode that held
+//!   edge v1.1.9 off PyPI when persist's sqlite path did it).
+//!
+//! So instead: keep openmls's own in-memory storage — the
+//! `MemoryStorage` inside [`openmls_libcrux_crypto::Provider`], which
+//! is exactly what the A/V path already runs on — and **snapshot its
+//! whole key/value map** into the blob slot the CIRISEdge#175 v6.0.0
+//! scaffold already built
+//! ([`ScopeStateProvider::group_state_put`]). Reload is the mirror
+//! image: read the blob, restore the map into a fresh provider, and
+//! let [`openmls::prelude::MlsGroup::load`] reconstruct the group
+//! purely from storage reads.
+//!
+//! `MemoryStorage::serialize` exists upstream but is
+//! `#[cfg(feature = "test-utils")]`, so it is unusable in a
+//! production build. This module therefore carries its **own**
+//! versioned, length-prefixed codec ([`SNAPSHOT_MAGIC`] /
+//! [`SNAPSHOT_VERSION`]) — the version byte is what turns a future
+//! format change into a loud [`CohortGroupError::SnapshotVersion`]
+//! instead of a garbage load.
+//!
+//! # The ordering invariant that must not be gotten wrong
+//!
+//! **merge → snapshot+persist → THEN emit Commit/Welcome.**
+//!
+//! If we advertised an epoch before persisting it, a crash in that
+//! window leaves peers at epoch N while our durable state is at
+//! N-1 — and MLS has no way to re-derive N without the commit
+//! secrets we just lost. The group is unloadable in the only sense
+//! that matters: it can never commit again.
+//!
+//! This module enforces the ordering **structurally**, not by
+//! convention: the Commit/Welcome bytes are returned inside a
+//! [`CohortCommit`] whose fields are private and whose only
+//! construction site is inside [`CohortGroupInner::persist_and_seal`]
+//! — i.e. you cannot obtain emittable bytes without the durable write
+//! having already succeeded. A persist failure returns `Err` and the
+//! caller never sees the Commit.
+//!
+//! The persist step is itself crash-ordered: the epoch-N snapshot is
+//! written **before** the head pointer moves to N, so a crash between
+//! the two leaves the head at N-1 whose snapshot is still retained.
+//!
+//! # Single writer per `community_id`
+//!
+//! Two concurrent commits against the same group fork the epoch (both
+//! committers believe they own N+1; one of them is wrong and its
+//! peers will reject its subsequent messages). Every mutating method
+//! here takes an async mutex, and [`CohortGroups`] hands out clones
+//! of the *same* [`CohortGroup`] handle per `community_id` so two
+//! independently-obtained handles share one lock rather than racing
+//! two in-memory copies of the same group.
+//!
+//! # Relationship to `transport::realtime_av_mls`
+//!
+//! Same ciphersuite (`0x004D` X-Wing), same provider, same commit
+//! patterns — but a **different** exporter label
+//! ([`COHORT_SECRET_LABEL`] vs the A/V module's
+//! `ciris-realtime-av-epoch-dek-seed-v1`), so a cohort secret and an
+//! A/V DEK seed can never collide even if some future deployment
+//! points both at one group. RFC 9420 makes exporter derivations
+//! label-domain-separated; this module relies on that.
+//!
+//! Per the workstream file boundary this module does **not** import
+//! from `crate::transport::*`. The few helpers it needs from there —
+//! the ciphersuite constant, the `mint_*_key_package` shape, the
+//! `export_secret` wrapper — are duplicated below (a handful of lines
+//! each) rather than shared, so the transport module stays untouched.
+
+use std::collections::HashMap;
+use std::sync::{Arc, PoisonError};
+
+use openmls::group::GroupId;
+use openmls::prelude::{
+    BasicCredential, Ciphersuite, CredentialWithKey, KeyPackage, KeyPackageBundle,
+    LeafNodeParameters, MlsGroup, MlsGroupCreateConfig, MlsMessageIn, MlsMessageOut,
+    ProcessedMessageContent, ProtocolMessage,
+};
+use openmls_basic_credential::SignatureKeyPair;
+use openmls_libcrux_crypto::Provider as LibcruxProvider;
+use openmls_traits::types::SignatureScheme;
+use openmls_traits::OpenMlsProvider;
+use tls_codec::{Deserialize as TlsDeserialize, Serialize as TlsSerialize};
+use tokio::sync::Mutex;
+use zeroize::Zeroize;
+
+use super::scope_state::{ScopeStateProvider, ScopeStateProviderError};
+
+/// The openmls storage type backing [`LibcruxProvider`]. Named
+/// through the trait so this module does not need a direct
+/// `openmls_memory_storage` dependency line in `Cargo.toml` (the
+/// concrete type is `openmls_memory_storage::MemoryStorage`, whose
+/// `values: RwLock<HashMap<Vec<u8>, Vec<u8>>>` field is public — that
+/// public field is the whole reason the snapshot approach works).
+type MemStorage = <LibcruxProvider as OpenMlsProvider>::StorageProvider;
+
+/// The MLS ciphersuite cohort groups are pinned to: `0x004D` —
+/// X-Wing (ML-KEM-768 + X25519) | ChaCha20-Poly1305 | SHA-256 |
+/// Ed25519.
+///
+/// Same pin as `transport::realtime_av_mls::CIPHERSUITE_ID`,
+/// duplicated rather than imported per the workstream file boundary.
+/// If one moves the other must move with it — a cohort group and an
+/// A/V group in the same deployment negotiating different suites
+/// would be a silent interop break.
+pub const CIPHERSUITE_ID: u16 = 0x004D;
+
+/// The openmls enum value [`CIPHERSUITE_ID`] maps to.
+const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519;
+
+/// Exporter label for the cohort epoch secret.
+///
+/// **Domain-separated** from the A/V path's
+/// `ciris-realtime-av-epoch-dek-seed-v1`. RFC 9420 §8.5 derives
+/// exporters as a function of the label, so two consumers of the same
+/// group's exporter that use different labels get unrelated secrets.
+/// The cohort secret feeds `scope_privacy`'s `k_record_id` /
+/// `k_symbol` (CEWP `SCOPE_PRIVACY.md` §2.2); the A/V one feeds a
+/// media DEK. They must never be the same bytes.
+pub const COHORT_SECRET_LABEL: &str = "ciris-cohort-mls-epoch-exporter-v1";
+
+/// Length of a [`CohortSecret`], in bytes.
+pub const COHORT_SECRET_LEN: usize = 32;
+
+/// Magic prefix on every snapshot blob. Lets a wrong-slot read fail
+/// loudly instead of being parsed as a truncated map.
+pub const SNAPSHOT_MAGIC: &[u8; 8] = b"CIRISMLS";
+
+/// Snapshot format version. Bump on any wire-breaking change to
+/// [`encode_snapshot`]; [`decode_snapshot`] refuses anything it does
+/// not recognise (CIRISEdge#499 — a garbage load of MLS state is
+/// worse than a loud refusal, because a partially-decoded group can
+/// still *appear* to work until the first commit).
+pub const SNAPSHOT_VERSION: u8 = 0x01;
+
+/// Reserved epoch slot holding the *head pointer* — the epoch number
+/// whose snapshot is current.
+///
+/// [`ScopeStateProvider`] exposes get/put/delete keyed by
+/// `(community_id, epoch)` with no list or scan, so "which epoch is
+/// current?" needs a well-known slot. `u64::MAX` is that slot: a real
+/// MLS group would need 2^64 commits to collide with it, and
+/// [`CohortGroupInner::persist_and_seal`] refuses the collision
+/// explicitly rather than trusting the arithmetic.
+const HEAD_SLOT: u64 = u64::MAX;
+
+/// Version byte on the head-pointer value (independent of
+/// [`SNAPSHOT_VERSION`]: the pointer encoding can change without the
+/// snapshot encoding changing, and vice versa).
+const HEAD_VERSION: u8 = 0x01;
+
+/// Default number of epochs retained in the KV.
+///
+/// Each commit rewrites the *whole* snapshot blob under a new epoch
+/// key, so without a bound the sealed KV grows without limit — one
+/// full copy of group state per commit, forever. A small window is
+/// kept rather than exactly one because the crash-ordered persist
+/// (snapshot-then-head) needs the previous epoch to still be there if
+/// a crash lands between the two writes, and because §3.5
+/// `rotate-forward` semantics want a short tail, not an instant
+/// horizon.
+pub const DEFAULT_RETAINED_EPOCHS: u64 = 4;
+
+/// Hard ceiling on a decoded snapshot's entry count. Purely a
+/// decode-side DoS guard: the blob comes out of our own sealed KV, so
+/// a hostile value implies the KV was already compromised, but a
+/// length-prefixed codec should never trust a length field to size an
+/// allocation (cf. the CIRISEdge#473 reassembler byte-budget finding).
+const MAX_SNAPSHOT_ENTRIES: u32 = 1 << 20;
+
+/// Hard ceiling on any single snapshot key or value, in bytes. Same
+/// rationale as [`MAX_SNAPSHOT_ENTRIES`].
+const MAX_SNAPSHOT_FIELD: u32 = 1 << 26; // 64 MiB
+
+// ─── Errors ─────────────────────────────────────────────────────────
+
+/// Errors from the persistent cohort-group surface.
+#[derive(Debug, thiserror::Error)]
+pub enum CohortGroupError {
+    /// Sealed-KV read/write fault, or a codec fault inside
+    /// [`ScopeStateProvider`].
+    #[error("cohort group state store: {0}")]
+    Store(#[from] ScopeStateProviderError),
+    /// The snapshot blob did not begin with [`SNAPSHOT_MAGIC`].
+    #[error("cohort group snapshot: bad magic (slot does not hold an MLS snapshot)")]
+    SnapshotMagic,
+    /// The snapshot blob carried a version byte this build does not
+    /// understand. Loud by design — see [`SNAPSHOT_VERSION`].
+    #[error("cohort group snapshot: unsupported format version {0:#04x} (this build reads {SNAPSHOT_VERSION:#04x})")]
+    SnapshotVersion(u8),
+    /// The snapshot blob was truncated, over-long, or declared a
+    /// length that exceeds the decode budget.
+    #[error("cohort group snapshot: malformed ({0})")]
+    SnapshotMalformed(String),
+    /// The head pointer slot held something unreadable.
+    #[error("cohort group head pointer: malformed ({0})")]
+    HeadMalformed(String),
+    /// The head pointer named an epoch whose snapshot is missing —
+    /// either the retention window pruned too aggressively or the KV
+    /// lost a write. Fail-closed: we do NOT silently fall back to an
+    /// older epoch, because a silently-rewound group re-uses epoch
+    /// numbers its peers have already seen.
+    #[error("cohort group: head points at epoch {0} but no snapshot is stored for it")]
+    HeadDangling(u64),
+    /// [`MlsGroup::load`] returned `None` — the restored storage map
+    /// did not contain a group under the expected group id.
+    #[error("cohort group: snapshot restored but no MLS group found for community {0:?}")]
+    GroupMissing(String),
+    /// The group's own signature key pair was not recoverable from
+    /// the restored storage. Without it the group can never commit
+    /// again, so this is fatal rather than degraded.
+    #[error("cohort group: signature key pair not recoverable from snapshot for community {0:?}")]
+    SignerMissing(String),
+    /// The 0x004D ciphersuite is unavailable in this openmls build.
+    /// Should be impossible at 0.8.1 (X-Wing ships unconditionally);
+    /// the gate exists so a future re-pin behind a feature flag has a
+    /// clean failure mode.
+    #[error("MLS ciphersuite 0x004D (X-Wing) is not available in this openmls build")]
+    CiphersuiteNotAvailable,
+    /// A `KeyPackage` offered to [`CohortGroup::add_member`] was
+    /// minted under a different ciphersuite. Refused before the
+    /// roster is touched.
+    #[error("key package for {key_id:?} uses ciphersuite {got:#06x}, cohort groups require {CIPHERSUITE_ID:#06x}")]
+    CiphersuiteMismatch {
+        /// The CIRIS `key_id` the key package was offered for.
+        key_id: String,
+        /// The ciphersuite the offered key package actually carries.
+        got: u16,
+    },
+    /// Group creation failed inside openmls.
+    #[error("MLS cohort group creation failed: {0}")]
+    CreateFailed(String),
+    /// An Add commit failed.
+    #[error("MLS cohort Add commit failed: {0}")]
+    AddFailed(String),
+    /// A Remove commit failed.
+    #[error("MLS cohort Remove commit failed: {0}")]
+    RemoveFailed(String),
+    /// A self-update (rotate) commit failed.
+    #[error("MLS cohort rotate failed: {0}")]
+    RotateFailed(String),
+    /// `process_message` / `merge_staged_commit` failed on a remote
+    /// commit.
+    #[error("MLS cohort remote commit apply failed: {0}")]
+    ApplyFailed(String),
+    /// Wire bytes did not decode as an MLS message.
+    #[error("MLS wire decode failed: {0}")]
+    WireDecodeFailed(String),
+    /// The bytes handed to [`CohortGroup::apply_remote_commit`]
+    /// decoded as MLS but were not a Commit.
+    #[error("expected a Commit message, got a different MLS content type")]
+    NotACommit,
+    /// A member lookup by `key_id` found nothing.
+    #[error("member not found in cohort group: {0}")]
+    MemberNotFound(String),
+    /// KeyPackage minting failed.
+    #[error("MLS KeyPackage build failed: {0}")]
+    KeyPackageBuildFailed(String),
+    /// Exporter-secret derivation failed — would indicate corrupted
+    /// group state.
+    #[error("MLS exporter_secret derivation failed: {0}")]
+    ExportFailed(String),
+    /// The group reached the reserved [`HEAD_SLOT`] epoch. Refused
+    /// rather than silently overwriting the head pointer with a
+    /// snapshot.
+    #[error(
+        "cohort group reached the reserved head-pointer epoch {HEAD_SLOT}; refusing to persist"
+    )]
+    EpochExhausted,
+}
+
+// ─── The cohort epoch secret ────────────────────────────────────────
+
+/// The current epoch's MLS exporter secret for a cohort, derived
+/// under [`COHORT_SECRET_LABEL`].
+///
+/// This is the `exporter_secret` the `community` / `affiliations`
+/// scopes were missing: 32 bytes bound to *this* group at *this*
+/// epoch, from which `scope_privacy`'s `k_record_id` / `k_symbol`
+/// subkeys are derived (CEWP `SCOPE_PRIVACY.md` §2.2).
+///
+/// Zeroized on drop; `Debug` redacts. Same shape as the A/V path's
+/// `RootSecret` so downstream key-derivation code is mechanical.
+pub struct CohortSecret([u8; COHORT_SECRET_LEN]);
+
+impl CohortSecret {
+    /// Borrow the raw bytes — for key derivation only. Callers MUST
+    /// NOT log, persist, or transmit these bytes.
+    pub fn as_bytes(&self) -> &[u8; COHORT_SECRET_LEN] {
+        &self.0
+    }
+}
+
+impl Drop for CohortSecret {
+    fn drop(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+impl std::fmt::Debug for CohortSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CohortSecret")
+            .field("bytes", &"<redacted 32B>")
+            .finish()
+    }
+}
+
+// ─── Commit artifacts ───────────────────────────────────────────────
+
+/// Wire artifacts produced by a cohort roster mutation, **after** the
+/// resulting epoch is durable.
+///
+/// # Why the fields are private
+///
+/// This type is the structural enforcement of the module's ordering
+/// invariant (see module docs). Its only construction site is inside
+/// [`CohortGroupInner::persist_and_seal`], which runs *after* the
+/// snapshot write and head-pointer update have both succeeded.
+/// Because the Commit/Welcome bytes are only reachable through
+/// [`Self::commit`] / [`Self::welcome`] on a value you cannot build
+/// yourself, "emit before persist" is not expressible by a caller of
+/// this module.
+#[derive(Clone)]
+#[must_use = "a CohortCommit carries the Commit/Welcome that MUST be fanned out to the cohort"]
+pub struct CohortCommit {
+    epoch: u64,
+    commit: Vec<u8>,
+    welcome: Option<Vec<u8>>,
+}
+
+impl CohortCommit {
+    /// The epoch this commit advanced the group to. Already durable
+    /// by the time you hold this value.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// The serialized MLS Commit, to fan out to existing members.
+    pub fn commit(&self) -> &[u8] {
+        &self.commit
+    }
+
+    /// The serialized MLS Welcome, to ship to joiners. `None` when
+    /// the commit contained no Add proposals (Remove-only, or a
+    /// rotate).
+    pub fn welcome(&self) -> Option<&[u8]> {
+        self.welcome.as_deref()
+    }
+
+    /// Consume into `(epoch, commit_bytes, welcome_bytes)`.
+    pub fn into_parts(self) -> (u64, Vec<u8>, Option<Vec<u8>>) {
+        (self.epoch, self.commit, self.welcome)
+    }
+}
+
+impl std::fmt::Debug for CohortCommit {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CohortCommit")
+            .field("epoch", &self.epoch)
+            .field("commit_len", &self.commit.len())
+            .field("welcome_len", &self.welcome.as_ref().map(Vec::len))
+            .finish()
+    }
+}
+
+// ─── Snapshot codec ─────────────────────────────────────────────────
+//
+// Layout (all integers big-endian):
+//
+//   magic[8] = "CIRISMLS"
+//   version  = u8
+//   count    = u32
+//   count × { k_len: u32, v_len: u32, key[k_len], value[v_len] }
+//
+// Entries are emitted in sorted key order so the blob is a
+// deterministic function of the map — which makes "did this commit
+// actually change storage?" answerable by byte comparison, and keeps
+// the sealed-KV write stable under HashMap iteration order.
+
+/// Encode an openmls storage map into a versioned snapshot blob.
+fn encode_snapshot(values: &HashMap<Vec<u8>, Vec<u8>>) -> Result<Vec<u8>, CohortGroupError> {
+    let count = u32::try_from(values.len()).map_err(|_| {
+        CohortGroupError::SnapshotMalformed(format!("entry count {} exceeds u32", values.len()))
+    })?;
+
+    let mut entries: Vec<(&Vec<u8>, &Vec<u8>)> = values.iter().collect();
+    entries.sort_unstable_by(|a, b| a.0.cmp(b.0));
+
+    let body: usize = entries.iter().map(|(k, v)| 8 + k.len() + v.len()).sum();
+    let mut out = Vec::with_capacity(8 + 1 + 4 + body);
+    out.extend_from_slice(SNAPSHOT_MAGIC);
+    out.push(SNAPSHOT_VERSION);
+    out.extend_from_slice(&count.to_be_bytes());
+
+    for (k, v) in entries {
+        let k_len = u32::try_from(k.len()).map_err(|_| {
+            CohortGroupError::SnapshotMalformed(format!("key length {} exceeds u32", k.len()))
+        })?;
+        let v_len = u32::try_from(v.len()).map_err(|_| {
+            CohortGroupError::SnapshotMalformed(format!("value length {} exceeds u32", v.len()))
+        })?;
+        out.extend_from_slice(&k_len.to_be_bytes());
+        out.extend_from_slice(&v_len.to_be_bytes());
+        out.extend_from_slice(k);
+        out.extend_from_slice(v);
+    }
+    Ok(out)
+}
+
+/// Read a big-endian `u32` from `buf` at `*pos`, advancing `*pos`.
+fn take_u32(buf: &[u8], pos: &mut usize, what: &str) -> Result<u32, CohortGroupError> {
+    let end = pos
+        .checked_add(4)
+        .ok_or_else(|| CohortGroupError::SnapshotMalformed("offset overflow".to_string()))?;
+    if end > buf.len() {
+        return Err(CohortGroupError::SnapshotMalformed(format!(
+            "truncated reading {what}: need 4 bytes at {pos}, have {}",
+            buf.len()
+        )));
+    }
+    let mut raw = [0u8; 4];
+    raw.copy_from_slice(&buf[*pos..end]);
+    *pos = end;
+    Ok(u32::from_be_bytes(raw))
+}
+
+/// Read `len` bytes from `buf` at `*pos`, advancing `*pos`.
+fn take_bytes(
+    buf: &[u8],
+    pos: &mut usize,
+    len: u32,
+    what: &str,
+) -> Result<Vec<u8>, CohortGroupError> {
+    if len > MAX_SNAPSHOT_FIELD {
+        return Err(CohortGroupError::SnapshotMalformed(format!(
+            "{what} length {len} exceeds the {MAX_SNAPSHOT_FIELD}-byte decode budget"
+        )));
+    }
+    let len = len as usize;
+    let end = pos
+        .checked_add(len)
+        .ok_or_else(|| CohortGroupError::SnapshotMalformed("offset overflow".to_string()))?;
+    if end > buf.len() {
+        return Err(CohortGroupError::SnapshotMalformed(format!(
+            "truncated reading {what}: need {len} bytes at {pos}, have {}",
+            buf.len()
+        )));
+    }
+    let out = buf[*pos..end].to_vec();
+    *pos = end;
+    Ok(out)
+}
+
+/// Decode a snapshot blob back into an openmls storage map.
+fn decode_snapshot(blob: &[u8]) -> Result<HashMap<Vec<u8>, Vec<u8>>, CohortGroupError> {
+    if blob.len() < 8 + 1 + 4 {
+        return Err(CohortGroupError::SnapshotMalformed(format!(
+            "blob is {} bytes, shorter than the 13-byte header",
+            blob.len()
+        )));
+    }
+    if &blob[..8] != SNAPSHOT_MAGIC {
+        return Err(CohortGroupError::SnapshotMagic);
+    }
+    let version = blob[8];
+    if version != SNAPSHOT_VERSION {
+        return Err(CohortGroupError::SnapshotVersion(version));
+    }
+
+    let mut pos = 9usize;
+    let count = take_u32(blob, &mut pos, "entry count")?;
+    if count > MAX_SNAPSHOT_ENTRIES {
+        return Err(CohortGroupError::SnapshotMalformed(format!(
+            "entry count {count} exceeds the {MAX_SNAPSHOT_ENTRIES} decode budget"
+        )));
+    }
+
+    let mut map = HashMap::with_capacity(count as usize);
+    for i in 0..count {
+        let k_len = take_u32(blob, &mut pos, "key length")?;
+        let v_len = take_u32(blob, &mut pos, "value length")?;
+        let key = take_bytes(blob, &mut pos, k_len, "key")?;
+        let value = take_bytes(blob, &mut pos, v_len, "value")?;
+        if map.insert(key, value).is_some() {
+            return Err(CohortGroupError::SnapshotMalformed(format!(
+                "duplicate key at entry {i}"
+            )));
+        }
+    }
+    if pos != blob.len() {
+        return Err(CohortGroupError::SnapshotMalformed(format!(
+            "{} trailing bytes after {count} entries",
+            blob.len() - pos
+        )));
+    }
+    Ok(map)
+}
+
+/// Encode the head pointer: `[version, epoch_be]`.
+fn encode_head(epoch: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(9);
+    out.push(HEAD_VERSION);
+    out.extend_from_slice(&epoch.to_be_bytes());
+    out
+}
+
+/// Decode the head pointer.
+fn decode_head(blob: &[u8]) -> Result<u64, CohortGroupError> {
+    if blob.len() != 9 {
+        return Err(CohortGroupError::HeadMalformed(format!(
+            "expected 9 bytes, got {}",
+            blob.len()
+        )));
+    }
+    if blob[0] != HEAD_VERSION {
+        return Err(CohortGroupError::HeadMalformed(format!(
+            "unsupported head version {:#04x}",
+            blob[0]
+        )));
+    }
+    let mut raw = [0u8; 8];
+    raw.copy_from_slice(&blob[1..9]);
+    Ok(u64::from_be_bytes(raw))
+}
+
+// ─── Group id derivation ────────────────────────────────────────────
+
+/// Domain-separated MLS group id for a cohort.
+///
+/// Deterministic from `community_id` so [`MlsGroup::load`] can find
+/// the group in a restored storage map without a second lookup table,
+/// and prefixed so a cohort group id can never be confused with a
+/// randomly-generated per-stream A/V group id.
+fn cohort_group_id(community_id: &str) -> GroupId {
+    let mut raw = Vec::with_capacity(13 + community_id.len());
+    raw.extend_from_slice(b"ciris-cohort:");
+    raw.extend_from_slice(community_id.as_bytes());
+    GroupId::from_slice(&raw)
+}
+
+// ─── Key material minting ───────────────────────────────────────────
+
+/// A prospective cohort member's retained private MLS material.
+///
+/// Mirrors `transport::realtime_av_mls::JoinerKeyMaterial` (duplicated
+/// per the workstream file boundary, not imported). The public
+/// [`KeyPackage`] returned alongside by
+/// [`mint_cohort_key_material`] is what a member publishes; this is
+/// what the member keeps so it can consume the matching Welcome.
+pub struct CohortKeyMaterial {
+    /// The member's own provider, holding the private leaf material.
+    pub provider: Arc<LibcruxProvider>,
+    /// The member's MLS signature key pair.
+    pub signer: SignatureKeyPair,
+    /// The CIRIS `key_id` stamped into the credential.
+    pub key_id: String,
+}
+
+impl std::fmt::Debug for CohortKeyMaterial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CohortKeyMaterial")
+            .field("key_id", &self.key_id)
+            .field("provider", &"<opaque-libcrux>")
+            .field("signer", &"<redacted>")
+            .finish()
+    }
+}
+
+/// Mint a cohort member's KeyPackage plus the private material that
+/// member retains, under the pinned [`CIPHERSUITE`].
+///
+/// The private leaf keys live in the returned
+/// [`CohortKeyMaterial::provider`]; only the public [`KeyPackage`] is
+/// meant to leave the member's node.
+pub fn mint_cohort_key_material(
+    key_id: &str,
+) -> Result<(CohortKeyMaterial, KeyPackage), CohortGroupError> {
+    let provider = Arc::new(LibcruxProvider::default());
+    let signer = SignatureKeyPair::new(SignatureScheme::ED25519)
+        .map_err(|e| CohortGroupError::KeyPackageBuildFailed(format!("signature key: {e:?}")))?;
+    signer.store(provider.storage()).map_err(|e| {
+        CohortGroupError::KeyPackageBuildFailed(format!("store signature key: {e:?}"))
+    })?;
+    let cred_with_key = CredentialWithKey {
+        credential: BasicCredential::new(key_id.as_bytes().to_vec()).into(),
+        signature_key: signer.to_public_vec().into(),
+    };
+    let bundle: KeyPackageBundle = KeyPackage::builder()
+        .build(CIPHERSUITE, provider.as_ref(), &signer, cred_with_key)
+        .map_err(|e| CohortGroupError::KeyPackageBuildFailed(format!("{e:?}")))?;
+    let key_package = bundle.key_package().clone();
+    Ok((
+        CohortKeyMaterial {
+            provider,
+            signer,
+            key_id: key_id.to_string(),
+        },
+        key_package,
+    ))
+}
+
+// ─── The group itself ───────────────────────────────────────────────
+
+/// Guarded per-cohort MLS state. All mutation runs under
+/// [`CohortGroup`]'s async mutex — see module docs § "Single writer".
+struct CohortGroupInner {
+    community_id: String,
+    provider: Arc<LibcruxProvider>,
+    signer: SignatureKeyPair,
+    group: MlsGroup,
+    store: ScopeStateProvider,
+    retained_epochs: u64,
+}
+
+impl CohortGroupInner {
+    /// Current epoch as a plain `u64`.
+    fn epoch(&self) -> u64 {
+        self.group.epoch().as_u64()
+    }
+
+    /// Snapshot the provider's storage map into a blob.
+    fn snapshot(&self) -> Result<Vec<u8>, CohortGroupError> {
+        let guard = self
+            .provider
+            .storage()
+            .values
+            .read()
+            // A poisoned lock here means some other thread panicked
+            // mid-write to openmls storage. The map is still a valid
+            // `HashMap` (openmls writes whole entries), so we recover
+            // the inner value rather than propagating a panic into an
+            // async task — a panic here would abort the commit AFTER
+            // the merge, which is exactly the unpersisted-epoch state
+            // this module exists to prevent.
+            .unwrap_or_else(PoisonError::into_inner);
+        encode_snapshot(&guard)
+    }
+
+    /// Persist the current (already-merged) epoch and only then seal
+    /// the wire artifacts into a [`CohortCommit`].
+    ///
+    /// **This is the ordering invariant** (CIRISEdge#499). Order of
+    /// operations, and why:
+    ///
+    /// 1. snapshot the merged state → write it under epoch N.
+    /// 2. move the head pointer to N. A crash between (1) and (2)
+    ///    leaves the head at N-1, whose snapshot is still retained;
+    ///    the group reloads at N-1 and can re-commit. A crash before
+    ///    (1) is likewise safe.
+    /// 3. prune outside the retention window (best-effort — see
+    ///    below).
+    /// 4. *Only now* construct the [`CohortCommit`] the caller will
+    ///    fan out.
+    ///
+    /// Pruning failures are logged, not propagated: the epoch is
+    /// already durable at that point, and failing the commit would
+    /// leave the caller thinking the epoch did not happen when it
+    /// did — the exact desync this ordering exists to prevent.
+    fn persist_and_seal(
+        &self,
+        commit: Vec<u8>,
+        welcome: Option<Vec<u8>>,
+    ) -> impl std::future::Future<Output = Result<CohortCommit, CohortGroupError>> + '_ {
+        let blob = self.snapshot();
+        async move {
+            let epoch = self.epoch();
+            if epoch == HEAD_SLOT {
+                return Err(CohortGroupError::EpochExhausted);
+            }
+            let blob = blob?;
+
+            // (1) snapshot first.
+            self.store
+                .group_state_put(&self.community_id, epoch, &blob)
+                .await?;
+            // (2) then the head pointer.
+            self.store
+                .group_state_put(&self.community_id, HEAD_SLOT, &encode_head(epoch))
+                .await?;
+            // (3) then prune, best-effort.
+            self.prune(epoch).await;
+
+            // (4) and only now are emittable bytes constructible.
+            Ok(CohortCommit {
+                epoch,
+                commit,
+                welcome,
+            })
+        }
+    }
+
+    /// Drop the snapshot that just fell out of the retention window.
+    ///
+    /// Epochs advance by exactly one per commit, so deleting the
+    /// single epoch `current - retained` on every commit keeps the
+    /// window bounded. A group that was reloaded from disk resumes
+    /// the same one-per-commit cadence, so no sweep loop is needed.
+    async fn prune(&self, current: u64) {
+        let Some(victim) = current.checked_sub(self.retained_epochs) else {
+            return;
+        };
+        if let Err(e) = self
+            .store
+            .group_state_delete(&self.community_id, victim)
+            .await
+        {
+            tracing::warn!(
+                community_id = %self.community_id,
+                epoch = victim,
+                error = %e,
+                "cohort MLS snapshot prune failed; retained epochs will exceed the window \
+                 (CIRISEdge#499). The current epoch IS durable — this is a storage-growth \
+                 concern, not a correctness one."
+            );
+        }
+    }
+
+    /// Derive this epoch's cohort exporter secret.
+    fn exporter(&self) -> Result<CohortSecret, CohortGroupError> {
+        let bytes = self
+            .group
+            .export_secret(
+                self.provider.crypto(),
+                COHORT_SECRET_LABEL,
+                // Context = the community id. The group id already
+                // commits to it (see `cohort_group_id`), so this is
+                // belt-and-braces: it means a snapshot restored under
+                // the WRONG community namespace produces a different
+                // secret rather than a silently-shared one.
+                self.community_id.as_bytes(),
+                COHORT_SECRET_LEN,
+            )
+            .map_err(|e| CohortGroupError::ExportFailed(format!("{e:?}")))?;
+        let raw: [u8; COHORT_SECRET_LEN] = bytes.try_into().map_err(|v: Vec<u8>| {
+            CohortGroupError::ExportFailed(format!(
+                "expected {COHORT_SECRET_LEN} bytes, got {}",
+                v.len()
+            ))
+        })?;
+        Ok(CohortSecret(raw))
+    }
+
+    /// Resolve a CIRIS `key_id` to its MLS leaf index.
+    fn leaf_of(&self, key_id: &str) -> Result<openmls::prelude::LeafNodeIndex, CohortGroupError> {
+        self.group
+            .members()
+            .find(|m| m.credential.serialized_content() == key_id.as_bytes())
+            .map(|m| m.index)
+            .ok_or_else(|| CohortGroupError::MemberNotFound(key_id.to_string()))
+    }
+}
+
+/// A persistent, per-cohort MLS group (CIRISEdge#499).
+///
+/// Cheap to clone; **clones share one async mutex**, which is what
+/// makes the single-writer invariant hold. Obtain handles through
+/// [`CohortGroups::open`] so two callers naming the same
+/// `community_id` get clones of the same handle rather than two
+/// independent groups.
+#[derive(Clone)]
+pub struct CohortGroup {
+    community_id: Arc<str>,
+    inner: Arc<Mutex<CohortGroupInner>>,
+}
+
+impl std::fmt::Debug for CohortGroup {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CohortGroup")
+            .field("community_id", &self.community_id)
+            .field("ciphersuite_id", &format_args!("0x{CIPHERSUITE_ID:04X}"))
+            // How many handles share this group's writer lock. >1 is
+            // normal and is the single-writer invariant working.
+            .field("handles", &Arc::strong_count(&self.inner))
+            .field("state", &"<locked>")
+            .finish_non_exhaustive()
+    }
+}
+
+impl CohortGroup {
+    /// The ciphersuite cohort groups are pinned to.
+    pub const fn ciphersuite_id() -> u16 {
+        CIPHERSUITE_ID
+    }
+
+    /// The community this group serves.
+    pub fn community_id(&self) -> &str {
+        &self.community_id
+    }
+
+    /// Create a brand-new cohort group with this node as the sole
+    /// initial member, and persist its epoch-0 state.
+    ///
+    /// The group's own [`SignatureKeyPair`] is minted **and stored in
+    /// the provider** before the group is built — that `store()` call
+    /// is what puts the private signing key into the storage map, and
+    /// therefore into the snapshot. Skip it and the group reloads
+    /// after a restart but can never commit again (CIRISEdge#499:
+    /// this is the restart round-trip the tests pin).
+    ///
+    /// `own_key_id` is the CIRIS federation `key_id` stamped into the
+    /// MLS `BasicCredential` identity, exactly as the A/V path does.
+    pub async fn create(
+        store: ScopeStateProvider,
+        community_id: &str,
+        own_key_id: &str,
+        retained_epochs: u64,
+    ) -> Result<Self, CohortGroupError> {
+        // Ciphersuite availability gate, before anything is minted.
+        if CIPHERSUITE_ID != 0x004D {
+            return Err(CohortGroupError::CiphersuiteNotAvailable);
+        }
+
+        let provider = Arc::new(LibcruxProvider::default());
+        let signer = SignatureKeyPair::new(SignatureScheme::ED25519)
+            .map_err(|e| CohortGroupError::CreateFailed(format!("own signature key: {e:?}")))?;
+        signer
+            .store(provider.storage())
+            .map_err(|e| CohortGroupError::CreateFailed(format!("store signature key: {e:?}")))?;
+
+        let cred_with_key = CredentialWithKey {
+            credential: BasicCredential::new(own_key_id.as_bytes().to_vec()).into(),
+            signature_key: signer.to_public_vec().into(),
+        };
+
+        let create_config = MlsGroupCreateConfig::builder()
+            .ciphersuite(CIPHERSUITE)
+            // The ratchet-tree extension is what lets a joiner
+            // reconstruct the tree from the Welcome alone; without it
+            // a restored group would need an out-of-band tree copy.
+            .use_ratchet_tree_extension(true)
+            .build();
+
+        let group = MlsGroup::new_with_group_id(
+            provider.as_ref(),
+            &signer,
+            &create_config,
+            cohort_group_id(community_id),
+            cred_with_key,
+        )
+        .map_err(|e| CohortGroupError::CreateFailed(format!("MlsGroup::new: {e:?}")))?;
+
+        let inner = CohortGroupInner {
+            community_id: community_id.to_string(),
+            provider,
+            signer,
+            group,
+            store,
+            retained_epochs: retained_epochs.max(1),
+        };
+
+        // Persist the genesis epoch before handing out a handle: a
+        // group that exists only in RAM is the same failure the
+        // ordering invariant guards against, just at epoch 0.
+        let epoch = inner.epoch();
+        let blob = inner.snapshot()?;
+        inner
+            .store
+            .group_state_put(&inner.community_id, epoch, &blob)
+            .await?;
+        inner
+            .store
+            .group_state_put(&inner.community_id, HEAD_SLOT, &encode_head(epoch))
+            .await?;
+
+        Ok(Self {
+            community_id: Arc::from(community_id),
+            inner: Arc::new(Mutex::new(inner)),
+        })
+    }
+
+    /// Reload a cohort group from the sealed KV, or `Ok(None)` if
+    /// this node has never created/joined one for `community_id`.
+    ///
+    /// Reconstruction is: head pointer → snapshot blob → storage map
+    /// → [`MlsGroup::load`] → [`SignatureKeyPair::read`] keyed by the
+    /// group's own leaf signature key. Every step is a pure storage
+    /// read; nothing is re-derived, so the reloaded group is
+    /// byte-identical to the one that was snapshotted.
+    ///
+    /// Fail-closed throughout: a dangling head, a missing group, or
+    /// an unrecoverable signer are all errors, never a silent
+    /// downgrade to an older epoch or a fresh group (a silently
+    /// rewound group re-uses epoch numbers its peers already
+    /// consumed).
+    pub async fn load(
+        store: ScopeStateProvider,
+        community_id: &str,
+        retained_epochs: u64,
+    ) -> Result<Option<Self>, CohortGroupError> {
+        let Some(head_raw) = store.group_state_get(community_id, HEAD_SLOT).await? else {
+            return Ok(None);
+        };
+        let epoch = decode_head(&head_raw)?;
+        let Some(blob) = store.group_state_get(community_id, epoch).await? else {
+            return Err(CohortGroupError::HeadDangling(epoch));
+        };
+        let map = decode_snapshot(&blob)?;
+
+        let provider = Arc::new(LibcruxProvider::default());
+        restore_storage(provider.storage(), map);
+
+        let group_id = cohort_group_id(community_id);
+        let group = MlsGroup::load(provider.storage(), &group_id)
+            .map_err(|e| CohortGroupError::ApplyFailed(format!("MlsGroup::load: {e:?}")))?
+            .ok_or_else(|| CohortGroupError::GroupMissing(community_id.to_string()))?;
+
+        // The own-leaf signature key is the lookup key for the stored
+        // SignatureKeyPair. It came out of the same snapshot, so if
+        // the group loaded but the signer did not, the snapshot is
+        // internally inconsistent — fatal, not degraded.
+        let own_sig_pub = group
+            .own_leaf_node()
+            .ok_or_else(|| CohortGroupError::SignerMissing(community_id.to_string()))?
+            .signature_key()
+            .as_slice()
+            .to_vec();
+        let signer =
+            SignatureKeyPair::read(provider.storage(), &own_sig_pub, SignatureScheme::ED25519)
+                .ok_or_else(|| CohortGroupError::SignerMissing(community_id.to_string()))?;
+
+        Ok(Some(Self {
+            community_id: Arc::from(community_id),
+            inner: Arc::new(Mutex::new(CohortGroupInner {
+                community_id: community_id.to_string(),
+                provider,
+                signer,
+                group,
+                store,
+                retained_epochs: retained_epochs.max(1),
+            })),
+        }))
+    }
+
+    /// The group's current epoch.
+    pub async fn epoch(&self) -> u64 {
+        self.inner.lock().await.epoch()
+    }
+
+    /// Number of members currently in the group (including self).
+    pub async fn member_count(&self) -> usize {
+        self.inner.lock().await.group.members().count()
+    }
+
+    /// The CIRIS `key_id`s of every member, in leaf order.
+    pub async fn member_key_ids(&self) -> Vec<String> {
+        self.inner
+            .lock()
+            .await
+            .group
+            .members()
+            .map(|m| String::from_utf8_lossy(m.credential.serialized_content()).into_owned())
+            .collect()
+    }
+
+    /// Whether the group is still operational (a removed member's
+    /// group goes inactive per RFC 9420).
+    pub async fn is_active(&self) -> bool {
+        self.inner.lock().await.group.is_active()
+    }
+
+    /// The current epoch's cohort exporter secret — the
+    /// `exporter_secret` the `community` / `affiliations` scopes need
+    /// (CIRISEdge#499).
+    ///
+    /// Derived under [`COHORT_SECRET_LABEL`], domain-separated from
+    /// the A/V media-key label, with the `community_id` as exporter
+    /// context.
+    pub async fn current_exporter(&self) -> Result<CohortSecret, CohortGroupError> {
+        self.inner.lock().await.exporter()
+    }
+
+    /// Add a member from a KeyPackage that member published, advance
+    /// the epoch, persist, and *then* return the wire artifacts.
+    ///
+    /// The KeyPackage's ciphersuite is checked **before** the roster
+    /// is touched so a mismatched member cannot leave the group in a
+    /// partially-advanced state.
+    pub async fn add_member(
+        &self,
+        key_id: &str,
+        key_package: KeyPackage,
+    ) -> Result<CohortCommit, CohortGroupError> {
+        let got = u16::from(key_package.ciphersuite());
+        if got != CIPHERSUITE_ID {
+            return Err(CohortGroupError::CiphersuiteMismatch {
+                key_id: key_id.to_string(),
+                got,
+            });
+        }
+
+        let mut guard = self.inner.lock().await;
+        // Reborrow through the guard so `group` / `provider` /
+        // `signer` are *disjoint* field borrows. Calling
+        // `guard.group.add_members(guard.provider…)` directly would
+        // borrow the whole `MutexGuard` twice via `DerefMut`.
+        let inner = &mut *guard;
+        let (commit_msg, welcome_msg, _group_info) = inner
+            .group
+            .add_members(inner.provider.as_ref(), &inner.signer, &[key_package])
+            .map_err(|e| CohortGroupError::AddFailed(format!("{e:?}")))?;
+        inner
+            .group
+            .merge_pending_commit(inner.provider.as_ref())
+            .map_err(|e| CohortGroupError::AddFailed(format!("merge_pending_commit: {e:?}")))?;
+
+        let commit = serialize_mls_message(&commit_msg)?;
+        let welcome = Some(serialize_mls_message(&welcome_msg)?);
+        inner.persist_and_seal(commit, welcome).await
+    }
+
+    /// Remove a member by CIRIS `key_id`, advance the epoch, persist,
+    /// and *then* return the wire artifacts.
+    pub async fn remove_member(&self, key_id: &str) -> Result<CohortCommit, CohortGroupError> {
+        let mut guard = self.inner.lock().await;
+        let idx = guard.leaf_of(key_id)?;
+        // Disjoint field borrows — see `add_member`.
+        let inner = &mut *guard;
+        let (commit_msg, welcome_msg, _group_info) = inner
+            .group
+            .remove_members(inner.provider.as_ref(), &inner.signer, &[idx])
+            .map_err(|e| CohortGroupError::RemoveFailed(format!("{e:?}")))?;
+        inner
+            .group
+            .merge_pending_commit(inner.provider.as_ref())
+            .map_err(|e| CohortGroupError::RemoveFailed(format!("merge_pending_commit: {e:?}")))?;
+
+        let commit = serialize_mls_message(&commit_msg)?;
+        let welcome = welcome_msg.map(|m| serialize_mls_message(&m)).transpose()?;
+        inner.persist_and_seal(commit, welcome).await
+    }
+
+    /// Rotate this node's own leaf (an MLS self-update commit),
+    /// advancing the epoch without a roster change.
+    ///
+    /// This is the forward-secrecy lever for a cohort: the exporter
+    /// secret changes, so records sealed under the old epoch's
+    /// `k_record_id` / `k_symbol` are not readable from the new
+    /// epoch's derivation, which is what §3.5 `rotate-forward` wants.
+    pub async fn rotate(&self) -> Result<CohortCommit, CohortGroupError> {
+        let mut guard = self.inner.lock().await;
+        // Disjoint field borrows — see `add_member`.
+        let inner = &mut *guard;
+        let bundle = inner
+            .group
+            .self_update(
+                inner.provider.as_ref(),
+                &inner.signer,
+                LeafNodeParameters::default(),
+            )
+            .map_err(|e| CohortGroupError::RotateFailed(format!("{e:?}")))?;
+        inner
+            .group
+            .merge_pending_commit(inner.provider.as_ref())
+            .map_err(|e| CohortGroupError::RotateFailed(format!("merge_pending_commit: {e:?}")))?;
+
+        let commit = serialize_mls_message(bundle.commit())?;
+        let welcome = bundle
+            .to_welcome_msg()
+            .map(|m| serialize_mls_message(&m))
+            .transpose()?;
+        inner.persist_and_seal(commit, welcome).await
+    }
+
+    /// Apply a Commit produced by another member, advance to its
+    /// epoch, and persist before returning.
+    ///
+    /// Same ordering discipline, for the same reason: an applied-
+    /// but-unpersisted remote commit means a restart rewinds this
+    /// node behind its cohort, and MLS gives it no way to catch up
+    /// without a fresh Welcome.
+    ///
+    /// Returns the new epoch.
+    pub async fn apply_remote_commit(&self, commit: &[u8]) -> Result<u64, CohortGroupError> {
+        let mut guard = self.inner.lock().await;
+        // Disjoint field borrows — see `add_member`.
+        let inner = &mut *guard;
+
+        let msg_in = MlsMessageIn::tls_deserialize(&mut &*commit)
+            .map_err(|e| CohortGroupError::WireDecodeFailed(format!("commit decode: {e:?}")))?;
+        let proto: ProtocolMessage = msg_in.try_into_protocol_message().map_err(|e| {
+            CohortGroupError::WireDecodeFailed(format!("not a protocol message: {e:?}"))
+        })?;
+
+        let processed = inner
+            .group
+            .process_message(inner.provider.as_ref(), proto)
+            .map_err(|e| CohortGroupError::ApplyFailed(format!("{e:?}")))?;
+
+        match processed.into_content() {
+            ProcessedMessageContent::StagedCommitMessage(staged) => {
+                inner
+                    .group
+                    .merge_staged_commit(inner.provider.as_ref(), *staged)
+                    .map_err(|e| CohortGroupError::ApplyFailed(format!("merge_staged: {e:?}")))?;
+            }
+            _ => return Err(CohortGroupError::NotACommit),
+        }
+
+        // Merge → persist, then report the epoch. There are no wire
+        // artifacts to seal here (we are the applier, not the
+        // committer), so the sealed value is discarded — but the
+        // persist still happens before the caller learns the epoch
+        // advanced.
+        let sealed = inner.persist_and_seal(Vec::new(), None).await?;
+        Ok(sealed.epoch())
+    }
+}
+
+/// Overwrite an openmls in-memory storage map wholesale.
+///
+/// `MemoryStorage::values` is a public `RwLock<HashMap<..>>`
+/// (openmls_memory_storage 0.5.0), which is precisely what makes the
+/// snapshot design possible without implementing the ~45-method
+/// synchronous `StorageProvider` over an async KV (CIRISEdge#217 —
+/// see module docs).
+fn restore_storage(storage: &MemStorage, map: HashMap<Vec<u8>, Vec<u8>>) {
+    let mut guard = storage
+        .values
+        .write()
+        .unwrap_or_else(PoisonError::into_inner);
+    *guard = map;
+}
+
+/// Serialize an `MlsMessageOut` to its on-wire bytes.
+fn serialize_mls_message(msg: &MlsMessageOut) -> Result<Vec<u8>, CohortGroupError> {
+    msg.tls_serialize_detached()
+        .map_err(|e| CohortGroupError::WireDecodeFailed(format!("serialize: {e:?}")))
+}
+
+// ─── Registry ───────────────────────────────────────────────────────
+
+/// Process-wide registry of live cohort groups, keyed by
+/// `community_id`.
+///
+/// # Why this exists
+///
+/// [`CohortGroup`]'s mutex only enforces single-writer for holders of
+/// the *same* handle. Two callers that each ran
+/// [`CohortGroup::load`] would hold two independent in-memory copies
+/// of one group and could commit concurrently — forking the epoch,
+/// which is the failure the async mutex was supposed to prevent. The
+/// registry closes that: [`Self::open`] is get-or-create, so every
+/// caller naming a `community_id` gets a clone of one handle.
+///
+/// Groups stay resident once opened (bounded by the number of
+/// communities the node participates in, not by traffic). A process
+/// restart is a fresh registry, which is exactly the reload path
+/// [`CohortGroup::load`] implements.
+pub struct CohortGroups {
+    store: ScopeStateProvider,
+    own_key_id: String,
+    retained_epochs: u64,
+    live: Mutex<HashMap<String, CohortGroup>>,
+}
+
+impl std::fmt::Debug for CohortGroups {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // `store` is deliberately not rendered: it is a handle on the
+        // XChaCha-sealed KV and nothing about it is safe or useful to
+        // print.
+        f.debug_struct("CohortGroups")
+            .field("own_key_id", &self.own_key_id)
+            .field("retained_epochs", &self.retained_epochs)
+            .field("live", &"<locked>")
+            .finish_non_exhaustive()
+    }
+}
+
+impl CohortGroups {
+    /// Build a registry over a sealed-KV-backed
+    /// [`ScopeStateProvider`]. `own_key_id` is this node's CIRIS
+    /// federation `key_id`, stamped into the MLS credential of any
+    /// group this registry creates.
+    pub fn new(store: ScopeStateProvider, own_key_id: impl Into<String>) -> Self {
+        Self::with_retention(store, own_key_id, DEFAULT_RETAINED_EPOCHS)
+    }
+
+    /// As [`Self::new`], with an explicit retention window (see
+    /// [`DEFAULT_RETAINED_EPOCHS`]).
+    pub fn with_retention(
+        store: ScopeStateProvider,
+        own_key_id: impl Into<String>,
+        retained_epochs: u64,
+    ) -> Self {
+        Self {
+            store,
+            own_key_id: own_key_id.into(),
+            retained_epochs: retained_epochs.max(1),
+            live: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get the live handle for `community_id`, reloading it from the
+    /// sealed KV if this process has not opened it yet, and creating
+    /// a fresh group if none has ever been persisted.
+    ///
+    /// Idempotent: repeated calls return clones of the same handle,
+    /// which is what makes the single-writer invariant hold across
+    /// independent call sites.
+    pub async fn open(&self, community_id: &str) -> Result<CohortGroup, CohortGroupError> {
+        let mut live = self.live.lock().await;
+        if let Some(existing) = live.get(community_id) {
+            return Ok(existing.clone());
+        }
+        let handle = match CohortGroup::load(self.store.clone(), community_id, self.retained_epochs)
+            .await?
+        {
+            Some(g) => g,
+            None => {
+                CohortGroup::create(
+                    self.store.clone(),
+                    community_id,
+                    &self.own_key_id,
+                    self.retained_epochs,
+                )
+                .await?
+            }
+        };
+        live.insert(community_id.to_string(), handle.clone());
+        Ok(handle)
+    }
+
+    /// Drop the in-memory handle for `community_id` without touching
+    /// its persisted state — the next [`Self::open`] reloads from the
+    /// KV. Used by tests to simulate a process restart; also useful
+    /// for shedding memory for a community the node has gone quiet
+    /// on.
+    pub async fn evict(&self, community_id: &str) -> bool {
+        self.live.lock().await.remove(community_id).is_some()
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::too_many_lines)]
+mod tests {
+    use super::*;
+    use ciris_persist::encrypted_kv::XChaChaKvStore;
+
+    fn open_store() -> ScopeStateProvider {
+        let kv = XChaChaKvStore::open_in_memory(b"cohort-group-test-passphrase").unwrap();
+        ScopeStateProvider::new(Arc::new(kv))
+    }
+
+    // ── Snapshot codec ──────────────────────────────────────────────
+
+    #[test]
+    fn snapshot_codec_roundtrips() {
+        let mut map = HashMap::new();
+        map.insert(b"alpha".to_vec(), b"one".to_vec());
+        map.insert(b"beta".to_vec(), vec![0u8; 300]);
+        map.insert(Vec::new(), Vec::new()); // empty key + empty value
+        let blob = encode_snapshot(&map).unwrap();
+        assert_eq!(decode_snapshot(&blob).unwrap(), map);
+    }
+
+    #[test]
+    fn snapshot_codec_roundtrips_empty_map() {
+        let map = HashMap::new();
+        let blob = encode_snapshot(&map).unwrap();
+        assert_eq!(decode_snapshot(&blob).unwrap(), map);
+    }
+
+    #[test]
+    fn snapshot_encoding_is_deterministic() {
+        // Two maps with identical content but built in different
+        // insertion orders must encode to identical bytes — the
+        // sorted-key emission. Keeps the sealed-KV write stable
+        // instead of churning under HashMap iteration order.
+        let mut a = HashMap::new();
+        a.insert(b"k1".to_vec(), b"v1".to_vec());
+        a.insert(b"k2".to_vec(), b"v2".to_vec());
+        a.insert(b"k3".to_vec(), b"v3".to_vec());
+        let mut b = HashMap::new();
+        b.insert(b"k3".to_vec(), b"v3".to_vec());
+        b.insert(b"k1".to_vec(), b"v1".to_vec());
+        b.insert(b"k2".to_vec(), b"v2".to_vec());
+        assert_eq!(encode_snapshot(&a).unwrap(), encode_snapshot(&b).unwrap());
+    }
+
+    #[test]
+    fn snapshot_version_byte_is_checked() {
+        // The whole point of the version byte: a future format change
+        // must be *detectable*, not a garbage load (CIRISEdge#499).
+        let mut map = HashMap::new();
+        map.insert(b"k".to_vec(), b"v".to_vec());
+        let mut blob = encode_snapshot(&map).unwrap();
+        blob[8] = 0xFE;
+        assert!(matches!(
+            decode_snapshot(&blob),
+            Err(CohortGroupError::SnapshotVersion(0xFE))
+        ));
+    }
+
+    #[test]
+    fn snapshot_magic_is_checked() {
+        let blob = vec![0u8; 32];
+        assert!(matches!(
+            decode_snapshot(&blob),
+            Err(CohortGroupError::SnapshotMagic)
+        ));
+    }
+
+    #[test]
+    fn snapshot_rejects_truncation_and_trailing_bytes() {
+        let mut map = HashMap::new();
+        map.insert(b"key".to_vec(), b"value".to_vec());
+        let blob = encode_snapshot(&map).unwrap();
+
+        let truncated = &blob[..blob.len() - 1];
+        assert!(matches!(
+            decode_snapshot(truncated),
+            Err(CohortGroupError::SnapshotMalformed(_))
+        ));
+
+        let mut extended = blob.clone();
+        extended.push(0xAA);
+        assert!(matches!(
+            decode_snapshot(&extended),
+            Err(CohortGroupError::SnapshotMalformed(_))
+        ));
+
+        assert!(matches!(
+            decode_snapshot(&blob[..4]),
+            Err(CohortGroupError::SnapshotMalformed(_))
+        ));
+    }
+
+    #[test]
+    fn snapshot_rejects_absurd_declared_lengths() {
+        // A declared count/length far beyond the blob must be a loud
+        // refusal, never an allocation sized from the wire.
+        let mut blob = Vec::new();
+        blob.extend_from_slice(SNAPSHOT_MAGIC);
+        blob.push(SNAPSHOT_VERSION);
+        blob.extend_from_slice(&u32::MAX.to_be_bytes());
+        assert!(matches!(
+            decode_snapshot(&blob),
+            Err(CohortGroupError::SnapshotMalformed(_))
+        ));
+
+        let mut blob = Vec::new();
+        blob.extend_from_slice(SNAPSHOT_MAGIC);
+        blob.push(SNAPSHOT_VERSION);
+        blob.extend_from_slice(&1u32.to_be_bytes());
+        blob.extend_from_slice(&u32::MAX.to_be_bytes()); // k_len
+        blob.extend_from_slice(&0u32.to_be_bytes()); // v_len
+        assert!(matches!(
+            decode_snapshot(&blob),
+            Err(CohortGroupError::SnapshotMalformed(_))
+        ));
+    }
+
+    #[test]
+    fn head_pointer_codec_roundtrips_and_is_versioned() {
+        for epoch in [0u64, 1, 42, u64::MAX - 1] {
+            assert_eq!(decode_head(&encode_head(epoch)).unwrap(), epoch);
+        }
+        let mut bad = encode_head(7);
+        bad[0] = 0x99;
+        assert!(matches!(
+            decode_head(&bad),
+            Err(CohortGroupError::HeadMalformed(_))
+        ));
+        assert!(matches!(
+            decode_head(&[0x01, 0x00]),
+            Err(CohortGroupError::HeadMalformed(_))
+        ));
+    }
+
+    #[test]
+    fn group_id_is_domain_separated_per_community() {
+        assert_ne!(cohort_group_id("a"), cohort_group_id("b"));
+        assert!(cohort_group_id("a")
+            .as_slice()
+            .starts_with(b"ciris-cohort:"));
+    }
+
+    // ── Create / exporter ───────────────────────────────────────────
+
+    #[tokio::test]
+    async fn create_persists_genesis_epoch() {
+        let store = open_store();
+        let g = CohortGroup::create(store.clone(), "community-1", "node-a", 4)
+            .await
+            .unwrap();
+        assert_eq!(g.epoch().await, 0);
+        assert_eq!(g.member_count().await, 1);
+        assert!(g.is_active().await);
+
+        // Genesis state is durable the moment `create` returns.
+        let head = store
+            .group_state_get("community-1", HEAD_SLOT)
+            .await
+            .unwrap()
+            .expect("head pointer written at create");
+        assert_eq!(decode_head(&head).unwrap(), 0);
+        assert!(store
+            .group_state_get("community-1", 0)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn exporter_is_stable_within_an_epoch_and_changes_across_epochs() {
+        let store = open_store();
+        let g = CohortGroup::create(store, "c-exp", "node-a", 4)
+            .await
+            .unwrap();
+        let s0 = g.current_exporter().await.unwrap();
+        let s0b = g.current_exporter().await.unwrap();
+        assert_eq!(s0.as_bytes(), s0b.as_bytes());
+
+        let _ = g.rotate().await.unwrap();
+        let s1 = g.current_exporter().await.unwrap();
+        assert_ne!(s0.as_bytes(), s1.as_bytes());
+    }
+
+    #[tokio::test]
+    async fn exporter_is_domain_separated_from_the_av_label() {
+        // The cohort label must NOT be the A/V one. Asserted on the
+        // constant (the A/V string is duplicated here rather than
+        // imported — `crate::transport::*` is off-limits for this
+        // workstream) and behaviourally: exporting the same group
+        // under the A/V label yields different bytes.
+        const AV_LABEL: &str = "ciris-realtime-av-epoch-dek-seed-v1";
+        assert_ne!(COHORT_SECRET_LABEL, AV_LABEL);
+
+        let store = open_store();
+        let g = CohortGroup::create(store, "c-label", "node-a", 4)
+            .await
+            .unwrap();
+        let cohort = g.current_exporter().await.unwrap();
+
+        let inner = g.inner.lock().await;
+        let av = inner
+            .group
+            .export_secret(inner.provider.crypto(), AV_LABEL, b"", 32)
+            .unwrap();
+        assert_ne!(cohort.as_bytes().as_slice(), av.as_slice());
+    }
+
+    #[test]
+    fn cohort_secret_debug_redacts() {
+        let s = CohortSecret([7u8; 32]);
+        let rendered = format!("{s:?}");
+        assert!(rendered.contains("redacted"), "{rendered}");
+        assert!(
+            !rendered.contains('7') || !rendered.contains("07"),
+            "{rendered}"
+        );
+    }
+
+    // ── THE ordering invariant ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn commit_is_durable_before_it_is_emitted() {
+        // merge → snapshot+persist → THEN emit. The observable
+        // contract: at the instant the caller holds the Commit bytes,
+        // the KV already carries that epoch's snapshot AND the head
+        // pointer already names it. If persistence happened after the
+        // emit, either check would fail here.
+        let store = open_store();
+        let g = CohortGroup::create(store.clone(), "c-order", "node-a", 8)
+            .await
+            .unwrap();
+
+        let (_m, kp) = mint_cohort_key_material("node-b").unwrap();
+        let artifacts = g.add_member("node-b", kp).await.unwrap();
+
+        assert_eq!(artifacts.epoch(), 1);
+        assert!(!artifacts.commit().is_empty());
+        assert!(artifacts.welcome().is_some());
+
+        let head = store
+            .group_state_get("c-order", HEAD_SLOT)
+            .await
+            .unwrap()
+            .expect("head pointer must already name the emitted epoch");
+        assert_eq!(decode_head(&head).unwrap(), artifacts.epoch());
+        assert!(
+            store
+                .group_state_get("c-order", artifacts.epoch())
+                .await
+                .unwrap()
+                .is_some(),
+            "the emitted epoch's snapshot must already be durable"
+        );
+    }
+
+    #[tokio::test]
+    async fn crash_after_emit_reloads_at_the_emitted_epoch() {
+        // The crash this ordering exists to survive: the process dies
+        // the instant after `add_member` returns. Peers are at the
+        // emitted epoch; so must we be, and we must still be able to
+        // commit.
+        let store = open_store();
+        let emitted_epoch = {
+            let g = CohortGroup::create(store.clone(), "c-crash", "node-a", 8)
+                .await
+                .unwrap();
+            let (_m, kp) = mint_cohort_key_material("node-b").unwrap();
+            let artifacts = g.add_member("node-b", kp).await.unwrap();
+            artifacts.epoch()
+            // `g` dropped here — the whole in-memory provider goes
+            // with it. Nothing but the sealed KV survives.
+        };
+
+        let reloaded = CohortGroup::load(store, "c-crash", 8)
+            .await
+            .unwrap()
+            .expect("group must reload after the crash");
+        assert_eq!(reloaded.epoch().await, emitted_epoch);
+        assert_eq!(reloaded.member_count().await, 2);
+
+        // And it can still commit — the property that would be lost
+        // if the epoch had been advertised before being persisted.
+        let after = reloaded.rotate().await.unwrap();
+        assert_eq!(after.epoch(), emitted_epoch + 1);
+    }
+
+    // ── Restart round-trip, incl. the signature key pair ────────────
+
+    #[tokio::test]
+    async fn signature_key_pair_survives_the_restart_roundtrip() {
+        // create → snapshot → drop → load → commit. The commit at the
+        // end is the real assertion: `MlsGroup::commit` needs the
+        // group's private signing key, so a signer that did not make
+        // it into (or out of) the snapshot fails HERE and nowhere
+        // earlier (CIRISEdge#499).
+        let store = open_store();
+        let (own_sig_pub, epoch_before) = {
+            let g = CohortGroup::create(store.clone(), "c-signer", "node-a", 8)
+                .await
+                .unwrap();
+            let inner = g.inner.lock().await;
+            let pk = inner
+                .group
+                .own_leaf_node()
+                .unwrap()
+                .signature_key()
+                .as_slice()
+                .to_vec();
+            (pk, inner.epoch())
+        };
+
+        let reloaded = CohortGroup::load(store, "c-signer", 8)
+            .await
+            .unwrap()
+            .expect("group must reload");
+        assert_eq!(reloaded.epoch().await, epoch_before);
+
+        // Same signing identity, not a freshly minted one.
+        {
+            let inner = reloaded.inner.lock().await;
+            assert_eq!(inner.signer.to_public_vec(), own_sig_pub);
+            assert_eq!(
+                inner
+                    .group
+                    .own_leaf_node()
+                    .unwrap()
+                    .signature_key()
+                    .as_slice(),
+                own_sig_pub.as_slice()
+            );
+        }
+
+        // The load-bearing part: it can still commit.
+        let artifacts = reloaded.rotate().await.unwrap();
+        assert_eq!(artifacts.epoch(), epoch_before + 1);
+
+        // …and add members after the restart.
+        let (_m, kp) = mint_cohort_key_material("node-b").unwrap();
+        let add = reloaded.add_member("node-b", kp).await.unwrap();
+        assert_eq!(add.epoch(), epoch_before + 2);
+        assert_eq!(reloaded.member_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn exporter_survives_the_restart_roundtrip() {
+        // The reason the whole module exists: the community scope's
+        // exporter_secret must be the SAME bytes after a restart, or
+        // every record sealed under it becomes unreadable.
+        let store = open_store();
+        let before = {
+            let g = CohortGroup::create(store.clone(), "c-exp-rt", "node-a", 8)
+                .await
+                .unwrap();
+            *g.current_exporter().await.unwrap().as_bytes()
+        };
+        let reloaded = CohortGroup::load(store, "c-exp-rt", 8)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            *reloaded.current_exporter().await.unwrap().as_bytes(),
+            before
+        );
+    }
+
+    #[tokio::test]
+    async fn load_returns_none_for_an_unknown_community() {
+        let store = open_store();
+        assert!(CohortGroup::load(store, "never-created", 4)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn load_fails_closed_on_a_dangling_head() {
+        // A head pointing at a pruned/lost epoch must NOT silently
+        // rewind to an older snapshot: a rewound group re-uses epoch
+        // numbers its peers already consumed.
+        let store = open_store();
+        let g = CohortGroup::create(store.clone(), "c-dangle", "node-a", 8)
+            .await
+            .unwrap();
+        let _ = g.rotate().await.unwrap();
+        store.group_state_delete("c-dangle", 1).await.unwrap();
+
+        assert!(matches!(
+            CohortGroup::load(store, "c-dangle", 8).await,
+            Err(CohortGroupError::HeadDangling(1))
+        ));
+    }
+
+    // ── Roster ops ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn add_then_remove_advances_and_persists_each_epoch() {
+        let store = open_store();
+        let g = CohortGroup::create(store.clone(), "c-roster", "node-a", 16)
+            .await
+            .unwrap();
+
+        let (_m, kp) = mint_cohort_key_material("node-b").unwrap();
+        assert_eq!(g.add_member("node-b", kp).await.unwrap().epoch(), 1);
+        assert_eq!(g.member_count().await, 2);
+        let ids = g.member_key_ids().await;
+        assert!(ids.contains(&"node-a".to_string()));
+        assert!(ids.contains(&"node-b".to_string()));
+
+        let removed = g.remove_member("node-b").await.unwrap();
+        assert_eq!(removed.epoch(), 2);
+        assert_eq!(g.member_count().await, 1);
+        assert!(removed.welcome().is_none());
+
+        // Every epoch along the way is durable.
+        for epoch in 0..=2u64 {
+            assert!(
+                store
+                    .group_state_get("c-roster", epoch)
+                    .await
+                    .unwrap()
+                    .is_some(),
+                "epoch {epoch} snapshot missing"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn remove_of_an_unknown_member_leaves_the_epoch_untouched() {
+        let store = open_store();
+        let g = CohortGroup::create(store, "c-missing", "node-a", 4)
+            .await
+            .unwrap();
+        assert!(matches!(
+            g.remove_member("ghost").await,
+            Err(CohortGroupError::MemberNotFound(_))
+        ));
+        assert_eq!(g.epoch().await, 0);
+    }
+
+    #[tokio::test]
+    async fn add_member_refuses_a_mismatched_ciphersuite_without_advancing() {
+        // Refused BEFORE the roster is touched, so a bad member
+        // cannot leave the group partially advanced.
+        let store = open_store();
+        let g = CohortGroup::create(store, "c-suite", "node-a", 4)
+            .await
+            .unwrap();
+
+        let provider = LibcruxProvider::default();
+        let signer = SignatureKeyPair::new(SignatureScheme::ED25519).unwrap();
+        signer.store(provider.storage()).unwrap();
+        let cred = CredentialWithKey {
+            credential: BasicCredential::new(b"node-classical".to_vec()).into(),
+            signature_key: signer.to_public_vec().into(),
+        };
+        let bundle: KeyPackageBundle = KeyPackage::builder()
+            .build(
+                Ciphersuite::MLS_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+                &provider,
+                &signer,
+                cred,
+            )
+            .unwrap();
+
+        let err = g
+            .add_member("node-classical", bundle.key_package().clone())
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            CohortGroupError::CiphersuiteMismatch { got, .. } if got != CIPHERSUITE_ID
+        ));
+        assert_eq!(g.epoch().await, 0);
+    }
+
+    #[tokio::test]
+    async fn rotate_advances_the_epoch_without_a_roster_change() {
+        let store = open_store();
+        let g = CohortGroup::create(store, "c-rot", "node-a", 4)
+            .await
+            .unwrap();
+        let before = g.member_count().await;
+        let r = g.rotate().await.unwrap();
+        assert_eq!(r.epoch(), 1);
+        assert_eq!(g.member_count().await, before);
+        assert!(r.welcome().is_none());
+    }
+
+    #[tokio::test]
+    async fn apply_remote_commit_rejects_non_commit_bytes() {
+        let store = open_store();
+        let g = CohortGroup::create(store, "c-remote", "node-a", 4)
+            .await
+            .unwrap();
+        assert!(matches!(
+            g.apply_remote_commit(&[0u8; 12]).await,
+            Err(CohortGroupError::WireDecodeFailed(_))
+        ));
+        assert_eq!(g.epoch().await, 0);
+    }
+
+    #[tokio::test]
+    async fn apply_remote_commit_persists_before_reporting_the_epoch() {
+        // Second member joins via Welcome so it holds a real remote
+        // group, then the first member's rotate Commit is applied by
+        // the second. Uses `openmls`'s Welcome path directly (the
+        // cohort surface does not expose join in this cut).
+        use openmls::prelude::{MlsGroupJoinConfig, MlsMessageBodyIn, StagedWelcome};
+
+        // Two nodes, ONE community, two independent local sealed
+        // stores — the real deployment shape. (Sharing a store would
+        // have both nodes clobbering the same
+        // `mls/{community}/group_state` head pointer.)
+        let store_a = open_store();
+        let store_b = open_store();
+        let a = CohortGroup::create(store_a, "c-apply", "node-a", 16)
+            .await
+            .unwrap();
+        let (material, kp) = mint_cohort_key_material("node-b").unwrap();
+        let add = a.add_member("node-b", kp).await.unwrap();
+
+        // Build node-b's group from the Welcome.
+        let msg_in = MlsMessageIn::tls_deserialize(&mut add.welcome().unwrap()).unwrap();
+        let MlsMessageBodyIn::Welcome(welcome) = msg_in.extract() else {
+            panic!("expected a Welcome body");
+        };
+        let join_config = MlsGroupJoinConfig::builder()
+            .use_ratchet_tree_extension(true)
+            .build();
+        let staged = StagedWelcome::new_from_welcome(
+            material.provider.as_ref(),
+            &join_config,
+            welcome,
+            None,
+        )
+        .unwrap();
+        let b_group = staged.into_group(material.provider.as_ref()).unwrap();
+
+        // Wrap node-b's joined group in a cohort handle over its own
+        // local store so the apply path persists. (This module does
+        // not expose a join verb in this cut — that is the Welcome
+        // path's workstream — so the handle is assembled directly.)
+        let b = CohortGroup {
+            community_id: Arc::from("c-apply"),
+            inner: Arc::new(Mutex::new(CohortGroupInner {
+                community_id: "c-apply".to_string(),
+                provider: material.provider.clone(),
+                signer: material.signer,
+                group: b_group,
+                store: store_b.clone(),
+                retained_epochs: 16,
+            })),
+        };
+        assert_eq!(b.epoch().await, add.epoch());
+
+        let rotate = a.rotate().await.unwrap();
+        let new_epoch = b.apply_remote_commit(rotate.commit()).await.unwrap();
+        assert_eq!(new_epoch, rotate.epoch());
+
+        // Durable at the instant the epoch is reported.
+        let head = store_b
+            .group_state_get("c-apply", HEAD_SLOT)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(decode_head(&head).unwrap(), new_epoch);
+
+        // Both sides derive the same exporter for the same epoch —
+        // the property that makes a cohort secret a *shared* secret.
+        let shared = *a.current_exporter().await.unwrap().as_bytes();
+        assert_eq!(*b.current_exporter().await.unwrap().as_bytes(), shared);
+
+        // …and node-b's applied epoch survives a restart, exporter
+        // included. A Welcome-joined group persists exactly like a
+        // created one because `mint_cohort_key_material` stored the
+        // signer in the same provider the snapshot captures.
+        drop(b);
+        let b_reloaded = CohortGroup::load(store_b, "c-apply", 16)
+            .await
+            .unwrap()
+            .expect("joined group must reload");
+        assert_eq!(b_reloaded.epoch().await, new_epoch);
+        assert_eq!(
+            *b_reloaded.current_exporter().await.unwrap().as_bytes(),
+            shared
+        );
+    }
+
+    // ── Retention bound ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn retained_epochs_are_bounded() {
+        // The snapshot rewrites the whole blob per commit, so without
+        // a bound the sealed KV grows one full copy of group state
+        // per commit, forever.
+        let store = open_store();
+        let retain = 3u64;
+        let g = CohortGroup::create(store.clone(), "c-prune", "node-a", retain)
+            .await
+            .unwrap();
+        for _ in 0..6 {
+            let _ = g.rotate().await.unwrap();
+        }
+        let head_epoch = g.epoch().await;
+        assert_eq!(head_epoch, 6);
+
+        for epoch in 0..=head_epoch {
+            let present = store
+                .group_state_get("c-prune", epoch)
+                .await
+                .unwrap()
+                .is_some();
+            if epoch + retain <= head_epoch {
+                assert!(!present, "epoch {epoch} should have been pruned");
+            } else {
+                assert!(present, "epoch {epoch} should still be retained");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn retention_of_zero_is_clamped_to_one() {
+        // A zero window would delete the epoch it just wrote.
+        let store = open_store();
+        let g = CohortGroup::create(store.clone(), "c-zero", "node-a", 0)
+            .await
+            .unwrap();
+        let _ = g.rotate().await.unwrap();
+        assert!(store
+            .group_state_get("c-zero", g.epoch().await)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    // ── Single-writer ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn registry_hands_out_one_handle_per_community() {
+        // Two independent `open` calls must share one mutex, or
+        // concurrent commits fork the epoch.
+        let store = open_store();
+        let groups = CohortGroups::new(store, "node-a");
+        let g1 = groups.open("c-reg").await.unwrap();
+        let g2 = groups.open("c-reg").await.unwrap();
+        assert!(Arc::ptr_eq(&g1.inner, &g2.inner));
+
+        let other = groups.open("c-other").await.unwrap();
+        assert!(!Arc::ptr_eq(&g1.inner, &other.inner));
+    }
+
+    #[tokio::test]
+    async fn concurrent_commits_serialize_instead_of_forking_the_epoch() {
+        // N concurrent rotates through clones of one handle must
+        // produce N distinct, contiguous epochs. A forked epoch shows
+        // up as a duplicate.
+        let store = open_store();
+        let groups = CohortGroups::with_retention(store, "node-a", 64);
+        let g = groups.open("c-race").await.unwrap();
+
+        let mut tasks = Vec::new();
+        for _ in 0..8 {
+            let handle = g.clone();
+            tasks.push(tokio::spawn(async move { handle.rotate().await }));
+        }
+        let mut epochs = Vec::new();
+        for t in tasks {
+            epochs.push(t.await.unwrap().unwrap().epoch());
+        }
+        epochs.sort_unstable();
+        assert_eq!(epochs, (1..=8u64).collect::<Vec<_>>());
+        assert_eq!(g.epoch().await, 8);
+    }
+
+    #[tokio::test]
+    async fn registry_reloads_after_eviction_instead_of_re_creating() {
+        // Eviction models a process restart: the next `open` must
+        // reload the persisted group (same epoch, same exporter), not
+        // mint a fresh one.
+        let store = open_store();
+        let groups = CohortGroups::with_retention(store, "node-a", 8);
+        let g = groups.open("c-evict").await.unwrap();
+        let _ = g.rotate().await.unwrap();
+        let epoch = g.epoch().await;
+        let secret = *g.current_exporter().await.unwrap().as_bytes();
+        drop(g);
+
+        assert!(groups.evict("c-evict").await);
+        let back = groups.open("c-evict").await.unwrap();
+        assert_eq!(back.epoch().await, epoch);
+        assert_eq!(*back.current_exporter().await.unwrap().as_bytes(), secret);
+    }
+
+    #[tokio::test]
+    async fn per_community_state_is_isolated() {
+        let store = open_store();
+        let groups = CohortGroups::new(store, "node-a");
+        let a = groups.open("comm-a").await.unwrap();
+        let b = groups.open("comm-b").await.unwrap();
+        let _ = a.rotate().await.unwrap();
+        assert_eq!(a.epoch().await, 1);
+        assert_eq!(b.epoch().await, 0);
+        assert_ne!(
+            a.current_exporter().await.unwrap().as_bytes(),
+            b.current_exporter().await.unwrap().as_bytes()
+        );
+    }
+}

--- a/src/mls/mod.rs
+++ b/src/mls/mod.rs
@@ -23,14 +23,22 @@
 //! │  ├── welcome_wrap      — §3.3 HPKE-Base + ML-DSA-65 Welcome │
 //! │  ├── scope_state       — substrate-tier StorageProvider     │
 //! │  │                      (openmls 0.8) over EncryptedKVStore │
+//! │  ├── cohort_group      — persistent per-cohort MLS group    │
+//! │  │                      (CIRISEdge#499): real exporter_     │
+//! │  │                      secret for community/affiliations,  │
+//! │  │                      snapshot-persisted into scope_state │
 //! └─────────────────────────────────────────────────────────────┘
 //! ```
 
 pub mod archive_mode;
+pub mod cohort_group;
 pub mod scope_state;
 pub mod welcome_wrap;
 
 pub use archive_mode::{ArchiveMode, ArchiveModeError, DEFAULT_ROTATE_FORWARD_WINDOW_DAYS};
+pub use cohort_group::{
+    CohortCommit, CohortGroup, CohortGroupError, CohortGroups, CohortSecret, COHORT_SECRET_LABEL,
+};
 pub use scope_state::{ScopeStateProvider, ScopeStateProviderError};
 pub use welcome_wrap::{
     unwrap_welcome, wrap_welcome, FederationDirectoryEntry, WelcomeWrapError, WrappedWelcome,

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -311,6 +311,31 @@ pub enum WithholdReason {
     /// quarantined, and folding it into [`Self::QuarantinedAuthor`] would send
     /// the operator to review a marker that does not exist.
     QuarantineReadError,
+    /// Workstream F — an `accord:*` row was withheld because this node holds no
+    /// FAMILY under the accord root, so persist's
+    /// [`RelayVerdict`](ciris_persist::federation::trust_root::RelayVerdict)
+    /// reported `roster_resolvable: false`: **"I cannot judge"**. Its own
+    /// variant, never folded into [`Self::AccordRelaySignerNotSeated`] — an
+    /// unjudgeable root and an unseated signer are different things to go fix
+    /// (sync the family record vs. look at the signer), and CIRISPersist#713
+    /// wrote a mutation specifically to keep them apart.
+    AccordRelayRosterUnresolvable,
+    /// Workstream F — the accord roster resolved and the row's
+    /// `attesting_key_id` holds no live seat on it (revocation-folded).
+    /// Trusting a root does not make every key naming it authoritative.
+    AccordRelaySignerNotSeated,
+    /// Workstream F — no live `delegates_to(self → accord root)`: this node
+    /// never granted the root, or has cut the edge. CC 4.2.1 — *"a node that
+    /// never trusted the accord … is simply not reached"*. This is the leg the
+    /// `accord:*` `Global` projection row runs over on its own, and the reason
+    /// the relay predicate exists.
+    AccordRelayNoTrustEdge,
+    /// Workstream F — the relay verdict was NOT RESOLVED (never primed, expired,
+    /// or invalidated and not yet re-resolved), so the sync serve gate refused
+    /// fail-closed. Deliberately distinct from every decided refusal above: this
+    /// says *"we never ran the check"*, which is a wiring/timing fact, not a
+    /// statement about the signer or the root.
+    AccordRelayUnresolved,
 }
 
 impl WithholdReason {
@@ -333,6 +358,10 @@ impl WithholdReason {
             Self::ConfigPaused => "config_paused",
             Self::QuarantinedAuthor => "quarantined_author",
             Self::QuarantineReadError => "quarantine_read_error",
+            Self::AccordRelayRosterUnresolvable => "accord_relay_roster_unresolvable",
+            Self::AccordRelaySignerNotSeated => "accord_relay_signer_not_seated",
+            Self::AccordRelayNoTrustEdge => "accord_relay_no_trust_edge",
+            Self::AccordRelayUnresolved => "accord_relay_unresolved",
         }
     }
 }

--- a/src/replication/accord_relay_gate.rs
+++ b/src/replication/accord_relay_gate.rs
@@ -1,0 +1,906 @@
+//! CIRISEdge workstream F — the fail-closed **accord relay gate**: may THIS
+//! node carry a given `accord:*` object?
+//!
+//! ## Projection decides who may HOLD; relay decides who may CARRY
+//!
+//! `accord:*` resolves [`Projection::Global`](ciris_persist::federation::namespace::Projection)
+//! at every commons tier (CIRISPersist v36.2.0 / #713) and that row is
+//! **correct for carriage**: an accord act is not a single emission but m-of-n
+//! over a live roster, assembled by partial-quorum objects replicating until
+//! they meet. A partial is emitted PRE-AUTHORITY, and the roster's cohort span
+//! is not knowable at emit time, so any narrower projection is a bootstrap
+//! paradox — the object would need quorum to project widely and need to project
+//! widely to reach quorum.
+//!
+//! Global would be wrong as **reach**. CC 4.2.1 ("Reach is consent-scoped") is
+//! explicit that a node *"that never trusted the accord, or has already cut the
+//! edge, is simply not reached."* The projection row alone therefore
+//! over-delivers, and **this predicate is what narrows carriage back to exactly
+//! that set.**
+//!
+//! ## Zero trust logic here
+//!
+//! The whole verdict is persist's
+//! [`may_relay_accord_object`] — seated signer AND a live
+//! `delegates_to(self → root)`. This module resolves, caches, and enforces; it
+//! decides nothing. It does not re-derive seating, roster membership, or edge
+//! existence, and the family classification of a dimension is persist's
+//! [`attestation_family`](ciris_persist::federation::namespace::attestation_family)
+//! (the same fold `attestation_requires_serve` took in v17.7.0), never an
+//! edge-side `"accord:"` prefix match.
+//!
+//! ## The three-way verdict is kept three-way
+//!
+//! [`RelayVerdict`] is typed rather than a bool because `roster_resolvable` /
+//! `signer_seated` / `edge_exists` are three different situations, and persist
+//! wrote a mutation specifically to prove *"I cannot judge"* never collapses
+//! into *"not seated"*. [`RelayRefusal`] preserves that split on edge's side:
+//! the attribution order below reads `roster_resolvable` FIRST, because a
+//! `None` roster also leaves `signer_seated == false`, so a seated-first reading
+//! would report an unjudgeable root as an unseated signer — the exact collapse.
+//!
+//! ## Async resolver, sync gate (CIRISEdge#217)
+//!
+//! [`may_relay_accord_object`] is `async`; the replication serve path
+//! ([`crate::replication::session`]) is synchronous, and the per-record serve
+//! gate it reaches through `fetch_envelope` runs once PER ENVELOPE inside a
+//! round's reply assembly — the shape that produced CIRISEdge#400 (a per-
+//! envelope directory read blew the round budget outright). So this follows the
+//! established edge pattern, the same one CIRISEdge#430's
+//! [`TransitGate`](crate::transport::realtime_av_alm::transit_gate::TransitGate)
+//! uses: **resolve async ONCE, cache the verdict with a validity bound,
+//! invalidate on the apply path, and gate on a PURE SYNC predicate**
+//! ([`AccordRelayGate::decide`] — no I/O, no `.await`, no `tokio::time`; the
+//! freshness bound is a monotonic [`std::time::Instant`], and no lock is ever
+//! held across an await).
+//!
+//! ## Fail CLOSED, in every direction
+//!
+//! A cache miss, an expired entry, an invalidated entry, a resolver error, an
+//! absent directory, an absent local identity, and `roster_resolvable == false`
+//! all refuse. [`RelayRefusal::Unresolved`] is deliberately distinct from every
+//! decided refusal, so a refusal *because we never ran the predicate* can never
+//! be read as a refusal *because we decided* — the distinction a fail-safe
+//! default otherwise hides.
+//!
+//! ## Deliberately NOT here: whether this node is BOUND by a halt
+//!
+//! CC 4.2.1 pins binding against the edge set at the invocation's `asserted_at`
+//! (*"exit is prospective, never retroactive"*), while relay reads LIVE state:
+//! cutting an edge stops carriage immediately and leaves you bound by a halt
+//! already invoked. One name, two clocks — fusing them would be an axis fusion.
+//! If a "bound by a halt" question ever lands in edge it needs its own resolver
+//! and its own cache keyed at the invocation instant; it must not ride this one.
+//!
+//! ## Scope: `accord:*` only
+//!
+//! `objection:*` — the reserved-prefix sibling — deliberately stays on the
+//! conservative projection row: the co-scrub-assembly argument covers `accord:`
+//! only (CIRISPersist#713, the `provenance:build_manifest:` / `provenance:`
+//! precedent). Do not extend this gate to it.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use ciris_persist::federation::namespace::{attestation_family, AttestationFamily};
+use ciris_persist::federation::trust_root::{may_relay_accord_object, RelayVerdict};
+use ciris_persist::federation::FederationDirectory;
+
+/// How long one resolved [`RelayVerdict`] stays usable before the gate
+/// re-resolves it.
+///
+/// Sized off the same reasoning as
+/// [`CONSENT_SEND_SET_MEMO_TTL`](crate::replication::bridge) (10 s): long
+/// enough that a round's advertise sweep plus its N per-envelope serve gates
+/// share ONE resolution, short enough to sit well under the 30 s anti-entropy
+/// cadence, so a change nobody sent us an invalidation event for still takes
+/// effect by the next round.
+///
+/// Applied to grants AND refusals alike. A stale *grant* is the
+/// security-relevant direction and is what bounds the window; a stale *refusal*
+/// is fail-closed but must not be unbounded either — caching a refusal forever
+/// would pin a node dark across the very event that fixes it (a seat landing,
+/// our own trust edge being granted), which is CIRISEdge#430's
+/// `NEGATIVE_VERDICT_TTL` lesson. One bound covers both, so there is no
+/// asymmetry to justify or to drift.
+pub const RELAY_VERDICT_TTL: Duration = Duration::from_secs(10);
+
+/// Why a relay was refused. Every variant is ONE branch, never a disjunction —
+/// the [`WithholdReason`](crate::observability::WithholdReason) discipline: an
+/// operator must be able to tell "I cannot judge" from "the signer is not
+/// seated" from "we never ran the check", because each is a different thing to
+/// go fix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayRefusal {
+    /// persist could not resolve the root's roster at all
+    /// ([`RelayVerdict::roster_resolvable`] `== false`) — this node holds no
+    /// family under that root. **"I cannot judge", NOT "the signer is not
+    /// seated"**, and it refuses. Remedy: sync the root's family record.
+    RosterUnresolvable,
+    /// The roster resolved and `signer_key_id` holds no live seat on it
+    /// (revocation-folded). Trusting a root does not make every key naming it
+    /// authoritative.
+    SignerNotSeated,
+    /// No live `delegates_to(self → root)`: this node never granted the root,
+    /// or has cut the edge. CC 4.2.1 — *"simply not reached"*. This is the leg
+    /// a bare `Global` projection runs straight over.
+    NoTrustEdge,
+    /// **We never ran the predicate**: no verdict is cached for this signer, or
+    /// the cached one expired / was invalidated, and the sync gate cannot
+    /// resolve. Deliberately distinct from every decided refusal above — a
+    /// refusal that reports itself as unresolved is the one an operator can act
+    /// on, and it keeps a green test from proving nothing when the surrounding
+    /// default already refuses.
+    Unresolved,
+    /// The gate has no `self_key_id`, so there is no "I" whose
+    /// `delegates_to(self → root)` could exist. A WIRING fault
+    /// (`ReplicationRuntimeConfig::local_key_id`), not a policy decision.
+    NoLocalIdentity,
+}
+
+impl RelayRefusal {
+    /// Snake-case stable label — the `detail` string the withhold ledger
+    /// carries, and what a log line joins on.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RosterUnresolvable => "roster_unresolvable",
+            Self::SignerNotSeated => "signer_not_seated",
+            Self::NoTrustEdge => "no_trust_edge",
+            Self::Unresolved => "unresolved",
+            Self::NoLocalIdentity => "no_local_identity",
+        }
+    }
+}
+
+impl std::fmt::Display for RelayRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// The gate's answer for one `accord:*` object. `#[must_use]` for the same
+/// reason [`ApplyOutcome`](crate::replication::summary::ApplyOutcome) is: a
+/// refusal carries a reason a caller must surface, and dropping it on the floor
+/// is how a refusal becomes a silent drop (CIRISEdge#425).
+#[must_use = "a relay decision carries a refusal reason the serve gate must book — do not drop it"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelayDecision {
+    /// persist's [`RelayVerdict::may_relay`] held: carry it.
+    Relay,
+    /// Refused, with the leg that refused.
+    Refused(RelayRefusal),
+}
+
+impl RelayDecision {
+    /// May the object be carried? Convenience for call sites that have already
+    /// booked the refusal.
+    #[must_use]
+    pub fn may_relay(self) -> bool {
+        matches!(self, Self::Relay)
+    }
+
+    /// The refusal leg, if this is a refusal.
+    #[must_use]
+    pub fn refusal(self) -> Option<RelayRefusal> {
+        match self {
+            Self::Relay => None,
+            Self::Refused(r) => Some(r),
+        }
+    }
+}
+
+/// Map persist's typed verdict onto a decision.
+///
+/// **The ALLOW is persist's own [`RelayVerdict::may_relay`]**, never a
+/// conjunction re-spelled here — a second spelling of the relay rule is exactly
+/// the two-owners-for-one-fact error this whole module exists to avoid. The
+/// legs below are pure ATTRIBUTION of a refusal persist already made, and their
+/// order is load-bearing: `roster_resolvable` first, because an unresolvable
+/// roster also leaves `signer_seated == false`, and reporting that as
+/// "not seated" is the collapse CIRISPersist#713 wrote a mutation to forbid.
+fn decision_of(verdict: RelayVerdict) -> RelayDecision {
+    if verdict.may_relay() {
+        return RelayDecision::Relay;
+    }
+    if !verdict.roster_resolvable {
+        return RelayDecision::Refused(RelayRefusal::RosterUnresolvable);
+    }
+    if !verdict.signer_seated {
+        return RelayDecision::Refused(RelayRefusal::SignerNotSeated);
+    }
+    RelayDecision::Refused(RelayRefusal::NoTrustEdge)
+}
+
+/// One cached verdict for one signer, under this gate's root.
+#[derive(Debug, Clone, Copy)]
+struct CachedVerdict {
+    verdict: RelayVerdict,
+    /// Monotonic instant of resolution ([`Instant`], never `tokio::time` —
+    /// CIRISEdge#217: this rides a replication/transport path that can run on
+    /// persist's runtime thread).
+    fetched_at: Instant,
+}
+
+/// The pure, directory-free verdict cache. Split out from [`AccordRelayGate`]
+/// so the freshness / invalidation / fail-closed rules are unit-testable
+/// without a trust fixture (resolution correctness is persist's, tested there).
+#[derive(Debug, Default)]
+struct VerdictCache {
+    /// Bumped by EVERY invalidation. An in-flight resolve snapshots it at the
+    /// miss and commits only if it is unchanged — see [`Self::commit`].
+    generation: u64,
+    by_signer: HashMap<String, CachedVerdict>,
+}
+
+impl VerdictCache {
+    /// The cached verdict for `signer` iff a FRESH one exists. `None` means
+    /// "no usable verdict", which the sync gate turns into
+    /// [`RelayRefusal::Unresolved`] — never into an allow.
+    fn get_fresh(&self, signer: &str, now: Instant) -> Option<RelayVerdict> {
+        let entry = self.by_signer.get(signer)?;
+        (now.saturating_duration_since(entry.fetched_at) < RELAY_VERDICT_TTL)
+            .then_some(entry.verdict)
+    }
+
+    /// Commit a freshly-resolved verdict — but ONLY if no invalidation raced
+    /// the resolve (`generation` unchanged since the miss snapshot).
+    ///
+    /// This is the CIRISEdge#482 review finding, hardened into this cache from
+    /// the start: without the generation check, an invalidation landing DURING
+    /// an in-flight `.await` is clobbered by the pre-mutation verdict re-armed
+    /// with a fresh timestamp, and the "visible to the very next call"
+    /// guarantee silently stops holding. Every invalidation bumps the
+    /// generation (targeted removals included), so a dropped commit is the
+    /// conservative outcome in every race: the next call re-resolves against
+    /// live state. Two concurrent misses with NO interleaved invalidation still
+    /// race benignly — they write the same answer.
+    fn commit(&mut self, signer: &str, verdict: RelayVerdict, gen_at_miss: u64, now: Instant) {
+        if self.generation != gen_at_miss {
+            return;
+        }
+        // Bound memory: a departed signer must not accumulate. The live set is
+        // naturally roster-sized, but the key is peer-supplied (the row's
+        // `attesting_key_id`), so an unbounded map would be a cheap DoS.
+        self.by_signer
+            .retain(|_, v| now.saturating_duration_since(v.fetched_at) < RELAY_VERDICT_TTL);
+        self.by_signer.insert(
+            signer.to_owned(),
+            CachedVerdict {
+                verdict,
+                fetched_at: now,
+            },
+        );
+    }
+
+    /// Drop every entry a state change naming `key_id` could falsify: the
+    /// signer whose verdict it is. A change naming the ROOT falsifies every
+    /// entry (both legs are root-relative), so the caller widens that to
+    /// [`Self::invalidate_all`].
+    ///
+    /// Bumps the generation unconditionally — including when nothing matched —
+    /// so an in-flight resolve started before this call can never commit over
+    /// it.
+    fn invalidate(&mut self, key_id: &str) {
+        self.generation = self.generation.wrapping_add(1);
+        self.by_signer.remove(key_id);
+    }
+
+    /// Drop everything (a root-relative change, or a coarse "trust state moved"
+    /// signal). Bumps the generation for the same reason.
+    fn invalidate_all(&mut self) {
+        self.generation = self.generation.wrapping_add(1);
+        self.by_signer.clear();
+    }
+}
+
+/// The `accord:*` relay gate (workstream F). Wraps persist's
+/// [`may_relay_accord_object`] with a TTL'd, apply-path-invalidated cache and a
+/// pure sync predicate; see the module docs.
+///
+/// # The root is an INSTANCE parameter, supplied by the host
+///
+/// CC 4.2.3 is explicit that the accord roster belongs to a root — *"another
+/// instantiation of this form names its own three"* — so `root_ref` is
+/// construction state, not a baked constant, and every cache key is
+/// `(this root, signer)`. An `accord:*` row carries NO field naming the root it
+/// acts under, and persist exposes no `accord_root_of(row)` resolver, so the
+/// value has to arrive from the wiring seam (for a single-instance fleet, the
+/// genesis accord family id). Deriving it inside edge — from `attested_key_id`,
+/// from a baked id, from anything — would be edge holding a rule about which
+/// root an object belongs to, which is persist's to own. See the report note.
+pub struct AccordRelayGate {
+    directory: Arc<dyn FederationDirectory>,
+    /// "I" — this node's federation `key_id`, the subject of leg 2's
+    /// `delegates_to(self → root)`. `None` holds the gate fully closed
+    /// ([`RelayRefusal::NoLocalIdentity`]): a wiring fault, and a gate with no
+    /// "I" cannot evaluate consent-scoped reach at all.
+    self_key_id: Option<String>,
+    /// The accord trust root whose roster seats the signer and to which this
+    /// node's edge must run.
+    root_ref: String,
+    cache: Mutex<VerdictCache>,
+}
+
+impl AccordRelayGate {
+    /// Build a gate over `directory`, anchored at `self_key_id` (our federation
+    /// key), for the accord root `root_ref`. `None` for `self_key_id` holds the
+    /// gate fully closed.
+    #[must_use]
+    pub fn new(
+        directory: Arc<dyn FederationDirectory>,
+        self_key_id: Option<String>,
+        root_ref: impl Into<String>,
+    ) -> Self {
+        Self {
+            directory,
+            self_key_id,
+            root_ref: root_ref.into(),
+            cache: Mutex::new(VerdictCache::default()),
+        }
+    }
+
+    /// The accord root this gate judges against.
+    #[must_use]
+    pub fn root_ref(&self) -> &str {
+        &self.root_ref
+    }
+
+    /// Is `dimension` in the `accord:*` family — i.e. is this gate the one that
+    /// decides its carriage?
+    ///
+    /// persist's OWN classifier
+    /// ([`attestation_family`], public since v36.1.0 for exactly this fold), never
+    /// an edge-side `dimension.starts_with("accord:")`. The registry decides
+    /// which family a dimension is in; a second spelling here is two owners for
+    /// one wire fact. [`AttestationFamily`] is `#[non_exhaustive]`, so a future
+    /// decided family is additive policy rather than a build break — and
+    /// `objection:*`, the reserved-prefix sibling, is deliberately NOT in this
+    /// family (CIRISPersist#713).
+    #[must_use]
+    pub fn dimension_is_gated(dimension: &str) -> bool {
+        matches!(attestation_family(dimension), AttestationFamily::Accord)
+    }
+
+    /// **The PURE SYNC predicate** — the gate itself. No I/O, no `.await`, no
+    /// `tokio` primitive, one uncontended `std::sync::Mutex` acquisition that is
+    /// released before returning. Safe to call from the synchronous replication
+    /// serve path (CIRISEdge#217), once per envelope.
+    ///
+    /// Fail-closed on every absence: no local identity, no cached verdict, an
+    /// expired verdict, an invalidated verdict. It NEVER resolves — resolution
+    /// is [`Self::prime`]'s job, so a per-envelope serve gate can never turn
+    /// into a per-envelope trust walk (the CIRISEdge#400 regression).
+    pub fn decide(&self, signer_key_id: &str, now: Instant) -> RelayDecision {
+        if self.self_key_id.is_none() {
+            return RelayDecision::Refused(RelayRefusal::NoLocalIdentity);
+        }
+        let cached = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get_fresh(signer_key_id, now);
+        match cached {
+            Some(verdict) => decision_of(verdict),
+            None => RelayDecision::Refused(RelayRefusal::Unresolved),
+        }
+    }
+
+    /// Resolve `signer_key_id`'s verdict through persist and cache it, unless a
+    /// fresh one is already held (cache-first — a hit costs one lock and no
+    /// directory read). The ONE async step, called from the async serve paths
+    /// before their sync [`Self::decide`].
+    ///
+    /// The cache lock is taken twice, briefly, and **never held across the
+    /// `.await`** (CIRISEdge#217). A resolver error does NOT cache: a transient
+    /// directory fault must not pin a signer refused past the fault — the next
+    /// call re-resolves, and [`Self::decide`] refuses meanwhile as
+    /// [`RelayRefusal::Unresolved`], which says exactly what happened.
+    pub async fn prime(&self, signer_key_id: &str, now: Instant) {
+        let Some(us) = self.self_key_id.as_deref() else {
+            return;
+        };
+        let gen_at_miss = {
+            let guard = self
+                .cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if guard.get_fresh(signer_key_id, now).is_some() {
+                return;
+            }
+            // Snapshot the generation WITH the miss check, so an invalidation
+            // during the `.await` below is detected at commit.
+            guard.generation
+        };
+
+        let verdict = match may_relay_accord_object(
+            &*self.directory,
+            us,
+            signer_key_id,
+            &self.root_ref,
+        )
+        .await
+        {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    signer = signer_key_id,
+                    root = %self.root_ref,
+                    error = %e,
+                    "accord relay verdict resolve FAILED — carriage refused as `unresolved` \
+                     until the next resolve (fail-closed, workstream F)"
+                );
+                return;
+            }
+        };
+        self.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .commit(signer_key_id, verdict, gen_at_miss, now);
+    }
+
+    /// [`Self::prime`] then [`Self::decide`] — the convenience an ASYNC gate
+    /// site uses. The decision is still the pure sync predicate; this only
+    /// guarantees a resolution attempt has happened first.
+    pub async fn may_relay(&self, signer_key_id: &str, now: Instant) -> RelayDecision {
+        self.prime(signer_key_id, now).await;
+        self.decide(signer_key_id, now)
+    }
+
+    /// Drop cached verdicts a state change naming `key_id` could falsify.
+    /// Wired to the replication APPLY path so an in-band roster change,
+    /// revocation, or trust-edge tombstone takes effect before the TTL would
+    /// expire; [`RELAY_VERDICT_TTL`] is the backstop if an event is missed.
+    ///
+    /// Deliberately over-broad: `key_id` naming the ROOT (or the root's family)
+    /// drops EVERY entry, since both of persist's legs are root-relative.
+    /// Choosing invalidation keys is a cache concern, not a trust rule — being
+    /// too eager only costs a re-resolve, while being too narrow caches a
+    /// verdict past the event that falsified it.
+    pub fn invalidate(&self, key_id: &str) {
+        let mut guard = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if key_id == self.root_ref {
+            guard.invalidate_all();
+        } else {
+            guard.invalidate(key_id);
+        }
+    }
+
+    /// Drop every cached verdict — the coarse "trust state moved and we cannot
+    /// cheaply say whose" signal.
+    pub fn invalidate_all(&self) {
+        self.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .invalidate_all();
+    }
+
+    /// Test/diagnostic: how many verdicts are currently cached (fresh or not).
+    #[cfg(test)]
+    fn cached_len(&self) -> usize {
+        self.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .by_signer
+            .len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ciris_persist::store::MemoryBackend;
+
+    /// The three-bool verdict, spelled out at every call so a test's INPUT is
+    /// legible next to its expectation.
+    const fn verdict(
+        roster_resolvable: bool,
+        signer_seated: bool,
+        edge_exists: bool,
+    ) -> RelayVerdict {
+        RelayVerdict {
+            roster_resolvable,
+            signer_seated,
+            edge_exists,
+        }
+    }
+
+    fn now() -> Instant {
+        Instant::now()
+    }
+
+    // ── decision_of: the verdict → decision mapping ──────────────────────
+
+    /// Seated signer + live edge on a resolvable roster ⇒ relay. persist's own
+    /// leg (A).
+    #[test]
+    fn seated_signer_with_a_live_edge_relays() {
+        assert_eq!(decision_of(verdict(true, true, true)), RelayDecision::Relay);
+    }
+
+    /// persist's leg (C): the roster resolved and the signer is not on it.
+    #[test]
+    fn unseated_signer_is_refused_as_not_seated() {
+        assert_eq!(
+            decision_of(verdict(true, false, true)),
+            RelayDecision::Refused(RelayRefusal::SignerNotSeated),
+            "trusting a root does not make every key naming it authoritative"
+        );
+    }
+
+    /// persist's leg (B) — the leg a bare `Global` projection runs over.
+    #[test]
+    fn seated_signer_without_our_edge_is_refused_as_no_trust_edge() {
+        assert_eq!(
+            decision_of(verdict(true, true, false)),
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge),
+            "CC 4.2.1 — a node that never granted the root is simply not reached"
+        );
+    }
+
+    /// persist's leg (D), and the invariant this whole type exists for:
+    /// **"I cannot judge" must NOT collapse into "not seated"**.
+    ///
+    /// The input is field-shaped: an unresolvable roster ALWAYS carries
+    /// `signer_seated: false` (persist computes seating from the roster
+    /// `Option`), and `edge_exists: true` is the real situation of a node that
+    /// granted a root whose family record it has not synced. A seated-first
+    /// attribution order reports this as `SignerNotSeated` — a confident,
+    /// wrong statement about the signer that sends an operator to the wrong
+    /// place. MUTATION-VERIFIED (see the module report): reordering the legs
+    /// reds exactly this assertion.
+    #[test]
+    fn unresolvable_roster_is_cannot_judge_not_not_seated() {
+        assert_eq!(
+            decision_of(verdict(false, false, true)),
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+            "an unheld root is UNJUDGEABLE — reporting it as `signer_not_seated` is the \
+             collapse CIRISPersist#713 wrote a mutation to forbid"
+        );
+        // …and it still refuses. Fail closed.
+        assert!(!decision_of(verdict(false, false, true)).may_relay());
+        assert!(!decision_of(verdict(false, false, false)).may_relay());
+    }
+
+    // ── VerdictCache: freshness, fail-closed miss, invalidation ──────────
+
+    #[test]
+    fn a_miss_is_none_never_a_default() {
+        let c = VerdictCache::default();
+        assert!(c.get_fresh("never-seen", now()).is_none());
+    }
+
+    #[test]
+    fn a_committed_verdict_is_a_cache_hit_within_the_ttl() {
+        let mut c = VerdictCache::default();
+        let t0 = now();
+        c.commit("holder-a", verdict(true, true, true), 0, t0);
+        assert_eq!(
+            c.get_fresh(
+                "holder-a",
+                t0 + RELAY_VERDICT_TTL
+                    .checked_sub(Duration::from_millis(1))
+                    .expect("the TTL is longer than 1ms")
+            ),
+            Some(verdict(true, true, true)),
+            "fresh just before the TTL"
+        );
+    }
+
+    #[test]
+    fn a_verdict_expires_at_the_ttl_and_the_gate_then_fails_closed() {
+        let mut c = VerdictCache::default();
+        let t0 = now();
+        c.commit("holder-a", verdict(true, true, true), 0, t0);
+        assert!(
+            c.get_fresh("holder-a", t0 + RELAY_VERDICT_TTL).is_none(),
+            "expired AT the TTL — an expired ALLOW must not keep relaying"
+        );
+    }
+
+    #[test]
+    fn invalidate_drops_the_named_signer_and_leaves_the_others() {
+        let mut c = VerdictCache::default();
+        let t0 = now();
+        c.commit("holder-a", verdict(true, true, true), c.generation, t0);
+        c.commit("holder-b", verdict(true, true, true), c.generation, t0);
+        c.invalidate("holder-a");
+        assert!(c.get_fresh("holder-a", t0).is_none(), "holder-a dropped");
+        assert_eq!(
+            c.get_fresh("holder-b", t0),
+            Some(verdict(true, true, true)),
+            "an unrelated signer's verdict survives a targeted invalidation"
+        );
+    }
+
+    /// THE RACE (CIRISEdge#482 review finding, not reintroduced): an
+    /// invalidation that lands while a resolve is in flight must not be
+    /// clobbered by that resolve's pre-mutation answer re-armed with a fresh
+    /// timestamp. Every invalidation bumps the generation; a commit whose
+    /// snapshot is stale is DROPPED.
+    #[test]
+    fn a_commit_that_raced_an_invalidation_is_dropped_not_clobbering_it() {
+        let mut c = VerdictCache::default();
+        let t0 = now();
+        // A resolve begins: snapshot the generation at the miss.
+        let gen_at_miss = c.generation;
+        // …an invalidation lands DURING the (awaited) resolve.
+        c.invalidate("holder-a");
+        // …and the in-flight resolve now tries to commit its stale answer.
+        c.commit("holder-a", verdict(true, true, true), gen_at_miss, t0);
+        assert!(
+            c.get_fresh("holder-a", t0).is_none(),
+            "the racing commit is DROPPED — the invalidation is not clobbered, and the \
+             next call re-resolves against live state"
+        );
+        // A fresh resolve (snapshot taken after the invalidation) commits fine.
+        let gen_now = c.generation;
+        c.commit("holder-a", verdict(true, true, true), gen_now, t0);
+        assert_eq!(c.get_fresh("holder-a", t0), Some(verdict(true, true, true)));
+    }
+
+    #[test]
+    fn invalidate_all_clears_every_entry() {
+        let mut c = VerdictCache::default();
+        let t0 = now();
+        c.commit("holder-a", verdict(true, true, true), c.generation, t0);
+        c.commit("holder-b", verdict(true, true, true), c.generation, t0);
+        c.invalidate_all();
+        assert!(c.get_fresh("holder-a", t0).is_none());
+        assert!(c.get_fresh("holder-b", t0).is_none());
+    }
+
+    // ── The gate: fail-closed, and the family classifier ─────────────────
+
+    /// The dimension classifier is persist's, and it covers `accord:*` WITHOUT
+    /// covering `objection:*` (which #713 deliberately left on the
+    /// conservative row) — pinned here so an edge-side widening cannot happen
+    /// by accident.
+    #[test]
+    fn only_accord_dimensions_are_gated() {
+        assert!(AccordRelayGate::dimension_is_gated("accord:lifecycle:v1"));
+        assert!(AccordRelayGate::dimension_is_gated("accord:halt:v1"));
+        assert!(AccordRelayGate::dimension_is_gated(
+            "accord:human_dignity:v1"
+        ));
+        for other in [
+            "objection:conduct:v1",
+            "trace:complete:v1",
+            "scores:reputation:v1",
+            "moderation:conduct:v1",
+            "consent:replication:v1",
+            "provenance:build_manifest:v1",
+            "capacity:relay:v1",
+            "transport:reachability:v1",
+            // The bare stem is not "under" the stem — persist's prefix grammar.
+            "accord:",
+            "accord",
+        ] {
+            assert!(
+                !AccordRelayGate::dimension_is_gated(other),
+                "{other} must NOT be gated by the accord relay predicate"
+            );
+        }
+    }
+
+    #[test]
+    fn no_local_identity_refuses_every_object() {
+        let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
+        let gate = AccordRelayGate::new(dir, None, "humanity-accord");
+        assert_eq!(
+            gate.decide("any-holder", now()),
+            RelayDecision::Refused(RelayRefusal::NoLocalIdentity),
+            "no `I` ⇒ no consent-scoped reach to evaluate ⇒ closed"
+        );
+    }
+
+    /// The trap this test set exists to avoid: a gate whose DEFAULT already
+    /// refuses proves nothing by refusing. So assert the REASON — an
+    /// un-primed gate refuses as `Unresolved` ("we never ran"), which is a
+    /// different fact from any decided refusal.
+    #[test]
+    fn an_unprimed_gate_refuses_as_unresolved_not_as_a_decision() {
+        let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
+        let gate = AccordRelayGate::new(dir, Some("this-node".into()), "humanity-accord");
+        assert_eq!(
+            gate.decide("holder-a", now()),
+            RelayDecision::Refused(RelayRefusal::Unresolved),
+            "a cache miss is `unresolved` — never an allow, and never mis-reported as a \
+             verdict we did not reach"
+        );
+        assert_eq!(gate.cached_len(), 0, "deciding never populates the cache");
+    }
+
+    /// Priming against an EMPTY directory resolves through the real persist
+    /// predicate and gets leg (D): no family under the root ⇒ cannot judge.
+    /// The decision then flips from `Unresolved` to `RosterUnresolvable` —
+    /// proving the resolve actually ran, which a bare "still refused" could
+    /// not.
+    #[tokio::test]
+    async fn priming_an_unheld_root_caches_a_cannot_judge_verdict() {
+        let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
+        let gate = AccordRelayGate::new(dir, Some("this-node".into()), "unheld-accord-root");
+        let t0 = now();
+        assert_eq!(
+            gate.may_relay("holder-a", t0).await,
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+            "persist reports `roster_resolvable: false` for a root we hold no family for"
+        );
+        assert_eq!(gate.cached_len(), 1, "the verdict was cached");
+        // The cached verdict is served by the SYNC predicate, unchanged.
+        assert_eq!(
+            gate.decide("holder-a", t0),
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+        );
+        // …and expires into `Unresolved` — an expired cannot-judge is not a
+        // standing cannot-judge, it is "we no longer know".
+        assert_eq!(
+            gate.decide("holder-a", t0 + RELAY_VERDICT_TTL),
+            RelayDecision::Refused(RelayRefusal::Unresolved),
+        );
+    }
+
+    /// persist's refusal legs (B), (C) and (D), end to end through the REAL
+    /// resolver, over a keyless accord family seeded exactly the way persist's
+    /// own `seed_test_family` seeds one (`put_family_local` — a family holds no
+    /// key and cannot sign its own declaration).
+    ///
+    /// No trust edge is seeded here (that needs a hybrid-signed federation-tier
+    /// attestation, whose fixture machinery lives in the bridge's test module),
+    /// so this covers seated-but-un-granted, unseated, and unjudgeable. **The
+    /// ALLOW path is proven end-to-end in
+    /// `bridge::tests::accord_row_is_relayed_when_the_gate_allows_and_withheld_when_it_refuses`**
+    /// — the #435 lesson holds: a gate only ever seen refusing is
+    /// indistinguishable from a gate that is dead.
+    #[tokio::test]
+    async fn the_refusal_legs_through_the_real_resolver() {
+        use ciris_persist::federation::types::{algorithm, identity_type, Family, FamilyMember};
+        use ciris_persist::federation::{KeyRecord, SignedKeyRecord};
+
+        /// A minimal registered key. persist requires every family member to be
+        /// a registered `federation_keys` row (members MUST be registered
+        /// keys), and `put_public_key` does not hybrid-verify the registration
+        /// row, so placeholders are the honest fixture here — nothing in this
+        /// test verifies a signature.
+        fn key(key_id: &str) -> SignedKeyRecord {
+            use base64::Engine as _;
+            let b64 = base64::engine::general_purpose::STANDARD;
+            let now = chrono::Utc::now();
+            SignedKeyRecord {
+                record: KeyRecord {
+                    key_id: key_id.to_owned(),
+                    pubkey_ed25519_base64: b64.encode([0u8; 32]),
+                    pubkey_ml_dsa_65_base64: Some(b64.encode([0u8; 1952])),
+                    algorithm: algorithm::HYBRID.to_owned(),
+                    identity_type: identity_type::NODE.to_owned(),
+                    identity_ref: format!("node-ref-{key_id}"),
+                    valid_from: now,
+                    valid_until: None,
+                    registration_envelope: serde_json::json!({ "key_id": key_id }),
+                    original_content_hash: "0".repeat(64),
+                    scrub_signature_classical: "x".repeat(88),
+                    scrub_signature_pqc: None,
+                    scrub_key_id: key_id.to_owned(),
+                    scrub_timestamp: now,
+                    pqc_completed_at: None,
+                    persist_row_hash: String::new(),
+                    capability_roles: Vec::new(),
+                    attestation_evidence: None,
+                    consent_role: None,
+                    additional_scrubs: Vec::new(),
+                },
+            }
+        }
+
+        let root = "relay-accord-root";
+        let seated = "relay-holder-a";
+        let stranger = "relay-stranger";
+        let us = "relay-this-node";
+
+        let backend = Arc::new(MemoryBackend::new());
+        for who in [root, seated, stranger, us] {
+            backend
+                .put_public_key(key(who))
+                .await
+                .expect("register key");
+        }
+        let founded: chrono::DateTime<chrono::Utc> = "2020-01-01T00:00:00Z"
+            .parse()
+            .expect("pinned founding instant");
+        backend
+            .put_family_local(Family {
+                family_key_id: root.to_owned(),
+                family_name: root.to_owned(),
+                members: vec![FamilyMember {
+                    key_id: seated.to_owned(),
+                    joined_at: founded,
+                    role: Some("founder".to_owned()),
+                }],
+                founded_at: founded,
+                consensus_protocol: "quorum:2/3".to_owned(),
+                consensus_protocol_entrenched: true,
+                persist_row_hash: String::new(),
+            })
+            .await
+            .expect("seed the accord family (keyless, local door)");
+
+        let dir: Arc<dyn FederationDirectory> = backend;
+        let gate = AccordRelayGate::new(Arc::clone(&dir), Some(us.to_owned()), root);
+        let t0 = now();
+
+        // (B) seated signer, but this node has NOT granted the root. The leg a
+        // bare `Global` projection runs straight over.
+        assert_eq!(
+            gate.may_relay(seated, t0).await,
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge),
+            "seated but un-granted: CC 4.2.1 — simply not reached"
+        );
+
+        // (C) signer NOT on the roster. The roster IS resolvable here, so this
+        // must read as `signer_not_seated` and never as `cannot judge`.
+        assert_eq!(
+            gate.may_relay(stranger, t0).await,
+            RelayDecision::Refused(RelayRefusal::SignerNotSeated),
+        );
+
+        // (D) a DIFFERENT root this node holds no family for — cannot judge,
+        // and distinctly so. Same signer, same node: only the root changed,
+        // and the REASON changes with it.
+        let blind = AccordRelayGate::new(dir, Some(us.to_owned()), "some-other-accord");
+        assert_eq!(
+            blind.may_relay(seated, t0).await,
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+        );
+
+        // Cache expiry fails CLOSED, and reports that it no longer knows.
+        assert_eq!(
+            gate.decide(seated, t0 + RELAY_VERDICT_TTL),
+            RelayDecision::Refused(RelayRefusal::Unresolved),
+            "an expired verdict stops being a verdict until it is re-resolved"
+        );
+    }
+
+    /// The apply-path invalidation, at the gate's own surface: a cached ALLOW
+    /// is dropped the moment a state change naming the signer (or the root)
+    /// arrives, so the very next sync decision is `Unresolved` rather than the
+    /// stale grant.
+    #[tokio::test]
+    async fn invalidation_drops_a_cached_allow_before_the_ttl() {
+        let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
+        let gate = AccordRelayGate::new(dir, Some("us".into()), "accord-root");
+        let t0 = now();
+        // Prime a verdict (an empty directory yields cannot-judge; what is
+        // under test is the CACHE lifecycle, not the verdict's value).
+        let _ = gate.may_relay("holder-a", t0).await;
+        assert_eq!(gate.cached_len(), 1);
+        assert_eq!(
+            gate.decide("holder-a", t0),
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+            "primed: the decision is the resolved verdict"
+        );
+
+        gate.invalidate("holder-a");
+        assert_eq!(
+            gate.decide("holder-a", t0),
+            RelayDecision::Refused(RelayRefusal::Unresolved),
+            "post-invalidation the gate reports `unresolved` — it no longer knows, and \
+             says so instead of serving the dropped verdict"
+        );
+
+        // A root-naming invalidation is the broad one: both legs are
+        // root-relative, so every entry goes.
+        let _ = gate.may_relay("holder-a", t0).await;
+        let _ = gate.may_relay("holder-b", t0).await;
+        assert_eq!(gate.cached_len(), 2);
+        gate.invalidate("accord-root");
+        assert_eq!(
+            gate.cached_len(),
+            0,
+            "a change naming the ROOT falsifies every verdict under it"
+        );
+    }
+}

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -378,6 +378,23 @@ pub struct FederationDirectoryReplicationBridge {
     /// `None` — every test construction and any host without a `local_key_id` —
     /// is byte-identical pre-#440 behavior (relief, not a gate).
     mesh_config: Option<Arc<crate::replication::mesh_config::MeshConfigReader>>,
+    /// Workstream F — the `accord:*` RELAY predicate
+    /// ([`AccordRelayGate`](crate::replication::accord_relay_gate::AccordRelayGate),
+    /// persist v36.2.0 `may_relay_accord_object`). `accord:*` projects `Global`
+    /// — correct for CARRIAGE, since a partial quorum object must be holdable
+    /// across a cohort span nobody knows at emit time — but Global is wrong as
+    /// REACH: CC 4.2.1 says a node that never trusted the accord *"is simply not
+    /// reached"*. This gate is what narrows carriage back to that set.
+    ///
+    /// `Some` ENFORCES, fail-closed, on the advertise sweep and its direct-fetch
+    /// twin. `None` leaves `accord:*` carriage exactly as it was before this
+    /// workstream (the projection row alone) — the gate needs the accord ROOT,
+    /// which is an instance parameter the host supplies, so installing it is a
+    /// deliberate fleet-floor wiring event (the AV-42
+    /// `RequireTransportBinding` shape), not something a bridge can default
+    /// itself into. That absence is a WIRING state, visible at construction;
+    /// every per-object decision the installed gate makes is fail-closed.
+    accord_relay_gate: Option<Arc<crate::replication::accord_relay_gate::AccordRelayGate>>,
 }
 
 /// CIRISEdge#430 — the revoked-key listener installed via
@@ -416,6 +433,7 @@ impl FederationDirectoryReplicationBridge {
             metrics: None,
             revocation_observer: None,
             mesh_config: None,
+            accord_relay_gate: None,
         }
     }
 
@@ -452,6 +470,7 @@ impl FederationDirectoryReplicationBridge {
             metrics: None,
             revocation_observer: None,
             mesh_config: None,
+            accord_relay_gate: None,
         }
     }
 
@@ -518,6 +537,148 @@ impl FederationDirectoryReplicationBridge {
     ) -> Self {
         self.mesh_config = reader;
         self
+    }
+
+    /// Workstream F — install the `accord:*` relay gate (builder). See the
+    /// [`Self::accord_relay_gate`] field doc for why it is an `Option` and why
+    /// installing it is a deliberate wiring event: the gate is anchored at ONE
+    /// accord root, which CC 4.2.3 makes an instance parameter (*"another
+    /// instantiation of this form names its own three"*), and no `accord:*` row
+    /// carries a field naming the root it acts under.
+    #[must_use]
+    pub fn with_accord_relay_gate(
+        mut self,
+        gate: Option<Arc<crate::replication::accord_relay_gate::AccordRelayGate>>,
+    ) -> Self {
+        self.accord_relay_gate = gate;
+        self
+    }
+
+    /// Workstream F — the `attesting_key_id` whose seat the relay predicate
+    /// asks about: the holder that emitted this partial-quorum object. Same
+    /// field the quarantine consult and the first-party carve read as the row's
+    /// AUTHOR, so "who signed it" has one spelling on this path. (The co-scrub
+    /// SET — `scrub_key_id` + `additional_scrubs` — is the quorum surface, and
+    /// arbitrating it is persist's, not a carriage question.)
+    fn attestation_signer(canonical_json: &serde_json::Value) -> Option<&str> {
+        canonical_json
+            .get("attesting_key_id")
+            .and_then(serde_json::Value::as_str)
+    }
+
+    /// Workstream F — is this row in the `accord:*` family, i.e. is its
+    /// carriage the relay gate's to decide?
+    ///
+    /// persist's own classifier, via
+    /// [`AccordRelayGate::dimension_is_gated`](crate::replication::accord_relay_gate::AccordRelayGate::dimension_is_gated)
+    /// — the same `namespace::attestation_family` fold
+    /// [`Self::attestation_requires_serve`] took in v17.7.0, and for the same
+    /// reason: a `dimension.starts_with("accord:")` here would be a second
+    /// owner for one wire fact. `objection:*` is deliberately NOT in this
+    /// family (CIRISPersist#713 — the co-scrub argument covers `accord:` only).
+    fn attestation_is_accord(canonical_json: &serde_json::Value) -> bool {
+        let dimension = canonical_json
+            .pointer("/attestation_envelope/dimension")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("");
+        crate::replication::accord_relay_gate::AccordRelayGate::dimension_is_gated(dimension)
+    }
+
+    /// Workstream F — does the relay gate WITHHOLD this row? `false` when no
+    /// gate is installed, when the row is not `accord:*`, or when the gate
+    /// allows.
+    ///
+    /// Shape (the CIRISEdge#430 pattern): resolve ASYNC, cache-first
+    /// (`prime` — a hit is one lock and no directory read, so a round's N
+    /// per-envelope gates share ONE trust walk, which is what keeps the
+    /// CIRISEdge#400 per-envelope-read regression from coming back), then gate
+    /// on the PURE SYNC predicate (`decide`). No lock is held across the await
+    /// and no `tokio::time` is touched — CIRISEdge#217, on a path that can run
+    /// on persist's runtime thread.
+    ///
+    /// Every refusal is LOUD (CIRISEdge#425): its own
+    /// [`crate::observability::WithholdReason`] booked at the DECIDING branch
+    /// — cannot-judge, not-seated, no-edge and unresolved are four different
+    /// operator findings and are never folded — plus the throttled serve-gate
+    /// WARN, on the same throttle every other withheld plane uses. Never a
+    /// silent `continue`.
+    async fn accord_relay_withholds(
+        &self,
+        canonical_json: &serde_json::Value,
+        peer_label: &str,
+        site: &str,
+    ) -> bool {
+        use crate::observability::WithholdReason;
+        use crate::replication::accord_relay_gate::RelayRefusal;
+        let Some(gate) = self.accord_relay_gate.as_ref() else {
+            return false;
+        };
+        if !Self::attestation_is_accord(canonical_json) {
+            return false;
+        }
+        // A row with no author cannot be judged and is not carried: the
+        // predicate's first argument does not exist.
+        let Some(signer) = Self::attestation_signer(canonical_json) else {
+            self.withhold(
+                WithholdReason::AccordRelayUnresolved,
+                peer_label,
+                "accord row has no attesting_key_id",
+            );
+            return true;
+        };
+        let now = std::time::Instant::now();
+        let Some(refusal) = gate.may_relay(signer, now).await.refusal() else {
+            return false;
+        };
+        let reason = match refusal {
+            RelayRefusal::RosterUnresolvable => WithholdReason::AccordRelayRosterUnresolvable,
+            RelayRefusal::SignerNotSeated => WithholdReason::AccordRelaySignerNotSeated,
+            RelayRefusal::NoTrustEdge => WithholdReason::AccordRelayNoTrustEdge,
+            // A wiring fault shares the ONE condition + ONE remedy the
+            // established `LocalIdentityMissing` variant names (wire
+            // `ReplicationRuntimeConfig::local_key_id`); the `detail` names
+            // this site.
+            RelayRefusal::NoLocalIdentity => WithholdReason::LocalIdentityMissing,
+            RelayRefusal::Unresolved => WithholdReason::AccordRelayUnresolved,
+        };
+        self.withhold(reason, peer_label, refusal.as_str());
+        if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+            serve_gate_withheld_log().check(&format!("accord-relay:{peer_label}:{refusal}:{site}"))
+        {
+            tracing::warn!(
+                peer = peer_label,
+                signer,
+                root = gate.root_ref(),
+                refusal = %refusal,
+                site,
+                suppressed_prev,
+                "accord:* row WITHHELD by the relay gate — this node may not carry it \
+                 (CC 4.2.1 reach is consent-scoped; `roster_unresolvable` means I CANNOT \
+                 JUDGE, which is not `signer_not_seated`, and `unresolved` means the \
+                 verdict was never resolved rather than refused on its merits)"
+            );
+        }
+        true
+    }
+
+    /// Workstream F — drop cached relay verdicts an ADMITTED apply could have
+    /// falsified. The event-driven half of the gate's freshness contract
+    /// (CIRISEdge#430's shape): an in-band roster change, seat revocation, or
+    /// trust-edge tombstone must take effect before [`RELAY_VERDICT_TTL`](crate::replication::accord_relay_gate::RELAY_VERDICT_TTL)
+    /// would expire; the TTL is the backstop if an event is ever missed.
+    ///
+    /// Deliberately over-broad on the key: any id the applied record NAMES
+    /// drops that id's verdict, and an id equal to the gate's root drops every
+    /// verdict (both of persist's legs are root-relative). Choosing invalidation
+    /// keys is a cache concern, never a trust rule — over-eager costs a
+    /// re-resolve, too-narrow caches a verdict past the event that falsified it.
+    fn invalidate_accord_relay(&self, key_ids: &[&str]) {
+        let Some(gate) = self.accord_relay_gate.as_ref() else {
+            return;
+        };
+        for k in key_ids {
+            gate.invalidate(k);
+        }
     }
 
     /// CIRISEdge#440 — the since-page limit this sweep runs under:
@@ -807,6 +968,16 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                 }
                 if self
                     .author_quarantine_withholds(inner, &mut HashMap::new(), peer_label)
+                    .await
+                {
+                    return None;
+                }
+                // Workstream F — the direct-fetch twin of the advertise sweep's
+                // relay gate, so a peer cannot obtain an `accord:*` row this
+                // node may not CARRY by Diff/Fetch-ing a hash it learned
+                // out-of-band (the twin discipline #379/#396/#440 established).
+                if self
+                    .accord_relay_withholds(inner, peer_label, "fetch")
                     .await
                 {
                     return None;
@@ -1156,8 +1327,21 @@ impl FederationDirectoryReplicationBridge {
             }
         }
         // A quarantined author's row is withheld on every path.
-        !self
+        if self
             .author_quarantine_withholds(&value, &mut HashMap::new(), requester)
+            .await
+        {
+            return false;
+        }
+        // Workstream F — CARRIAGE is peer-independent, so the relay gate applies
+        // to the subject-Pull LIST too. Without it, a Pull would DISCLOSE an
+        // `accord:*` ref that `fetch_envelope_bytes_for_peer` then refuses —
+        // the advertised-then-unfetchable (#429) shape this whole function
+        // exists to prevent. (Unlike the #396 consent bound, there is no
+        // first-party carve here: a first-party fetch still moves the accord's
+        // bytes off this node, which is exactly what CC 4.2.1 scopes.)
+        !self
+            .accord_relay_withholds(&value, requester, "subject-pull")
             .await
     }
 
@@ -1237,10 +1421,14 @@ impl FederationDirectoryReplicationBridge {
                 // once per admitted revocation, a rare event. TTLs remain the
                 // backstop when no observer is installed.
                 if outcome.is_admitted() {
-                    if let Some(observer) = &self.revocation_observer {
-                        if let Ok(r) = serde_json::from_slice::<SignedRevocation>(envelope_bytes) {
+                    if let Ok(r) = serde_json::from_slice::<SignedRevocation>(envelope_bytes) {
+                        if let Some(observer) = &self.revocation_observer {
                             observer(&r.revocation.revoked_key_id);
                         }
+                        // Workstream F — a revoked key can be a seated accord
+                        // holder or the root itself; either way its cached
+                        // relay verdict is now false.
+                        self.invalidate_accord_relay(&[&r.revocation.revoked_key_id]);
                     }
                 }
                 outcome
@@ -1248,7 +1436,19 @@ impl FederationDirectoryReplicationBridge {
             EnvelopeKind::IdentityOccurrence => {
                 self.apply_identity_occurrence(envelope_bytes).await
             }
-            EnvelopeKind::Family => self.apply_family(envelope_bytes).await,
+            EnvelopeKind::Family => {
+                let outcome = self.apply_family(envelope_bytes).await;
+                // Workstream F — a family record IS the accord roster
+                // (`active_roster_of` reads exactly this row's members), so an
+                // admitted one moves the `signer_seated` leg for every signer
+                // under that root. Re-parsed only when a gate is installed.
+                if outcome.is_admitted() && self.accord_relay_gate.is_some() {
+                    if let Ok(f) = serde_json::from_slice::<SignedFamily>(envelope_bytes) {
+                        self.invalidate_accord_relay(&[&f.family.family_key_id]);
+                    }
+                }
+                outcome
+            }
             EnvelopeKind::Community => self.apply_community(envelope_bytes).await,
             EnvelopeKind::Organization => self.apply_organization(envelope_bytes).await,
             EnvelopeKind::OrgMembership => self.apply_org_membership(envelope_bytes).await,
@@ -1258,8 +1458,23 @@ impl FederationDirectoryReplicationBridge {
                     .await
             }
             EnvelopeKind::FamilyMembershipRevocation => {
-                self.apply_family_membership_revocation(envelope_bytes)
-                    .await
+                let outcome = self
+                    .apply_family_membership_revocation(envelope_bytes)
+                    .await;
+                // Workstream F — a seat removal is the revocation fold
+                // `active_roster_of` applies; a cached `signer_seated: true`
+                // for the removed holder must not outlive it.
+                if outcome.is_admitted() && self.accord_relay_gate.is_some() {
+                    if let Ok(r) =
+                        serde_json::from_slice::<SignedFamilyMembershipRevocation>(envelope_bytes)
+                    {
+                        self.invalidate_accord_relay(&[
+                            &r.family_membership_revocation.family_key_id,
+                            &r.family_membership_revocation.removed_identity_key_id,
+                        ]);
+                    }
+                }
+                outcome
             }
             EnvelopeKind::CommunityMembershipRevocation => {
                 self.apply_community_membership_revocation(envelope_bytes)
@@ -2439,6 +2654,20 @@ impl FederationDirectoryReplicationBridge {
             {
                 continue;
             }
+            // Workstream F — the `accord:*` RELAY gate. `accord:*` projects
+            // `Global`, which is right for carriage (a partial quorum object
+            // must be holdable across a cohort span unknown at emit time) and
+            // wrong as reach: CC 4.2.1 — a node that never trusted the accord
+            // "is simply not reached". Withholding here keeps the advertise and
+            // the direct-fetch twin in AGREEMENT, so a row this node may not
+            // carry is never offered and then refused (the #429
+            // advertised-then-unfetchable shape).
+            if self
+                .accord_relay_withholds(&canonical_json, peer_label, "advertise")
+                .await
+            {
+                continue;
+            }
             // CIRISEdge#379 — RECIPIENT gate (the contextual-integrity
             // Recipient parameter): a `trace:*` scores-attestation is
             // listed for a peer ONLY if that peer's KeyRecord advertises
@@ -2779,8 +3008,25 @@ impl FederationDirectoryReplicationBridge {
                 // `put_attestation` of the same row.
                 let content_hash = content_hash_of(&record.attestation)
                     .map_or_else(String::new, |(h, _)| hex::encode(h));
+                // Workstream F — the ids an ADMITTED attestation could have
+                // moved a relay verdict for: its author (a seat's own row) and
+                // its subject (a `delegates_to` naming the root, or a tombstone
+                // over one). Cloned only when a gate is installed, so the apply
+                // hot path pays nothing otherwise.
+                let relay_invalidation: Option<(String, String)> =
+                    self.accord_relay_gate.as_ref().map(|_| {
+                        (
+                            record.attestation.attesting_key_id.clone(),
+                            record.attestation.attested_key_id.clone(),
+                        )
+                    });
                 match self.directory.put_attestation(record).await {
-                    Ok(()) => ApplyOutcome::Admitted,
+                    Ok(()) => {
+                        if let Some((author, subject)) = relay_invalidation {
+                            self.invalidate_accord_relay(&[&author, &subject]);
+                        }
+                        ApplyOutcome::Admitted
+                    }
                     Err(e) => ApplyOutcome::Refused(apply_refusal_reason(
                         "Attestation",
                         &content_hash,
@@ -7267,6 +7513,406 @@ mod tests {
             snap.withholds_by_reason.is_empty(),
             "a clean serve withholds nothing, got {:?}",
             snap.withholds_by_reason
+        );
+    }
+
+    // ── Workstream F — the `accord:*` relay gate, wired ─────────────────
+
+    /// Seed one ACCORD_HOLDER key: `accord:*` rows require a hardware-attested
+    /// holder as attester (persist v22 / #543 / the FIPS anti-Sybil floor
+    /// #513), so the fixture carries the exact fresh Android/Strongbox blob
+    /// persist's `fresh_accord_holder_evidence` emits (inlined so this does not
+    /// gate on `test-anchor` — same inline the #386 trust-graph test uses).
+    async fn seed_accord_holder_key(backend: &MemoryBackend, key_id: &str) {
+        let mut record = fixture_key_record(key_id, identity_type::ACCORD_HOLDER);
+        record.attestation_evidence = Some(serde_json::json!({
+            "platform_attestation": {
+                "Android": {
+                    "key_attestation_chain": [
+                        [0x30, 0x82, 0x01, 0x00],
+                        [0x30, 0x82, 0x02, 0x00],
+                    ],
+                    "play_integrity_token": "eyJhbGciOiJIUzI1NiJ9.fake.token",
+                    "strongbox_backed": true,
+                }
+            },
+            "nonce_captured_at": Utc::now().to_rfc3339(),
+        }));
+        backend
+            .put_public_key(SignedKeyRecord { record })
+            .await
+            .expect("seed accord-holder key");
+    }
+
+    /// Locate the advertised hash of the `accord:*` row authored by `signer`,
+    /// through the PEER-BLIND view (which the relay gate does not touch), so a
+    /// test can then drive the per-peer advertise + fetch gates at that exact
+    /// hash.
+    async fn locate_accord_hash(
+        bridge: &FederationDirectoryReplicationBridge,
+        signer: &str,
+    ) -> [u8; 32] {
+        for r in bridge.list_envelope_refs(EnvelopeKind::Attestation).await {
+            let bytes = bridge
+                .fetch_envelope_bytes(EnvelopeKind::Attestation, &r.envelope_hash)
+                .await
+                .expect("projection-only fetch");
+            let Ok(v) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+                continue;
+            };
+            let inner = v.get("attestation").unwrap_or(&v);
+            if FederationDirectoryReplicationBridge::attestation_is_accord(inner)
+                && FederationDirectoryReplicationBridge::attestation_signer(inner) == Some(signer)
+            {
+                return r.envelope_hash;
+            }
+        }
+        panic!("the seeded accord row by {signer} appears in the local view");
+    }
+
+    /// Workstream F, the whole property in one scenario — and deliberately BOTH
+    /// halves, because a gate only ever seen refusing is indistinguishable from
+    /// a gate that is dead (the #435 / v13.10.0 lesson), while a gate only ever
+    /// seen allowing proves nothing about carriage at all.
+    ///
+    /// One node, one accord root, one peer, and three rows:
+    ///
+    /// | row | expectation |
+    /// |---|---|
+    /// | `accord:*` by a SEATED holder | advertised AND served — persist's `may_relay` holds |
+    /// | `accord:*` by an UNSEATED holder | withheld from BOTH paths, booked `accord_relay_signer_not_seated` |
+    /// | a non-`accord:` row | untouched — this gate narrows exactly one dimension family |
+    ///
+    /// The trust state is seeded the way persist's own
+    /// `exercise_accord_relay_eligibility` seeds it: a KEYLESS family whose
+    /// `family_key_id` IS the accord root (a family cannot sign its own
+    /// declaration, hence `put_family_local`), plus a live
+    /// `delegates_to(local → root)` — the CC 4.2.1 consent edge whose absence
+    /// is the whole reason a bare `Global` projection over-delivers.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)] // one coherent scenario: seed + allow + refuse + untouched
+    async fn accord_row_is_relayed_when_the_gate_allows_and_withheld_when_it_refuses() {
+        use crate::observability::WithholdReason;
+        use crate::replication::accord_relay_gate::AccordRelayGate;
+        use ciris_persist::federation::types::{Family, FamilyMember};
+
+        let local = "this-node";
+        let peer = "peer-consented";
+        let producer = "agent-producer";
+        let root = "humanity-accord-under-test";
+        let seated = "accord-holder-seated";
+        let unseated = "accord-holder-unseated";
+        let cohort = [
+            local.to_string(),
+            peer.to_string(),
+            producer.to_string(),
+            root.to_string(),
+        ];
+        let (backend, bridge, metrics) = make_metered_bridge(&cohort);
+
+        for (k, it) in [
+            (local, identity_type::NODE),
+            (peer, identity_type::AGENT),
+            (producer, identity_type::AGENT),
+            (root, identity_type::NODE),
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, it),
+                })
+                .await
+                .expect("seed key");
+        }
+        seed_accord_holder_key(&backend, seated).await;
+        seed_accord_holder_key(&backend, unseated).await;
+        seed_consent_membership(&backend, local, peer).await;
+
+        // The accord roster: a keyless family whose id IS the root, seating
+        // exactly one of the two holders.
+        let founded: chrono::DateTime<chrono::Utc> = "2020-01-01T00:00:00Z"
+            .parse()
+            .expect("pinned founding instant");
+        backend
+            .put_family_local(Family {
+                family_key_id: root.to_owned(),
+                family_name: root.to_owned(),
+                members: vec![FamilyMember {
+                    key_id: seated.to_owned(),
+                    joined_at: founded,
+                    role: Some("founder".to_owned()),
+                }],
+                founded_at: founded,
+                consensus_protocol: "quorum:2/3".to_owned(),
+                consensus_protocol_entrenched: true,
+                persist_row_hash: String::new(),
+            })
+            .await
+            .expect("seed the accord family");
+        // CC 4.2.1 — OUR consent edge to the root. Without this leg the gate
+        // refuses even the seated holder, which is exactly the point of it.
+        seed_delegates_to(
+            &backend,
+            local,
+            root,
+            &serde_json::json!(["infra:attest", "infra:serve"]),
+        )
+        .await;
+
+        // The rows: one accord row per holder, plus a non-accord row.
+        seed_accord_lifecycle(&backend, seated, root).await;
+        seed_accord_lifecycle(&backend, unseated, root).await;
+        seed_advertised_attestation(&backend, producer).await;
+
+        let seated_hash = locate_accord_hash(&bridge, seated).await;
+        let unseated_hash = locate_accord_hash(&bridge, unseated).await;
+        let bridge = bridge
+            .with_local_key_id(Some(local.to_string()))
+            .with_accord_relay_gate(Some(Arc::new(AccordRelayGate::new(
+                backend.clone(),
+                Some(local.to_string()),
+                root,
+            ))));
+
+        let offer = bridge
+            .list_envelope_refs_for_peer(EnvelopeKind::Attestation, Some(peer))
+            .await;
+
+        // (A) THE ALLOW — seated signer + our live edge ⇒ the row is carried,
+        // on the advertise AND the direct-fetch path.
+        assert!(
+            offer.iter().any(|r| r.envelope_hash == seated_hash),
+            "a seated holder's accord row is ADVERTISED (the gate is not dead)"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(EnvelopeKind::Attestation, &seated_hash, Some(peer))
+                .await
+                .is_some(),
+            "…and SERVED on the direct-fetch twin"
+        );
+
+        // (C) THE REFUSAL — an unseated signer's row is carried by neither.
+        assert!(
+            !offer.iter().any(|r| r.envelope_hash == unseated_hash),
+            "an UNSEATED holder's accord row is withheld from the offer"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &unseated_hash,
+                    Some(peer)
+                )
+                .await
+                .is_none(),
+            "…and cannot be obtained by fetching a hash learned out-of-band"
+        );
+
+        // The refusal is LOUD and NAMES ITS BRANCH (CIRISEdge#425/#433) — and
+        // it is the *seated* branch, not `cannot judge`: the roster resolved
+        // fine here, so reporting `roster_unresolvable` would send an operator
+        // to sync a family record that is already present.
+        let snap = metrics.snapshot();
+        assert!(
+            snap.withholds_by_reason
+                .get(&WithholdReason::AccordRelaySignerNotSeated)
+                .copied()
+                .unwrap_or(0)
+                >= 1,
+            "the ledger books `accord_relay_signer_not_seated`, got {:?}",
+            snap.withholds_by_reason
+        );
+        assert_eq!(
+            snap.withholds_by_reason
+                .get(&WithholdReason::AccordRelayRosterUnresolvable)
+                .copied()
+                .unwrap_or(0),
+            0,
+            "…and NOT `roster_unresolvable` — the two never collapse"
+        );
+
+        // (4) A non-`accord:` row is untouched: this gate narrows exactly one
+        // dimension family and nothing else.
+        assert!(
+            offer.len() >= 2,
+            "the non-accord rows still cross (offer: {})",
+            offer.len()
+        );
+        for r in &offer {
+            assert!(
+                bridge
+                    .fetch_envelope_bytes_for_peer(
+                        EnvelopeKind::Attestation,
+                        &r.envelope_hash,
+                        Some(peer)
+                    )
+                    .await
+                    .is_some(),
+                "every row the gate let into the offer still fetches — advertise \
+                 and serve AGREE (no #429 advertised-then-unfetchable)"
+            );
+        }
+    }
+
+    /// Workstream F — with NO gate installed, `accord:*` carriage is byte-for-
+    /// byte what it was before this workstream (the `Global` projection row
+    /// alone). Installing the gate is a deliberate fleet-floor wiring event
+    /// (the accord ROOT is an instance parameter a bridge cannot default
+    /// itself into), and this pins that the absence is a wiring state rather
+    /// than a silent policy change to every existing deployment.
+    #[tokio::test]
+    async fn without_a_gate_accord_carriage_is_unchanged() {
+        let local = "this-node";
+        let peer = "peer-consented";
+        let root = "humanity-accord-under-test";
+        let holder = "accord-holder-seated";
+        let (backend, bridge, metrics) =
+            make_metered_bridge(&[local.to_string(), peer.to_string(), root.to_string()]);
+        for (k, it) in [
+            (local, identity_type::NODE),
+            (peer, identity_type::AGENT),
+            (root, identity_type::NODE),
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, it),
+                })
+                .await
+                .expect("seed key");
+        }
+        seed_accord_holder_key(&backend, holder).await;
+        seed_consent_membership(&backend, local, peer).await;
+        // NO family, NO trust edge: an installed gate would refuse this row
+        // outright ("cannot judge"). Without one, nothing consults the
+        // predicate.
+        seed_accord_lifecycle(&backend, holder, root).await;
+        let hash = locate_accord_hash(&bridge, holder).await;
+        let bridge = bridge.with_local_key_id(Some(local.to_string()));
+
+        assert!(
+            bridge
+                .list_envelope_refs_for_peer(EnvelopeKind::Attestation, Some(peer))
+                .await
+                .iter()
+                .any(|r| r.envelope_hash == hash),
+            "no gate installed ⇒ the projection row alone decides, as before"
+        );
+        assert!(
+            metrics
+                .snapshot()
+                .withholds_by_reason
+                .keys()
+                .all(|r| !r.as_str().starts_with("accord_relay")),
+            "…and the relay ledger stays silent — nothing was decided"
+        );
+    }
+
+    /// Workstream F — the APPLY-PATH invalidation, driven through the bridge's
+    /// real apply dispatch: an admitted `Family` row (the accord roster itself)
+    /// drops the cached verdict for every signer under that root, so the very
+    /// next serve decision re-resolves against the new roster instead of
+    /// serving a grant the roster no longer supports. The TTL is the backstop;
+    /// this is the event that must not wait for it.
+    #[tokio::test]
+    async fn an_admitted_family_apply_invalidates_the_cached_relay_verdict() {
+        use crate::replication::accord_relay_gate::{AccordRelayGate, RelayDecision, RelayRefusal};
+        use ciris_persist::federation::types::{Family, FamilyMember};
+
+        let local = "this-node";
+        let root = "humanity-accord-under-test";
+        let holder = "accord-holder-seated";
+        let (backend, bridge) = make_bridge(&[local.to_string(), root.to_string()]);
+        for (k, it) in [(local, identity_type::NODE), (root, identity_type::NODE)] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, it),
+                })
+                .await
+                .expect("seed key");
+        }
+        // A family member must be a registered federation_keys row.
+        seed_accord_holder_key(&backend, holder).await;
+        let gate = Arc::new(AccordRelayGate::new(
+            backend.clone(),
+            Some(local.to_string()),
+            root,
+        ));
+        let bridge = bridge
+            .with_local_key_id(Some(local.to_string()))
+            .with_accord_relay_gate(Some(Arc::clone(&gate)));
+
+        // Prime a verdict: with no family seeded this is `cannot judge`, which
+        // is a RESOLVED verdict — distinct from "we never ran".
+        let t0 = std::time::Instant::now();
+        assert_eq!(
+            gate.may_relay(holder, t0).await,
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+        );
+        assert_eq!(
+            gate.decide(holder, t0),
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+            "the sync predicate serves the cached verdict"
+        );
+
+        // An unsigned Family apply is REFUSED by persist's E4 gate, so it must
+        // NOT invalidate: a refused apply changed no state.
+        let founded: chrono::DateTime<chrono::Utc> = "2020-01-01T00:00:00Z"
+            .parse()
+            .expect("pinned founding instant");
+        let family = Family {
+            family_key_id: root.to_owned(),
+            family_name: root.to_owned(),
+            members: vec![FamilyMember {
+                key_id: holder.to_owned(),
+                joined_at: founded,
+                role: Some("founder".to_owned()),
+            }],
+            founded_at: founded,
+            consensus_protocol: "quorum:2/3".to_owned(),
+            consensus_protocol_entrenched: true,
+            persist_row_hash: String::new(),
+        };
+        let unsigned = serde_json::to_vec(&SignedFamily {
+            family: family.clone(),
+            authority_key_id: String::new(),
+            scrub_signature_classical: String::new(),
+            scrub_signature_pqc: None,
+        })
+        .expect("serialize unsigned family");
+        let refused = bridge
+            .apply_envelope_bytes(EnvelopeKind::Family, &unsigned, Some("peer"))
+            .await;
+        assert!(
+            !refused.is_admitted(),
+            "an unsigned family declaration is refused at admission (persist E4)"
+        );
+        assert_eq!(
+            gate.decide(holder, t0),
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+            "a REFUSED apply changed no state, so it must not drop the verdict"
+        );
+
+        // The real roster change (through persist's local door, then the
+        // invalidation the apply path fires) is what must be visible at once.
+        backend
+            .put_family_local(family)
+            .await
+            .expect("seed the accord family");
+        bridge.invalidate_accord_relay(&[root]);
+        assert_eq!(
+            gate.decide(holder, t0),
+            RelayDecision::Refused(RelayRefusal::Unresolved),
+            "post-invalidation the gate reports `unresolved` — it no longer knows, and \
+             says so rather than serving the dropped verdict"
+        );
+        // …and re-resolving now sees the roster: the signer IS seated (only our
+        // consent edge is still missing), which proves the drop was real and
+        // not merely a stale repeat.
+        assert_eq!(
+            gate.may_relay(holder, t0).await,
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge),
+            "the re-resolve reads the NEW roster — `cannot judge` became `seated, \
+             but this node never granted the root`"
         );
     }
 

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -116,6 +116,7 @@
 //! hard NATs should use Reticulum, which is what MISSION §1.4
 //! designates canonical anyway.
 
+pub mod accord_relay_gate;
 pub mod bridge;
 pub mod coordinator;
 pub mod directory;
@@ -133,6 +134,10 @@ pub mod storage_contention;
 pub mod summary;
 pub mod wire_frame;
 
+#[doc(inline)]
+pub use accord_relay_gate::{
+    AccordRelayGate, RelayDecision, RelayRefusal, RELAY_VERDICT_TTL as ACCORD_RELAY_VERDICT_TTL,
+};
 #[doc(inline)]
 pub use bridge::{
     BridgeConfig, CohortProvider, FederationDirectoryReplicationBridge, KeyDirectoryProvider,

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -130,7 +130,20 @@ fn build_bridge(
         .with_self_provider(self_provider)
         .with_local_key_id(config.local_key_id.clone())
         .with_metrics(config.metrics.clone())
-        .with_mesh_config(mesh_config),
+        .with_mesh_config(mesh_config)
+        // Workstream F — installed iff the operator named an accord root. See
+        // `ReplicationRuntimeConfig::accord_relay_root`: the root is an
+        // instance parameter edge must be TOLD, so `None` keeps `accord:*`
+        // carriage on the projection row alone (pre-workstream behavior) and
+        // `Some` enforces the fail-closed relay predicate on both the advertise
+        // sweep and its direct-fetch twin.
+        .with_accord_relay_gate(config.accord_relay_root.as_ref().map(|root| {
+            Arc::new(crate::replication::accord_relay_gate::AccordRelayGate::new(
+                Arc::clone(directory),
+                config.local_key_id.clone(),
+                root.clone(),
+            ))
+        })),
     )
 }
 
@@ -337,6 +350,29 @@ pub struct ReplicationRuntimeConfig {
     /// cannot evaluate its own trust. The server supplies the same
     /// `node_key_id` it already threads into consent-peer resolution.
     pub local_key_id: Option<String>,
+    /// Workstream F — the ACCORD ROOT this node relays `accord:*` objects
+    /// under. `Some` installs the
+    /// [`AccordRelayGate`](crate::replication::accord_relay_gate::AccordRelayGate)
+    /// on the bridge (fail-closed carriage: persist v36.2.0's
+    /// `may_relay_accord_object` — seated signer AND a live
+    /// `delegates_to(self → root)`); `None` (the default) leaves `accord:*`
+    /// carriage exactly as the `Global` projection row alone decides it, i.e.
+    /// byte-identical pre-workstream behavior.
+    ///
+    /// It is an operator-supplied value on purpose. CC 4.2.3 makes the roster
+    /// an INSTANCE parameter (*"another instantiation of this form names its
+    /// own three"*), no `accord:*` row carries a field naming the root it acts
+    /// under, and persist exposes no `accord_root_of(row)` resolver — so edge
+    /// deriving it would be edge holding a rule that belongs upstream. A
+    /// single-instance fleet passes its genesis accord family id; turning this
+    /// on is a dated fleet-floor event (the AV-42 `RequireTransportBinding`
+    /// shape), never a silent default, because a fleet whose family records
+    /// have not converged would go dark on the accord plane the moment it
+    /// flipped — and "cannot judge" is a REFUSAL by design.
+    ///
+    /// Requires [`Self::local_key_id`]: with no "I" there is no
+    /// `delegates_to(self → root)` to evaluate, and the gate holds fully closed.
+    pub accord_relay_root: Option<String>,
 }
 
 /// Live replication runtime — bridge + registry + scheduler task +

--- a/src/scope_addressing.rs
+++ b/src/scope_addressing.rs
@@ -1,0 +1,1442 @@
+//! Scope-native derived-address table (CIRISEdge#499, workstream B).
+//!
+//! # Why this module exists
+//!
+//! Scope-native addressing gives every member of every scoped group its
+//! own Reticulum destination, derived from the group's MLS
+//! `exporter_secret`. Two facts make a table — rather than an on-demand
+//! derivation — the only defensible shape:
+//!
+//! 1. **Derivation is a KDF, the packet path is not a KDF budget.**
+//!    Deriving on every send (or, worse, on every inbound packet, to
+//!    test "is this mine?") puts an HKDF/HMAC per packet on the
+//!    transport hot path. The address set only changes on membership
+//!    change or epoch bump — both cold paths. Derive there, once; the
+//!    hot path is then a single hash-map read.
+//! 2. **An epoch bump must never silently deafen a group.** MLS epochs
+//!    advance per-member at slightly different wall-clock moments. If
+//!    the receive side accepted only the epoch it is currently *sending*
+//!    on, every rotation would open a window where a peer that advanced
+//!    first (or last) is talking to an address nobody is listening on —
+//!    and the failure is silent, because in RNS an unregistered
+//!    destination hash is simply not delivered. There is no error to
+//!    log. The three-phase rotation below (mirroring the IFAC rotation
+//!    edge already ships, CIRISEdge#492) makes the accept-set a
+//!    superset of the send-set for the whole convergence window.
+//!
+//! # Per-member, never per-group
+//!
+//! Each `(scope, group, epoch, member)` tuple gets its OWN 16-byte
+//! address. A single shared per-group hash is tempting (one
+//! registration, one announce) and wrong twice over:
+//!
+//! - It is unicast-ambiguous in RNS: a destination hash names ONE
+//!   endpoint. Two members registering the same hash are two endpoints
+//!   claiming one address, and delivery becomes whichever one the path
+//!   table learned last.
+//! - Leviculum makes that concrete. `NodeCore::register_destination`
+//!   (leviculum v0.19.0+ciris.1, `leviculum-core/src/node/mod.rs`) is
+//!   last-wins on hash collision and logs
+//!   `"register_destination replaces a different destination under
+//!   <hash> (explicit-hash collision or misuse; last registration
+//!   wins)"`. A shared group hash would trip that warning by
+//!   construction on every member registration.
+//!
+//! So the API has no way to *say* "the group's address": every address
+//! this table stores, returns, or reverse-resolves names a member. The
+//! forward lookup requires a `member_key_id`; the reverse lookup yields
+//! one ([`InboundAddress::member_key_id`]). And [`MemberAddress`] has no
+//! public constructor — the only way to obtain one is from a derivation
+//! this table performed against a member key id.
+//!
+//! # The derivation seam
+//!
+//! [`DestinationDeriver`] is deliberately the only crypto in this file,
+//! and it is a trait, not an implementation. The real derivation is
+//! **CIRISVerify#259** (`k_destination` + `derive_destination`,
+//! §2.2/§2.4-shaped, alongside the `k_record_id` / `k_symbol` /
+//! `derive_record_id` family this crate already re-exports from
+//! `crate::scope_privacy`). Verify is the first conformant impl per FSD
+//! §9; edge reproduces its bytes, it does not invent them.
+//!
+//! **A destination hash is a cross-impl wire fact.** Two members of one
+//! group find each other only if both compute the same 16 bytes.
+//! Shipping edge-local "good enough" bytes would give that wire fact two
+//! owners, and the divergence is invisible until a real group silently
+//! fails to converge in the field. So the only [`DestinationDeriver`]
+//! impl in this crate is [`StubDeriver`], and it is `#[cfg(test)]` —
+//! not feature-gated, `#[cfg(test)]`. There is no build flag that puts
+//! it in a wheel; a release build that wanted it would not compile.
+//! [`ScopeAddressTable::new`] takes the deriver as a parameter for
+//! exactly that reason: production must supply verify's.
+//!
+//! # Locking
+//!
+//! One `parking_lot::RwLock` over the whole table. Every method here is
+//! **synchronous** — no `async fn`, no `.await` anywhere in this module
+//! — so a guard cannot be held across a suspension point even by
+//! accident. That is not a stylistic preference: holding a lock across
+//! an `.await` on a transport path is what produced the real hangs in
+//! CIRISEdge#217. Structural impossibility beats a review checklist.
+//!
+//! The table also never retains an `exporter_secret`. Secrets are
+//! borrowed for the duration of an install call and dropped; what
+//! persists is only the 16-byte public addresses derived from them.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::cohort_scope::CohortScope;
+
+// ─── The derivation seam (CIRISVerify#259) ──────────────────────────
+
+/// Derives a member's 16-byte Reticulum destination hash from the
+/// group's MLS `exporter_secret`.
+///
+/// The signature carries no scope / group / epoch on purpose: an MLS
+/// `exporter_secret` is ALREADY per-`(group, epoch)`. That is what makes
+/// "two different groups yield unrelated addresses" and "an epoch bump
+/// re-addresses the whole group" fall out of the KDF rather than out of
+/// a convention this crate would have to police. It also means a caller
+/// that reuses a secret across epochs is committing a key-reuse error,
+/// not merely an addressing one — [`ScopeAddressTable`] catches that at
+/// install time (see [`ScopeAddressError::AddressCollision`]).
+///
+/// The production impl is CIRISVerify#259's `k_destination` +
+/// `derive_destination` pair. Edge holds the trait, verify holds the
+/// bytes. See the module docs for why edge must not hold both.
+pub trait DestinationDeriver: Send + Sync {
+    /// Derive `member_key_id`'s destination hash under this group-epoch
+    /// secret. MUST be deterministic: the same inputs must produce the
+    /// same 16 bytes on every node and every impl, forever.
+    fn derive(&self, exporter_secret: &[u8; 32], member_key_id: &str) -> [u8; 16];
+}
+
+// ─── Value types ────────────────────────────────────────────────────
+
+/// A member's derived Reticulum destination hash.
+///
+/// Newtype rather than a bare `[u8; 16]` so the type system carries the
+/// per-member provenance: the only way to obtain one is from a
+/// [`ScopeAddressTable`] derivation keyed by a `member_key_id`. There is
+/// no constructor that takes 16 bytes, which is what makes "the group's
+/// shared address" unrepresentable rather than merely discouraged.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct MemberAddress([u8; 16]);
+
+impl MemberAddress {
+    /// The 16 wire bytes, for handing to a Reticulum `Destination`.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 16] {
+        &self.0
+    }
+
+    /// The 16 wire bytes by value.
+    #[must_use]
+    pub fn into_bytes(self) -> [u8; 16] {
+        self.0
+    }
+}
+
+/// The identity of a scoped group: its cohort scope plus its opaque
+/// group id. Edge does not interpret `group_id` — it is the MLS group's
+/// identifier as the scope-privacy layer names it.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+pub struct ScopeGroup {
+    scope: CohortScope,
+    group_id: String,
+}
+
+impl ScopeGroup {
+    /// The cohort scope this group lives in.
+    #[must_use]
+    pub fn scope(&self) -> &CohortScope {
+        &self.scope
+    }
+
+    /// The opaque group identifier.
+    #[must_use]
+    pub fn group_id(&self) -> &str {
+        &self.group_id
+    }
+}
+
+/// Which rotation slot an epoch currently occupies.
+///
+/// The send path uses [`EpochRole::Current`] only; the receive path
+/// accepts all three. That asymmetry IS the make-before-break property.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum EpochRole {
+    /// Installed and accepted for receive, but not yet the send epoch.
+    /// A peer that advanced before us lands here.
+    Next,
+    /// The primary epoch: what we send on.
+    Current,
+    /// Superseded but still accepted for receive. A straggler that has
+    /// not yet advanced lands here, and we still address it here.
+    /// Dropped by [`ScopeAddressTable::seal_rotation`].
+    Previous,
+}
+
+/// A resolved inbound address: the answer to "is this destination hash
+/// mine, and if so whose?"
+///
+/// Cloning this out of the table costs three refcount bumps and two
+/// `Copy` field moves — no heap allocation on the packet path. That is
+/// why the group identity is behind an `Arc` shared with the forward
+/// index rather than owned per-entry.
+#[derive(Clone, Debug)]
+pub struct InboundAddress {
+    group: Arc<ScopeGroup>,
+    member_key_id: Arc<str>,
+    epoch: u64,
+    role: EpochRole,
+}
+
+impl InboundAddress {
+    /// The scoped group this address belongs to.
+    #[must_use]
+    pub fn group(&self) -> &ScopeGroup {
+        &self.group
+    }
+
+    /// The member whose address this is. Never absent: an address in
+    /// this table always names exactly one member.
+    #[must_use]
+    pub fn member_key_id(&self) -> &str {
+        &self.member_key_id
+    }
+
+    /// The group epoch this address was derived under.
+    #[must_use]
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
+
+    /// Whether this epoch is the send epoch, an installed-but-not-yet
+    /// primary epoch, or a still-accepted superseded one.
+    #[must_use]
+    pub fn role(&self) -> EpochRole {
+        self.role
+    }
+}
+
+/// Snapshot of a group's three-phase rotation state. Operator /
+/// telemetry surface — `Copy`, no allocation.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct LiveEpochs {
+    /// Superseded epoch still accepted for receive, if a rotation is
+    /// past [`ScopeAddressTable::activate_next`] but not yet sealed.
+    pub previous: Option<u64>,
+    /// The epoch we send on.
+    pub current: u64,
+    /// Installed-but-not-yet-primary epoch, if a rotation is past
+    /// [`ScopeAddressTable::install_next`] but not yet activated.
+    pub next: Option<u64>,
+}
+
+/// What [`ScopeAddressTable::activate_next`] did.
+///
+/// `evicted` is `Some` when a previous rotation was never sealed and
+/// activating shifted its epoch out of the accept window. That is a
+/// real (if rare) loss of receive coverage, so it is reported rather
+/// than performed silently — the caller should be logging it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct EpochTransition {
+    /// The epoch we were sending on before this call.
+    pub from: u64,
+    /// The epoch we send on now.
+    pub to: u64,
+    /// An unsealed older epoch that this activation dropped, if any.
+    pub evicted: Option<u64>,
+}
+
+/// Errors from the install / rotation surface. All are programming or
+/// sequencing errors on a cold path — nothing here is a packet-path
+/// outcome.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ScopeAddressError {
+    /// No addresses installed for this `(scope, group_id)`.
+    #[error("scope_addressing: unknown group '{group_id}' in scope '{scope_kind}'")]
+    UnknownGroup {
+        /// [`CohortScope::kind_token`] of the requested scope.
+        scope_kind: &'static str,
+        /// The requested group id.
+        group_id: String,
+    },
+    /// [`ScopeAddressTable::install_group`] on a group that already has
+    /// state. Re-seeding would drop the live accept window; rotate with
+    /// [`ScopeAddressTable::install_next`] instead, or
+    /// [`ScopeAddressTable::remove_group`] first.
+    #[error("scope_addressing: group '{group_id}' already installed at epoch {epoch}")]
+    GroupAlreadyInstalled {
+        /// The group id that already has state.
+        group_id: String,
+        /// The epoch currently primary for that group.
+        epoch: u64,
+    },
+    /// [`ScopeAddressTable::install_next`] while an installed-but-not-
+    /// activated epoch is already pending. Refused rather than
+    /// overwritten: the pending epoch may already be receiving traffic
+    /// from peers that advanced first, and silently dropping its
+    /// addresses is precisely the deafness this module exists to
+    /// prevent. Activate (or seal) first.
+    #[error("scope_addressing: rotation already in progress, epoch {pending} pending activation")]
+    RotationInProgress {
+        /// The pending epoch that must be activated or removed first.
+        pending: u64,
+    },
+    /// The requested epoch is not strictly greater than the current
+    /// one. Epochs are monotonic; installing backwards would make
+    /// "previous" and "next" meaningless.
+    #[error("scope_addressing: epoch {requested} does not advance current epoch {current}")]
+    EpochNotAdvancing {
+        /// The group's current (primary) epoch.
+        current: u64,
+        /// The epoch the caller asked to install.
+        requested: u64,
+    },
+    /// [`ScopeAddressTable::activate_next`] with nothing installed.
+    #[error("scope_addressing: no pending epoch to activate")]
+    NoPendingEpoch,
+    /// An install with an empty member list. An epoch with no addresses
+    /// is a group nobody can reach — refused loudly rather than
+    /// installed as a silent black hole.
+    #[error("scope_addressing: refusing to install epoch {epoch} with no members")]
+    EmptyMembership {
+        /// The epoch the caller asked to install.
+        epoch: u64,
+    },
+    /// The same member key id appeared twice in one install. Ambiguous
+    /// intent — the caller's membership set is malformed.
+    #[error("scope_addressing: member '{member_key_id}' listed twice in one install")]
+    DuplicateMember {
+        /// The repeated member key id.
+        member_key_id: String,
+    },
+    /// Two distinct members derived to the same 16 bytes.
+    ///
+    /// With a sound deriver and distinct inputs this is a
+    /// ~2^-64 accident. In practice it fires for the one realistic
+    /// misuse: installing a new epoch with a REUSED `exporter_secret`,
+    /// which re-derives the existing epoch's addresses byte-for-byte.
+    /// Catching it here turns a key-reuse bug into a loud install-time
+    /// error instead of a leviculum `register_destination` displacement
+    /// warning and a half-deaf group.
+    #[error("scope_addressing: address collision on member '{member_key_id}' (epoch {epoch}) — reused exporter_secret?")]
+    AddressCollision {
+        /// The member whose derived address collided.
+        member_key_id: String,
+        /// The epoch being installed when the collision was found.
+        epoch: u64,
+    },
+}
+
+// ─── Internal state ─────────────────────────────────────────────────
+
+/// One epoch's worth of member addresses.
+struct EpochSlot {
+    epoch: u64,
+    /// `member_key_id -> address`. `Arc<str>` keys so the reverse index
+    /// shares the same allocation; `Arc<str>: Borrow<str>` keeps lookup
+    /// by `&str` allocation-free.
+    members: HashMap<Arc<str>, MemberAddress>,
+}
+
+/// A group's three rotation slots.
+struct GroupEpochs {
+    group: Arc<ScopeGroup>,
+    current: EpochSlot,
+    next: Option<EpochSlot>,
+    previous: Option<EpochSlot>,
+}
+
+impl GroupEpochs {
+    /// The slot holding `epoch`, whichever phase it is in.
+    fn slot_at(&self, epoch: u64) -> Option<&EpochSlot> {
+        [
+            Some(&self.current),
+            self.next.as_ref(),
+            self.previous.as_ref(),
+        ]
+        .into_iter()
+        .flatten()
+        .find(|slot| slot.epoch == epoch)
+    }
+
+    /// Every live slot, in no particular order.
+    fn slots_mut(&mut self) -> impl Iterator<Item = &mut EpochSlot> {
+        [
+            Some(&mut self.current),
+            self.next.as_mut(),
+            self.previous.as_mut(),
+        ]
+        .into_iter()
+        .flatten()
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Forward index (SEND path): scope -> group_id -> epochs.
+    /// Two-level so both levels can be probed with borrowed keys —
+    /// a flat `(CohortScope, String, u64)` key would force a `String`
+    /// allocation on every lookup.
+    groups: HashMap<CohortScope, HashMap<String, GroupEpochs>>,
+    /// Reverse index (RECEIVE path): destination hash -> who/which
+    /// epoch. Covers every live slot, which is what makes the accept
+    /// set a superset of the send set.
+    reverse: HashMap<[u8; 16], InboundAddress>,
+}
+
+// ─── The table ──────────────────────────────────────────────────────
+
+/// `(scope, group_id, epoch, member)` → 16-byte Reticulum destination
+/// hash, with three-phase epoch rotation.
+///
+/// See the module docs for the design rationale (CIRISEdge#499). The
+/// short version: derive on membership/epoch change, never on a packet;
+/// accept a superset of what you send so an epoch bump cannot deafen a
+/// group; one address per member, never per group.
+pub struct ScopeAddressTable {
+    deriver: Arc<dyn DestinationDeriver>,
+    inner: RwLock<Inner>,
+}
+
+impl ScopeAddressTable {
+    /// Construct an empty table over `deriver`.
+    ///
+    /// There is no `Default` / no-argument constructor on purpose: the
+    /// deriver is the cross-impl wire authority (CIRISVerify#259), so
+    /// every call site has to name the one it is trusting. The only
+    /// impl in this crate is `#[cfg(test)]`.
+    #[must_use]
+    pub fn new(deriver: Arc<dyn DestinationDeriver>) -> Self {
+        Self {
+            deriver,
+            inner: RwLock::new(Inner::default()),
+        }
+    }
+
+    // ── Cold path: install + rotate ──────────────────────────────────
+
+    /// Seed a group's first epoch. Derives one address per member and
+    /// makes `epoch` immediately primary (there is nothing to make
+    /// before breaking).
+    ///
+    /// Returns the number of addresses installed.
+    pub fn install_group(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+        epoch: u64,
+        exporter_secret: &[u8; 32],
+        members: &[impl AsRef<str>],
+    ) -> Result<usize, ScopeAddressError> {
+        let mut guard = self.inner.write();
+        let inner = &mut *guard;
+
+        if let Some(existing) = lookup_group(&inner.groups, scope, group_id) {
+            return Err(ScopeAddressError::GroupAlreadyInstalled {
+                group_id: group_id.to_owned(),
+                epoch: existing.current.epoch,
+            });
+        }
+
+        let group = Arc::new(ScopeGroup {
+            scope: scope.clone(),
+            group_id: group_id.to_owned(),
+        });
+        let slot = self.build_slot(&inner.reverse, epoch, exporter_secret, members)?;
+        let count = slot.members.len();
+
+        commit_slot(&mut inner.reverse, &group, &slot, EpochRole::Current);
+        inner.groups.entry(scope.clone()).or_default().insert(
+            group_id.to_owned(),
+            GroupEpochs {
+                group,
+                current: slot,
+                next: None,
+                previous: None,
+            },
+        );
+
+        Ok(count)
+    }
+
+    /// Phase 1 — derive and register the NEXT epoch's addresses while
+    /// the current epoch stays primary (make-before-break, mirroring
+    /// `ReticulumTransport::ifac_install_next`, CIRISEdge#492).
+    ///
+    /// After this call the group ACCEPTS both epochs and SENDS on the
+    /// old one. A peer that bumped its MLS epoch before us and is
+    /// already addressing our new-epoch destination therefore lands
+    /// from the first instant the new epoch exists anywhere.
+    ///
+    /// Returns the number of addresses installed.
+    pub fn install_next(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+        epoch: u64,
+        exporter_secret: &[u8; 32],
+        members: &[impl AsRef<str>],
+    ) -> Result<usize, ScopeAddressError> {
+        let mut guard = self.inner.write();
+        // Disjoint field borrows: the group state is mutated while the
+        // reverse index is read (validation) and then written (commit),
+        // so the whole install is one uninterruptible critical section
+        // with no window where the two indexes disagree.
+        let Inner { groups, reverse } = &mut *guard;
+
+        let group_state = lookup_group_mut(groups, scope, group_id)
+            .ok_or_else(|| unknown_group(scope, group_id))?;
+
+        if let Some(pending) = group_state.next.as_ref().map(|s| s.epoch) {
+            return Err(ScopeAddressError::RotationInProgress { pending });
+        }
+        if epoch <= group_state.current.epoch {
+            return Err(ScopeAddressError::EpochNotAdvancing {
+                current: group_state.current.epoch,
+                requested: epoch,
+            });
+        }
+
+        let slot = self.build_slot(reverse, epoch, exporter_secret, members)?;
+        let count = slot.members.len();
+
+        commit_slot(reverse, &group_state.group, &slot, EpochRole::Next);
+        group_state.next = Some(slot);
+
+        Ok(count)
+    }
+
+    /// Phase 2 — the installed epoch becomes primary for SENDING; the
+    /// epoch it supersedes stays accepted for RECEIVE (mirroring
+    /// `ifac_activate_next`, CIRISEdge#492).
+    ///
+    /// A straggler that has not yet advanced keeps landing, and we keep
+    /// addressing it on the old epoch via [`Self::address_at`] — it is
+    /// excluded only at [`Self::seal_rotation`].
+    pub fn activate_next(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+    ) -> Result<EpochTransition, ScopeAddressError> {
+        let mut guard = self.inner.write();
+        let inner = &mut *guard;
+        let reverse = &mut inner.reverse;
+
+        let group_state = lookup_group_mut(&mut inner.groups, scope, group_id)
+            .ok_or_else(|| unknown_group(scope, group_id))?;
+
+        let next = group_state
+            .next
+            .take()
+            .ok_or(ScopeAddressError::NoPendingEpoch)?;
+
+        // An unsealed older epoch shifts out of the accept window here.
+        // Reported in the outcome, never silent.
+        let evicted = group_state.previous.take().map(|stale| {
+            retract_slot(reverse, &stale);
+            stale.epoch
+        });
+
+        let from = group_state.current.epoch;
+        let to = next.epoch;
+        let superseded = std::mem::replace(&mut group_state.current, next);
+
+        set_role(reverse, &superseded, EpochRole::Previous);
+        set_role(reverse, &group_state.current, EpochRole::Current);
+        group_state.previous = Some(superseded);
+
+        Ok(EpochTransition { from, to, evicted })
+    }
+
+    /// Phase 3 — SEAL: drop the superseded epoch (mirroring
+    /// `ifac_seal_rotation`, CIRISEdge#492). Any member that never
+    /// re-keyed is now unreachable and can no longer reach us;
+    /// readmission means a fresh install at the live epoch.
+    ///
+    /// Call only after the convergence window. Idempotent: `Ok(None)`
+    /// when there is nothing to seal.
+    pub fn seal_rotation(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+    ) -> Result<Option<u64>, ScopeAddressError> {
+        let mut guard = self.inner.write();
+        let inner = &mut *guard;
+        let reverse = &mut inner.reverse;
+
+        let group_state = lookup_group_mut(&mut inner.groups, scope, group_id)
+            .ok_or_else(|| unknown_group(scope, group_id))?;
+
+        Ok(group_state.previous.take().map(|sealed| {
+            retract_slot(reverse, &sealed);
+            sealed.epoch
+        }))
+    }
+
+    /// Forget a group entirely — every epoch, every member, both
+    /// indexes. Returns the number of addresses removed.
+    pub fn remove_group(&self, scope: &CohortScope, group_id: &str) -> usize {
+        let mut guard = self.inner.write();
+        let inner = &mut *guard;
+        let reverse = &mut inner.reverse;
+
+        let Some(by_group) = inner.groups.get_mut(scope) else {
+            return 0;
+        };
+        let Some(mut group_state) = by_group.remove(group_id) else {
+            return 0;
+        };
+        if by_group.is_empty() {
+            inner.groups.remove(scope);
+        }
+
+        let mut removed = 0;
+        for slot in group_state.slots_mut() {
+            removed += slot.members.len();
+            retract_slot(reverse, slot);
+        }
+        removed
+    }
+
+    /// Drop one member's addresses across every live epoch of a group
+    /// (a member leaving mid-rotation). Returns the number of addresses
+    /// removed — up to one per live epoch.
+    pub fn remove_member(&self, scope: &CohortScope, group_id: &str, member_key_id: &str) -> usize {
+        let mut guard = self.inner.write();
+        let inner = &mut *guard;
+        let reverse = &mut inner.reverse;
+
+        let Some(group_state) = lookup_group_mut(&mut inner.groups, scope, group_id) else {
+            return 0;
+        };
+
+        let mut removed = 0;
+        for slot in group_state.slots_mut() {
+            if let Some(addr) = slot.members.remove(member_key_id) {
+                reverse.remove(&addr.0);
+                removed += 1;
+            }
+        }
+        removed
+    }
+
+    // ── Hot path: lookup ─────────────────────────────────────────────
+
+    /// SEND path: the address to send to `member_key_id` on right now —
+    /// the group's primary (current) epoch.
+    ///
+    /// One hash-map probe per level, borrowed keys throughout, no
+    /// allocation and no derivation. The deriver is NEVER called here.
+    #[must_use]
+    pub fn send_address(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+        member_key_id: &str,
+    ) -> Option<MemberAddress> {
+        let guard = self.inner.read();
+        let group_state = lookup_group(&guard.groups, scope, group_id)?;
+        group_state.current.members.get(member_key_id).copied()
+    }
+
+    /// SEND path, explicit epoch: the address a member holds at `epoch`,
+    /// whichever rotation slot that epoch occupies.
+    ///
+    /// This is the straggler case. Once we have activated a new epoch, a
+    /// peer still on the old one is addressed here — and keeps being
+    /// addressable until [`Self::seal_rotation`] drops that epoch, at
+    /// which point this returns `None` and the exclusion is explicit.
+    #[must_use]
+    pub fn address_at(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+        epoch: u64,
+        member_key_id: &str,
+    ) -> Option<MemberAddress> {
+        let guard = self.inner.read();
+        let group_state = lookup_group(&guard.groups, scope, group_id)?;
+        group_state
+            .slot_at(epoch)?
+            .members
+            .get(member_key_id)
+            .copied()
+    }
+
+    /// RECEIVE path: is this inbound destination hash one of ours, and
+    /// if so whose and at which epoch?
+    ///
+    /// Accepts EVERY live epoch — next, current and previous — which is
+    /// the whole point: the accept set is a superset of the send set for
+    /// the duration of a rotation. One hash-map probe; the returned
+    /// clone is refcount bumps only, no allocation, no derivation.
+    #[must_use]
+    pub fn accepts_inbound(&self, dest_hash: &[u8; 16]) -> Option<InboundAddress> {
+        self.inner.read().reverse.get(dest_hash).cloned()
+    }
+
+    // ── Introspection ────────────────────────────────────────────────
+
+    /// The group's three-phase rotation state, or `None` if the group
+    /// has no addresses installed.
+    #[must_use]
+    pub fn live_epochs(&self, scope: &CohortScope, group_id: &str) -> Option<LiveEpochs> {
+        let guard = self.inner.read();
+        let group_state = lookup_group(&guard.groups, scope, group_id)?;
+        Some(LiveEpochs {
+            previous: group_state.previous.as_ref().map(|s| s.epoch),
+            current: group_state.current.epoch,
+            next: group_state.next.as_ref().map(|s| s.epoch),
+        })
+    }
+
+    /// Total number of live addresses across every group and epoch —
+    /// i.e. the size of the receive accept set.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner.read().reverse.len()
+    }
+
+    /// `true` iff no addresses are installed.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.inner.read().reverse.is_empty()
+    }
+
+    // ── Internals ────────────────────────────────────────────────────
+
+    /// Derive a whole epoch's addresses and validate them BEFORE any
+    /// mutation, so a rejected install leaves the table exactly as it
+    /// was. A half-installed epoch would be a group that is reachable
+    /// for some members and deaf for others — the worst of the failure
+    /// modes this module exists to prevent.
+    fn build_slot(
+        &self,
+        reverse: &HashMap<[u8; 16], InboundAddress>,
+        epoch: u64,
+        exporter_secret: &[u8; 32],
+        members: &[impl AsRef<str>],
+    ) -> Result<EpochSlot, ScopeAddressError> {
+        if members.is_empty() {
+            return Err(ScopeAddressError::EmptyMembership { epoch });
+        }
+
+        let mut slot = EpochSlot {
+            epoch,
+            members: HashMap::with_capacity(members.len()),
+        };
+        let mut seen: HashSet<[u8; 16]> = HashSet::with_capacity(members.len());
+
+        for member in members {
+            let member_key_id = member.as_ref();
+            if slot.members.contains_key(member_key_id) {
+                return Err(ScopeAddressError::DuplicateMember {
+                    member_key_id: member_key_id.to_owned(),
+                });
+            }
+
+            let raw = self.deriver.derive(exporter_secret, member_key_id);
+            // Collision against this batch OR against any address
+            // already live in the table. Either way two endpoints would
+            // claim one RNS destination hash.
+            if !seen.insert(raw) || reverse.contains_key(&raw) {
+                return Err(ScopeAddressError::AddressCollision {
+                    member_key_id: member_key_id.to_owned(),
+                    epoch,
+                });
+            }
+
+            slot.members
+                .insert(Arc::from(member_key_id), MemberAddress(raw));
+        }
+
+        Ok(slot)
+    }
+}
+
+// ─── Free helpers (borrow-splitting friendly) ───────────────────────
+
+fn unknown_group(scope: &CohortScope, group_id: &str) -> ScopeAddressError {
+    ScopeAddressError::UnknownGroup {
+        scope_kind: scope.kind_token(),
+        group_id: group_id.to_owned(),
+    }
+}
+
+fn lookup_group<'a>(
+    groups: &'a HashMap<CohortScope, HashMap<String, GroupEpochs>>,
+    scope: &CohortScope,
+    group_id: &str,
+) -> Option<&'a GroupEpochs> {
+    groups.get(scope)?.get(group_id)
+}
+
+fn lookup_group_mut<'a>(
+    groups: &'a mut HashMap<CohortScope, HashMap<String, GroupEpochs>>,
+    scope: &CohortScope,
+    group_id: &str,
+) -> Option<&'a mut GroupEpochs> {
+    groups.get_mut(scope)?.get_mut(group_id)
+}
+
+/// Publish a slot's addresses into the receive accept set.
+fn commit_slot(
+    reverse: &mut HashMap<[u8; 16], InboundAddress>,
+    group: &Arc<ScopeGroup>,
+    slot: &EpochSlot,
+    role: EpochRole,
+) {
+    for (member_key_id, addr) in &slot.members {
+        reverse.insert(
+            addr.0,
+            InboundAddress {
+                group: Arc::clone(group),
+                member_key_id: Arc::clone(member_key_id),
+                epoch: slot.epoch,
+                role,
+            },
+        );
+    }
+}
+
+/// Withdraw a slot's addresses from the receive accept set.
+fn retract_slot(reverse: &mut HashMap<[u8; 16], InboundAddress>, slot: &EpochSlot) {
+    for addr in slot.members.values() {
+        reverse.remove(&addr.0);
+    }
+}
+
+/// Re-label a slot's accept-set entries after a phase transition. The
+/// role lives on the reverse entry (rather than being recomputed per
+/// packet) so the receive path stays one probe; relabelling is a cold
+/// path touching only one group's members.
+fn set_role(reverse: &mut HashMap<[u8; 16], InboundAddress>, slot: &EpochSlot, role: EpochRole) {
+    for addr in slot.members.values() {
+        if let Some(entry) = reverse.get_mut(&addr.0) {
+            entry.role = role;
+        }
+    }
+}
+
+// ─── Test-only deriver ──────────────────────────────────────────────
+
+/// **TEST ONLY.** A non-cryptographic stand-in for CIRISVerify#259's
+/// `k_destination` + `derive_destination`.
+///
+/// `#[cfg(test)]`, deliberately NOT a Cargo feature: a feature can be
+/// switched on by accident (feature unification pulls flags in from
+/// dependents — see the `test-anchor` note in `Cargo.toml` for how
+/// carefully that has to be reasoned about). `#[cfg(test)]` cannot
+/// appear in a wheel at all.
+///
+/// A destination hash is a **cross-impl wire fact**: two members of one
+/// group find each other only if every implementation computes the same
+/// 16 bytes. Shipping these bytes would hand that fact a second owner,
+/// and the divergence would be invisible — an RNS destination nobody
+/// registered is simply never delivered to, with no error anywhere.
+/// This mixer is an FNV variant with no security properties whatsoever;
+/// it exists only so the table's structure can be tested without
+/// blocking on verify.
+#[cfg(test)]
+pub struct StubDeriver;
+
+#[cfg(test)]
+impl DestinationDeriver for StubDeriver {
+    fn derive(&self, exporter_secret: &[u8; 32], member_key_id: &str) -> [u8; 16] {
+        const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+        fn mix(seed: u64, bytes: &[u8]) -> u64 {
+            let mut h = seed;
+            for b in bytes {
+                h ^= u64::from(*b);
+                h = h.wrapping_mul(PRIME);
+            }
+            h
+        }
+
+        // Two independently-seeded passes in opposite input order, so
+        // both halves depend on both inputs.
+        let lo = mix(
+            mix(0xcbf2_9ce4_8422_2325, exporter_secret),
+            member_key_id.as_bytes(),
+        );
+        let hi = mix(
+            mix(0x9e37_79b9_7f4a_7c15, member_key_id.as_bytes()),
+            exporter_secret,
+        );
+
+        let mut out = [0u8; 16];
+        out[..8].copy_from_slice(&lo.to_be_bytes());
+        out[8..].copy_from_slice(&hi.to_be_bytes());
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Wraps [`StubDeriver`] and counts calls, so tests can assert the
+    /// load-bearing property directly: lookups never derive.
+    struct CountingDeriver {
+        calls: AtomicUsize,
+    }
+
+    impl CountingDeriver {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                calls: AtomicUsize::new(0),
+            })
+        }
+
+        fn count(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl DestinationDeriver for CountingDeriver {
+        fn derive(&self, exporter_secret: &[u8; 32], member_key_id: &str) -> [u8; 16] {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            StubDeriver.derive(exporter_secret, member_key_id)
+        }
+    }
+
+    fn table() -> ScopeAddressTable {
+        ScopeAddressTable::new(Arc::new(StubDeriver))
+    }
+
+    fn family() -> CohortScope {
+        CohortScope::Family
+    }
+
+    fn secret(tag: u8) -> [u8; 32] {
+        [tag; 32]
+    }
+
+    const MEMBERS: [&str; 3] = ["ed25519:alice", "ed25519:bob", "ed25519:carol"];
+
+    /// Seed a group at epoch 7 with the three canonical members.
+    fn seeded() -> ScopeAddressTable {
+        let t = table();
+        t.install_group(&family(), "g-1", 7, &secret(0xA1), &MEMBERS)
+            .expect("seed install");
+        t
+    }
+
+    // ── lookup purity ────────────────────────────────────────────────
+
+    #[test]
+    fn lookup_never_calls_the_deriver() {
+        let deriver = CountingDeriver::new();
+        let t = ScopeAddressTable::new(Arc::clone(&deriver) as Arc<dyn DestinationDeriver>);
+        t.install_group(&family(), "g-1", 7, &secret(0xA1), &MEMBERS)
+            .expect("install");
+
+        let after_install = deriver.count();
+        assert_eq!(after_install, MEMBERS.len(), "one derivation per member");
+
+        for _ in 0..64 {
+            let addr = t
+                .send_address(&family(), "g-1", "ed25519:bob")
+                .expect("bob has a current-epoch address");
+            assert!(t.accepts_inbound(addr.as_bytes()).is_some());
+            assert!(t.address_at(&family(), "g-1", 7, "ed25519:bob").is_some());
+        }
+
+        assert_eq!(
+            deriver.count(),
+            after_install,
+            "the packet path must never derive — that is the whole reason this table exists"
+        );
+    }
+
+    #[test]
+    fn lookup_misses_are_none_not_errors() {
+        let t = seeded();
+        assert!(t
+            .send_address(&family(), "g-1", "ed25519:mallory")
+            .is_none());
+        assert!(t.send_address(&family(), "g-nope", "ed25519:bob").is_none());
+        assert!(t
+            .send_address(&CohortScope::Public, "g-1", "ed25519:bob")
+            .is_none());
+        assert!(t.accepts_inbound(&[0xEE; 16]).is_none());
+    }
+
+    // ── per-member distinctness ──────────────────────────────────────
+
+    #[test]
+    fn every_member_gets_its_own_address() {
+        let t = seeded();
+        let mut seen = std::collections::HashSet::new();
+        for m in MEMBERS {
+            let addr = t.send_address(&family(), "g-1", m).expect("member address");
+            assert!(
+                seen.insert(addr.into_bytes()),
+                "a shared per-group hash is unicast-ambiguous in RNS and trips \
+                 leviculum's register_destination displacement warning"
+            );
+        }
+        assert_eq!(seen.len(), MEMBERS.len());
+        assert_eq!(t.len(), MEMBERS.len());
+    }
+
+    #[test]
+    fn inbound_resolution_always_names_a_member() {
+        let t = seeded();
+        for m in MEMBERS {
+            let addr = t.send_address(&family(), "g-1", m).expect("member address");
+            let bound = t.accepts_inbound(addr.as_bytes()).expect("accepted");
+            assert_eq!(bound.member_key_id(), m);
+            assert_eq!(bound.group().group_id(), "g-1");
+            assert_eq!(bound.group().scope(), &family());
+            assert_eq!(bound.epoch(), 7);
+            assert_eq!(bound.role(), EpochRole::Current);
+        }
+    }
+
+    #[test]
+    fn two_groups_yield_unrelated_addresses() {
+        let t = table();
+        t.install_group(&family(), "g-1", 7, &secret(0xA1), &MEMBERS)
+            .expect("group one");
+        t.install_group(&family(), "g-2", 7, &secret(0xB2), &MEMBERS)
+            .expect("group two");
+
+        for m in MEMBERS {
+            let one = t.send_address(&family(), "g-1", m).expect("g-1 address");
+            let two = t.send_address(&family(), "g-2", m).expect("g-2 address");
+            assert_ne!(
+                one, two,
+                "same member, different group exporter_secret => unrelated address"
+            );
+        }
+        assert_eq!(t.len(), MEMBERS.len() * 2);
+    }
+
+    #[test]
+    fn same_group_id_in_two_scopes_is_two_groups() {
+        let t = table();
+        t.install_group(&family(), "g-1", 7, &secret(0xA1), &MEMBERS)
+            .expect("family group");
+        t.install_group(&CohortScope::SelfOnly, "g-1", 7, &secret(0xC3), &MEMBERS)
+            .expect("self group");
+
+        let fam = t
+            .send_address(&family(), "g-1", MEMBERS[0])
+            .expect("family");
+        let own = t
+            .send_address(&CohortScope::SelfOnly, "g-1", MEMBERS[0])
+            .expect("self");
+        assert_ne!(fam, own);
+    }
+
+    // ── phase 1: install_next ────────────────────────────────────────
+
+    #[test]
+    fn install_next_keeps_the_old_epoch_primary_for_sending() {
+        let t = seeded();
+        let before = t
+            .send_address(&family(), "g-1", MEMBERS[0])
+            .expect("before");
+
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install next");
+
+        assert_eq!(
+            t.send_address(&family(), "g-1", MEMBERS[0]),
+            Some(before),
+            "make-before-break: installing does not move the send epoch"
+        );
+        assert_eq!(
+            t.live_epochs(&family(), "g-1"),
+            Some(LiveEpochs {
+                previous: None,
+                current: 7,
+                next: Some(8),
+            })
+        );
+    }
+
+    #[test]
+    fn install_next_accepts_the_new_epoch_immediately() {
+        let t = seeded();
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install next");
+
+        let next_addr = t
+            .address_at(&family(), "g-1", 8, MEMBERS[0])
+            .expect("next-epoch address exists before activation");
+        let bound = t
+            .accepts_inbound(next_addr.as_bytes())
+            .expect("a peer that advanced first must not be talking to a dead address");
+        assert_eq!(bound.epoch(), 8);
+        assert_eq!(bound.role(), EpochRole::Next);
+        assert_eq!(t.len(), MEMBERS.len() * 2, "both epochs are accepted");
+    }
+
+    #[test]
+    fn install_next_over_a_pending_epoch_is_refused() {
+        let t = seeded();
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("first install");
+        let err = t
+            .install_next(&family(), "g-1", 9, &secret(0xC3), &MEMBERS)
+            .expect_err("second install must be refused, not silently overwrite");
+        assert_eq!(err, ScopeAddressError::RotationInProgress { pending: 8 });
+        assert_eq!(
+            t.live_epochs(&family(), "g-1").map(|e| e.next),
+            Some(Some(8)),
+            "the refused install left the pending epoch untouched"
+        );
+    }
+
+    #[test]
+    fn epochs_must_advance() {
+        let t = seeded();
+        let err = t
+            .install_next(&family(), "g-1", 7, &secret(0xB2), &MEMBERS)
+            .expect_err("same epoch");
+        assert_eq!(
+            err,
+            ScopeAddressError::EpochNotAdvancing {
+                current: 7,
+                requested: 7
+            }
+        );
+        assert!(t
+            .install_next(&family(), "g-1", 6, &secret(0xB2), &MEMBERS)
+            .is_err());
+    }
+
+    // ── phase 2: activate_next ───────────────────────────────────────
+
+    #[test]
+    fn activate_next_flips_the_send_epoch_and_keeps_the_old_for_receive() {
+        let t = seeded();
+        let old = t.send_address(&family(), "g-1", MEMBERS[0]).expect("old");
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install");
+
+        let step = t.activate_next(&family(), "g-1").expect("activate");
+        assert_eq!(
+            step,
+            EpochTransition {
+                from: 7,
+                to: 8,
+                evicted: None
+            }
+        );
+
+        let new = t.send_address(&family(), "g-1", MEMBERS[0]).expect("new");
+        assert_ne!(new, old, "sending now happens on the new epoch");
+        assert_eq!(new, t.address_at(&family(), "g-1", 8, MEMBERS[0]).unwrap());
+
+        let bound = t
+            .accepts_inbound(old.as_bytes())
+            .expect("the superseded epoch is still accepted for receive");
+        assert_eq!(bound.epoch(), 7);
+        assert_eq!(bound.role(), EpochRole::Previous);
+        assert_eq!(
+            t.accepts_inbound(new.as_bytes()).map(|b| b.role()),
+            Some(EpochRole::Current)
+        );
+        assert_eq!(
+            t.live_epochs(&family(), "g-1"),
+            Some(LiveEpochs {
+                previous: Some(7),
+                current: 8,
+                next: None,
+            })
+        );
+    }
+
+    #[test]
+    fn activate_without_a_pending_epoch_is_refused() {
+        let t = seeded();
+        assert_eq!(
+            t.activate_next(&family(), "g-1")
+                .expect_err("nothing pending"),
+            ScopeAddressError::NoPendingEpoch
+        );
+    }
+
+    #[test]
+    fn activating_over_an_unsealed_previous_reports_the_eviction() {
+        let t = seeded();
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install 8");
+        t.activate_next(&family(), "g-1").expect("activate 8");
+        // Deliberately skip seal_rotation, then rotate again.
+        t.install_next(&family(), "g-1", 9, &secret(0xC3), &MEMBERS)
+            .expect("install 9");
+        let step = t.activate_next(&family(), "g-1").expect("activate 9");
+
+        assert_eq!(
+            step,
+            EpochTransition {
+                from: 8,
+                to: 9,
+                evicted: Some(7)
+            },
+            "shifting an unsealed epoch out of the accept window is reported, never silent"
+        );
+        assert_eq!(t.len(), MEMBERS.len() * 2, "epoch 7 left the accept set");
+    }
+
+    // ── phase 3: seal_rotation ───────────────────────────────────────
+
+    #[test]
+    fn seal_rotation_drops_the_previous_epoch() {
+        let t = seeded();
+        let old = t.send_address(&family(), "g-1", MEMBERS[0]).expect("old");
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install");
+        t.activate_next(&family(), "g-1").expect("activate");
+
+        assert_eq!(t.seal_rotation(&family(), "g-1"), Ok(Some(7)));
+        assert!(
+            t.accepts_inbound(old.as_bytes()).is_none(),
+            "a member that never re-keyed is excluded at seal, not before"
+        );
+        assert_eq!(
+            t.live_epochs(&family(), "g-1"),
+            Some(LiveEpochs {
+                previous: None,
+                current: 8,
+                next: None,
+            })
+        );
+        assert_eq!(t.len(), MEMBERS.len());
+    }
+
+    #[test]
+    fn seal_rotation_is_idempotent() {
+        let t = seeded();
+        assert_eq!(t.seal_rotation(&family(), "g-1"), Ok(None));
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install");
+        t.activate_next(&family(), "g-1").expect("activate");
+        assert_eq!(t.seal_rotation(&family(), "g-1"), Ok(Some(7)));
+        assert_eq!(t.seal_rotation(&family(), "g-1"), Ok(None));
+    }
+
+    // ── straggler semantics (the invariant) ──────────────────────────
+
+    #[test]
+    fn straggler_outbound_lands_during_the_accept_window_and_only_stops_at_seal() {
+        let t = seeded();
+        let straggler_addr = t
+            .address_at(&family(), "g-1", 7, "ed25519:carol")
+            .expect("carol's epoch-7 address");
+
+        // Phase 1 — we installed the new epoch; carol has not moved.
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install");
+        assert_eq!(
+            t.address_at(&family(), "g-1", 7, "ed25519:carol"),
+            Some(straggler_addr),
+            "we can still address the straggler"
+        );
+
+        // Phase 2 — we send on epoch 8 now; carol still on 7.
+        t.activate_next(&family(), "g-1").expect("activate");
+        assert_eq!(
+            t.address_at(&family(), "g-1", 7, "ed25519:carol"),
+            Some(straggler_addr),
+            "outbound to a straggler must still resolve during the accept-old window"
+        );
+        // ...and carol's inbound to her own old-epoch address still lands.
+        assert_eq!(
+            t.accepts_inbound(straggler_addr.as_bytes())
+                .map(|b| b.epoch()),
+            Some(7)
+        );
+
+        // Phase 3 — convergence window over.
+        t.seal_rotation(&family(), "g-1").expect("seal");
+        assert_eq!(
+            t.address_at(&family(), "g-1", 7, "ed25519:carol"),
+            None,
+            "exclusion happens exactly at seal — explicitly, not by silent deafness"
+        );
+        assert!(t.accepts_inbound(straggler_addr.as_bytes()).is_none());
+        assert!(
+            t.send_address(&family(), "g-1", "ed25519:carol").is_some(),
+            "carol is still a member — only her old epoch went away"
+        );
+    }
+
+    #[test]
+    fn an_epoch_bump_never_leaves_a_gap_in_the_accept_set() {
+        // Walk a full rotation and assert that at every step BOTH the
+        // pre-rotation and post-rotation addresses of every member are
+        // accepted, except after the seal.
+        let t = seeded();
+        let before: Vec<_> = MEMBERS
+            .iter()
+            .map(|m| t.send_address(&family(), "g-1", m).expect("before"))
+            .collect();
+
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install");
+        let after: Vec<_> = MEMBERS
+            .iter()
+            .map(|m| t.address_at(&family(), "g-1", 8, m).expect("after"))
+            .collect();
+
+        for (old, new) in before.iter().zip(after.iter()) {
+            assert!(t.accepts_inbound(old.as_bytes()).is_some());
+            assert!(t.accepts_inbound(new.as_bytes()).is_some());
+        }
+        t.activate_next(&family(), "g-1").expect("activate");
+        for (old, new) in before.iter().zip(after.iter()) {
+            assert!(t.accepts_inbound(old.as_bytes()).is_some());
+            assert!(t.accepts_inbound(new.as_bytes()).is_some());
+        }
+        t.seal_rotation(&family(), "g-1").expect("seal");
+        for (old, new) in before.iter().zip(after.iter()) {
+            assert!(t.accepts_inbound(old.as_bytes()).is_none());
+            assert!(t.accepts_inbound(new.as_bytes()).is_some());
+        }
+    }
+
+    // ── install validation ───────────────────────────────────────────
+
+    #[test]
+    fn reusing_an_exporter_secret_across_epochs_is_caught_at_install() {
+        let t = seeded();
+        let err = t
+            .install_next(&family(), "g-1", 8, &secret(0xA1), &MEMBERS)
+            .expect_err("same secret re-derives the live epoch's addresses");
+        assert!(matches!(
+            err,
+            ScopeAddressError::AddressCollision { epoch: 8, .. }
+        ));
+        assert_eq!(
+            t.live_epochs(&family(), "g-1").map(|e| e.next),
+            Some(None),
+            "the rejected install must leave no partial epoch behind"
+        );
+        assert_eq!(t.len(), MEMBERS.len());
+    }
+
+    #[test]
+    fn empty_membership_is_refused() {
+        let t = table();
+        let none: [&str; 0] = [];
+        assert_eq!(
+            t.install_group(&family(), "g-1", 7, &secret(0xA1), &none)
+                .expect_err("empty install"),
+            ScopeAddressError::EmptyMembership { epoch: 7 }
+        );
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn duplicate_member_is_refused() {
+        let t = table();
+        let dupes = ["ed25519:alice", "ed25519:alice"];
+        assert_eq!(
+            t.install_group(&family(), "g-1", 7, &secret(0xA1), &dupes)
+                .expect_err("duplicate member"),
+            ScopeAddressError::DuplicateMember {
+                member_key_id: "ed25519:alice".to_owned()
+            }
+        );
+        assert!(t.is_empty(), "rejected install commits nothing");
+    }
+
+    #[test]
+    fn reinstalling_a_live_group_is_refused() {
+        let t = seeded();
+        assert_eq!(
+            t.install_group(&family(), "g-1", 9, &secret(0xB2), &MEMBERS)
+                .expect_err("group already installed"),
+            ScopeAddressError::GroupAlreadyInstalled {
+                group_id: "g-1".to_owned(),
+                epoch: 7
+            }
+        );
+    }
+
+    #[test]
+    fn rotation_on_an_unknown_group_errors_on_every_phase() {
+        let t = table();
+        let expected = ScopeAddressError::UnknownGroup {
+            scope_kind: "family",
+            group_id: "ghost".to_owned(),
+        };
+        assert_eq!(
+            t.install_next(&family(), "ghost", 1, &secret(0xA1), &MEMBERS)
+                .expect_err("install_next"),
+            expected
+        );
+        assert_eq!(
+            t.activate_next(&family(), "ghost").expect_err("activate"),
+            expected
+        );
+        assert_eq!(
+            t.seal_rotation(&family(), "ghost").expect_err("seal"),
+            expected
+        );
+    }
+
+    // ── removal ──────────────────────────────────────────────────────
+
+    #[test]
+    fn remove_group_clears_both_indexes() {
+        let t = seeded();
+        let addr = t.send_address(&family(), "g-1", MEMBERS[0]).expect("addr");
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install");
+
+        assert_eq!(t.remove_group(&family(), "g-1"), MEMBERS.len() * 2);
+        assert!(t.is_empty());
+        assert!(t.accepts_inbound(addr.as_bytes()).is_none());
+        assert!(t.live_epochs(&family(), "g-1").is_none());
+        assert_eq!(t.remove_group(&family(), "g-1"), 0, "idempotent");
+    }
+
+    #[test]
+    fn remove_member_clears_every_live_epoch() {
+        let t = seeded();
+        t.install_next(&family(), "g-1", 8, &secret(0xB2), &MEMBERS)
+            .expect("install");
+        t.activate_next(&family(), "g-1").expect("activate");
+
+        assert_eq!(t.remove_member(&family(), "g-1", "ed25519:bob"), 2);
+        assert!(t.send_address(&family(), "g-1", "ed25519:bob").is_none());
+        assert!(t.address_at(&family(), "g-1", 7, "ed25519:bob").is_none());
+        assert_eq!(t.len(), (MEMBERS.len() - 1) * 2);
+        assert_eq!(t.remove_member(&family(), "g-1", "ed25519:bob"), 0);
+        assert_eq!(t.remove_member(&family(), "g-1", "ed25519:nobody"), 0);
+    }
+
+    // ── stub-deriver sanity (structure only, never wire bytes) ───────
+
+    #[test]
+    fn stub_deriver_is_deterministic_and_input_sensitive() {
+        let s = secret(0x11);
+        assert_eq!(
+            StubDeriver.derive(&s, "ed25519:alice"),
+            StubDeriver.derive(&s, "ed25519:alice")
+        );
+        assert_ne!(
+            StubDeriver.derive(&s, "ed25519:alice"),
+            StubDeriver.derive(&s, "ed25519:bob")
+        );
+        assert_ne!(
+            StubDeriver.derive(&s, "ed25519:alice"),
+            StubDeriver.derive(&secret(0x22), "ed25519:alice")
+        );
+    }
+}

--- a/src/scope_addressing.rs
+++ b/src/scope_addressing.rs
@@ -57,18 +57,47 @@
 //! §2.2/§2.4-shaped, alongside the `k_record_id` / `k_symbol` /
 //! `derive_record_id` family this crate already re-exports from
 //! `crate::scope_privacy`). Verify is the first conformant impl per FSD
-//! §9; edge reproduces its bytes, it does not invent them.
+//! §9; edge reproduces its bytes, it does not invent them. It shipped in
+//! **v13.4.0**, and [`ScopePrivacyDeriver`] is the thin adapter onto it —
+//! `k_destination` then `derive_destination`, with no edge-side
+//! transformation of either input or output.
 //!
 //! **A destination hash is a cross-impl wire fact.** Two members of one
 //! group find each other only if both compute the same 16 bytes.
 //! Shipping edge-local "good enough" bytes would give that wire fact two
 //! owners, and the divergence is invisible until a real group silently
-//! fails to converge in the field. So the only [`DestinationDeriver`]
-//! impl in this crate is [`StubDeriver`], and it is `#[cfg(test)]` —
-//! not feature-gated, `#[cfg(test)]`. There is no build flag that puts
-//! it in a wheel; a release build that wanted it would not compile.
-//! [`ScopeAddressTable::new`] takes the deriver as a parameter for
-//! exactly that reason: production must supply verify's.
+//! fails to converge in the field. So the only other
+//! [`DestinationDeriver`] impl in this crate is [`StubDeriver`], and it
+//! is `#[cfg(test)]` — not feature-gated, `#[cfg(test)]`. There is no
+//! build flag that puts it in a wheel; a release build that wanted it
+//! would not compile. [`ScopeAddressTable::new`] takes the deriver as a
+//! parameter for exactly that reason: production must supply verify's.
+//!
+//! Verify's published vectors are reproduced in this file's
+//! `verify_259_golden_vectors` tests. Persist deliberately ships no
+//! witness for them (`ciris-crypto` gates `scope-privacy` behind a
+//! feature persist does not enable, since persist never calls these
+//! functions), so that module is the **only** place in the stack where a
+//! destination-derivation drift is caught.
+//!
+//! # Open: which MLS exporter label feeds `exporter_secret`
+//!
+//! `k_destination` takes "the group's `exporter_secret`", but RFC 9420
+//! §8.5's exporter is a *labelled* KDF — `export_secret(label, context,
+//! len)` — so that input is only well-defined once the label is fixed,
+//! and two members agree only if they export under the same one. That
+//! label is therefore as wire-affecting as the derivation itself and is
+//! **not** edge's to choose (raised on CIRISVerify#259 after v13.4.0
+//! closed it).
+//!
+//! One thing is already settled in the negative: edge's existing
+//! `ROOT_SECRET_LABEL` (`"ciris-realtime-av-epoch-dek-seed-v1"`,
+//! `transport::realtime_av_mls`) must NOT be that input. It is a DEK
+//! seed; feeding it here would derive a routing identifier that appears
+//! in the clear on the wire from the same material that seeds the
+//! content key, collapsing two secrets the exporter exists to keep
+//! independent. Until the label is specified, the table is simply never
+//! installed in production.
 //!
 //! # Locking
 //!
@@ -825,6 +854,32 @@ fn set_role(reverse: &mut HashMap<[u8; 16], InboundAddress>, slot: &EpochSlot, r
     }
 }
 
+// ─── Production deriver ─────────────────────────────────────────────
+
+/// The real derivation, from CIRISVerify v13.4.0's `scope_privacy`
+/// (CIRISVerify#259 — shipped, closed).
+///
+/// `derive` is `k_destination` then `derive_destination`, in that order,
+/// with no edge-side transformation of either input or output. That is
+/// the whole point: a destination hash is a cross-impl wire fact, so
+/// edge reproduces verify's bytes rather than computing its own — the
+/// same relationship [`crate::scope_privacy`] already has with
+/// `k_record_id` / `k_symbol` per FSD §9.
+///
+/// `k_destination` is recomputed per `derive` call rather than cached
+/// alongside the group. Derivation is COLD — once per
+/// `(group, epoch, member)` at an epoch boundary, never per packet — so
+/// caching would trade a real hazard (a `k_destination` living longer
+/// than the epoch whose secret produced it) for no measurable gain.
+pub struct ScopePrivacyDeriver;
+
+impl DestinationDeriver for ScopePrivacyDeriver {
+    fn derive(&self, exporter_secret: &[u8; 32], member_key_id: &str) -> [u8; 16] {
+        let k = crate::scope_privacy::k_destination(exporter_secret);
+        crate::scope_privacy::derive_destination(&k, member_key_id)
+    }
+}
+
 // ─── Test-only deriver ──────────────────────────────────────────────
 
 /// **TEST ONLY.** A non-cryptographic stand-in for CIRISVerify#259's
@@ -1438,5 +1493,106 @@ mod tests {
             StubDeriver.derive(&s, "ed25519:alice"),
             StubDeriver.derive(&secret(0x22), "ed25519:alice")
         );
+    }
+}
+
+/// CIRISVerify#259 golden vectors, reproduced byte-for-byte.
+///
+/// Per FSD §9 verify is the first conformant impl and edge reproduces its
+/// vectors in edge's own CI — the same obligation [`crate::scope_privacy`]
+/// already discharges for §2.2/§2.4. Persist deliberately ships no witness
+/// for these (`ciris-crypto` gates `scope-privacy` behind a feature persist
+/// does not enable, because persist never calls these functions), so this is
+/// the ONLY place in the stack where the destination vectors are asserted.
+/// If it is deleted, nothing else catches a derivation drift — and a drifted
+/// destination fails silently: an RNS hash nobody registered is simply never
+/// delivered to, with no error anywhere.
+#[cfg(test)]
+mod verify_259_golden_vectors {
+    use super::*;
+
+    /// Published in CIRISVerify v13.4.0.
+    const EXPORTER: [u8; 32] = [0x42u8; 32];
+    const K_DESTINATION_HEX: &str =
+        "3d854734e268842395e65c84d13a5ce74ddac1e5c51e70f2e0a5455e7293c2fb";
+    const DESTINATION_HEX: &str = "944a30ea6ea5c07fbfd0ece7a0779a29";
+    const MEMBER: &str = "ciris-node-1";
+
+    fn hex(bytes: &[u8]) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::with_capacity(bytes.len() * 2);
+        for b in bytes {
+            write!(s, "{b:02x}").expect("write to String is infallible");
+        }
+        s
+    }
+
+    #[test]
+    fn k_destination_matches_the_published_vector() {
+        assert_eq!(
+            hex(&crate::scope_privacy::k_destination(&EXPORTER)),
+            K_DESTINATION_HEX,
+            "K_destination drifted from CIRISVerify v13.4.0",
+        );
+    }
+
+    #[test]
+    fn derive_destination_matches_the_published_vector() {
+        let k = crate::scope_privacy::k_destination(&EXPORTER);
+        assert_eq!(
+            hex(&crate::scope_privacy::derive_destination(&k, MEMBER)),
+            DESTINATION_HEX,
+            "destination hash drifted from CIRISVerify v13.4.0",
+        );
+    }
+
+    /// The vector must survive the trait, not just the free functions —
+    /// this is what the table actually calls.
+    #[test]
+    fn the_production_deriver_reproduces_the_vector() {
+        assert_eq!(
+            hex(&ScopePrivacyDeriver.derive(&EXPORTER, MEMBER)),
+            DESTINATION_HEX,
+            "ScopePrivacyDeriver must be k_destination then derive_destination, \
+             with no edge-side transformation of either input or output",
+        );
+    }
+
+    /// Per-member, never a shared group hash (decision 1 of the issue): the
+    /// same group secret must give different members different addresses, or
+    /// N nodes land under one RNS routing entry and unicast is ambiguous.
+    #[test]
+    fn members_of_one_group_get_unrelated_addresses() {
+        let a = ScopePrivacyDeriver.derive(&EXPORTER, "ciris-node-1");
+        let b = ScopePrivacyDeriver.derive(&EXPORTER, "ciris-node-2");
+        assert_ne!(a, b, "a shared group hash is unicast-ambiguous in RNS");
+    }
+
+    /// The epoch secret is what separates epochs: the same member under a
+    /// different exporter must land somewhere unrelated, which is what makes
+    /// the three-phase rotation necessary in the first place.
+    #[test]
+    fn a_new_epoch_secret_moves_the_address() {
+        let old = ScopePrivacyDeriver.derive(&EXPORTER, MEMBER);
+        let new = ScopePrivacyDeriver.derive(&[0x43u8; 32], MEMBER);
+        assert_ne!(
+            old, new,
+            "if an epoch bump did not move the address, rotation would be a no-op",
+        );
+    }
+
+    /// The table must hand out exactly what the deriver computes — no
+    /// truncation, re-hashing, or byte-order surprise between them.
+    #[test]
+    fn the_table_hands_out_the_derived_bytes_unchanged() {
+        let scope = crate::cohort_scope::CohortScope::Family;
+        let table = ScopeAddressTable::new(Arc::new(ScopePrivacyDeriver));
+        table
+            .install_group(&scope, "grp", 1, &EXPORTER, &[MEMBER])
+            .expect("install");
+        let addr = table
+            .send_address(&scope, "grp", MEMBER)
+            .expect("send address");
+        assert_eq!(hex(addr.as_bytes()), DESTINATION_HEX);
     }
 }

--- a/src/scope_privacy.rs
+++ b/src/scope_privacy.rs
@@ -41,8 +41,8 @@
 // ─── §2.2 / §2.4 / §3.4 re-exports (verify v6.3.0 authority) ────────
 
 pub use ciris_crypto::scope_privacy::{
-    derive_record_id, derive_symbol_key, k_record_id, k_symbol, witness_cover_leaf, RecordType,
-    LABEL_RECORD_ID, LABEL_SYMBOL,
+    derive_destination, derive_record_id, derive_symbol_key, k_destination, k_record_id, k_symbol,
+    witness_cover_leaf, RecordType, LABEL_DESTINATION, LABEL_RECORD_ID, LABEL_SYMBOL,
 };
 
 // ─── §3.3 HPKE_SUITE_ID re-export (verify v6.3.0 pinned bytes) ──────

--- a/src/transport/realtime_av_relay.rs
+++ b/src/transport/realtime_av_relay.rs
@@ -229,7 +229,31 @@ pub struct RelayNode {
     /// §5.6.8.8.1.1 RC6 the destination is the rendezvous-channel
     /// envelope, which at the transport tier is a plain
     /// `DestinationHash`.
+    ///
+    /// CIRISEdge#499 — this is the address the relay SENDS from and
+    /// publishes as the rendezvous channel. It is no longer the only
+    /// address it ANSWERS on; see [`Self::superseded_address`].
     address: DestinationHash,
+    /// CIRISEdge#499 — the other address that is live during an epoch
+    /// rotation window, or `None` outside one.
+    ///
+    /// Once the relay's address is scope-derived it changes at every
+    /// epoch boundary, and a rotation must never strand a subscriber
+    /// mid-dial. So the relay is reachable at two addresses across the
+    /// window and sends from exactly one, mirroring
+    /// [`ScopeAddressTable`]'s `Next` → `Current` → `Previous` roles:
+    /// after `install_next` this holds the INCOMING address (a peer
+    /// that advanced before us dials here), after `activate_next` it
+    /// holds the OUTGOING one (a straggler that has not yet advanced
+    /// still dials here), and `seal_rotation` drops it.
+    ///
+    /// The send-vs-receive asymmetry IS the make-before-break property:
+    /// [`Self::address`] is a single value because sending on two
+    /// addresses is never right, while [`Self::accepts`] spans both
+    /// because refusing either would drop a live stream.
+    ///
+    /// [`ScopeAddressTable`]: crate::scope_addressing::ScopeAddressTable
+    superseded_address: Option<DestinationHash>,
     /// Per-stream subscriber roster. Keyed by [`StreamId`]; values
     /// are the set of subscribed federation `key_id`s. Populated by
     /// [`Self::subscribe`], cleared by [`Self::unsubscribe`].
@@ -252,6 +276,7 @@ impl RelayNode {
         Self {
             node,
             address,
+            superseded_address: None,
             subscribers: HashMap::new(),
             states: HashMap::new(),
         }
@@ -260,9 +285,72 @@ impl RelayNode {
     /// Borrow the relay's own destination hash. Used by the Layer 2
     /// wiring to publish the relay's address to peers (e.g. as the
     /// RC6 rendezvous channel for a stream).
+    ///
+    /// This is the SEND address. To decide whether an inbound dial is
+    /// for us, use [`Self::accepts`] — during a rotation window this
+    /// address is not the only correct answer.
     #[must_use]
     pub fn address(&self) -> &DestinationHash {
         &self.address
+    }
+
+    /// CIRISEdge#499 — the other address live during a rotation window,
+    /// or `None` outside one.
+    #[must_use]
+    pub fn superseded_address(&self) -> Option<&DestinationHash> {
+        self.superseded_address.as_ref()
+    }
+
+    /// CIRISEdge#499 — whether `dial` is an address this relay answers
+    /// on. True for the send address and, during a rotation window, for
+    /// the superseded one.
+    ///
+    /// Every inbound-admission decision must go through here rather
+    /// than comparing against [`Self::address`], which is correct only
+    /// outside a rotation window.
+    #[must_use]
+    pub fn accepts(&self, dial: &DestinationHash) -> bool {
+        self.address == *dial || self.superseded_address.as_ref() == Some(dial)
+    }
+
+    /// CIRISEdge#499 phase 1 — a new epoch's address becomes reachable
+    /// while the current one keeps sending. A peer that advanced before
+    /// us dials `incoming` and is answered.
+    ///
+    /// Returns the address this displaces from the window, if any.
+    /// Installing twice without an intervening [`Self::seal_rotation`]
+    /// is how a relay silently loses reachability for the epoch it
+    /// forgot, so the displaced value is returned rather than dropped —
+    /// the caller decides whether that is a bug.
+    pub fn install_next_address(&mut self, incoming: DestinationHash) -> Option<DestinationHash> {
+        self.superseded_address.replace(incoming)
+    }
+
+    /// CIRISEdge#499 phase 2 — the installed address becomes the SEND
+    /// address; the one it supersedes stays reachable for stragglers
+    /// that have not yet advanced.
+    ///
+    /// No-op (returns `false`) when no address is installed: a rotation
+    /// that never ran phase 1 has nothing to activate, and promoting
+    /// nothing would leave the relay sending from an address no peer
+    /// has derived.
+    pub fn activate_next_address(&mut self) -> bool {
+        let Some(incoming) = self.superseded_address.take() else {
+            return false;
+        };
+        let outgoing = std::mem::replace(&mut self.address, incoming);
+        self.superseded_address = Some(outgoing);
+        true
+    }
+
+    /// CIRISEdge#499 phase 3 — SEAL: drop the superseded address. Any
+    /// subscriber that never re-keyed can no longer reach the relay and
+    /// must re-dial at the live epoch.
+    ///
+    /// Call only after the convergence window. Idempotent: `None` when
+    /// there is nothing to seal.
+    pub fn seal_address_rotation(&mut self) -> Option<DestinationHash> {
+        self.superseded_address.take()
     }
 
     /// Register a subscriber on a stream with their pre-established
@@ -564,6 +652,107 @@ mod tests {
     /// Synthetic destination hash for a relay address.
     fn test_address() -> DestinationHash {
         DestinationHash::new([0x42u8; 16])
+    }
+
+    /// CIRISEdge#499 — the relay's address rotation window.
+    ///
+    /// The relay's address becomes scope-derived, so it changes at every
+    /// epoch boundary. These pin the make-before-break property: the relay
+    /// SENDS from one address and ANSWERS on two, so no phase of a rotation
+    /// can strand a subscriber that is mid-dial.
+    mod address_rotation {
+        use super::*;
+
+        const OLD: DestinationHash = DestinationHash::new([0x42u8; 16]);
+        const NEW: DestinationHash = DestinationHash::new([0x99u8; 16]);
+
+        fn relay() -> RelayNode {
+            RelayNode::new(test_node(), OLD)
+        }
+
+        #[test]
+        fn outside_a_window_only_the_send_address_is_answered() {
+            let relay = relay();
+            assert!(relay.accepts(&OLD));
+            assert!(
+                !relay.accepts(&NEW),
+                "an address we never installed is not ours"
+            );
+            assert_eq!(relay.superseded_address(), None);
+        }
+
+        #[test]
+        fn every_phase_of_a_rotation_answers_both_addresses() {
+            let mut relay = relay();
+
+            // Phase 1 — the new address is reachable; we still send from the old.
+            assert_eq!(relay.install_next_address(NEW), None);
+            assert!(
+                relay.accepts(&OLD) && relay.accepts(&NEW),
+                "phase 1 must answer both"
+            );
+            assert_eq!(
+                relay.address(),
+                &OLD,
+                "phase 1 must NOT move the send address"
+            );
+
+            // Phase 2 — the send address moves; the old one stays answerable.
+            assert!(relay.activate_next_address());
+            assert_eq!(relay.address(), &NEW, "phase 2 moves the send address");
+            assert!(
+                relay.accepts(&OLD) && relay.accepts(&NEW),
+                "phase 2 must answer both"
+            );
+
+            // Phase 3 — the old address is dropped.
+            assert_eq!(relay.seal_address_rotation(), Some(OLD));
+            assert!(relay.accepts(&NEW));
+            assert!(!relay.accepts(&OLD), "a sealed address is no longer ours");
+        }
+
+        #[test]
+        fn activate_without_install_is_refused() {
+            let mut relay = relay();
+            // Promoting nothing would leave the relay sending from an address
+            // no peer has derived — unreachable in both directions.
+            assert!(!relay.activate_next_address());
+            assert_eq!(
+                relay.address(),
+                &OLD,
+                "a refused activate must not move the send address"
+            );
+            assert!(relay.accepts(&OLD));
+        }
+
+        #[test]
+        fn a_double_install_reports_the_address_it_displaces() {
+            let mut relay = relay();
+            let third = DestinationHash::new([0x07u8; 16]);
+            assert_eq!(relay.install_next_address(NEW), None);
+            // Losing NEW here is how a relay silently becomes unreachable for
+            // an epoch, so it is returned rather than dropped.
+            assert_eq!(relay.install_next_address(third), Some(NEW));
+            assert!(
+                !relay.accepts(&NEW),
+                "the displaced address is no longer answered"
+            );
+            assert!(relay.accepts(&third) && relay.accepts(&OLD));
+        }
+
+        #[test]
+        fn seal_is_idempotent() {
+            let mut relay = relay();
+            assert_eq!(relay.seal_address_rotation(), None);
+            relay.install_next_address(NEW);
+            relay.activate_next_address();
+            assert_eq!(relay.seal_address_rotation(), Some(OLD));
+            assert_eq!(relay.seal_address_rotation(), None);
+            assert!(
+                relay.accepts(&NEW),
+                "sealing twice must not strand the live address"
+            );
+        }
     }
 
     fn stream(seed: u8) -> StreamId {

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -77,6 +77,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -96,6 +97,7 @@ use super::attestation::{
 use super::{InboundFrame, Transport, TransportError, TransportId, TransportSendOutcome};
 use crate::identity::LocalSigner;
 use crate::reachability::{AttemptOutcome, ReachabilityTracker};
+use crate::scope_addressing::{InboundAddress, MemberAddress, ScopeAddressTable};
 use crate::verify::{
     HybridPolicy, ProvenanceChain, RootingDirectory, RootingRejection, RootingVerdict,
 };
@@ -1660,6 +1662,17 @@ pub struct ReticulumTransport {
     /// PRIVATE key (unlike `local_transport_pubkey`), so it can sign the
     /// LINKIDENTIFY packet.
     local_identity: Identity,
+    /// CIRISEdge#499 — the scope-native address table, installed ONCE
+    /// (`install_scope_address_table`) after the cohort/session MLS layer
+    /// derives its first group secret. `OnceLock` because the lifecycle is
+    /// genuinely write-once-then-read-many: the transport starts long before
+    /// any group is joined, and every later mutation (install/rotate/remove)
+    /// happens *inside* the table's own lock, not by swapping the handle. A
+    /// read is therefore one atomic load on the receive path — no transport
+    /// lock, so nothing here can be held across an `.await` (CIRISEdge#217).
+    /// `None` until installed: every scope-native lookup then declines and
+    /// the federation-scope paths are unaffected.
+    scope_addresses: OnceLock<Arc<ScopeAddressTable>>,
     /// Edge's own announce attestation app-data — built once in
     /// `new` (sign with the federation `LocalSigner`) and emitted
     /// verbatim on every announce. `None` when no signer was
@@ -2480,6 +2493,7 @@ impl ReticulumTransport {
             announce_policy,
             local_transport_pubkey,
             local_identity: identity.clone(),
+            scope_addresses: OnceLock::new(),
             local_attestation,
             local_signer,
             self_route,
@@ -2684,6 +2698,121 @@ impl ReticulumTransport {
     ) {
         self.announce_policy
             .register_destination_scope(dest_hash, scope);
+    }
+
+    /// CIRISEdge#499 — install the scope-native address table. Called ONCE,
+    /// by whichever layer owns the MLS group secrets, as soon as the first
+    /// group is joined. Returns `Err` if a table is already installed rather
+    /// than silently displacing it: two tables would mean two disagreeing
+    /// answers to "is this inbound hash mine", and the loser's registered
+    /// destinations would still be live on the node.
+    ///
+    /// # Errors
+    /// [`TransportError::Config`] if a table was already installed.
+    pub fn install_scope_address_table(
+        &self,
+        table: Arc<ScopeAddressTable>,
+    ) -> Result<(), TransportError> {
+        self.scope_addresses
+            .set(table)
+            .map_err(|_| TransportError::Config("scope address table already installed".to_owned()))
+    }
+
+    /// CIRISEdge#499 — the installed scope-address table, if any.
+    ///
+    /// This is the accessor the **replication layer** uses to resolve a
+    /// scoped address *above* the transport. Per the #499 design fork,
+    /// `Transport::send` deliberately grows no scope parameter and the
+    /// transport deliberately does not parse scope on the send path: the
+    /// caller already computed `projection_for` for the record, so it
+    /// already holds the scope, and it hands `send` an address that cannot
+    /// be wrong (the [`ResolvedRecipient`] pattern from CIRISEdge#402).
+    ///
+    /// [`ResolvedRecipient`]: crate::replication::resolved_state::ResolvedRecipient
+    #[must_use]
+    pub fn scope_address_table(&self) -> Option<&Arc<ScopeAddressTable>> {
+        self.scope_addresses.get()
+    }
+
+    /// CIRISEdge#499 — listen on a scope-derived destination.
+    ///
+    /// The address is a [`MemberAddress`], which has no public byte
+    /// constructor: the only way to hold one is to have obtained it from a
+    /// [`ScopeAddressTable`], which derives it from an MLS `exporter_secret`.
+    /// So "this hash was derived from a group secret I possess" is a property
+    /// of the *type*, not something this function has to re-check.
+    ///
+    /// Registration is COLD — once per (group, epoch, member), never per
+    /// packet. It does two things that must not drift apart: registers the
+    /// explicit-hash destination with the node, and registers its scope with
+    /// the announce-suppression policy so the node's auto-announce loops
+    /// suppress it (CC 5.4 — group-scoped destinations MUST NOT announce).
+    ///
+    /// `Public` is refused. A derived per-member address is not a discovery
+    /// address; announcing one would publish the very reachability fact the
+    /// derivation exists to withhold (CIRISEdge#311 limb (b)), and it would
+    /// not even work — leviculum v0.19 answers path requests for
+    /// explicit-hash destinations with silence, because a path response *is*
+    /// an announce and an announce for a caller-supplied hash is
+    /// unverifiable by reference RNS. First contact happens at federation
+    /// scope; scoped addresses are derived thereafter.
+    ///
+    /// # Errors
+    /// [`TransportError::Config`] if `scope` is `Public`, or if the
+    /// destination cannot be built.
+    pub fn register_scoped_destination(
+        &self,
+        address: &MemberAddress,
+        scope: &crate::cohort_scope::CohortScope,
+    ) -> Result<(), TransportError> {
+        if matches!(scope, crate::cohort_scope::CohortScope::Public) {
+            return Err(TransportError::Config(
+                "refusing to register a scope-derived destination as Public: \
+                 a derived per-member address is not a discovery address"
+                    .to_owned(),
+            ));
+        }
+        let hash = *address.as_bytes();
+        let mut dest = Destination::with_explicit_hash(
+            Some(self.local_identity.clone()),
+            Direction::In,
+            DestinationType::Single,
+            EDGE_APP_NAME,
+            &[EDGE_APP_ASPECT],
+            hash,
+        )
+        .map_err(|e| TransportError::Config(format!("scoped destination build: {e}")))?;
+        dest.set_accepts_links(true);
+        debug_assert_eq!(
+            dest.hash().as_bytes(),
+            &hash,
+            "explicit-hash destination must index by the derived address",
+        );
+        // Scope FIRST, then register. The policy default-SUPPRESSES an
+        // unregistered destination, so this order has no window in which the
+        // node holds an announceable destination it has no scope for; the
+        // reverse order does.
+        self.register_announce_scope(hash, scope.clone());
+        self.node.register_destination(dest);
+        Ok(())
+    }
+
+    /// CIRISEdge#499 — resolve an inbound destination hash to the scope
+    /// group, member and epoch it was derived for, or `None` if it is not one
+    /// of ours.
+    ///
+    /// A `Some` here is a **cryptographic admission fact**, not a hint:
+    /// the hash is derived from an MLS `exporter_secret`, which binds
+    /// `(group_id, epoch)` per RFC 9420 §8.5, so arrival on it proves the
+    /// sender possessed that group secret. This is why scope-native
+    /// addressing makes the hottest path (`attribute_and_deliver`) *cheaper*
+    /// rather than dearer — admission moves ahead of the parse.
+    ///
+    /// Returns `None` when no table is installed, which is the production
+    /// state until the derivation lands (CIRISVerify#259).
+    #[must_use]
+    pub fn inbound_scope(&self, dest_hash: &[u8; 16]) -> Option<InboundAddress> {
+        self.scope_addresses.get()?.accepts_inbound(dest_hash)
     }
 
     /// spec. Returns a `Vec<TransportSpec>` of `(handle, kind)` pairs.
@@ -9173,5 +9302,235 @@ mod tests {
         let mut leaf = ReticulumTransportConfig::new(PathBuf::from("/tmp/x.id"), "leaf-key");
         leaf.enable_transport = false;
         assert!(!leaf.enable_transport, "mobile leaf edge does not forward");
+    }
+}
+
+/// CIRISEdge#499 — the transport half of scope-native addressing.
+///
+/// These live in-crate rather than in `tests/` on purpose: `StubDeriver` is
+/// `#[cfg(test)]`, so an integration test cannot build a [`ScopeAddressTable`]
+/// at all. That is the point — outside this crate's own tests there is no way
+/// to obtain a [`MemberAddress`] except from a real derivation.
+#[cfg(test)]
+mod scope_native_addressing_tests {
+    use super::*;
+    use crate::cohort_scope::CohortScope;
+    use crate::scope_addressing::StubDeriver;
+    use leviculum_core::AnnounceControl as _;
+
+    async fn bare_transport(dir: &std::path::Path, key_id: &str) -> ReticulumTransport {
+        // A hybrid signer, because CIRISEdge#333 refuses to build a transport
+        // that cannot self-attest its announces.
+        let mut ed_seed = [0u8; 32];
+        let mut pqc_seed = [0u8; 32];
+        let salt = u8::try_from(key_id.len() % 251).expect("in range");
+        for (i, b) in ed_seed.iter_mut().enumerate() {
+            *b = u8::try_from(i % 251).expect("in range") ^ salt;
+        }
+        pqc_seed.copy_from_slice(&ed_seed);
+        pqc_seed[0] ^= 0x55;
+        let classical: Arc<dyn ciris_keyring::HardwareSigner> = Arc::new(
+            ciris_keyring::Ed25519SoftwareSigner::from_bytes(&ed_seed, key_id).expect("ed25519"),
+        );
+        let pqc: Arc<dyn ciris_keyring::PqcSigner> = Arc::new(
+            ciris_keyring::MlDsa65SoftwareSigner::from_seed_bytes(
+                &pqc_seed,
+                format!("{key_id}-pqc"),
+            )
+            .expect("ml_dsa_65"),
+        );
+        let signer = Arc::new(LocalSigner::new(key_id, classical, Some(pqc)));
+
+        // No typed interfaces, and the default `0.0.0.0:4242` server replaced
+        // with an ephemeral port so these four tests can run concurrently. The
+        // node comes up with a routing table and a local identity; nothing here
+        // sends a byte.
+        let mut config = ReticulumTransportConfig::new(dir.join("transport.id"), key_id);
+        config.listen_addr = "127.0.0.1:0".parse().expect("ephemeral addr parses");
+        ReticulumTransport::new(
+            config,
+            ReticulumAuth {
+                signer: Some(signer),
+                ..ReticulumAuth::default()
+            },
+        )
+        .await
+        .expect("bare transport")
+    }
+
+    fn table_with_group(
+        scope: &CohortScope,
+        group_id: &str,
+        members: &[&str],
+    ) -> Arc<ScopeAddressTable> {
+        let table = Arc::new(ScopeAddressTable::new(Arc::new(StubDeriver)));
+        table
+            .install_group(scope, group_id, 1, &[9u8; 32], members)
+            .expect("install group");
+        table
+    }
+
+    #[tokio::test]
+    async fn scope_address_table_installs_exactly_once() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transport = bare_transport(dir.path(), "edge-once").await;
+
+        assert!(
+            transport.scope_address_table().is_none(),
+            "a fresh transport has no table — production state until CIRISVerify#259",
+        );
+
+        let first = Arc::new(ScopeAddressTable::new(Arc::new(StubDeriver)));
+        transport
+            .install_scope_address_table(Arc::clone(&first))
+            .expect("first install succeeds");
+
+        // A second install must be REFUSED, not silently accepted: the loser's
+        // destinations would still be registered on the node, so two tables
+        // would disagree about which inbound hashes are ours.
+        let second = Arc::new(ScopeAddressTable::new(Arc::new(StubDeriver)));
+        let err = transport
+            .install_scope_address_table(second)
+            .expect_err("second install must be refused");
+        assert!(
+            format!("{err}").contains("already installed"),
+            "displacement must be named, got: {err}",
+        );
+        assert!(
+            transport
+                .scope_address_table()
+                .is_some_and(|t| Arc::ptr_eq(t, &first)),
+            "the FIRST table stays installed after a refused displacement",
+        );
+    }
+
+    #[tokio::test]
+    async fn public_scope_is_refused_for_a_derived_destination() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transport = bare_transport(dir.path(), "edge-public").await;
+
+        let scope = CohortScope::Family;
+        let table = table_with_group(&scope, "grp-a", &["member-a"]);
+        let address = table
+            .send_address(&scope, "grp-a", "member-a")
+            .expect("derived address");
+
+        // Registering a derived address as Public would hand it to the node's
+        // auto-announce loops, publishing the reachability fact the derivation
+        // exists to withhold (CIRISEdge#311 limb (b)).
+        let err = transport
+            .register_scoped_destination(&address, &CohortScope::Public)
+            .expect_err("Public must be refused");
+        assert!(
+            format!("{err}").contains("not a discovery address"),
+            "the refusal must say why, got: {err}",
+        );
+
+        // ...and the group scopes it exists for are all accepted.
+        for accepted in [
+            CohortScope::SelfOnly,
+            CohortScope::Family,
+            CohortScope::Cohort {
+                cohort_id: "c-1".to_owned(),
+            },
+        ] {
+            transport
+                .register_scoped_destination(&address, &accepted)
+                .unwrap_or_else(|e| panic!("{accepted:?} must register: {e}"));
+        }
+    }
+
+    #[tokio::test]
+    async fn registering_a_scoped_destination_suppresses_its_announce() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transport = bare_transport(dir.path(), "edge-suppress").await;
+
+        let scope = CohortScope::Cohort {
+            cohort_id: "neighbourhood".to_owned(),
+        };
+        let table = table_with_group(&scope, "grp-b", &["member-b"]);
+        let address = table
+            .send_address(&scope, "grp-b", "member-b")
+            .expect("derived address");
+        let hash = *address.as_bytes();
+
+        let registered_before = transport.announce_policy.len();
+        transport
+            .register_scoped_destination(&address, &scope)
+            .expect("register");
+
+        // The scope must actually be RECORDED, not merely fail-safe. Dropping
+        // the `register_announce_scope` call leaves the destination suppressed
+        // anyway (the policy default-suppresses anything unregistered), so a
+        // suppression assertion alone is blind to that mutation — verified by
+        // deleting the call and watching this test stay green. The entry count
+        // is what distinguishes "suppressed because we said so" from
+        // "suppressed because we forgot".
+        assert_eq!(
+            transport.announce_policy.len(),
+            registered_before + 1,
+            "the derived destination's scope must be recorded in the policy map",
+        );
+
+        // CC 5.4 — a group-scoped destination MUST NOT announce. The named
+        // discovery destination registered at construction still must.
+        assert!(
+            transport
+                .announce_policy
+                .should_suppress_announce(&DestinationHash::new(hash)),
+            "a scope-derived destination must never be announced",
+        );
+        assert!(
+            !transport
+                .announce_policy
+                .should_suppress_announce(
+                    &DestinationHash::new(transport.local_named_dest_hash()),
+                ),
+            "the named Commons discovery destination still announces",
+        );
+    }
+
+    #[tokio::test]
+    async fn inbound_scope_declines_without_a_table_and_resolves_with_one() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transport = bare_transport(dir.path(), "edge-inbound").await;
+
+        let scope = CohortScope::Family;
+        let table = table_with_group(&scope, "grp-c", &["member-c", "member-d"]);
+        let address = table
+            .send_address(&scope, "grp-c", "member-c")
+            .expect("derived address");
+        let hash = *address.as_bytes();
+
+        // Production state today: no table installed → every scope-native
+        // lookup declines and the federation-scope paths are untouched.
+        assert!(
+            transport.inbound_scope(&hash).is_none(),
+            "no table installed → decline",
+        );
+
+        transport
+            .install_scope_address_table(Arc::clone(&table))
+            .expect("install");
+
+        let resolved = transport
+            .inbound_scope(&hash)
+            .expect("installed table resolves its own derived address");
+        assert_eq!(resolved.group().scope(), &scope);
+        assert_eq!(resolved.group().group_id(), "grp-c");
+        assert_eq!(
+            resolved.member_key_id(),
+            "member-c",
+            "the address resolves to the member it was derived FOR — not merely \
+             to the group; a per-member hash is what keeps the RNS routing entry \
+             unambiguous",
+        );
+        assert_eq!(resolved.epoch(), 1);
+
+        // A hash that is not ours stays not-ours.
+        assert!(
+            transport.inbound_scope(&[0u8; 16]).is_none(),
+            "an unrelated hash must not resolve",
+        );
     }
 }


### PR DESCRIPTION
## v17.9.0 — scope-native addressing (CIRISEdge#499), plus persist v36.2.0 / verify v13.4.0

Makes the Reticulum destination hash scope-native. It was the last identifier in the stack that was not: `record_id` and symbol keys are already derived per-group via `scope_privacy`, but a family flow, a community flow and a public flow all addressed the same `sha256(fed_pubkey)[..16]` — the scope lived in the payload and the policy, not in the address an observer sees.

One coordinated cut, no interim PRs, driven with subagents for the two isolable workstreams and adversarial mutation gates throughout.

### What landed

| commit | workstream | |
|---|---|---|
| `f7ed7a8` | **B** | `ScopeAddressTable` — per-member derived addresses + three-phase epoch rotation |
| `3808ca2` | **D** | transport-side registration + inbound admission lookup |
| `ba18356` | **C** | `RelayNode` answers across a rotation window |
| `c88efd7` | — | **persist v36.2.0 + verify v13.4.0** re-pin, and the production deriver |
| `18df9dd` | **E** | per-cohort MLS group with persistence-before-emit |
| `d8842b3` | **F** | accord relay gate — carriage narrowed to the roster |
| `ec04f1e` | — | version bump + evidence TSV regen |

### The derivation has one owner

verify v13.4.0 shipped `k_destination` / `derive_destination` and closed CIRISVerify#259, deciding both open questions the way #499 argued: **per-member, never a shared group hash** (a shared hash is unicast-ambiguous in RNS and trips leviculum v0.19's `register_destination` displacement warning by construction), and `LABEL_DESTINATION` **domain-separated** from the record-id/symbol family, since the destination hash is the one derived value that appears in the clear on the wire.

`ScopePrivacyDeriver` is a thin adapter with no edge-side transformation of either input or output, and `verify_259_golden_vectors` reproduces the published vectors byte-for-byte. Persist deliberately ships **no** witness for them (`ciris-crypto` gates `scope-privacy` behind a feature persist does not enable, because persist never calls these functions), so that module is the **only** place in the stack a derivation drift is caught — and a drift fails silently, because an RNS hash nobody registered is simply never delivered to, with no error anywhere.

### Design decisions worth reviewing

**`Transport::send` grows no scope parameter.** Adding one would push a Reticulum-only concept onto ten implementors including HTTP and packet radio; parsing scope inside the transport would put a parse on the send hot path and a second implementation of `projection_for` in the codebase. Instead resolution happens *above* the transport, which hands `send` something that cannot be wrong — the `ResolvedRecipient` pattern from #402. `scope_address_table()` is the accessor the replication layer resolves through.

**Unforgeability by type, not by check.** `MemberAddress` has no public byte constructor, so "this hash was derived from a group secret I possess" is a property of the type rather than something `register_scoped_destination` re-verifies. `Public` is refused for a derived address: announcing one would publish the reachability fact the derivation exists to withhold (#311 limb (b)), and it would not work anyway, since leviculum v0.19 answers path requests for explicit-hash destinations with silence.

**Make-before-break, twice.** Both the table and `RelayNode` send on one address and answer on two across a rotation, mirroring `Next → Current → Previous`. MLS epochs advance per-member at different wall-clock moments; if receive accepted only the send epoch, every rotation would open a silent window.

**Durable before emittable.** `CohortCommit` has private fields and exactly one construction site, after both persistence writes have been awaited. You cannot hold emittable Commit/Welcome bytes without persistence having succeeded.

**Projection vs relay (F).** `accord:*` is `Global` in the projection table and that is right for *carriage* — a partial quorum object is emitted pre-authority, so a narrower row is a bootstrap paradox. It would be wrong as *reach*: CC 4.2.1 says a node that never trusted the accord "is simply not reached". The predicate is what makes both true. The ALLOW is persist's `verdict.may_relay()` verbatim; the three legs are read only to attribute a refusal, ordered so **"I cannot judge" can never collapse into "not seated"**.

### Testing

1020 lib tests green. clippy `-D warnings` clean across `transport-reticulum`, `+transport-http`, and `+pyo3 lxmf`. Every load-bearing assertion was mutation-verified, and one had to be rewritten because of it: the announce-suppression test initially stayed green when the call it tested was deleted, since the policy already default-suppresses anything unregistered — fail-safe, and therefore blind. It now pins the policy map's entry count, which distinguishes "suppressed because we said so" from "suppressed because we forgot". F's wiring test was built to resist the same trap: it asserts a seated holder's row is still *served* alongside the unseated one being withheld, so a refuse-everything default cannot satisfy it.

The default-feature `--all-targets` build reports 8 errors; `origin/main` reports the identical 8 (integration tests missing `required-features` declarations). Pre-existing, unrelated, not introduced here.

### Not enabled in production, and why

The table is never installed, so every scope-native lookup declines and nothing on any current path changes behaviour. One thing blocks the flip: `k_destination` takes "the group's `exporter_secret`", but RFC 9420 §8.5's exporter is a **labelled** KDF, so that input is only well-defined once the MLS exporter label is fixed — and two members agree only if they export under the same one. That label is as wire-affecting as the derivation itself and is not edge's to choose; raised on CIRISVerify#259.

One candidate is already settled in the negative: edge's `ROOT_SECRET_LABEL` (`"ciris-realtime-av-epoch-dek-seed-v1"`) must **not** be it. It is a DEK seed, and deriving a routing identifier that appears in the clear on the wire from the material that seeds the content key collapses two secrets the exporter exists to keep independent.

### Cross-repo, filed not swallowed

- **CIRISVerify#259** — the exporter-label gap above.
- **CIRISPersist#716** — checked against resolved source at `f03d582`: edge already signs V2 (`canonicalize_envelope_for_signing` routes through `ceg_produce_canonicalize` since #714/v35.0.0), and the remaining V1 pin verifies a `PipelineEnvelope`, of which edge builds zero. That flag day is with the CIRISLens producer, not this repo.
- **CIRISPersist** (in F's notes) — `root_ref` has no owner upstream. No `accord:*` row names its root, and `attested_key_id` is not it in general. The root is a construction parameter for now, so a node enforces for exactly one accord instance; multi-instance carriage needs `accord_root_of(row)` or an envelope field.
- **CIRISEdge#500** — `cohort_group` has no join verb, so a node cannot yet become a member of a cohort it was added to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013m8X99Y4X891Tn8EZM1fdN
