### PR TITLE
v18.0.0 — scope-native addressing end to end (#499)

### DIFF
--- a/.github/workflows/bench-mesh.yml
+++ b/.github/workflows/bench-mesh.yml
@@ -1,0 +1,151 @@
+name: Bench Mesh
+
+# The multi-container mesh harness (`bench-mesh/`). Separate containers,
+# each a distinct edge occurrence with its own identity and keystore,
+# pushing real encoded video and a real blob in fan-out across a real
+# docker network.
+#
+# This answers the question `benches/` cannot: not "what does the
+# substrate cost per operation" but "does a real edge occurrence deliver
+# real video to N peers across a network through relays while the roster
+# changes". `benches/` stays exactly as it is — it feeds the
+# deterministic instruction-count gate (CIRISEdge#461), which is the
+# cheap per-operation alarm.
+#
+# ── COST ────────────────────────────────────────────────────────────
+#
+# `workflow_dispatch` + weekly ONLY. NEVER per-PR, and NEVER on push.
+# One run builds a full release image of the crate (openmls + libcrux +
+# leviculum + persist from git) and stands up eight containers. The repo
+# has a documented runner budget; `bench.yml` guards cost the same way
+# and this is strictly heavier. If you are tempted to add a `pull_request`
+# trigger here, add an instruction-count bench instead.
+#
+# ── HONESTY ─────────────────────────────────────────────────────────
+#
+# The job's verdict comes from the harness's own JSONL, parsed by
+# `bench-mesh/run.sh`, which fails the run when ANY leg reports
+# `ran: false`. A skipped leg is a failed run, not a green one. The job
+# does not infer success from a zero exit code alone — it uploads the
+# JSONL and prints the leg census either way.
+
+on:
+  schedule:
+    # Monday 08:00 UTC — after bench.yml's 06:00, so the cheap
+    # per-operation trend lands before the expensive mesh run.
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      relays:
+        description: 'Number of relay hops (K)'
+        required: false
+        default: '1'
+      subscribers:
+        description: 'Number of subscribers (M)'
+        required: false
+        default: '2'
+      frames:
+        description: 'Frames to publish'
+        required: false
+        default: '120'
+      sweep:
+        description: 'Sweep M in {1,2,4} for the fan-out curve'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bench-mesh-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  mesh:
+    name: mesh harness (K=${{ inputs.relays || 1 }}, M=${{ inputs.subscribers || 2 }})
+    runs-on: ubuntu-latest
+    # A stuck barrier must not burn an hour of runner budget. Every
+    # barrier inside the harness is bounded too; this is the backstop.
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker preflight
+        # If docker is unavailable the job says so and fails. It does not
+        # fall back to something cheaper and report that as a mesh run.
+        run: |
+          docker version
+          docker compose version
+
+      - name: Run the mesh
+        id: mesh
+        working-directory: bench-mesh
+        env:
+          MESH_FRAMES: ${{ inputs.frames || '120' }}
+        run: |
+          set -o pipefail
+          if [ "${{ inputs.sweep }}" = "true" ]; then
+            ./run.sh --sweep --relays "${{ inputs.relays || 1 }}" --frames "${MESH_FRAMES}"
+          else
+            ./run.sh \
+              --relays "${{ inputs.relays || 1 }}" \
+              --subs   "${{ inputs.subscribers || 2 }}" \
+              --frames "${MESH_FRAMES}"
+          fi
+
+      - name: Leg census
+        # Runs even when the harness failed — the census is the point.
+        if: always()
+        working-directory: bench-mesh
+        run: |
+          shopt -s nullglob
+          files=(results/*.jsonl)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "NO RESULTS FILES — the harness measured nothing." >&2
+            exit 1
+          fi
+          python3 - "${files[@]}" <<'PY'
+          import json, sys
+          total = ran = ok = 0
+          for path in sys.argv[1:]:
+              print(f"── {path}")
+              for line in open(path):
+                  line = line.strip()
+                  if not line.startswith('{'):
+                      continue
+                  leg = json.loads(line)
+                  total += 1
+                  if leg.get("ran"):
+                      ran += 1
+                      if leg.get("ok") is True:
+                          ok += 1
+                      else:
+                          print(f"  FAILED      {leg['node']}/{leg['leg']}")
+                  else:
+                      print(f"  DID NOT RUN {leg['node']}/{leg['leg']}: {leg.get('not_run_reason')}")
+          print(f"── legs={total} ran={ran} passed={ok}")
+          PY
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-mesh-results
+          path: bench-mesh/results/*.jsonl
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Container logs on failure
+        if: failure()
+        working-directory: bench-mesh
+        run: |
+          docker compose -f compose.yaml \
+            --profile relays2 --profile subs2 --profile subs4 \
+            logs --no-color --tail 400 || true
+
+      - name: Tear down
+        if: always()
+        working-directory: bench-mesh
+        run: ./run.sh --clean || true

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -285,7 +285,7 @@ jobs:
           run_bench "transport-http,transport-reticulum" realtime_av_fanout
           run_bench "transport-reticulum"                realtime_av_relay
           run_bench "transport-http,transport-reticulum" realtime_av_rekey
-          run_bench "transport-http,transport-reticulum" realtime_av_mesh_e2e
+          run_bench "transport-http,transport-reticulum" realtime_av_mdc_substrate
           # CIRISEdge#438 — real-RaptorQ reconstruction: measured decode-success
           # d(m) + the availability×decode composite the fountain_defaults
           # table's design target is judged against (the bench is the oracle).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1211,7 +1211,7 @@ required-features = ["transport-reticulum"]
 # fidelity property holds (~5.2 µs per added sub-stream); planner
 # picks 4 distinct primaries across the 4 sub-stream paths.
 [[bench]]
-name = "realtime_av_mesh_e2e"
+name = "realtime_av_mdc_substrate"
 harness = false
 required-features = ["transport-http", "transport-reticulum"]
 
@@ -1322,3 +1322,20 @@ inherits = "release"
 debug = "full"
 strip = "none"
 incremental = false
+
+# Multi-container mesh harness (bench-mesh/). ONE edge occurrence per
+# process: its own federation seed, its own leviculum transport identity,
+# its own on-disk sealed KV, its own persist directory handle. Roles are
+# env-driven (`EDGE_ROLE=publisher|relay|subscriber|nonmember`) and the
+# topology comes up under `bench-mesh/compose.yaml`.
+#
+# This is the counterpart to — NOT a replacement for — the criterion
+# benches: those measure per-operation substrate cost in-process and feed
+# the deterministic instruction-count gate (CIRISEdge#461); this measures
+# whether real occurrences deliver real media across a real network while
+# the roster changes. `required-features` because it needs a live
+# Reticulum transport to be a real node at all.
+[[bin]]
+name = "edge_node"
+path = "src/bin/edge_node.rs"
+required-features = ["transport-reticulum"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.3.0", version = "36", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.0.1", version = "37", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -1250,7 +1250,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.3.0", version = "36", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.0.1", version = "37", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.0.1", version = "37", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.1.0", version = "37", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.0.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.5.0", version = "13", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.5.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.6.1", version = "13", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.6.1", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.5.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.5.0", version = "13" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.6.1", version = "13" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1250,7 +1250,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.0.1", version = "37", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.1.0", version = "37", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "17.10.0"
+version = "18.0.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,7 +213,7 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.2.0", version = "36", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.3.0", version = "36", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -237,8 +237,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.2.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.4.0", version = "13", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.4.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.5.0", version = "13", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.5.0", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -247,7 +247,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.4.0
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.4.0", version = "13" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.5.0", version = "13" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1250,7 +1250,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.2.0", version = "36", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v36.3.0", version = "36", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -602,8 +602,8 @@ tempfile       = { version = "3", optional = true }
 # crate semver is now 0.16. CHANGELOG-gotcha lesson from their release: grep for
 # conflict markers before tagging (prose doesn't compile). Adoption sequenced in #484:
 # awaited variants next, then #482 item-1 buffer_unordered dispatcher.
-leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.19.0+ciris.1", version = "0.19", optional = true }
-leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.19.0+ciris.1", version = "0.19", optional = true }
+leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.20.0+ciris.1", version = "0.20", optional = true }
+leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.20.0+ciris.1", version = "0.20", optional = true }
 # v15.20.0 (CIRISEdge#169) — LXMF store-and-forward propagation. The
 # `leviculum-lxmf` workspace member (same pinned tag) ships the whole
 # LXMF wire protocol: propagation-node discovery/upload/`/get` codecs,
@@ -613,7 +613,7 @@ leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.19.0+
 # features keep `pow` on (the stamp/ticket cost we validate at
 # admission). Gated behind the `lxmf` feature — see the `[features]`
 # block. Edge INTEGRATES this crate's protocol; it never reimplements it.
-leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.19.0+ciris.1", version = "0.19", optional = true }
+leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.20.0+ciris.1", version = "0.20", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in

--- a/bench-mesh/.gitignore
+++ b/bench-mesh/.gitignore
@@ -1,0 +1,2 @@
+results/
+logs-*.txt

--- a/bench-mesh/Dockerfile
+++ b/bench-mesh/Dockerfile
@@ -1,0 +1,121 @@
+# syntax=docker/dockerfile:1.7
+#
+# The mesh-harness image: one `edge_node` binary plus one deterministic
+# encoded video file. Every container in `compose.yaml` runs this image;
+# what differs between them is the environment and the volumes.
+#
+# Two things this Dockerfile is careful about:
+#
+#   1. **Cache.** `ciris-edge` pulls openmls + libcrux + leviculum +
+#      persist from git; a cold build is tens of minutes. Cargo's
+#      registry, git checkouts, and `target/` are all mounted as BuildKit
+#      caches, so a warm rebuild after an edit to `src/bin/edge_node.rs`
+#      relinks the binary rather than rebuilding the dependency graph.
+#      Without this the edit-run loop is unusable.
+#
+#      Two things to know. `COPY . /src` preserves source mtimes, which
+#      is what keeps cargo's fingerprints valid across builds — if that
+#      ever stops holding, every build becomes a cold one. And the
+#      `target/` mount is `sharing=locked`, so a build killed mid-flight
+#      can leave the next one recompiling from scratch; `docker buildx
+#      prune` if a "warm" rebuild is inexplicably slow.
+#
+#   2. **Determinism of the media.** The video is generated at IMAGE BUILD
+#      time from ffmpeg's synthetic `testsrc` with fixed duration, fixed
+#      size, fixed rate, and fixed encoder settings, so the same
+#      Dockerfile produces the same bytes and run-to-run numbers are
+#      comparable. Nothing large or license-encumbered enters the repo.
+
+# ─── Stage 1: the media ─────────────────────────────────────────────
+FROM debian:bookworm-slim AS media
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ffmpeg ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG MEDIA_SECONDS=8
+ARG MEDIA_SIZE=320x240
+ARG MEDIA_FPS=15
+
+# `-preset ultrafast -tune zerolatency -g 15` keeps the encode cheap and
+# the GOP short, so a mid-stream epoch advance lands near an IDR rather
+# than deep inside a long GOP. `-bf 0` removes B-frames so access units
+# come out in decode order — the harness ships them in sequence.
+#
+# `-fflags +bitexact -flags +bitexact` and the fixed `-sws_flags` pin the
+# encoder's non-deterministic knobs; the SHA-256 is printed at build time
+# so a media change is visible in the build log rather than silently
+# moving every latency number.
+RUN set -eux; \
+    ffmpeg -hide_banner -loglevel error -nostdin \
+      -f lavfi -i "testsrc=duration=${MEDIA_SECONDS}:size=${MEDIA_SIZE}:rate=${MEDIA_FPS}" \
+      -c:v libx264 -preset ultrafast -tune zerolatency \
+      -pix_fmt yuv420p -g "${MEDIA_FPS}" -bf 0 -crf 26 \
+      -fflags +bitexact -flags +bitexact -sws_flags bitexact \
+      -f h264 /media/testsrc.h264 2>/dev/null \
+    || { mkdir -p /media; ffmpeg -hide_banner -loglevel error -nostdin \
+      -f lavfi -i "testsrc=duration=${MEDIA_SECONDS}:size=${MEDIA_SIZE}:rate=${MEDIA_FPS}" \
+      -c:v libx264 -preset ultrafast -tune zerolatency \
+      -pix_fmt yuv420p -g "${MEDIA_FPS}" -bf 0 -crf 26 \
+      -fflags +bitexact -flags +bitexact -sws_flags bitexact \
+      -f h264 /media/testsrc.h264; }; \
+    ls -l /media/testsrc.h264; \
+    sha256sum /media/testsrc.h264 | tee /media/testsrc.h264.sha256
+
+# ─── Stage 2: build ─────────────────────────────────────────────────
+FROM rust:1.97-bookworm AS build
+
+# `libsqlite3-dev` — persist links the system libsqlite3 dynamically
+# (CIRISPersist#132/#133); building without it fails at link time.
+# `cmake`/`clang` are libcrux's build-time requirements for the X-Wing
+# ciphersuite provider.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      libsqlite3-dev pkg-config cmake clang git ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# The whole crate: `edge_node` is a `[[bin]]` inside it, and `build.rs`
+# runs uniffi over `udl/`, so a dependency-only pre-build layer would
+# have to reproduce the manifest exactly. The BuildKit caches below make
+# the incremental case fast without that fragility.
+COPY . /src
+
+ARG FEATURES=transport-reticulum
+ARG PROFILE=release
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/usr/local/cargo/git,sharing=locked \
+    --mount=type=cache,target=/src/target,sharing=locked \
+    set -eux; \
+    cargo build --profile "${PROFILE}" --features "${FEATURES}" --bin edge_node; \
+    install -Dm0755 "/src/target/${PROFILE}/edge_node" /out/edge_node
+
+# ─── Stage 3: runtime ───────────────────────────────────────────────
+FROM debian:bookworm-slim AS runtime
+
+# Runtime needs only libsqlite3 (dynamically linked, above) and CA certs.
+# No ffmpeg, no toolchain — the media is copied in already encoded.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libsqlite3-0 ca-certificates \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system --create-home --uid 10001 edge
+
+COPY --from=build /out/edge_node /usr/local/bin/edge_node
+COPY --from=media /media/testsrc.h264 /media/testsrc.h264
+COPY --from=media /media/testsrc.h264.sha256 /media/testsrc.h264.sha256
+
+# `/state` is the container's PRIVATE volume: its federation seed, its
+# leviculum transport identity, its sealed KV. `/mesh` is the SHARED
+# volume and carries public bootstrap data only.
+RUN mkdir -p /state /mesh /results && chown -R edge:edge /state /mesh /results
+USER edge
+
+ENV EDGE_MEDIA=/media/testsrc.h264 \
+    EDGE_STATE_DIR=/state \
+    EDGE_MESH_DIR=/mesh \
+    EDGE_RESULTS=/results/mesh.jsonl \
+    RUST_BACKTRACE=1
+
+ENTRYPOINT ["/usr/local/bin/edge_node"]

--- a/bench-mesh/README.md
+++ b/bench-mesh/README.md
@@ -1,0 +1,324 @@
+# bench-mesh — the multi-container mesh harness
+
+`benches/` measures **what the substrate costs per operation**, in
+process, on synthetic payloads. This measures **whether real edge
+occurrences deliver real video to N peers across a real network while the
+roster changes**.
+
+Those are different questions and neither answer substitutes for the
+other. `benches/` stays exactly as it is — it feeds the deterministic
+instruction-count regression gate (CIRISEdge#461), and deleting any of it
+would blind that alarm.
+
+---
+
+## Run it
+
+```sh
+cd bench-mesh
+./run.sh                        # 1 relay, 2 subscribers, 120 frames
+./run.sh --relays 2 --subs 4    # two relay hops, four subscribers
+./run.sh --sweep                # M ∈ {1,2,4} — the fan-out curve
+./run.sh --clean                # drop every volume; next run mints fresh identities
+```
+
+Requires `docker` with compose v2+. Nothing else — ffmpeg, the Rust
+toolchain, and libsqlite3 all live inside the image.
+
+`--no-build` skips the image build when you know the image is current —
+useful when running the sweep points one at a time. Check with
+`docker images ciris-edge-bench-mesh --format '{{.CreatedAt}}'` against
+the mtime of `src/bin/edge_node.rs`; a stale image will silently measure
+old code.
+
+Only one run at a time: `run.sh` takes an exclusive lock and refuses a
+second. Two concurrent runs tear down each other's containers between
+`up` and `docker wait` and neither ever finishes, which presents as a
+mysteriously slow run rather than an error.
+
+The first build is slow (openmls + libcrux + leviculum + persist come
+from git). Cargo's registry, git checkouts, and `target/` are BuildKit
+caches, so an edit to `src/bin/edge_node.rs` rebuilds that crate and
+nothing else.
+
+Results land in `bench-mesh/results/relays-K-subs-M.jsonl`, one JSON
+object per leg per node.
+
+---
+
+## The topology, and why
+
+```
+publisher ──► relay-1 ──► sub-1, sub-2, nonmember
+                 └──────► relay-2 ──► sub-3, sub-4
+```
+
+Connectivity over Reticulum TCP interfaces is exactly "who dialled whom".
+A subscriber that only dials a relay **cannot** reach the publisher
+directly, so publisher↔subscriber traffic genuinely transits a relay, and
+`sub-3`/`sub-4` genuinely transit two hops. That is what makes `relay` a
+real role — it runs with `with_transport_node(true)` and carries other
+nodes' frames — rather than a third leaf.
+
+**Every container is a distinct occurrence.** Each gets its own named
+volume at `/state` holding its own Ed25519 federation seed (CSPRNG-minted
+on first boot, never leaving that volume), its own leviculum transport
+identity, and its own XChaCha-sealed KV. The only shared writable volume
+is `/mesh`, and it carries **public bootstrap data only**: the roster of
+`(key_id, public key, host:port)` and the steward-signed `federation_keys`
+rows. That is exactly the data production learns through directory-cache
+anti-entropy (CIRISEdge#175). No private key is ever written there. If a
+future edit makes two containers share `/state`, the harness stops
+measuring what it claims to measure.
+
+The `nonmember` container exists so the refusal assertion is falsifiable.
+It is rooted, reachable, and handed the same ciphertext as everyone else,
+and it must still be unable to derive a cohort-scoped address or open a
+frame. Without it, "a non-member cannot fetch" could pass by refusing
+everything.
+
+---
+
+## What is real
+
+- **Real distinct identities.** Per-container federation seed, transport
+  identity, sealed KV, persist directory handle.
+- **Real Reticulum transport** over TCP on a real docker network, and
+  **real announce-based rooting** — a node learns its peers by verifying
+  their signed announce attestations against the federation directory.
+  No primed peer binding on the federation plane.
+- **Real MLS.** openmls 0.8.1, X-Wing ciphersuite 0x004D, joined across
+  process boundaries: the joiner mints a real KeyPackage, ships it over
+  the real wire, and the creator's `add_member` Welcome comes back the
+  same way.
+- **The scope-address lifecycle driven exactly as documented**, with the
+  live `ReticulumTransport` as the `ScopedDestinationSink`:
+  ```rust
+  let snap = cohort_addressing::snapshot(&community).await?;
+  lifecycle.install(&scope, &snap)?;   // or .advance(&scope, &snap, now)
+  lifecycle.seal_due(now);
+  ```
+  So an install registers a destination on the leviculum node and a seal
+  retires it — both halves, on the real node.
+- **Real encoded video.** ffmpeg generates a fixed-duration, fixed-size,
+  fixed-rate, bit-exact-flagged H.264 elementary stream at image-build
+  time; its SHA-256 is printed in the build log. The publisher reads real
+  Annex-B access units out of it and seals each with `seal_av_inner` under
+  an MLS-derived key, then `seal_av_outer` per link. Never `vec![0u8; N]`.
+- **A real blob** — the media file itself, chunked and fanned out over the
+  same transport, verified end to end by SHA-256.
+
+## What is stubbed, and where
+
+Three seams. Each is a named trait in `src/bin/edge_node.rs` so the real
+API drops in as a second impl without touching measurement or reporting.
+
+| Seam | Trait | Today | Blocked on |
+|---|---|---|---|
+| A/V chunk transport | `MediaLink` | `Transport::send` — the real RNS resource path | `src/transport/av_spine.rs` (join→subscribe→relay→heal), in flight |
+| Dialling a scope-derived address | `ScopedDialer` | the harness installs the peer binding itself, then `link_open` | no transport verb accepts a `ScopeAddressTable::send_address` result |
+| Scope-native blob fetch | `BlobPlane` | push over the transport, gated on cohort membership | `src/blob_swarm/` scope-native fetch, in flight |
+
+The A/V seam exists for a structural reason worth knowing: `AvPublisher`
+/ `AvRelay` / `LeviculumAvSender` / `LinkDataPump` all need an
+`Arc<ReticulumNode>`, and `ReticulumTransport::node()` is `pub(crate)`
+and `#[cfg(feature = "pyo3")]`. A downstream consumer holding a
+`ReticulumTransport` cannot reach the node, so it cannot construct the
+real-RNS A/V sender at all.
+
+The `ScopedDialer` leg stamps `dial_binding: "harness_installed"` on its
+own output, so nobody can read the seal-retirement result as evidence
+that a production dial path exists.
+
+**The media DEK and the per-link transit key are a labelled harness
+derivation** (`epoch_keys`, HKDF over the cohort's record-plane exporter
+with a `ciris-edge/bench-mesh/media/v1` info string). Production takes
+the DEK from an `AvSession`'s own MLS group and the transit key from a
+`FederationSession` hybrid KEX; neither is reachable across processes
+today (the A/V session join rides the in-flight spine, and
+`SessionHandshakeMsg` has no serde wire form). The substitute is still a
+real MLS exporter that every member derives identically and that changes
+on every epoch advance — which is the property the rotation leg turns on
+— but it is not the production key schedule, and the code says so.
+
+---
+
+## Reading the numbers
+
+Every line is one leg from one node:
+
+```json
+{"leg":"perf.publish_fanout","node":"publisher","role":"publisher",
+ "ran":true,"ok":true,"detail":{...}}
+```
+
+`ran` and `ok` are separate on purpose, and `ok` is absent when `ran` is
+false. **There is no way to spell "green because we skipped it."**
+`run.sh` and each container's exit code both treat a leg that did not run
+as a failed run.
+
+### Performance legs
+
+| Leg | Field | Means |
+|---|---|---|
+| `perf.publish_fanout` | `send_latency.p50_us` / `p95_us` / `p99_us` | per-chunk publisher-side delivery latency, microseconds |
+| | `fanout_chunks_per_s` | chunks × subscribers per second — the fan-out throughput at this M. Excludes the rotation barrier (`rotation_stall_ms`), which is a wait for a peer to show up, not fan-out work. Leaving it in made this number two orders of magnitude apart between M=1 and M=2 for reasons that had nothing to do with fan-out. |
+| | `rotation_stall_ms` | wall time the publisher spent waiting at the mid-stream rotation. Large values mean the late joiner was slow to present its KeyPackage, not that the mesh was slow. |
+| | `fanout_bytes_per_s` | sealed bytes per second |
+| | `access_units_in_file` | how many real encoded access units the media held |
+| `perf.receive` | `time_to_first_frame_ms` | from the subscriber entering its receive loop to the first frame |
+| | `open_latency.p50_us` … | double-AEAD open cost per chunk |
+| | `delivery_ratio` | distinct sequence numbers opened ÷ frames the publisher announced |
+| `perf.blob_fanout` | `completion_ms_per_peer` | per-peer blob completion, milliseconds. `null` means that peer did not complete — never 0 |
+| `conformance.member_can_fetch` | `chunks_arrived_before_announcement` | chunks that outran their `BlobStart`. Control and data ride separate channels, so nothing orders them; a non-zero value is normal and means the receiver's hold-and-replay path did its job. `early_chunks_dropped_over_budget > 0` means it overflowed and the completion is genuinely short. |
+| `conformance.member_can_fetch` | `completion_ms` | receiver-side blob completion |
+
+**The curve, not one point.** `--sweep` runs M ∈ {1,2,4} and writes one
+file per point; `fanout_chunks_per_s` across those files is the fan-out
+throughput curve. A single point cannot show where fan-out stops scaling.
+
+### Conformance legs — these matter more
+
+| Leg | Passes when |
+|---|---|
+| `conformance.rotation_frame_loss` | a member present across the mid-stream epoch advance saw `missing_seqs: []` **and** `crossed_an_epoch_advance: true`. This is the acceptance criterion for CIRISEdge#499's make-before-break design: **zero frames may be lost across a rotation.** A node admitted *at* the rotation reports this leg as `ran: false` with the reason — pre-admission frames are not losses, and scoring it would score the wrong node. |
+| `conformance.nonmember_cannot_fetch` | the non-member derived **no** scoped address and opened **zero** frames, *and* `ciphertext_frames_offered > 0`. If no ciphertext ever reached it the leg reports `ran: false` — a leg that refuses nothing proves nothing. Only the first few frames are addressed to it (`observer_frames_each`): the refusal is an AEAD key it does not hold, which fails identically on every frame, and addressing it the whole stream would make the publisher pay a transport timeout per frame the moment the observer stops reading — quietly turning `fanout_chunks_per_s` into a measure of how fast a dead peer fails. Observer sends are excluded from the throughput numbers (`observer_sends_excluded_from_throughput`). |
+| `conformance.member_can_fetch` | a member reassembled the blob and the SHA-256 matched. The paired half of the above: the two together are what stop the test passing by refusing everything. |
+| `scope.seal` | the **owner-side** half of retirement, measured by the member that owns the address: after the convergence window, `sealed > 0`, `unretired: 0`, the superseded address is gone from the table, and the live one still answers. |
+| `conformance.seal_retires` | the **peer-side** half: a *different* node dials the owner's live and superseded addresses, before and after the seal, and the superseded one must stop answering while the live one keeps answering. The dialler derives both addresses from its **own** table, so a dial that lands is also cross-node derivation agreement. Both are dialled **before** the seal; if they did not both answer then, the leg reports `ran: false` rather than scoring a pass off a dead dial. **This leg currently reports `ran: false` on this branch — see below.** |
+| `conformance.relay_holds_no_cohort_address` | a relay, which is not in the cohort roster, derived no address — no exporter secret reaches it. |
+
+### Two shapes of epoch advance
+
+At **M ≥ 2** the advance is a real roster change: the last subscriber is
+held back and admitted mid-stream via `add_member`, which is the case
+CIRISEdge#499's criterion is written about. `scope.rotation` reports
+`kind: "member_join"`.
+
+At **M = 1** there is nobody to hold back — the late joiner would *be*
+the only member, leaving no one present across the advance to assert
+zero-loss on. The publisher rekeys with `CohortGroup::rotate()` instead:
+still a real MLS epoch advance and still a full address re-derivation,
+but no roster change. `scope.rotation` reports `kind: "rekey_only"`, so
+the two are never confused in a results file.
+
+The node admitted at the rotation reports
+`conformance.rotation_frame_loss` as `ran: false` — the frames that
+preceded its admission are not losses, and scoring them against it would
+score the wrong node.
+
+### A known `ran: false`: `conformance.seal_retires`
+
+On this branch the peer-side dial does not establish, and the leg says so
+with the diagnosis rather than a shrug. The cause is not a failed seal:
+
+A scope-derived destination is registered with
+`Destination::with_explicit_hash`, and an explicit-hash destination
+**cannot announce** (`AnnounceError::ExplicitHashCannotAnnounce`;
+leviculum answers a path request for one with silence, because a path
+response *is* an announce and an announce for a caller-supplied hash is
+unverifiable by reference RNS). So no multi-hop RNS path to a scoped
+address can exist — and this topology deliberately puts a relay between
+the dialler and the owner.
+
+The federation-scope destination does not have this problem because a
+node also registers an *announceable* named destination alongside it. A
+scope-derived address has no such twin, by design: announcing one would
+publish the very reachability fact the derivation exists to withhold.
+
+What that means for the claim: the **owner-side** half is measured and
+passes (`scope.seal` — table closed, transport retired, `unretired: 0`,
+live address still answering). The **peer-dials-it** half is not
+measurable from a relayed peer today. Do not read the `ran: false` as a
+seal failure, and do not "fix" it by putting the dialler on the same
+link as the owner — that would make the leg pass while measuring
+something narrower than it claims.
+
+### A measured limit: M=4 through a single relay
+
+A run of `--subs 4 --relays 1` on a laptop-class host degraded hard and
+the harness reported it rather than smoothing it: the publisher's rooting
+took 31.5 s against 0.5 s for every other node, `send_latency.p95` hit
+~4.0 s (the transport timeout), `fanout_chunks_per_s` fell to 0.37, and
+no peer completed the blob (`completion_ms_per_peer` all `null`). Twelve
+legs reported `ran: false`, including `scope.seal` with
+`send SealProbe: transport timeout after 30s`.
+
+Six nodes all routing through one relay is a plausible saturation point
+and this is exactly the class of thing the harness exists to find — but
+it has not been root-caused, and it may be an artefact of the topology
+rather than a substrate limit. Run `--subs 4 --relays 2` (which puts
+`sub-3`/`sub-4` behind a second relay) before drawing a conclusion. Do
+not read the M=4 point as a substrate number.
+
+### How to read a regression
+
+1. **Any `ran: false`.** Read `not_run_reason` first. Nothing else in the
+   file is trustworthy until you know which legs actually executed.
+2. **`conformance.*` before `perf.*`.** A conformance failure is a claim
+   the release makes turning out to be false; a perf move is a number. If
+   `rotation_frame_loss` fails with a non-empty `missing_seqs`, the
+   make-before-break window is wrong — either the convergence window is
+   too short for this topology (`MESH_CONVERGENCE_SECS`) or the rotation
+   is not actually make-before-break.
+3. **`p99` moving while `p50` holds** is tail behaviour: relay queueing or
+   link re-establishment, not per-chunk cost. Compare against
+   `benches/transport_reticulum_loopback` — if the micro-bench is flat and
+   this moved, it is the *mesh*, not the substrate.
+4. **`fanout_chunks_per_s` falling as M rises** across the sweep is the
+   expected shape; what matters is where the knee is versus the previous
+   run at the same M. Compare like for like — a curve point is only
+   comparable to the same point.
+5. **`delivery_ratio < 1` on a member present across the advance** is the
+   loudest signal in the file. That is the rotation dropping frames.
+
+### The results file is refused if it merges runs
+
+`run.sh` asserts that each `(node, leg)` pair appears **at most once** in
+a results file and fails the point outright if it does not. That guard
+exists because of a trap this harness fell into once: reading the results
+with `docker run -v <volume>:/r` re-creates the volume *without* compose's
+project labels, after which `docker compose down -v` silently leaves it
+behind and the next run appends to it. The file then looks normal and is
+several runs merged. `run.sh` now removes the volumes by name, and the
+duplicate check is the backstop that would catch it happening again.
+
+### What the harness will not do
+
+It will not report a number it did not measure. Absent statistics are
+`null`, not zero; an empty latency sample yields `null` percentiles, not
+`0`; a peer that did not complete the blob is `null`, not a time. If a
+leg cannot run it says so and the run fails. This exists because a green
+summary over a skipped leg is worse than a red one.
+
+---
+
+## CI
+
+Wire as `workflow_dispatch` + weekly only — **never per-PR.** This starts
+eight containers and builds a full release image; the repo has a
+documented runner budget and `.github/workflows/bench.yml` already guards
+cost the same way. The per-operation regression alarm is the
+instruction-count gate on `benches/`, and that one is cheap; this is the
+periodic "does the mesh still work end to end" instrument.
+
+---
+
+## Environment reference
+
+Set by `run.sh`; override for one-off runs.
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `EDGE_ROLE` | — | `publisher` \| `relay` \| `subscriber` \| `nonmember` |
+| `EDGE_NODE_ID` | — | this occurrence's federation key id |
+| `EDGE_EXPECT` | — | every node id in the mesh; the roster barrier waits for all of them |
+| `EDGE_COHORT_MEMBERS` | — | the cohort roster, **publisher first** |
+| `EDGE_BOOTSTRAP` | — | comma-separated `host:port` to dial |
+| `EDGE_SCOPE` | `cohort:bench` | `family` or `cohort:<id>` |
+| `MESH_FRAMES` | 120 | frames to publish |
+| `MESH_ROTATE_AT` | frames/2 | frame index at which the late joiner is admitted |
+| `MESH_LATE_JOINER` | last subscriber | which node joins mid-stream |
+| `MESH_CONVERGENCE_SECS` | 20 | make-before-break window before a seal |
+| `MESH_ROOT_TIMEOUT_SECS` | 180 | ceiling on announce-rooting cold start |
+| `MESH_BARRIER_TIMEOUT_SECS` | 300 | ceiling on any single barrier |

--- a/bench-mesh/compose.yaml
+++ b/bench-mesh/compose.yaml
@@ -1,0 +1,235 @@
+# The mesh topology: 1 publisher, K relays, M subscribers, 1 non-member,
+# each a distinct edge occurrence on a real docker network.
+#
+# ── Why this shape ──────────────────────────────────────────────────
+#
+#   publisher ──► relay-1 ──► sub-1, sub-2, nonmember
+#                    └──────► relay-2 ──► sub-3, sub-4
+#
+# Connectivity over TCP interfaces is exactly "who dialled whom", so a
+# subscriber that only dials a relay CANNOT reach the publisher directly.
+# Publisher↔subscriber traffic therefore genuinely transits a relay, and
+# sub-3/sub-4 genuinely transit two hops. That is what makes `relay` a
+# meaningful role rather than a third leaf: relays run with
+# `with_transport_node(true)` and carry other nodes' frames.
+#
+# ── Distinct occurrences, enforced by the infrastructure ────────────
+#
+# Every container gets its OWN named volume at `/state`. Its federation
+# seed, its leviculum transport identity, and its XChaCha-sealed KV live
+# there and are unreachable from any other container. The only shared
+# writable volume is `/mesh`, which carries PUBLIC bootstrap data — the
+# roster of `(key_id, public key, host:port)` and the steward-signed
+# `federation_keys` rows. That is the data production learns through
+# directory-cache anti-entropy (CIRISEdge#175); no private key is ever
+# written there.
+#
+# ── Parameterisation ────────────────────────────────────────────────
+#
+# `./run.sh` computes RELAYS / SUBSCRIBERS and sets the profiles plus the
+# MESH_EXPECT / MESH_COHORT lists. Run it rather than `docker compose up`
+# directly, or the roster barrier will wait for nodes that never start.
+#
+#   ./run.sh                    # K=1, M=2   (the default point)
+#   ./run.sh --relays 2 --subs 4
+#   ./run.sh --sweep            # M ∈ {1,2,4} for the fan-out curve
+
+name: ciris-edge-bench-mesh
+
+x-node: &node
+  image: ciris-edge-bench-mesh:local
+  build:
+    context: ..
+    dockerfile: bench-mesh/Dockerfile
+  networks: [mesh]
+  environment: &node-env
+    EDGE_LISTEN: "0.0.0.0:4242"
+    EDGE_COMMUNITY: "${MESH_COMMUNITY:-bench-mesh}"
+    EDGE_SCOPE: "${MESH_SCOPE:-cohort:bench}"
+    EDGE_EXPECT: "${MESH_EXPECT:?run ./run.sh — MESH_EXPECT must list every node}"
+    EDGE_COHORT_MEMBERS: "${MESH_COHORT:?run ./run.sh — MESH_COHORT must list the cohort roster}"
+    EDGE_OBSERVERS: "${MESH_OBSERVERS:-}"
+    EDGE_FRAMES: "${MESH_FRAMES:-120}"
+    EDGE_ROTATE_AT: "${MESH_ROTATE_AT:-60}"
+    # NO `:-default` here. `${VAR:-x}` substitutes x when VAR is set but
+    # EMPTY, which would override run.sh deliberately choosing "no late
+    # joiner" for a single-subscriber topology. run.sh is the single
+    # source of truth for this value.
+    EDGE_LATE_JOINER: "${MESH_LATE_JOINER:-}"
+    EDGE_LATE_JOIN_DELAY_SECS: "${MESH_LATE_JOIN_DELAY_SECS:-10}"
+    EDGE_CONVERGENCE_SECS: "${MESH_CONVERGENCE_SECS:-20}"
+    EDGE_ROOT_TIMEOUT_SECS: "${MESH_ROOT_TIMEOUT_SECS:-180}"
+    EDGE_BARRIER_TIMEOUT_SECS: "${MESH_BARRIER_TIMEOUT_SECS:-300}"
+    RUST_BACKTRACE: "1"
+  volumes:
+    - mesh:/mesh
+    - results:/results
+  # A node that cannot come up must fail the run, not restart into a
+  # half-measured second attempt.
+  restart: "no"
+  stop_grace_period: 5s
+
+services:
+
+  # ─── The publisher: cohort creator, stream + blob source, steward ──
+  publisher:
+    <<: *node
+    container_name: bm-publisher
+    hostname: publisher
+    environment:
+      <<: *node-env
+      EDGE_ROLE: publisher
+      EDGE_NODE_ID: publisher
+      EDGE_ADVERTISE: "publisher:4242"
+      # No bootstrap: everyone else dials in.
+    volumes:
+      - state-publisher:/state
+      - mesh:/mesh
+      - results:/results
+
+  # ─── Relays: real transit nodes, no cohort secret ─────────────────
+  relay-1:
+    <<: *node
+    container_name: bm-relay-1
+    hostname: relay-1
+    depends_on: [publisher]
+    environment:
+      <<: *node-env
+      EDGE_ROLE: relay
+      EDGE_NODE_ID: relay-1
+      EDGE_ADVERTISE: "relay-1:4242"
+      EDGE_BOOTSTRAP: "publisher:4242"
+    volumes:
+      - state-relay-1:/state
+      - mesh:/mesh
+      - results:/results
+
+  relay-2:
+    <<: *node
+    container_name: bm-relay-2
+    hostname: relay-2
+    profiles: ["relays2"]
+    depends_on: [relay-1]
+    environment:
+      <<: *node-env
+      EDGE_ROLE: relay
+      EDGE_NODE_ID: relay-2
+      EDGE_ADVERTISE: "relay-2:4242"
+      EDGE_BOOTSTRAP: "relay-1:4242"
+    volumes:
+      - state-relay-2:/state
+      - mesh:/mesh
+      - results:/results
+
+  # ─── Subscribers: cohort members ──────────────────────────────────
+  #
+  # sub-1 is the default late joiner: it delays before presenting its
+  # KeyPackage so its admission lands MID-STREAM and drives the epoch
+  # advance the rotation conformance leg turns on.
+  sub-1:
+    <<: *node
+    container_name: bm-sub-1
+    hostname: sub-1
+    depends_on: [relay-1]
+    environment:
+      <<: *node-env
+      EDGE_ROLE: subscriber
+      EDGE_NODE_ID: sub-1
+      EDGE_ADVERTISE: "sub-1:4242"
+      EDGE_BOOTSTRAP: "relay-1:4242"
+    volumes:
+      - state-sub-1:/state
+      - mesh:/mesh
+      - results:/results
+
+  sub-2:
+    <<: *node
+    container_name: bm-sub-2
+    hostname: sub-2
+    profiles: ["subs2", "subs4"]
+    depends_on: [relay-1]
+    environment:
+      <<: *node-env
+      EDGE_ROLE: subscriber
+      EDGE_NODE_ID: sub-2
+      EDGE_ADVERTISE: "sub-2:4242"
+      EDGE_BOOTSTRAP: "relay-1:4242"
+    volumes:
+      - state-sub-2:/state
+      - mesh:/mesh
+      - results:/results
+
+  sub-3:
+    <<: *node
+    container_name: bm-sub-3
+    hostname: sub-3
+    profiles: ["subs4"]
+    depends_on: [relay-1]
+    environment:
+      <<: *node-env
+      EDGE_ROLE: subscriber
+      EDGE_NODE_ID: sub-3
+      EDGE_ADVERTISE: "sub-3:4242"
+      # Two hops from the publisher when relay-2 is up.
+      EDGE_BOOTSTRAP: "${MESH_DEEP_BOOTSTRAP:-relay-1:4242}"
+    volumes:
+      - state-sub-3:/state
+      - mesh:/mesh
+      - results:/results
+
+  sub-4:
+    <<: *node
+    container_name: bm-sub-4
+    hostname: sub-4
+    profiles: ["subs4"]
+    depends_on: [relay-1]
+    environment:
+      <<: *node-env
+      EDGE_ROLE: subscriber
+      EDGE_NODE_ID: sub-4
+      EDGE_ADVERTISE: "sub-4:4242"
+      EDGE_BOOTSTRAP: "${MESH_DEEP_BOOTSTRAP:-relay-1:4242}"
+    volumes:
+      - state-sub-4:/state
+      - mesh:/mesh
+      - results:/results
+
+  # ─── The non-member: on the mesh, not in the cohort ───────────────
+  #
+  # Rooted, reachable, and handed the same ciphertext — and it must still
+  # be unable to derive a cohort-scoped address or open a frame. Without
+  # it the refusal assertion could pass by refusing everything.
+  nonmember:
+    <<: *node
+    container_name: bm-nonmember
+    hostname: nonmember
+    depends_on: [relay-1]
+    environment:
+      <<: *node-env
+      EDGE_ROLE: nonmember
+      EDGE_NODE_ID: nonmember
+      EDGE_ADVERTISE: "nonmember:4242"
+      EDGE_BOOTSTRAP: "relay-1:4242"
+    volumes:
+      - state-nonmember:/state
+      - mesh:/mesh
+      - results:/results
+
+networks:
+  mesh:
+    driver: bridge
+
+volumes:
+  # PUBLIC bootstrap data only.
+  mesh:
+  # JSONL results, one line per leg per node.
+  results:
+  # PRIVATE per-occurrence state. One volume per container, never shared.
+  state-publisher:
+  state-relay-1:
+  state-relay-2:
+  state-sub-1:
+  state-sub-2:
+  state-sub-3:
+  state-sub-4:
+  state-nonmember:

--- a/bench-mesh/run.sh
+++ b/bench-mesh/run.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+#
+# One command to run the mesh harness.
+#
+#   ./run.sh                       # K=1 relay, M=2 subscribers
+#   ./run.sh --relays 2 --subs 4   # two relay hops, four subscribers
+#   ./run.sh --sweep               # M ∈ {1,2,4}, for the fan-out curve
+#   ./run.sh --clean               # drop every volume (fresh identities)
+#
+# The roster is a hard barrier: every node waits until every id in
+# EDGE_EXPECT has published its public record. So the EXPECT list must
+# match exactly the set of containers that will start — which is why this
+# script computes it rather than compose hard-coding one.
+#
+# Honesty: this script NEVER reports a result it did not read out of the
+# results volume, and it exits non-zero if any node exited non-zero or if
+# any leg reports `ran: false`. A leg that did not run is a failed run.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+RELAYS=1
+SUBS=2
+SWEEP=0
+CLEAN=0
+FRAMES="${MESH_FRAMES:-120}"
+NO_BUILD=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --relays) RELAYS="$2"; shift 2 ;;
+    --subs)   SUBS="$2";   shift 2 ;;
+    --frames) FRAMES="$2"; shift 2 ;;
+    --sweep)  SWEEP=1;     shift ;;
+    --clean)  CLEAN=1;     shift ;;
+    --no-build) NO_BUILD=1; shift ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# A killed build leaves an orphaned buildx process holding the
+# `sharing=locked` target-cache mount, after which every later build
+# blocks on it and looks merely slow. Clear any orphan before starting.
+reap_orphan_builds() {
+  local mine=$$
+  pgrep -f 'docker-buildx bake' 2>/dev/null | while read -r pid; do
+    # Only reap a bake whose parent has already died (orphan reparented
+    # to init) — never one another live run is driving.
+    local ppid
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    if [[ -n "$ppid" && "$ppid" == "1" ]]; then
+      echo "reaping orphaned buildx bake pid=$pid (it holds the build cache lock)" >&2
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+  : "$mine"
+}
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo '{"fatal":"docker is not available on this host; the mesh harness cannot run"}' >&2
+  exit 1
+fi
+
+# Exactly one run at a time. Two concurrent runs tear down each other's
+# containers between `up` and `docker wait`, and neither ever finishes —
+# a livelock that presents as a mysteriously slow run rather than an
+# error. The lock turns it into a refusal.
+LOCK="${TMPDIR:-/tmp}/ciris-edge-bench-mesh.lock"
+exec 9>"$LOCK"
+if ! flock -n 9; then
+  echo "another bench-mesh run holds $LOCK — refusing to start a second one" >&2
+  exit 1
+fi
+
+compose() { docker compose -f compose.yaml "$@"; }
+
+# The compose profiles declare subscribers in blocks (subs2, subs4), so
+# only these counts produce a container set that MATCHES the EXPECT list.
+# Any other value would leave the roster barrier waiting on a node that
+# never starts — a hang, not a measurement.
+case "$SUBS" in
+  1|2|4) ;;
+  *) echo "--subs must be 1, 2, or 4 (compose profiles come in blocks)" >&2; exit 2 ;;
+esac
+case "$RELAYS" in
+  1|2) ;;
+  *) echo "--relays must be 1 or 2" >&2; exit 2 ;;
+esac
+
+if [[ "$CLEAN" == 1 ]]; then
+  compose --profile relays2 --profile subs2 --profile subs4 down -v --remove-orphans || true
+  docker ps -aq --filter "name=^bm-" | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker volume ls --format '{{.Name}}' \
+    | grep '^ciris-edge-bench-mesh_' \
+    | xargs -r docker volume rm -f >/dev/null 2>&1 || true
+  echo "volumes dropped; the next run mints fresh identities"
+  exit 0
+fi
+
+# ── Topology → profiles + roster lists ──────────────────────────────
+build_topology() {
+  local subs="$1" relays="$2"
+  PROFILES=()
+  local nodes=("publisher" "relay-1")
+  [[ "$relays" -ge 2 ]] && { PROFILES+=("--profile" "relays2"); nodes+=("relay-2"); }
+  [[ "$subs" -ge 2 ]] && PROFILES+=("--profile" "subs2")
+  [[ "$subs" -ge 3 ]] && PROFILES+=("--profile" "subs4")
+  local cohort=("publisher")
+  for i in $(seq 1 "$subs"); do
+    nodes+=("sub-$i"); cohort+=("sub-$i")
+  done
+  nodes+=("nonmember")
+  MESH_EXPECT="$(IFS=,; echo "${nodes[*]}")"
+  MESH_COHORT="$(IFS=,; echo "${cohort[*]}")"
+  # sub-3/sub-4 sit behind relay-2 when there is one, so those two are a
+  # genuine second hop from the publisher.
+  if [[ "$relays" -ge 2 ]]; then MESH_DEEP_BOOTSTRAP="relay-2:4242"; else MESH_DEEP_BOOTSTRAP="relay-1:4242"; fi
+  export MESH_EXPECT MESH_COHORT MESH_DEEP_BOOTSTRAP
+}
+
+run_point() {
+  local subs="$1" relays="$2"
+  build_topology "$subs" "$relays"
+  export MESH_FRAMES="$FRAMES"
+  # The late joiner is the LAST subscriber, so at least one member is
+  # present across the whole stream for the zero-loss assertion.
+  # A single-subscriber run has nobody to hold back: the late joiner
+  # would BE the only member, leaving no one present ACROSS the advance
+  # to assert zero-loss on. In that case the publisher rekeys with
+  # `CohortGroup::rotate()` instead — still a real MLS epoch advance.
+  if [[ "$subs" -ge 2 ]]; then
+    export MESH_LATE_JOINER="sub-${subs}"
+  else
+    export MESH_LATE_JOINER=""
+  fi
+  export MESH_ROTATE_AT="$(( FRAMES / 2 ))"
+  # The non-member is a rooted peer on the mesh that the publisher
+  # deliberately addresses ciphertext to, so its refusal is falsifiable.
+  export MESH_OBSERVERS="nonmember"
+
+  echo "── mesh: relays=${relays} subscribers=${subs} frames=${FRAMES}"
+  echo "   expect: ${MESH_EXPECT}"
+  echo "   cohort: ${MESH_COHORT}"
+  echo "   late joiner: ${MESH_LATE_JOINER} at frame ${MESH_ROTATE_AT}"
+
+  # Fresh volumes per point: identities and MLS state must not carry over
+  # between measurements, and `CohortGroup::join` refuses a second join
+  # into a community it already holds state for.
+  #
+  # `down -v` alone is NOT enough, and the reason is a trap worth naming:
+  # reading the results with `docker run -v <name>:/r` RE-CREATES that
+  # volume without compose's project labels, after which `compose down -v`
+  # silently leaves it behind. The results then accumulate across runs and
+  # a "results file" is really several runs merged. So the volumes are
+  # removed by NAME, unconditionally, and the leg census below refuses a
+  # file that still contains duplicates.
+  compose "${PROFILES[@]}" down -v --remove-orphans >/dev/null 2>&1 || true
+  docker ps -aq --filter "name=^bm-" | xargs -r docker rm -f >/dev/null 2>&1 || true
+  docker volume ls --format '{{.Name}}' \
+    | grep '^ciris-edge-bench-mesh_' \
+    | xargs -r docker volume rm -f >/dev/null 2>&1 || true
+
+  if [[ "$NO_BUILD" == 0 ]]; then
+    reap_orphan_builds
+    compose "${PROFILES[@]}" build
+  fi
+
+  # Detached, then wait on the PUBLISHER specifically. `--abort-on-
+  # container-exit` would kill every container the moment any one of them
+  # finished normally — which is how the first run lost every subscriber
+  # leg, including the zero-loss acceptance criterion. The publisher is
+  # the orchestrator and the last to finish, so its exit is the run's.
+  local rc=0
+  compose "${PROFILES[@]}" up -d
+  trap 'compose "${PROFILES[@]}" down -v --remove-orphans >/dev/null 2>&1 || true' INT TERM
+  rc=$(docker wait bm-publisher 2>/dev/null || echo 1)
+  # Give the leaves a moment to flush their final legs, then stop.
+  sleep 5
+  compose "${PROFILES[@]}" logs --no-color --tail 2000 > "logs-relays-${relays}-subs-${subs}.txt" 2>&1 || true
+  compose "${PROFILES[@]}" stop >/dev/null 2>&1 || true
+
+  # Read the results out of the volume — never out of scrollback.
+  local out="results/relays-${relays}-subs-${subs}.jsonl"
+  mkdir -p results
+  docker run --rm -v ciris-edge-bench-mesh_results:/r debian:bookworm-slim \
+    sh -c 'cat /r/mesh.jsonl 2>/dev/null || true' > "$out" || true
+
+  if [[ ! -s "$out" ]]; then
+    echo "NO RESULTS: the harness produced no JSONL. The run did not measure anything." >&2
+    return 1
+  fi
+
+  python3 - "$out" "$rc" <<'PY'
+import collections, json, sys
+path, rc = sys.argv[1], int(sys.argv[2])
+legs = [json.loads(l) for l in open(path) if l.strip().startswith('{')]
+
+# A (node, leg) pair may appear at most once. More than one means the
+# results volume survived a previous run and this file is several runs
+# merged — every number in it would be ambiguous, so refuse it outright
+# rather than average over a mixture.
+dupes = [k for k, n in collections.Counter(
+    (l["node"], l["leg"]) for l in legs).items() if n > 1]
+if dupes:
+    print(f"  CONTAMINATED: {len(dupes)} (node, leg) pairs appear more than once — "
+          f"this file merges multiple runs and none of its numbers can be trusted.")
+    for d in dupes[:8]:
+        print(f"    duplicated: {d[0]}/{d[1]}")
+    sys.exit(1)
+
+not_run = [l for l in legs if not l.get("ran")]
+failed  = [l for l in legs if l.get("ran") and l.get("ok") is not True]
+print(f"  legs recorded: {len(legs)}  |  did not run: {len(not_run)}  |  failed: {len(failed)}")
+for l in not_run:
+    print(f"  DID NOT RUN  {l['node']}/{l['leg']}: {l.get('not_run_reason')}")
+for l in failed:
+    print(f"  FAILED       {l['node']}/{l['leg']}: {json.dumps(l.get('detail'))[:300]}")
+if not legs:
+    print("  NO LEGS — nothing was measured."); sys.exit(1)
+sys.exit(0 if (rc == 0 and not not_run and not failed) else 1)
+PY
+}
+
+overall=0
+if [[ "$SWEEP" == 1 ]]; then
+  for m in 1 2 4; do
+    run_point "$m" "$RELAYS" || overall=1
+  done
+  echo "── fan-out curve: one results/relays-*-subs-*.jsonl per point"
+else
+  run_point "$SUBS" "$RELAYS" || overall=1
+fi
+
+exit "$overall"

--- a/benches/content_fetch_roundtrip.rs
+++ b/benches/content_fetch_roundtrip.rs
@@ -184,6 +184,7 @@ fn bench_content_fetch(c: &mut Criterion) {
                         received_at: Utc::now(),
                         source_key_id: None,
                         link_key_id: None,
+                        arrival_scope: None, // CIRISEdge#499 — federation arrival
                     };
                     edge.dispatch_inbound_for_test(black_box(frame)).await;
                 }

--- a/benches/dispatch_inbound.rs
+++ b/benches/dispatch_inbound.rs
@@ -235,6 +235,7 @@ fn bench_dispatch(c: &mut Criterion) {
                         received_at: Utc::now(),
                         source_key_id: None,
                         link_key_id: None,
+                        arrival_scope: None, // CIRISEdge#499 — federation arrival
                     };
                     edge.dispatch_inbound_for_test(black_box(frame)).await;
                 }

--- a/benches/realtime_av_mdc_substrate.rs
+++ b/benches/realtime_av_mdc_substrate.rs
@@ -1,3 +1,27 @@
+//! `realtime_av_mdc_substrate` — MDC decomposition + reassembly bench
+//! (renamed from `realtime_av_mesh_e2e`, CIRISEdge#499).
+//!
+//! # It was never end-to-end, and now it does not claim to be
+//!
+//! This measures the MDC/ALM **substrate**: dyadic decomposition,
+//! multi-parent dedup, proportional-fidelity degradation,
+//! `AlmJoinPlanner` parent-distinctness, and per-step cost. All of that
+//! is real and none of it is replaced by anything else.
+//!
+//! What it never did — and its own docs said so — is validate a real
+//! codec or a real network: the payloads are synthetic buffers and every
+//! participant is in one process. The `_e2e` name promised the opposite,
+//! and a reader comparing "the e2e bench is green" against a field
+//! failure would be comparing against the wrong instrument.
+//!
+//! The end-to-end question now has its own instrument: `bench-mesh/`
+//! runs separate containers, each a distinct edge occurrence with its
+//! own identity and sealed KV, pushing ffmpeg-encoded H.264 and real
+//! blobs across a real network while the roster changes. Go there for
+//! "does it work"; stay here for "what does the substrate cost".
+//!
+//! Original header follows.
+//!
 //! `realtime_av_mesh_e2e` — full holographic-mesh round-trip bench
 //! (v3.8.0 CIRISEdge#128 MDC substrate validation).
 //!

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -48,7 +48,7 @@ The trend page carries two kinds of series, both consumed by the same
   concurrency changes, not per-packet lock-holds; see the bench's own docs
   for the A/B that established this),
   `realtime_av_fanout` (seal cost), `realtime_av_relay`,
-  `realtime_av_rekey`, `realtime_av_mesh_e2e`. Each bench's
+  `realtime_av_rekey`, `realtime_av_mdc_substrate`. Each bench's
   `required-features` (see `Cargo.toml`) is honored.
 - **Fixed-operating-point SIM metrics** (semantic values — ratios / ms /
   rounds — published **un-normalized**, emitted by the three

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v17.10.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.10.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v17.10.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v17.10.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v17.10.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.10.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v17.10.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.0.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.0.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.0.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.0.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.0.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.0.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ classifiers = [
 # an install-time index requirement (so the "unresolvable from PyPI" shape is by
 # design, not a regression).
 dependencies = [
-    "ciris-persist>=36,<37",
+    "ciris-persist>=37,<38",
 ]
 dynamic = ["version"]
 

--- a/src/av_addressing.rs
+++ b/src/av_addressing.rs
@@ -1,0 +1,120 @@
+//! A/V session → scoped-address wiring (CIRISEdge#499).
+//!
+//! The twin of [`crate::cohort_addressing`], for the other kind of MLS
+//! group edge holds. Cohorts make a *community* addressable; this makes
+//! a *call inside it* addressable, and the two are deliberately separate
+//! groups with separate secrets:
+//!
+//! ```text
+//! CohortGroup   community membership   → who is in the community, and where
+//! AvSession     one stream's media     → who is on THIS call, and where
+//! ```
+//!
+//! Both derive through the same [`ScopeAddressTable`] and the same
+//! [`ScopeLifecycle`], so a community call and a community message get
+//! their addresses from one mechanism with one set of rotation rules.
+//! What differs is only which group's exporter feeds it.
+//!
+//! # Why a call needs its own addresses at all
+//!
+//! Without this, a call inside a community is reachable at the
+//! community's addresses, which means **being on the call is
+//! observable to the whole community** — the roster of a specific
+//! conversation leaks to everyone entitled to the room. Contextual
+//! integrity treats that as a distinct flow: the community is the
+//! context for "is a member", the call is the context for "is talking
+//! to whom, now". Per-session derivation keeps the second from being a
+//! side effect of the first.
+//!
+//! An observer with the community secret still cannot enumerate call
+//! participants, because the session's exporter is a different secret
+//! under a different group.
+//!
+//! # The relay
+//!
+//! [`RelayNode`](crate::transport::realtime_av_relay::RelayNode) holds
+//! current+next across a rotation for the same reason the table does —
+//! MLS epochs advance per-member at different moments, and a
+//! `DestinationHash` is used to dial and listen, never per chunk, so a
+//! rotation must never strand a subscriber mid-dial. [`advance_av_addresses`]
+//! moves both together, so the relay's answerable set and the table's
+//! accept-set cannot disagree.
+
+use crate::scope_lifecycle::{ScopeGroupSnapshot, TransitionOutcome};
+use crate::transport::realtime_av_session::{AvSession, AvSessionError};
+
+/// Why a session's addresses could not be installed.
+#[derive(Debug, thiserror::Error)]
+pub enum AvAddressError {
+    /// The session's destination secret could not be derived.
+    #[error("A/V session exporter: {0}")]
+    Exporter(#[from] AvSessionError),
+}
+
+/// The table group id for a session: its [`StreamId`], hex-encoded.
+///
+/// Distinct by construction from any community id, so a session and the
+/// community it runs inside can never collide in the table even under
+/// the same scope.
+///
+/// [`StreamId`]: crate::transport::realtime_av::StreamId
+#[must_use]
+pub fn session_group_id(session: &AvSession) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(70);
+    out.push_str("av-stream:");
+    for b in session.stream_id().0 {
+        write!(out, "{b:02x}").expect("write to String is infallible");
+    }
+    out
+}
+
+/// **The adapter.** Reduce a session to the one shape the lifecycle
+/// takes.
+///
+/// Identical in form to [`crate::cohort_addressing::snapshot`] — that
+/// is the point. Downstream writes the same two lines whether it is
+/// standing up a community or a call inside one:
+///
+/// ```ignore
+/// let snap = av_addressing::snapshot(&call)?;
+/// lifecycle.install(&community_scope, &snap)?;
+/// ```
+///
+/// # Errors
+/// [`AvAddressError::Exporter`] on corrupted group state.
+pub fn snapshot(session: &AvSession) -> Result<ScopeGroupSnapshot, AvAddressError> {
+    Ok(ScopeGroupSnapshot {
+        group_id: session_group_id(session),
+        epoch: session.epoch().0,
+        members: session.member_key_ids(),
+        // The DESTINATION plane specifically — never the DEK seed.
+        destination_secret: session.destination_secret()?,
+    })
+}
+
+/// Move the relay's answerable window onto the epoch the lifecycle just
+/// activated.
+///
+/// Call immediately after [`ScopeLifecycle::advance`] when this node is
+/// the relay for the stream. Kept separate from the advance rather than
+/// folded into it because not every node running a session relays it,
+/// and a verb that silently did nothing on non-relays would be the kind
+/// of quiet no-op this codebase keeps paying for.
+///
+/// The relay answers on current+next for the same reason the table
+/// does: a `DestinationHash` is used to dial and listen, never per
+/// chunk, so a rotation must not strand a subscriber mid-dial.
+pub fn advance_relay_window(
+    relay: &mut crate::transport::realtime_av_relay::RelayNode,
+    activated: &TransitionOutcome,
+) {
+    let displaced = relay.install_next_address(leviculum_core::DestinationHash::new(
+        *activated.own_address.as_bytes(),
+    ));
+    debug_assert!(
+        displaced.is_none(),
+        "a relay rotation was installed without an intervening seal",
+    );
+    relay.activate_next_address();
+}

--- a/src/av_addressing.rs
+++ b/src/av_addressing.rs
@@ -40,7 +40,11 @@
 //! moves both together, so the relay's answerable set and the table's
 //! accept-set cannot disagree.
 
-use crate::scope_lifecycle::{ScopeGroupSnapshot, TransitionOutcome};
+use crate::scope_lifecycle::ScopeGroupSnapshot;
+// Only the relay half consumes a `TransitionOutcome`, and the relay is
+// gated with the Reticulum surface.
+#[cfg(feature = "_reticulum-module")]
+use crate::scope_lifecycle::TransitionOutcome;
 use crate::transport::realtime_av_session::{AvSession, AvSessionError};
 
 /// Why a session's addresses could not be installed.
@@ -105,16 +109,36 @@ pub fn snapshot(session: &AvSession) -> Result<ScopeGroupSnapshot, AvAddressErro
 /// The relay answers on current+next for the same reason the table
 /// does: a `DestinationHash` is used to dial and listen, never per
 /// chunk, so a rotation must not strand a subscriber mid-dial.
+///
+/// # Two rotations inside one convergence window
+///
+/// The relay's window holds exactly one superseded address, so a second
+/// rotation before the first has sealed pushes the oldest one out early.
+/// That is **not** a bug — three people joining a call inside five
+/// minutes produces it — and it is exactly what
+/// [`ScopeAddressTable::activate_next`] does to an unsealed older epoch,
+/// which reports it as `EpochTransition::evicted` rather than asserting
+/// on it. So this returns the address that left the window early instead
+/// of claiming it cannot happen; the caller logs it, and a peer still
+/// dialling that address re-dials at the live epoch.
+///
+/// [`ScopeAddressTable::activate_next`]: crate::scope_addressing::ScopeAddressTable::activate_next
+///
+/// Gated with [`RelayNode`] itself: the relay is part of the Reticulum
+/// surface, and an HTTP-only build has no relay to advance. Without the
+/// gate this module fails to compile in any reticulum-free feature
+/// subset — which `--all-features` cannot show, since a union build
+/// always has the dependency present.
+///
+/// [`RelayNode`]: crate::transport::realtime_av_relay::RelayNode
+#[cfg(feature = "_reticulum-module")]
 pub fn advance_relay_window(
     relay: &mut crate::transport::realtime_av_relay::RelayNode,
     activated: &TransitionOutcome,
-) {
+) -> Option<leviculum_core::DestinationHash> {
     let displaced = relay.install_next_address(leviculum_core::DestinationHash::new(
         *activated.own_address.as_bytes(),
     ));
-    debug_assert!(
-        displaced.is_none(),
-        "a relay rotation was installed without an intervening seal",
-    );
     relay.activate_next_address();
+    displaced
 }

--- a/src/bin/edge_node.rs
+++ b/src/bin/edge_node.rs
@@ -1,0 +1,2905 @@
+//! `edge_node` — ONE edge occurrence, for the multi-container mesh harness.
+//!
+//! The criterion benches in `benches/` answer *"what does the substrate
+//! cost per operation"*. They are all in-process, and the one that calls
+//! itself e2e (now `benches/realtime_av_mdc_substrate.rs`) said in its own docs
+//! that it "does NOT validate a real MDC codec" — it pushes `vec![0u8;
+//! N]` through seal/fan-out arithmetic.
+//!
+//! This binary answers the other question: **does a real edge occurrence
+//! deliver real video to N peers across a real network while the roster
+//! changes.** One process, one container, one identity. `bench-mesh/`
+//! stands several of them up on a docker network.
+//!
+//! # What is REAL here
+//!
+//! - **A distinct occurrence per container.** Its own Ed25519 federation
+//!   seed (generated in its own private volume, never shared), its own
+//!   leviculum transport identity, its own on-disk XChaCha-sealed KV
+//!   ([`XChaChaKvStore::open`]), its own persist federation directory
+//!   handle. Nothing is shared between containers except *public*
+//!   bootstrap data.
+//! - **A real `ReticulumTransport`** over real TCP interfaces on a real
+//!   docker network, and **real announce-based rooting** — a node learns
+//!   its peers by verifying their signed announce attestations against
+//!   the federation directory. No `inject_rooted_peer_for_test` on the
+//!   federation plane.
+//! - **A real MLS `CohortGroup`** (openmls 0.8.1, X-Wing ciphersuite
+//!   0x004D), joined **across process boundaries**: the joiner mints a
+//!   real KeyPackage, ships it over the real RNS wire, and the creator's
+//!   `add_member` Welcome comes back over the same wire.
+//! - **The scope-address lifecycle driven exactly as documented** —
+//!   `cohort_addressing::snapshot(&group).await?` → `lifecycle.install`
+//!   / `.advance` / `.seal_due`, with the **real `ReticulumTransport` as
+//!   the [`ScopedDestinationSink`]**, so every register/retire hits the
+//!   live leviculum node's routing table.
+//! - **Real encoded video.** `bench-mesh/` generates a fixed-duration,
+//!   fixed-seed H.264 file with ffmpeg at image-build time; the
+//!   publisher reads **real encoded frames** out of it (Annex-B NAL
+//!   framing) and seals each one with `seal_av_inner` under an
+//!   MLS-derived key, then `seal_av_outer` per link.
+//! - **A real blob** — the media file itself, fanned out chunk-by-chunk
+//!   over the same real transport, verified end-to-end by SHA-256.
+//!
+//! # What is a SEAM (stubbed, and named)
+//!
+//! Three things the harness cannot reach today, each behind a narrow
+//! trait so the real API drops in as a second impl without touching the
+//! measurement or the reporting. Two are APIs being built concurrently
+//! (`av_spine`, scope-native blob fetch); the third is a verb that does
+//! not exist at all yet:
+//!
+//! - [`MediaLink`] — how a sealed chunk crosses the wire. Today's impl
+//!   ([`TransportMediaLink`]) uses `Transport::send`, the real RNS
+//!   resource path. `src/transport/av_spine.rs` (join→subscribe→relay→
+//!   heal) is the intended production driver; when it lands it becomes a
+//!   second `MediaLink` impl and nothing else here changes.
+//!
+//!   *Why the seam is needed at all*: `AvPublisher`/`AvRelay`/
+//!   `LeviculumAvSender`/`LinkDataPump` in `realtime_av_runtime.rs`
+//!   require an `Arc<ReticulumNode>`, and `ReticulumTransport::node()`
+//!   is `pub(crate)` + `#[cfg(feature = "pyo3")]`. A downstream consumer
+//!   holding a `ReticulumTransport` **cannot** reach the node, so it
+//!   cannot construct the real-RNS A/V sender. See the report.
+//!
+//! - [`ScopedDialer`] — how a *scope-derived* address is dialled.
+//!   `ScopeAddressTable::send_address` hands you the peer's 16 bytes and
+//!   there is no transport verb that takes them; `link_open` resolves
+//!   its signing key from the rooted-peer map, which is keyed on
+//!   federation destinations. The harness installs the missing binding
+//!   itself ([`HarnessScopedDialer`]) and says so in its output
+//!   (`dial_binding: "harness_installed"`), so no reader mistakes the
+//!   seal-retirement leg for proof that a production dial path exists.
+//!
+//!   Running it produced a second, larger finding: **a scope-derived
+//!   destination is not reachable off-link at all.** It is registered
+//!   with `Destination::with_explicit_hash`, and an explicit-hash
+//!   destination cannot announce, so no multi-hop RNS path to one can
+//!   exist. The federation destination escapes this only because a node
+//!   registers an *announceable* named destination beside it; a scoped
+//!   address has no such twin by design, since announcing one would
+//!   publish the reachability fact the derivation exists to withhold.
+//!   So the peer-dials-it half of "a sealed address finds nobody home"
+//!   is not measurable from a relayed peer today, and the leg reports
+//!   `ran: false` carrying that diagnosis. The owner-side half IS
+//!   measured, by the member's own `scope.seal` leg.
+//!
+//! Blob fetch is scope-*gated* here but not yet scope-*native*:
+//! `src/blob_swarm/` is being extended concurrently. See [`BlobPlane`].
+//!
+//! # Honesty
+//!
+//! Every leg emits exactly one JSON line ([`Leg`]) carrying `ran` and,
+//! only when `ran` is true, `ok`. **A leg that did not run reports that
+//! it did not run.** There is no path in this file that reports a
+//! measurement it did not take, and no summary that is green over a
+//! skipped leg. `main` exits non-zero if any leg did not run or did not
+//! pass.
+//!
+//! # CIRISEdge#217
+//!
+//! Every duration here is `std::time::Instant` (never `tokio::time::
+//! Instant`, which panics under the cross-cdylib runtime aliasing
+//! class), and no lock guard is held across an `.await`.
+//!
+//! [`XChaChaKvStore::open`]: ciris_persist::encrypted_kv::XChaChaKvStore::open
+//! [`ScopedDestinationSink`]: ciris_edge::scope_lifecycle::ScopedDestinationSink
+
+// The harness stands up real nodes and measures them; it is not library
+// code and its role functions are long by nature.
+#![allow(clippy::too_many_lines)]
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine as _;
+use sha2::{Digest, Sha256};
+use tokio::sync::{mpsc, Mutex};
+
+use ciris_crypto::{kdf, ClassicalSigner, Ed25519Signer};
+use ciris_edge::cohort_scope::CohortScope;
+use ciris_edge::identity::LocalSigner;
+use ciris_edge::mls::cohort_group::mint_cohort_key_material;
+use ciris_edge::mls::{CohortGroup, ScopeStateProvider};
+use ciris_edge::scope_addressing::{MemberAddress, ScopeAddressTable, ScopePrivacyDeriver};
+use ciris_edge::scope_lifecycle::{ScopeLifecycle, ScopedDestinationSink, TransitionOutcome};
+use ciris_edge::transport::realtime_av::{
+    open_av_chunk, seal_av_inner, seal_av_outer, ChunkLayer, ChunkSeq, Epoch, EpochDek,
+    SealedAvChunk, StreamId, CODEC_OPAQUE,
+};
+use ciris_edge::transport::reticulum::{
+    ReticulumAuth, ReticulumTransport, ReticulumTransportConfig,
+};
+use ciris_edge::transport::{InboundFrame, Transport, TransportError};
+use ciris_edge::verify::{HybridPolicy, RootingDirectory};
+use ciris_persist::encrypted_kv::XChaChaKvStore;
+use ciris_persist::federation::FederationDirectory;
+use ciris_persist::prelude::{FederationDirectorySqlite, KeyRecord, SignedKeyRecord};
+use ciris_persist::store::backend::Backend;
+use ciris_persist::store::sqlite::SqliteBackend;
+
+// ═══════════════════════════════════════════════════════════════════
+// Reporting — the honesty layer
+// ═══════════════════════════════════════════════════════════════════
+
+/// One measured or attempted leg of the harness.
+///
+/// `ran` and `ok` are deliberately separate and `ok` is `Option`: a leg
+/// that did not run has no verdict, and there is no way to spell "green
+/// because we skipped it". `main` treats `ran == false` as a failure of
+/// the run, so a skipped leg can never be read as a pass.
+#[derive(Debug, serde::Serialize)]
+struct Leg {
+    /// Stable leg name, e.g. `conformance.rotation_frame_loss`.
+    #[serde(rename = "leg")]
+    name: String,
+    /// Emitting node's federation key id.
+    node: String,
+    /// Emitting node's role.
+    role: String,
+    /// Did this leg actually execute end to end?
+    ran: bool,
+    /// Verdict. `None` iff `!ran`.
+    ok: Option<bool>,
+    /// Why it did not run. `Some` iff `!ran`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    not_run_reason: Option<String>,
+    /// Leg-specific measurements. Never synthesised.
+    detail: serde_json::Value,
+}
+
+/// Sink for [`Leg`] lines: stdout always, plus `EDGE_RESULTS` when set.
+struct Reporter {
+    node: String,
+    role: String,
+    path: Option<PathBuf>,
+    legs: std::sync::Mutex<Vec<serde_json::Value>>,
+}
+
+impl Reporter {
+    fn new(node: &str, role: &str, path: Option<PathBuf>) -> Self {
+        Self {
+            node: node.to_owned(),
+            role: role.to_owned(),
+            path,
+            legs: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Record a leg that ran, with its verdict and measurements.
+    fn ran(&self, leg: &str, ok: bool, detail: serde_json::Value) {
+        self.emit(&Leg {
+            name: leg.to_owned(),
+            node: self.node.clone(),
+            role: self.role.clone(),
+            ran: true,
+            ok: Some(ok),
+            not_run_reason: None,
+            detail,
+        });
+    }
+
+    /// Record a leg that did NOT run. There is no `ok`.
+    fn not_run(&self, leg: &str, reason: impl Into<String>) {
+        self.emit(&Leg {
+            name: leg.to_owned(),
+            node: self.node.clone(),
+            role: self.role.clone(),
+            ran: false,
+            ok: None,
+            not_run_reason: Some(reason.into()),
+            detail: serde_json::json!({}),
+        });
+    }
+
+    fn emit(&self, leg: &Leg) {
+        let value = serde_json::to_value(leg).unwrap_or(serde_json::Value::Null);
+        let line = serde_json::to_string(&value).unwrap_or_else(|_| "{}".to_owned());
+        println!("{line}");
+        if let Some(p) = self.path.as_ref() {
+            use std::io::Write as _;
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(p)
+            {
+                let _ = writeln!(f, "{line}");
+            }
+        }
+        self.legs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(value);
+    }
+
+    /// `(any_leg_recorded, all_ran_and_passed)`.
+    fn verdict(&self) -> (bool, bool) {
+        let legs = self
+            .legs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let all = legs.iter().all(|l| {
+            l.get("ran").and_then(serde_json::Value::as_bool) == Some(true)
+                && l.get("ok").and_then(serde_json::Value::as_bool) == Some(true)
+        });
+        (!legs.is_empty(), all)
+    }
+}
+
+/// Percentile over a sorted-in-place sample, in the sample's own units.
+/// Returns `None` for an empty sample — a percentile over nothing is not
+/// zero, it is absent, and the JSON says so.
+fn pct(sorted: &[u128], p: f64) -> Option<u128> {
+    if sorted.is_empty() {
+        return None;
+    }
+    #[allow(
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss,
+        clippy::cast_possible_truncation
+    )]
+    let idx = ((sorted.len() - 1) as f64 * p).round() as usize;
+    sorted.get(idx).copied()
+}
+
+/// Latency summary in microseconds. Every field is `Option` so an
+/// unmeasured statistic is absent rather than zero.
+fn latency_json(samples: &mut [u128]) -> serde_json::Value {
+    samples.sort_unstable();
+    serde_json::json!({
+        "n": samples.len(),
+        "p50_us": pct(samples, 0.50),
+        "p95_us": pct(samples, 0.95),
+        "p99_us": pct(samples, 0.99),
+        "min_us": samples.first().copied(),
+        "max_us": samples.last().copied(),
+    })
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Configuration — role and topology from the environment
+// ═══════════════════════════════════════════════════════════════════
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Role {
+    /// Creates the cohort, publishes the stream and the blob.
+    Publisher,
+    /// A transit node — carries ciphertext, holds no cohort secret.
+    Relay,
+    /// A cohort member: receives frames and the blob, measures.
+    Subscriber,
+    /// A real node on the mesh that is NOT in the cohort. Exists so the
+    /// refusal leg cannot pass by refusing everything.
+    NonMember,
+}
+
+impl Role {
+    fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "publisher" => Ok(Self::Publisher),
+            "relay" => Ok(Self::Relay),
+            "subscriber" => Ok(Self::Subscriber),
+            "nonmember" => Ok(Self::NonMember),
+            other => Err(format!(
+                "EDGE_ROLE={other:?} is not one of publisher|relay|subscriber|nonmember"
+            )),
+        }
+    }
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Publisher => "publisher",
+            Self::Relay => "relay",
+            Self::Subscriber => "subscriber",
+            Self::NonMember => "nonmember",
+        }
+    }
+    /// Does this role hold the cohort's MLS state?
+    fn in_cohort(self) -> bool {
+        matches!(self, Self::Publisher | Self::Subscriber)
+    }
+}
+
+struct Config {
+    role: Role,
+    node_id: String,
+    /// Private, per-container. Federation seed + transport identity +
+    /// sealed KV live here and nowhere else.
+    state_dir: PathBuf,
+    /// Shared, PUBLIC-ONLY. Carries the bootstrap roster that
+    /// production learns via directory-cache anti-entropy
+    /// (CIRISEdge#175). No private key is ever written here.
+    mesh_dir: PathBuf,
+    listen: std::net::SocketAddr,
+    /// `host:port` this node is reachable at on the docker network.
+    advertise: String,
+    /// Peers to dial with a TCP client interface.
+    bootstrap: Vec<String>,
+    /// Every node id expected in the mesh, publisher first.
+    expect: Vec<String>,
+    /// Cohort members (a subset of `expect`) — publisher + subscribers.
+    cohort_members: Vec<String>,
+    /// Rooted peers on the mesh that are NOT in the cohort, and which the
+    /// publisher addresses ciphertext to anyway. Without this the
+    /// "a non-member cannot fetch" leg has nothing to refuse, and a leg
+    /// that refuses nothing proves nothing.
+    observers: Vec<String>,
+    community_id: String,
+    scope: CohortScope,
+    media_path: PathBuf,
+    frames: usize,
+    /// Frame index at which a late joiner is admitted mid-stream, which
+    /// advances the MLS epoch and re-derives every member's address.
+    rotate_at: Option<usize>,
+    /// The node admitted at `rotate_at` (a subscriber that waits).
+    late_joiner: Option<String>,
+    convergence: Duration,
+    /// Ceiling on the announce-rooting cold start.
+    root_timeout: Duration,
+    /// Ceiling on any single barrier.
+    barrier_timeout: Duration,
+    results: Option<PathBuf>,
+}
+
+fn env_str(k: &str) -> Option<String> {
+    std::env::var(k).ok().filter(|v| !v.is_empty())
+}
+
+fn env_list(k: &str) -> Vec<String> {
+    env_str(k)
+        .map(|v| {
+            v.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(ToOwned::to_owned)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn env_usize(k: &str, default: usize) -> usize {
+    env_str(k).and_then(|v| v.parse().ok()).unwrap_or(default)
+}
+
+fn env_secs(k: &str, default: u64) -> Duration {
+    Duration::from_secs(env_str(k).and_then(|v| v.parse().ok()).unwrap_or(default))
+}
+
+impl Config {
+    fn from_env() -> Result<Self, String> {
+        let role = Role::parse(&env_str("EDGE_ROLE").ok_or("EDGE_ROLE is required")?)?;
+        let node_id = env_str("EDGE_NODE_ID").ok_or("EDGE_NODE_ID is required")?;
+        let listen = env_str("EDGE_LISTEN")
+            .unwrap_or_else(|| "0.0.0.0:4242".to_owned())
+            .parse()
+            .map_err(|e| format!("EDGE_LISTEN: {e}"))?;
+        let scope = match env_str("EDGE_SCOPE")
+            .unwrap_or_else(|| "family".to_owned())
+            .as_str()
+        {
+            "family" => CohortScope::Family,
+            other => other.strip_prefix("cohort:").map_or_else(
+                || CohortScope::Cohort {
+                    cohort_id: other.to_owned(),
+                },
+                |id| CohortScope::Cohort {
+                    cohort_id: id.to_owned(),
+                },
+            ),
+        };
+        let expect = env_list("EDGE_EXPECT");
+        if expect.is_empty() {
+            return Err("EDGE_EXPECT must list every node id in the mesh".to_owned());
+        }
+        let cohort_members = env_list("EDGE_COHORT_MEMBERS");
+        if cohort_members.is_empty() {
+            return Err("EDGE_COHORT_MEMBERS must list the cohort roster".to_owned());
+        }
+        Ok(Self {
+            role,
+            node_id: node_id.clone(),
+            state_dir: PathBuf::from(
+                env_str("EDGE_STATE_DIR").unwrap_or_else(|| format!("/state/{node_id}")),
+            ),
+            mesh_dir: PathBuf::from(env_str("EDGE_MESH_DIR").unwrap_or_else(|| "/mesh".to_owned())),
+            listen,
+            advertise: env_str("EDGE_ADVERTISE")
+                .unwrap_or_else(|| format!("{node_id}:{}", listen.port())),
+            bootstrap: env_list("EDGE_BOOTSTRAP"),
+            expect,
+            cohort_members,
+            observers: env_list("EDGE_OBSERVERS"),
+            community_id: env_str("EDGE_COMMUNITY").unwrap_or_else(|| "bench-mesh".to_owned()),
+            scope,
+            media_path: PathBuf::from(
+                env_str("EDGE_MEDIA").unwrap_or_else(|| "/media/testsrc.h264".to_owned()),
+            ),
+            frames: env_usize("EDGE_FRAMES", 120),
+            rotate_at: env_str("EDGE_ROTATE_AT").and_then(|v| v.parse().ok()),
+            late_joiner: env_str("EDGE_LATE_JOINER"),
+            convergence: env_secs("EDGE_CONVERGENCE_SECS", 20),
+            root_timeout: env_secs("EDGE_ROOT_TIMEOUT_SECS", 120),
+            barrier_timeout: env_secs("EDGE_BARRIER_TIMEOUT_SECS", 180),
+            results: env_str("EDGE_RESULTS").map(PathBuf::from),
+        })
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Bootstrap ceremony — public data only crosses the shared volume
+// ═══════════════════════════════════════════════════════════════════
+
+/// What a node publishes about itself so the mesh can reach and root it.
+///
+/// Everything here is public: an Ed25519 public key, a leviculum
+/// transport public key, and a `host:port`. The private halves are
+/// generated in the node's own state dir and never leave it.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct RosterEntry {
+    key_id: String,
+    role: String,
+    advertise: String,
+    /// Base64 32-byte Ed25519 federation public key.
+    fed_pubkey_b64: String,
+}
+
+/// The steward that scrub-signs the roster into `federation_keys` rows.
+///
+/// A federation has a trust root; in a harness the publisher plays it.
+/// Its seed lives in the publisher's own private state dir. The shared
+/// volume carries only the resulting signed *rows*.
+const STEWARD_KEY_ID: &str = "bench-mesh-steward";
+
+fn roster_dir(mesh: &Path) -> PathBuf {
+    mesh.join("roster")
+}
+
+fn directory_path(mesh: &Path) -> PathBuf {
+    mesh.join("directory.json")
+}
+
+/// Publish this node's public bootstrap record.
+fn publish_roster_entry(mesh: &Path, entry: &RosterEntry) -> std::io::Result<()> {
+    let dir = roster_dir(mesh);
+    std::fs::create_dir_all(&dir)?;
+    let tmp = dir.join(format!("{}.tmp", entry.key_id));
+    let final_path = dir.join(format!("{}.json", entry.key_id));
+    std::fs::write(&tmp, serde_json::to_vec_pretty(entry).unwrap_or_default())?;
+    // Rename so a reader never observes a half-written record.
+    std::fs::rename(&tmp, &final_path)
+}
+
+/// The transport half of a node's public record, published once its
+/// leviculum identity exists. Separate from [`RosterEntry`] because it
+/// cannot be known until after the transport is built, and the
+/// directory-signing barrier depends on the first half.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct TransportEntry {
+    key_id: String,
+    /// Base64 of the ed25519 half (bytes 32..64) of the dual-key
+    /// leviculum transport identity.
+    transport_ed25519_b64: String,
+}
+
+fn publish_transport_entry(mesh: &Path, entry: &TransportEntry) -> std::io::Result<()> {
+    let dir = roster_dir(mesh);
+    std::fs::create_dir_all(&dir)?;
+    let tmp = dir.join(format!("{}.transport.tmp", entry.key_id));
+    let final_path = dir.join(format!("{}.transport.json", entry.key_id));
+    std::fs::write(&tmp, serde_json::to_vec_pretty(entry).unwrap_or_default())?;
+    std::fs::rename(&tmp, &final_path)
+}
+
+/// Read a peer's transport ed25519 half, or `None` if it has not
+/// published one yet.
+fn peer_transport_ed25519(mesh: &Path, key_id: &str) -> Option<[u8; 32]> {
+    let path = roster_dir(mesh).join(format!("{key_id}.transport.json"));
+    let bytes = std::fs::read(path).ok()?;
+    let entry: TransportEntry = serde_json::from_slice(&bytes).ok()?;
+    let raw = B64.decode(entry.transport_ed25519_b64).ok()?;
+    raw.try_into().ok()
+}
+
+fn read_roster(mesh: &Path) -> BTreeMap<String, RosterEntry> {
+    let mut out = BTreeMap::new();
+    let Ok(rd) = std::fs::read_dir(roster_dir(mesh)) else {
+        return out;
+    };
+    for e in rd.flatten() {
+        let p = e.path();
+        let is_transport_half = p
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with(".transport.json"));
+        if p.extension().is_some_and(|x| x == "json") && !is_transport_half {
+            if let Ok(bytes) = std::fs::read(&p) {
+                if let Ok(entry) = serde_json::from_slice::<RosterEntry>(&bytes) {
+                    out.insert(entry.key_id.clone(), entry);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Wait until every id in `expect` has published a roster entry.
+///
+/// Returns `Err` with the ids still missing when the deadline passes —
+/// the caller reports a leg that did not run, never a green one.
+async fn await_roster(
+    mesh: &Path,
+    expect: &[String],
+    timeout: Duration,
+) -> Result<BTreeMap<String, RosterEntry>, String> {
+    let start = Instant::now();
+    loop {
+        let roster = read_roster(mesh);
+        let missing: Vec<&String> = expect.iter().filter(|k| !roster.contains_key(*k)).collect();
+        if missing.is_empty() {
+            return Ok(roster);
+        }
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "roster barrier timed out after {}s; still missing {missing:?}",
+                timeout.as_secs()
+            ));
+        }
+        tokio_sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// Runtime-agnostic sleep (CIRISEdge#217 — never `tokio::time::sleep` on
+/// a path that may be driven by a foreign runtime).
+async fn tokio_sleep(d: Duration) {
+    futures_timer::Delay::new(d).await;
+}
+
+/// Wait for a file to appear, then read it.
+async fn await_file(path: &Path, timeout: Duration) -> Result<Vec<u8>, String> {
+    let start = Instant::now();
+    loop {
+        if let Ok(b) = std::fs::read(path) {
+            if !b.is_empty() {
+                return Ok(b);
+            }
+        }
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "{} did not appear within {}s",
+                path.display(),
+                timeout.as_secs()
+            ));
+        }
+        tokio_sleep(Duration::from_millis(250)).await;
+    }
+}
+
+/// A deterministic-from-seed federation identity.
+///
+/// The seed itself is CSPRNG-generated on first boot **inside the node's
+/// own private state dir**; it is written once and reloaded thereafter,
+/// so a restarted container keeps its identity and two containers can
+/// never share one.
+struct FedKey {
+    seed: [u8; 32],
+}
+
+impl FedKey {
+    /// Load the seed at `dir/ed25519.seed`, generating it on first boot.
+    fn load_or_create(key_id: &str, dir: &Path) -> Result<Self, String> {
+        std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+        let path = dir.join("ed25519.seed");
+        let seed = if path.exists() {
+            let b = std::fs::read(&path).map_err(|e| format!("read seed: {e}"))?;
+            let arr: [u8; 32] = b
+                .try_into()
+                .map_err(|_| format!("{} is not a 32-byte seed", path.display()))?;
+            arr
+        } else {
+            // Edge has no "mint a fresh federation identity" verb — every
+            // existing fixture writes the seed itself. Recorded as a DX
+            // finding; the harness does the same, from the CSPRNG.
+            let mut arr = [0u8; 32];
+            ciris_crypto::random::fill(&mut arr).map_err(|e| format!("csprng: {e}"))?;
+            std::fs::write(&path, arr).map_err(|e| format!("write seed: {e}"))?;
+            arr
+        };
+        let _ = key_id;
+        Ok(Self { seed })
+    }
+
+    fn signer(&self) -> Result<Ed25519Signer, String> {
+        Ed25519Signer::from_seed(&self.seed).map_err(|e| format!("ed25519 from seed: {e}"))
+    }
+
+    fn pubkey_b64(&self) -> Result<String, String> {
+        Ok(B64.encode(
+            self.signer()?
+                .public_key()
+                .map_err(|e| format!("pubkey: {e}"))?,
+        ))
+    }
+}
+
+/// Build one scrub-signed `federation_keys` row.
+///
+/// Same shape as `tests/common::signed_record` / `benches/common::
+/// signed_record` — kept in step with them deliberately: a change to the
+/// admitted row shape must break all three at once.
+fn signed_record(
+    subject_key_id: &str,
+    subject_pubkey_b64: &str,
+    signer: &Ed25519Signer,
+    signer_key_id: &str,
+    identity_type: &str,
+) -> Result<KeyRecord, String> {
+    let envelope = serde_json::json!({ "key_id": subject_key_id });
+    let canonical = serde_json::to_vec(&envelope).map_err(|e| format!("canonical: {e}"))?;
+    let digest = Sha256::digest(&canonical);
+    let sig = signer
+        .sign(digest.as_slice())
+        .map_err(|e| format!("scrub sign: {e}"))?;
+    let ts = chrono::DateTime::parse_from_rfc3339("2026-05-01T00:00:00Z")
+        .map_err(|e| format!("ts: {e}"))?
+        .into();
+    Ok(KeyRecord {
+        key_id: subject_key_id.to_owned(),
+        pubkey_ed25519_base64: subject_pubkey_b64.to_owned(),
+        pubkey_ml_dsa_65_base64: None,
+        algorithm: "hybrid".to_owned(),
+        identity_type: identity_type.to_owned(),
+        identity_ref: subject_key_id.to_owned(),
+        valid_from: ts,
+        valid_until: None,
+        registration_envelope: envelope,
+        original_content_hash: hex::encode(digest),
+        scrub_signature_classical: B64.encode(sig),
+        scrub_signature_pqc: None,
+        scrub_key_id: signer_key_id.to_owned(),
+        scrub_timestamp: ts,
+        pqc_completed_at: None,
+        persist_row_hash: String::new(),
+        capability_roles: Vec::new(),
+        attestation_evidence: None,
+        consent_role: None,
+        additional_scrubs: Vec::new(),
+    })
+}
+
+/// Open a fresh per-container persist directory and seed it with `rows`.
+///
+/// One backend per container — the containers never share a handle, a
+/// file, or a connection pool.
+async fn open_directory(rows: Vec<KeyRecord>) -> Result<Arc<SqliteBackend>, String> {
+    let backend = FederationDirectorySqlite::open(":memory:")
+        .await
+        .map_err(|e| format!("open directory: {e}"))?;
+    backend
+        .run_migrations()
+        .await
+        .map_err(|e| format!("migrate: {e}"))?;
+    for rec in rows {
+        backend
+            .put_public_key(SignedKeyRecord { record: rec })
+            .await
+            .map_err(|e| format!("put_public_key: {e}"))?;
+    }
+    Ok(backend)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// The wire — a compact harness frame over the real RNS resource path
+// ═══════════════════════════════════════════════════════════════════
+
+/// `MESH1` ‖ u8 kind ‖ u32be header_len ‖ header JSON ‖ payload.
+///
+/// The transport carries opaque bytes (its own loopback acceptance test
+/// asserts byte-exactness), so the harness frames its own control and
+/// media messages rather than pretending each video chunk is a signed
+/// federation envelope.
+const MAGIC: &[u8; 5] = b"MESH1";
+/// Blob fan-out chunk size. Fixed so completion times compare run to run.
+const BLOB_CHUNK: usize = 32 * 1024;
+/// How many frames are addressed to a non-member observer.
+///
+/// The refusal claim is about an AEAD key the observer does not hold, so
+/// it fails identically on every frame — a handful is as conclusive as a
+/// thousand, and a thousand would mean the publisher paying a transport
+/// timeout per frame after the observer exits, which would quietly turn
+/// the fan-out throughput number into a measure of how fast a dead peer
+/// fails.
+const OBSERVER_FRAMES: usize = 4;
+/// Ceiling on frames a subscriber will hold awaiting a not-yet-applied
+/// epoch commit. Bounds the make-before-break buffer against a peer that
+/// floods wrong-epoch headers.
+const MAX_DEFERRED: usize = 4096;
+const KIND_CONTROL: u8 = 1;
+const KIND_MEDIA: u8 = 2;
+const KIND_BLOB: u8 = 3;
+
+fn encode_frame(kind: u8, header: &serde_json::Value, payload: &[u8]) -> Vec<u8> {
+    let h = serde_json::to_vec(header).unwrap_or_default();
+    let mut out = Vec::with_capacity(MAGIC.len() + 5 + h.len() + payload.len());
+    out.extend_from_slice(MAGIC);
+    out.push(kind);
+    out.extend_from_slice(&u32::try_from(h.len()).unwrap_or(0).to_be_bytes());
+    out.extend_from_slice(&h);
+    out.extend_from_slice(payload);
+    out
+}
+
+fn decode_frame(bytes: &[u8]) -> Option<(u8, serde_json::Value, &[u8])> {
+    if bytes.len() < MAGIC.len() + 5 || &bytes[..MAGIC.len()] != MAGIC {
+        return None;
+    }
+    let kind = bytes[MAGIC.len()];
+    let len_at = MAGIC.len() + 1;
+    let header_len = u32::from_be_bytes(bytes.get(len_at..len_at + 4)?.try_into().ok()?) as usize;
+    let body_at = len_at + 4;
+    let header = serde_json::from_slice(bytes.get(body_at..body_at + header_len)?).ok()?;
+    Some((kind, header, bytes.get(body_at + header_len..)?))
+}
+
+/// Control-plane messages. Carried over the same real transport as the
+/// media, so the MLS join really does cross the wire.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "t")]
+enum Control {
+    /// Joiner → creator: a real openmls KeyPackage.
+    KeyPackage { key_id: String, kp_b64: String },
+    /// Creator → joiner: the Welcome `add_member` produced.
+    Welcome { key_id: String, welcome_b64: String },
+    /// Creator → existing members: an MLS commit to apply.
+    Commit { epoch: u64, commit_b64: String },
+    /// Member → creator: "my cohort state and addresses are installed".
+    Ready { key_id: String, epoch: u64 },
+    /// Creator → all: the stream is about to start.
+    StreamStart {
+        stream_id_hex: String,
+        frames: usize,
+    },
+    /// Creator → all: no more frames.
+    StreamEnd { frames_sent: usize },
+    /// Creator → all: blob metadata.
+    BlobStart {
+        sha256: String,
+        bytes: usize,
+        chunks: usize,
+    },
+    /// Member → creator: "dial my live and superseded addresses BEFORE
+    /// I seal". Carries no addresses: the creator derives them from its
+    /// OWN table, which is additionally the cross-node agreement check —
+    /// a dial that lands proves both nodes derived the same 16 bytes.
+    /// Sent only by a member that crossed an epoch advance and therefore
+    /// has a superseded epoch to retire.
+    SealProbe {
+        key_id: String,
+        superseded_epoch: u64,
+    },
+    /// Creator → member: "I have taken the before-reading; seal now".
+    SealGo { key_id: String },
+    /// Member → creator: the seal ran; here is what it did.
+    Sealed {
+        key_id: String,
+        sealed: usize,
+        unretired: usize,
+    },
+    /// Member → creator: final per-node measurements.
+    Report {
+        key_id: String,
+        body: serde_json::Value,
+    },
+}
+
+/// One inbound data frame: `(attributed sender, header, payload)`.
+type DataFrame = (Option<String>, serde_json::Value, Vec<u8>);
+/// One inbound control frame: `(attributed sender, message)`.
+type ControlFrame = (Option<String>, Control);
+
+/// A live inbound mailbox: the `listen` sink demultiplexed by frame kind.
+struct Mailbox {
+    control: Mutex<mpsc::UnboundedReceiver<ControlFrame>>,
+    media: Mutex<mpsc::UnboundedReceiver<DataFrame>>,
+    blob: Mutex<mpsc::UnboundedReceiver<DataFrame>>,
+}
+
+/// Spawn the transport listener and the demultiplexer.
+///
+/// `listen` may be called exactly once per transport, so this is the one
+/// place that does it.
+fn spawn_inbound(transport: &Arc<ReticulumTransport>) -> Arc<Mailbox> {
+    let (tx, mut rx) = mpsc::channel::<InboundFrame>(4096);
+    let (ctl_tx, ctl_rx) = mpsc::unbounded_channel();
+    let (med_tx, med_rx) = mpsc::unbounded_channel();
+    let (blb_tx, blb_rx) = mpsc::unbounded_channel();
+
+    let t = Arc::clone(transport);
+    tokio::spawn(async move {
+        if let Err(e) = t.listen(tx).await {
+            tracing::error!(error = %e, "transport listener exited");
+        }
+    });
+
+    tokio::spawn(async move {
+        while let Some(frame) = rx.recv().await {
+            let src = frame.source_key_id.as_ref().map(|k| k.as_str().to_owned());
+            let Some((kind, header, payload)) = decode_frame(&frame.envelope_bytes) else {
+                tracing::debug!("dropping a non-harness inbound frame");
+                continue;
+            };
+            match kind {
+                KIND_CONTROL => match serde_json::from_value::<Control>(header) {
+                    Ok(c) => {
+                        let _ = ctl_tx.send((src, c));
+                    }
+                    Err(e) => tracing::warn!(error = %e, "undecodable control frame"),
+                },
+                KIND_MEDIA => {
+                    let _ = med_tx.send((src, header, payload.to_vec()));
+                }
+                KIND_BLOB => {
+                    let _ = blb_tx.send((src, header, payload.to_vec()));
+                }
+                other => tracing::warn!(kind = other, "unknown harness frame kind"),
+            }
+        }
+    });
+
+    Arc::new(Mailbox {
+        control: Mutex::new(ctl_rx),
+        media: Mutex::new(med_rx),
+        blob: Mutex::new(blb_rx),
+    })
+}
+
+impl Mailbox {
+    /// Await the next control message, or `Err` on timeout.
+    ///
+    /// The receiver guard is taken and released inside the `select!`
+    /// arm's own future — no guard is alive across the timeout branch
+    /// (CIRISEdge#217).
+    async fn next_control(&self, timeout: Duration) -> Result<(Option<String>, Control), String> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            {
+                let mut rx = self.control.lock().await;
+                if let Ok(msg) = rx.try_recv() {
+                    return Ok(msg);
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(format!("no control frame within {}s", timeout.as_secs()));
+            }
+            tokio_sleep(Duration::from_millis(20)).await;
+        }
+    }
+}
+
+/// Send a control message over the real transport.
+async fn send_control(
+    transport: &ReticulumTransport,
+    to: &str,
+    msg: &Control,
+) -> Result<(), TransportError> {
+    let header = serde_json::to_value(msg).unwrap_or(serde_json::Value::Null);
+    let bytes = encode_frame(KIND_CONTROL, &header, &[]);
+    transport.send(to, &bytes).await.map(|_| ())
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// The two in-flight seams
+// ═══════════════════════════════════════════════════════════════════
+
+/// **SEAM 1 — how a sealed A/V chunk crosses the wire.**
+///
+/// `src/transport/av_spine.rs` (join→subscribe→relay→heal) is being
+/// built concurrently and is the intended production driver. It cannot
+/// be used from here today for a structural reason worth recording:
+/// `AvPublisher` / `AvRelay` / `LeviculumAvSender` / `LinkDataPump` all
+/// need an `Arc<ReticulumNode>`, and `ReticulumTransport::node()` is
+/// `pub(crate)` + `#[cfg(feature = "pyo3")]` — a downstream consumer
+/// holding a `ReticulumTransport` cannot reach the node, and a second
+/// node would need the event receiver the transport's listener already
+/// owns.
+///
+/// So the harness drives the wire through the verb it *can* reach, and
+/// keeps it behind this trait so the spine slots in as a second impl.
+#[async_trait::async_trait]
+trait MediaLink: Send + Sync {
+    /// Name of the mechanism actually used, for the JSON output.
+    fn mechanism(&self) -> &'static str;
+    /// Deliver one sealed chunk to one peer.
+    async fn deliver(
+        &self,
+        to: &str,
+        header: &serde_json::Value,
+        chunk: &[u8],
+    ) -> Result<(), String>;
+}
+
+/// Today's `MediaLink`: the real RNS resource path.
+struct TransportMediaLink {
+    transport: Arc<ReticulumTransport>,
+}
+
+#[async_trait::async_trait]
+impl MediaLink for TransportMediaLink {
+    fn mechanism(&self) -> &'static str {
+        "reticulum_transport_send"
+    }
+    async fn deliver(
+        &self,
+        to: &str,
+        header: &serde_json::Value,
+        chunk: &[u8],
+    ) -> Result<(), String> {
+        let bytes = encode_frame(KIND_MEDIA, header, chunk);
+        self.transport
+            .send(to, &bytes)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+}
+
+/// **SEAM 2 — how a *scope-derived* address is dialled.**
+///
+/// `ScopeAddressTable::send_address(scope, group, member)` hands back a
+/// peer's 16-byte derived address and there is no transport verb that
+/// accepts one: `register_scoped_destination` / `retire_scoped_
+/// destination` / `inbound_scope` cover the LISTEN half, and
+/// `link_open` resolves its peer signing key from the rooted-peer map,
+/// which is keyed on federation destinations. `send_address` has zero
+/// non-test callers in the tree.
+///
+/// The harness supplies the binding itself so the seal-retirement leg
+/// can make a real *network* assertion, and stamps
+/// `dial_binding: "harness_installed"` on the result so nobody reads
+/// that leg as evidence a production dial path exists.
+#[async_trait::async_trait]
+trait ScopedDialer: Send + Sync {
+    fn binding_source(&self) -> &'static str;
+    /// Try to establish a link to a scope-derived address. `Ok(true)`
+    /// means somebody answered.
+    async fn dial(
+        &self,
+        address: &MemberAddress,
+        peer_transport_ed25519: [u8; 32],
+        timeout: Duration,
+    ) -> bool;
+}
+
+struct HarnessScopedDialer {
+    transport: Arc<ReticulumTransport>,
+}
+
+#[async_trait::async_trait]
+impl ScopedDialer for HarnessScopedDialer {
+    fn binding_source(&self) -> &'static str {
+        // Named, not hidden: the production verb does not exist yet.
+        "harness_installed"
+    }
+    async fn dial(
+        &self,
+        address: &MemberAddress,
+        peer_transport_ed25519: [u8; 32],
+        timeout: Duration,
+    ) -> bool {
+        let hash = *address.as_bytes();
+        // Install exactly the (derived hash → peer transport key) binding
+        // the missing `dial_scoped` verb would resolve internally. A
+        // pseudo key id keyed on the hash keeps it out of the federation
+        // peer namespace.
+        let pseudo = format!("scoped:{}", hex::encode(hash));
+        self.transport
+            .inject_rooted_peer_for_test(&pseudo, hash, peer_transport_ed25519)
+            .await;
+        self.transport.link_open(&hash, timeout).await.is_ok()
+    }
+}
+
+/// **SEAM 3 — scope-native blob fetch.**
+///
+/// `src/blob_swarm/` is being extended concurrently with a scope-native
+/// fetch path. Today the harness pushes the blob over the same real
+/// transport and gates *admission* on cohort membership, which is enough
+/// to assert both halves of the refusal property; it is not yet a swarm
+/// fetch. When the scope-native fetch lands it becomes the second impl
+/// of this trait.
+#[async_trait::async_trait]
+trait BlobPlane: Send + Sync {
+    fn mechanism(&self) -> &'static str;
+    async fn push_chunk(
+        &self,
+        to: &str,
+        header: &serde_json::Value,
+        chunk: &[u8],
+    ) -> Result<(), String>;
+}
+
+struct TransportBlobPlane {
+    transport: Arc<ReticulumTransport>,
+}
+
+#[async_trait::async_trait]
+impl BlobPlane for TransportBlobPlane {
+    fn mechanism(&self) -> &'static str {
+        "reticulum_transport_send"
+    }
+    async fn push_chunk(
+        &self,
+        to: &str,
+        header: &serde_json::Value,
+        chunk: &[u8],
+    ) -> Result<(), String> {
+        let bytes = encode_frame(KIND_BLOB, header, chunk);
+        self.transport
+            .send(to, &bytes)
+            .await
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Media — real encoded frames out of the ffmpeg-generated file
+// ═══════════════════════════════════════════════════════════════════
+
+/// Split an Annex-B elementary stream into access units.
+///
+/// `bench-mesh/Dockerfile` produces `testsrc.h264` — a raw H.264
+/// elementary stream from `testsrc`, fixed duration and fixed encoder
+/// settings, so the byte content is identical on every build. Each
+/// returned element is a real encoded access unit (its own NAL start
+/// codes intact), not a slice of a buffer of zeros.
+///
+/// Returns `Err` when the file has no start codes at all — that means
+/// the media step did not produce what the harness expects, and the leg
+/// must report that rather than "publish" nothing.
+fn annexb_access_units(bytes: &[u8]) -> Result<Vec<Vec<u8>>, String> {
+    let mut starts = Vec::new();
+    let mut i = 0usize;
+    while i + 3 < bytes.len() {
+        if bytes[i] == 0 && bytes[i + 1] == 0 && bytes[i + 2] == 1 {
+            starts.push(i);
+            i += 3;
+        } else if i + 4 < bytes.len()
+            && bytes[i] == 0
+            && bytes[i + 1] == 0
+            && bytes[i + 2] == 0
+            && bytes[i + 3] == 1
+        {
+            starts.push(i);
+            i += 4;
+        } else {
+            i += 1;
+        }
+    }
+    if starts.is_empty() {
+        return Err(
+            "no Annex-B start code found — the media file is not a raw H.264 elementary stream"
+                .to_owned(),
+        );
+    }
+    // Group NALs into access units: a new AU begins at each VCL NAL that
+    // follows a non-VCL one. Coarse but deterministic, and every emitted
+    // unit is real encoded video.
+    let mut units = Vec::new();
+    for (n, &s) in starts.iter().enumerate() {
+        let e = starts.get(n + 1).copied().unwrap_or(bytes.len());
+        units.push(bytes[s..e].to_vec());
+    }
+    Ok(units)
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// The occurrence
+// ═══════════════════════════════════════════════════════════════════
+
+/// One live edge occurrence: identity, sealed state, transport, and the
+/// scope-address lifecycle driving the real transport.
+struct Occurrence {
+    cfg: Config,
+    transport: Arc<ReticulumTransport>,
+    mailbox: Arc<Mailbox>,
+    table: Arc<ScopeAddressTable>,
+    lifecycle: Arc<ScopeLifecycle>,
+    roster: BTreeMap<String, RosterEntry>,
+    reporter: Arc<Reporter>,
+}
+
+/// Build the whole occurrence: keys, sealed KV, directory, transport,
+/// address table, lifecycle.
+async fn stand_up(cfg: Config, reporter: Arc<Reporter>) -> Result<Occurrence, String> {
+    std::fs::create_dir_all(&cfg.state_dir)
+        .map_err(|e| format!("create state dir {}: {e}", cfg.state_dir.display()))?;
+
+    // ── 1. This node's own federation key (private; own volume only) ──
+    let fed = FedKey::load_or_create(&cfg.node_id, &cfg.state_dir.join("fed"))?;
+
+    // ── 2. Publish the public half + reachability ────────────────────
+    publish_roster_entry(
+        &cfg.mesh_dir,
+        &RosterEntry {
+            key_id: cfg.node_id.clone(),
+            role: cfg.role.as_str().to_owned(),
+            advertise: cfg.advertise.clone(),
+            fed_pubkey_b64: fed.pubkey_b64()?,
+        },
+    )
+    .map_err(|e| format!("publish roster entry: {e}"))?;
+
+    // ── 3. The publisher plays steward and signs the directory ───────
+    let dir_path = directory_path(&cfg.mesh_dir);
+    if cfg.role == Role::Publisher {
+        let roster = await_roster(&cfg.mesh_dir, &cfg.expect, cfg.barrier_timeout).await?;
+        let steward = FedKey::load_or_create(STEWARD_KEY_ID, &cfg.state_dir.join("steward"))?;
+        let steward_signer = steward.signer()?;
+        let mut rows = vec![signed_record(
+            STEWARD_KEY_ID,
+            &steward.pubkey_b64()?,
+            &steward_signer,
+            STEWARD_KEY_ID,
+            "steward",
+        )?];
+        for entry in roster.values() {
+            rows.push(signed_record(
+                &entry.key_id,
+                &entry.fed_pubkey_b64,
+                &steward_signer,
+                STEWARD_KEY_ID,
+                "agent",
+            )?);
+        }
+        let tmp = cfg.mesh_dir.join("directory.tmp");
+        std::fs::write(
+            &tmp,
+            serde_json::to_vec_pretty(&rows).map_err(|e| format!("encode directory: {e}"))?,
+        )
+        .map_err(|e| format!("write directory: {e}"))?;
+        std::fs::rename(&tmp, &dir_path).map_err(|e| format!("publish directory: {e}"))?;
+    }
+
+    // ── 4. Every node opens its OWN directory from the signed rows ───
+    let dir_bytes = await_file(&dir_path, cfg.barrier_timeout).await?;
+    let rows: Vec<KeyRecord> =
+        serde_json::from_slice(&dir_bytes).map_err(|e| format!("decode directory: {e}"))?;
+    let directory = open_directory(rows).await?;
+    let roster = read_roster(&cfg.mesh_dir);
+
+    // ── 5. The federation signer, from this node's own seed ──────────
+    let (classical, _pqc) = ciris_keyring::load_local_seed(ciris_keyring::LocalSeedConfig {
+        key_id: cfg.node_id.clone(),
+        key_path: cfg.state_dir.join("fed/ed25519.seed"),
+        pqc_key_id: None,
+        pqc_key_path: None,
+    })
+    .await
+    .map_err(|e| format!("load_local_seed: {e}"))?;
+    let signer = Arc::new(LocalSigner::new(cfg.node_id.clone(), classical, None));
+
+    // ── 6. The real transport, on the real docker network ────────────
+    //
+    // The legacy `listen_addr` + `bootstrap_peers` shape rather than the
+    // typed `add_interface` one, deliberately: it is the configuration
+    // `benches/transport_reticulum_loopback.rs::build_loopback` proves
+    // converges through **real announce-based rooting**, with no primed
+    // binding anywhere. `interfaces` being non-empty suppresses both
+    // fields, so the two styles cannot be mixed.
+    let mut tcfg =
+        ReticulumTransportConfig::new(cfg.state_dir.join("transport.id"), cfg.node_id.clone());
+    tcfg.listen_addr = cfg.listen;
+    tcfg.announce_interval = Duration::from_secs(2);
+    for peer in &cfg.bootstrap {
+        tcfg.bootstrap_peers
+            .push(resolve_addr(peer, cfg.barrier_timeout).await?);
+    }
+    // A relay carries other nodes' traffic; leaves do not.
+    tcfg = tcfg.with_transport_node(cfg.role == Role::Relay);
+
+    let auth = ReticulumAuth {
+        signer: Some(signer),
+        rooting: Some(Arc::clone(&directory) as Arc<dyn RootingDirectory>),
+        resolver: None,
+        hybrid_policy: HybridPolicy::Ed25519Fallback,
+        ..ReticulumAuth::default()
+    };
+    let transport = Arc::new(
+        ReticulumTransport::new(tcfg, auth)
+            .await
+            .map_err(|e| format!("build transport: {e}"))?,
+    );
+    let mut own_transport_ed25519 = [0u8; 32];
+    own_transport_ed25519.copy_from_slice(&transport.local_transport_pubkey()[32..64]);
+    publish_transport_entry(
+        &cfg.mesh_dir,
+        &TransportEntry {
+            key_id: cfg.node_id.clone(),
+            transport_ed25519_b64: B64.encode(own_transport_ed25519),
+        },
+    )
+    .map_err(|e| format!("publish transport entry: {e}"))?;
+
+    // ── 7. The address table + lifecycle, over the REAL transport ────
+    //
+    // This is the DX under test: the sink IS the live transport, so a
+    // lifecycle install registers a destination on the leviculum node
+    // and a seal retires it.
+    let table = Arc::new(ScopeAddressTable::new(Arc::new(ScopePrivacyDeriver)));
+    transport
+        .install_scope_address_table(Arc::clone(&table))
+        .map_err(|e| format!("install scope address table: {e}"))?;
+    let lifecycle = Arc::new(ScopeLifecycle::new(
+        Arc::clone(&table),
+        Arc::clone(&transport) as Arc<dyn ScopedDestinationSink>,
+        cfg.node_id.clone(),
+        cfg.convergence,
+    ));
+
+    let mailbox = spawn_inbound(&transport);
+
+    Ok(Occurrence {
+        cfg,
+        transport,
+        mailbox,
+        table,
+        lifecycle,
+        roster,
+        reporter,
+    })
+}
+
+/// Resolve `host:port` with retries — a container's DNS name may not
+/// resolve until its peer is up.
+async fn resolve_addr(hostport: &str, timeout: Duration) -> Result<std::net::SocketAddr, String> {
+    use std::net::ToSocketAddrs as _;
+    let start = Instant::now();
+    loop {
+        if let Ok(mut it) = hostport.to_socket_addrs() {
+            if let Some(a) = it.next() {
+                return Ok(a);
+            }
+        }
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "could not resolve {hostport} within {}s",
+                timeout.as_secs()
+            ));
+        }
+        tokio_sleep(Duration::from_millis(500)).await;
+    }
+}
+
+impl Occurrence {
+    /// Wait for real announce-based rooting to converge with every peer
+    /// we need to talk to. No test hook: this is the production
+    /// cold-start path, and a timeout is reported as a leg that did not
+    /// run.
+    async fn await_rooting(&self, peers: &[String]) -> Result<Duration, String> {
+        let start = Instant::now();
+        loop {
+            let mut missing = Vec::new();
+            for p in peers {
+                if p != &self.cfg.node_id && !self.transport.knows_peer(p).await {
+                    missing.push(p.clone());
+                }
+            }
+            if missing.is_empty() {
+                return Ok(start.elapsed());
+            }
+            if start.elapsed() >= self.cfg.root_timeout {
+                return Err(format!(
+                    "announce rooting did not converge within {}s; unrooted: {missing:?}",
+                    self.cfg.root_timeout.as_secs()
+                ));
+            }
+            tokio_sleep(Duration::from_millis(500)).await;
+        }
+    }
+
+    /// Install this cohort's scope addresses through the documented two
+    /// lines, against the real transport.
+    async fn install_addresses(&self, group: &CohortGroup) -> Result<TransitionOutcome, String> {
+        let snap = ciris_edge::cohort_addressing::snapshot(group)
+            .await
+            .map_err(|e| format!("cohort_addressing::snapshot: {e}"))?;
+        self.lifecycle
+            .install(&self.cfg.scope, &snap)
+            .map_err(|e| format!("lifecycle.install: {e}"))
+    }
+
+    /// Advance them make-before-break after an epoch bump.
+    async fn advance_addresses(&self, group: &CohortGroup) -> Result<TransitionOutcome, String> {
+        let snap = ciris_edge::cohort_addressing::snapshot(group)
+            .await
+            .map_err(|e| format!("cohort_addressing::snapshot: {e}"))?;
+        self.lifecycle
+            .advance(&self.cfg.scope, &snap, Instant::now())
+            .map_err(|e| format!("lifecycle.advance: {e}"))
+    }
+
+    fn group_id(&self) -> String {
+        format!("cohort:{}", self.cfg.community_id)
+    }
+}
+
+/// Open this node's own on-disk sealed KV.
+///
+/// The passphrase is derived from the node's own federation seed, so two
+/// containers can never open each other's store even if the files were
+/// swapped. One sealed KV per occurrence — never shared.
+fn open_sealed_kv(state_dir: &Path, fed_seed_path: &Path) -> Result<XChaChaKvStore, String> {
+    let seed = std::fs::read(fed_seed_path).map_err(|e| format!("read seed: {e}"))?;
+    let pass = kdf::hkdf_sha256(
+        &seed,
+        b"ciris-edge/bench-mesh/sealed-kv/v1",
+        b"cohort-mls-state",
+        32,
+    )
+    .map_err(|e| format!("kv passphrase kdf: {e}"))?;
+    std::fs::create_dir_all(state_dir).map_err(|e| format!("create kv dir: {e}"))?;
+    XChaChaKvStore::open(state_dir.join("cohort-state.kv"), &pass)
+        .map_err(|e| format!("open sealed kv: {e}"))
+}
+
+/// The media DEK and the per-link transit key for an epoch.
+///
+/// **Labelled, harness-only derivation.** Production takes the A/V DEK
+/// from an `AvSession`'s own MLS group and the transit key from a
+/// `FederationSession` hybrid KEX. Neither is reachable across process
+/// boundaries today: the A/V session join rides on the in-flight spine,
+/// and `SessionHandshakeMsg` has no serde wire form, so a cross-process
+/// KEX would need a hand-rolled codec.
+///
+/// What is used instead is still a *real* MLS exporter — the cohort's
+/// record-plane secret, which every member derives identically and which
+/// changes on every epoch advance (which is exactly the property the
+/// rotation conformance leg turns on). It is a separate labelled
+/// derivation, not a reuse of the record plane's key: the info string
+/// names the harness and the plane.
+fn epoch_keys(
+    record_secret: &[u8; 32],
+    stream: &StreamId,
+    epoch: u64,
+) -> Result<([u8; 32], [u8; 32]), String> {
+    let mut info = Vec::with_capacity(64);
+    info.extend_from_slice(b"ciris-edge/bench-mesh/media/v1");
+    info.extend_from_slice(&stream.0);
+    info.extend_from_slice(&epoch.to_be_bytes());
+    let dek = kdf::hkdf_sha256(record_secret, b"bench-mesh-dek", &info, 32)
+        .map_err(|e| format!("dek kdf: {e}"))?;
+    let transit = kdf::hkdf_sha256(record_secret, b"bench-mesh-transit", &info, 32)
+        .map_err(|e| format!("transit kdf: {e}"))?;
+    let mut d = [0u8; 32];
+    d.copy_from_slice(&dek);
+    let mut t = [0u8; 32];
+    t.copy_from_slice(&transit);
+    Ok((d, t))
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// Roles
+// ═══════════════════════════════════════════════════════════════════
+
+/// The publisher: cohort creator, stream source, blob source, and the
+/// node that drives the mid-stream epoch advance.
+async fn run_publisher(occ: Occurrence) -> Result<(), String> {
+    let rep = Arc::clone(&occ.reporter);
+    let cfg = &occ.cfg;
+
+    // ── Rooting ──────────────────────────────────────────────────────
+    let peers: Vec<String> = cfg
+        .expect
+        .iter()
+        .filter(|k| *k != &cfg.node_id)
+        .cloned()
+        .collect();
+    let root_elapsed = match occ.await_rooting(&peers).await {
+        Ok(d) => d,
+        Err(e) => {
+            rep.not_run("mesh.rooting", e.clone());
+            return Err(e);
+        }
+    };
+    rep.ran(
+        "mesh.rooting",
+        true,
+        serde_json::json!({
+            "peers": peers.len(),
+            "converged_ms": root_elapsed.as_millis(),
+            "mechanism": "announce_attestation_rooting",
+        }),
+    );
+
+    // ── Cohort: create, admit members over the real wire ─────────────
+    let kv = Arc::new(open_sealed_kv(
+        &cfg.state_dir,
+        &cfg.state_dir.join("fed/ed25519.seed"),
+    )?);
+    let store = ScopeStateProvider::new(kv);
+    let group = CohortGroup::create(store, &cfg.community_id, &cfg.node_id, 16)
+        .await
+        .map_err(|e| format!("CohortGroup::create: {e}"))?;
+
+    // Members that join before the stream starts. The late joiner (if
+    // any) is deliberately held back so its admission rotates the epoch
+    // MID-STREAM, which is what the conformance leg measures.
+    let early: Vec<String> = cfg
+        .cohort_members
+        .iter()
+        .filter(|m| *m != &cfg.node_id && Some(*m) != cfg.late_joiner.as_ref())
+        .cloned()
+        .collect();
+
+    let join_start = Instant::now();
+    let mut admitted: Vec<String> = Vec::new();
+    let mut pending_late: Option<(String, String)> = None;
+    while admitted.len() < early.len() {
+        let (_src, msg) = occ
+            .mailbox
+            .next_control(cfg.barrier_timeout)
+            .await
+            .map_err(|e| format!("waiting for KeyPackages: {e}"))?;
+        let Control::KeyPackage { key_id, kp_b64 } = msg else {
+            continue;
+        };
+        if Some(&key_id) == cfg.late_joiner.as_ref() {
+            // Hold it: this one is admitted mid-stream.
+            pending_late = Some((key_id, kp_b64));
+            continue;
+        }
+        if admitted.contains(&key_id) {
+            continue;
+        }
+        let (welcome, _commit, _epoch) = admit(&group, &key_id, &kp_b64).await?;
+        send_control(
+            &occ.transport,
+            &key_id,
+            &Control::Welcome {
+                key_id: key_id.clone(),
+                welcome_b64: B64.encode(&welcome),
+            },
+        )
+        .await
+        .map_err(|e| format!("send Welcome to {key_id}: {e}"))?;
+        admitted.push(key_id);
+    }
+    rep.ran(
+        "cohort.join",
+        true,
+        serde_json::json!({
+            "members_admitted": admitted.len(),
+            "epoch": group.epoch().await,
+            "elapsed_ms": join_start.elapsed().as_millis(),
+            "mechanism": "real_mls_keypackage_and_welcome_over_rns",
+        }),
+    );
+
+    // ── Scope addresses, through the documented two lines ────────────
+    let installed = occ.install_addresses(&group).await?;
+    rep.ran(
+        "scope.install",
+        true,
+        serde_json::json!({
+            "derived": installed.derived,
+            "epoch": installed.epoch,
+            "own_address": hex::encode(installed.own_address.as_bytes()),
+            "registered_on_transport": occ
+                .transport
+                .inbound_scope(installed.own_address.as_bytes())
+                .is_some(),
+        }),
+    );
+
+    // Wait for every early member to say its addresses are installed.
+    let mut ready: Vec<String> = Vec::new();
+    while ready.len() < admitted.len() {
+        let (_src, msg) = occ
+            .mailbox
+            .next_control(cfg.barrier_timeout)
+            .await
+            .map_err(|e| format!("waiting for Ready: {e}"))?;
+        match msg {
+            Control::Ready { key_id, .. } => {
+                if !ready.contains(&key_id) {
+                    ready.push(key_id);
+                }
+            }
+            // The late joiner's KeyPackage races this barrier. Dropping
+            // it here loses it for good: the joiner then waits out its
+            // whole barrier for a Welcome that can never come, and the
+            // mid-stream advance never happens.
+            Control::KeyPackage { key_id, kp_b64 } if Some(&key_id) == cfg.late_joiner.as_ref() => {
+                pending_late = Some((key_id, kp_b64));
+            }
+            _ => {}
+        }
+    }
+
+    // ── The stream ───────────────────────────────────────────────────
+    let media = std::fs::read(&cfg.media_path)
+        .map_err(|e| format!("read media {}: {e}", cfg.media_path.display()))?;
+    let units = annexb_access_units(&media)?;
+    let media_sha = hex::encode(Sha256::digest(&media));
+
+    let mut stream_id_bytes = [0u8; 32];
+    stream_id_bytes.copy_from_slice(&Sha256::digest(cfg.community_id.as_bytes()));
+    let stream_id = StreamId(stream_id_bytes);
+
+    for m in &admitted {
+        let _ = send_control(
+            &occ.transport,
+            m,
+            &Control::StreamStart {
+                stream_id_hex: hex::encode(stream_id.0),
+                frames: cfg.frames,
+            },
+        )
+        .await;
+    }
+
+    let link = TransportMediaLink {
+        transport: Arc::clone(&occ.transport),
+    };
+    let mut record = *group
+        .record_secret()
+        .await
+        .map_err(|e| format!("record_secret: {e}"))?
+        .as_bytes();
+    let mut epoch = group.epoch().await;
+    let (mut dek_bytes, mut transit) = epoch_keys(&record, &stream_id, epoch)?;
+
+    let mut send_lat: Vec<u128> = Vec::new();
+    let mut rotation: Option<serde_json::Value> = None;
+    let mut frames_sent = 0usize;
+    let mut bytes_sent = 0u64;
+    // Wall time spent at the rotation barrier, excluded from the fan-out
+    // window below and reported on its own.
+    let mut rotation_stall = Duration::ZERO;
+    let mut live: Vec<String> = admitted.clone();
+    let stream_start = Instant::now();
+
+    for seq in 0..cfg.frames {
+        // Mid-stream epoch advance: admit the late joiner, then move the
+        // addresses make-before-break. Every existing member must keep
+        // receiving across this.
+        if cfg.rotate_at == Some(seq) {
+            // The late joiner may have presented its KeyPackage after the
+            // pre-stream collection loop ended, in which case it is sitting
+            // in the mailbox rather than in `pending_late`. Drain for it,
+            // bounded — and if it never comes, report a leg that did not run
+            // rather than a rotation that silently did not happen.
+            if pending_late.is_none() && cfg.late_joiner.is_some() {
+                let want = cfg.late_joiner.clone();
+                let until = Instant::now() + cfg.barrier_timeout;
+                while pending_late.is_none() && Instant::now() < until {
+                    if let Ok((_s, Control::KeyPackage { key_id, kp_b64 })) =
+                        occ.mailbox.next_control(Duration::from_secs(5)).await
+                    {
+                        if Some(&key_id) == want.as_ref() {
+                            pending_late = Some((key_id, kp_b64));
+                        }
+                    }
+                }
+            }
+            let rotation_started = Instant::now();
+            let t0 = rotation_started;
+            // Two ways to advance the epoch mid-stream, both real MLS:
+            // admitting a late joiner (the roster changes - what
+            // CIRISEdge#499's criterion is written about), or a plain
+            // `rotate()` when the topology has no member to hold back
+            // (M=1, where holding one back would leave nobody present
+            // ACROSS the advance to assert zero-loss on).
+            let (commit_bytes, new_epoch, joiner) = match pending_late.take() {
+                Some((late_id, late_kp)) => {
+                    let (welcome, commit_bytes, new_epoch) =
+                        admit(&group, &late_id, &late_kp).await?;
+                    send_control(
+                        &occ.transport,
+                        &late_id,
+                        &Control::Welcome {
+                            key_id: late_id.clone(),
+                            welcome_b64: B64.encode(&welcome),
+                        },
+                    )
+                    .await
+                    .map_err(|e| format!("send late Welcome: {e}"))?;
+                    (commit_bytes, new_epoch, Some(late_id))
+                }
+                None if cfg.late_joiner.is_some() => {
+                    rep.not_run(
+                        "scope.rotation",
+                        "EDGE_ROTATE_AT named a late joiner that never presented a \
+                         KeyPackage, so no mid-stream epoch advance was driven",
+                    );
+                    return Err("late joiner never presented a KeyPackage".to_owned());
+                }
+                None => {
+                    let commit = group
+                        .rotate()
+                        .await
+                        .map_err(|e| format!("CohortGroup::rotate: {e}"))?;
+                    let epoch = commit.epoch();
+                    let (_e, bytes, _w) = commit.into_parts();
+                    (bytes, epoch, None)
+                }
+            };
+            // Existing members apply the commit and advance in step.
+            let commit_b64 = B64.encode(&commit_bytes);
+            for m in &live {
+                let _ = send_control(
+                    &occ.transport,
+                    m,
+                    &Control::Commit {
+                        epoch: new_epoch,
+                        commit_b64: commit_b64.clone(),
+                    },
+                )
+                .await;
+            }
+            let advanced = occ.advance_addresses(&group).await?;
+            record = *group
+                .record_secret()
+                .await
+                .map_err(|e| format!("record_secret after advance: {e}"))?
+                .as_bytes();
+            epoch = new_epoch;
+            let keys = epoch_keys(&record, &stream_id, epoch)?;
+            dek_bytes = keys.0;
+            transit = keys.1;
+            if let Some(id) = joiner.as_ref() {
+                live.push(id.clone());
+            }
+            rotation = Some(serde_json::json!({
+                "at_frame": seq,
+                "new_epoch": new_epoch,
+                "kind": if joiner.is_some() { "member_join" } else { "rekey_only" },
+                "late_joiner": joiner,
+                "derived": advanced.derived,
+                "own_address": hex::encode(advanced.own_address.as_bytes()),
+                "pending_seals": occ.lifecycle.pending_seals(),
+                "advance_ms": t0.elapsed().as_millis(),
+            }));
+            rotation_stall += rotation_started.elapsed();
+        }
+
+        let plaintext = &units[seq % units.len()];
+        let dek = EpochDek::from_bytes(dek_bytes);
+        let inner = seal_av_inner(
+            plaintext,
+            &dek,
+            stream_id,
+            Epoch(epoch),
+            ChunkSeq(seq as u64),
+            CODEC_OPAQUE,
+            ChunkLayer::BASE,
+        )
+        .map_err(|e| format!("seal_av_inner: {e}"))?;
+
+        // Members get the chunk to open; observers get the identical
+        // ciphertext to fail on, for a bounded prefix of the stream.
+        // Sending to an observer is deliberate — it is what makes the
+        // refusal falsifiable.
+        let observers: &[String] = if seq < OBSERVER_FRAMES {
+            &cfg.observers
+        } else {
+            &[]
+        };
+        for m in live.iter().chain(observers.iter()) {
+            let sealed = seal_av_outer(&inner, &transit, m.as_bytes(), seq as u64)
+                .map_err(|e| format!("seal_av_outer: {e}"))?;
+            let wire = sealed.to_bytes();
+            let header = serde_json::json!({
+                "seq": seq,
+                "epoch": epoch,
+                "from": cfg.node_id,
+            });
+            let t0 = Instant::now();
+            let is_member = live.iter().any(|l| l == m);
+            match link.deliver(m, &header, &wire).await {
+                Ok(()) => {
+                    // Only member deliveries are the fan-out being timed;
+                    // observer sends exist for the refusal leg and would
+                    // otherwise inflate the throughput number.
+                    if is_member {
+                        send_lat.push(t0.elapsed().as_micros());
+                        bytes_sent += wire.len() as u64;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(peer = %m, error = %e, "chunk delivery failed");
+                }
+            }
+        }
+        frames_sent += 1;
+    }
+    // The fan-out window is the streaming wall time MINUS the rotation
+    // barrier — the barrier is a wait for a peer, not fan-out work.
+    let stream_elapsed = stream_start.elapsed().saturating_sub(rotation_stall);
+
+    for m in &live {
+        let _ = send_control(&occ.transport, m, &Control::StreamEnd { frames_sent }).await;
+    }
+
+    let secs = stream_elapsed.as_secs_f64();
+    #[allow(clippy::cast_precision_loss)]
+    let chunks_per_s = (secs > 0.0).then(|| (frames_sent * live.len()) as f64 / secs);
+    #[allow(clippy::cast_precision_loss)]
+    let bytes_per_s = (secs > 0.0).then(|| bytes_sent as f64 / secs);
+    rep.ran(
+        "perf.publish_fanout",
+        frames_sent == cfg.frames,
+        serde_json::json!({
+            "frames_sent": frames_sent,
+            "frames_requested": cfg.frames,
+            "subscribers": live.len(),
+            "media_sha256": media_sha,
+            "access_units_in_file": units.len(),
+            "bytes_sent": bytes_sent,
+            "elapsed_ms": stream_elapsed.as_millis(),
+            "rotation_stall_ms": rotation_stall.as_millis(),
+            "throughput_excludes_rotation_stall": true,
+            "fanout_chunks_per_s": chunks_per_s,
+            "fanout_bytes_per_s": bytes_per_s,
+            "send_latency": latency_json(&mut send_lat),
+            "link_mechanism": link.mechanism(),
+            "observers": cfg.observers.len(),
+            "observer_frames_each": OBSERVER_FRAMES.min(cfg.frames),
+            "observer_sends_excluded_from_throughput": true,
+        }),
+    );
+
+    let rotated = rotation.is_some();
+    match rotation {
+        Some(r) => rep.ran("scope.rotation", true, r),
+        None => rep.not_run(
+            "scope.rotation",
+            "EDGE_ROTATE_AT was not set, so no mid-stream epoch advance was driven",
+        ),
+    }
+
+    // ── Blob fan-out ─────────────────────────────────────────────────
+    let blob = TransportBlobPlane {
+        transport: Arc::clone(&occ.transport),
+    };
+    let chunks: Vec<&[u8]> = media.chunks(BLOB_CHUNK).collect();
+    for m in &live {
+        let _ = send_control(
+            &occ.transport,
+            m,
+            &Control::BlobStart {
+                sha256: media_sha.clone(),
+                bytes: media.len(),
+                chunks: chunks.len(),
+            },
+        )
+        .await;
+    }
+    let mut per_peer_ms = serde_json::Map::new();
+    let blob_start = Instant::now();
+    for m in &live {
+        let t0 = Instant::now();
+        let mut ok = true;
+        for (i, c) in chunks.iter().enumerate() {
+            let header = serde_json::json!({ "i": i, "n": chunks.len(), "sha256": media_sha });
+            if let Err(e) = blob.push_chunk(m, &header, c).await {
+                tracing::warn!(peer = %m, error = %e, "blob chunk push failed");
+                ok = false;
+                break;
+            }
+        }
+        per_peer_ms.insert(
+            m.clone(),
+            if ok {
+                serde_json::json!(t0.elapsed().as_millis())
+            } else {
+                serde_json::Value::Null
+            },
+        );
+    }
+    rep.ran(
+        "perf.blob_fanout",
+        per_peer_ms.values().all(|v| !v.is_null()),
+        serde_json::json!({
+            "bytes": media.len(),
+            "chunk_bytes": BLOB_CHUNK,
+            "chunks": chunks.len(),
+            "peers": live.len(),
+            "total_ms": blob_start.elapsed().as_millis(),
+            "completion_ms_per_peer": per_peer_ms,
+            "mechanism": blob.mechanism(),
+            "scope_native_fetch": false,
+            "note": "push over the real transport; scope-native swarm fetch is the in-flight seam",
+        }),
+    );
+
+    // ── The tail: one drain loop over every post-stream message ──────
+    //
+    // Reports and the seal handshake interleave, so a single state
+    // machine handles both. Two loops each discarding the other's
+    // messages is the shape that silently loses one.
+    let dialer = HarnessScopedDialer {
+        transport: Arc::clone(&occ.transport),
+    };
+    let dial_timeout = Duration::from_secs(10);
+    let mut member_reports = serde_json::Map::new();
+    let mut seal_probe: Option<(String, MemberAddress, MemberAddress, bool, bool)> = None;
+    // No rotation means no superseded address, so the leg says that up
+    // front rather than by timing out on a probe that can never come.
+    let mut seal_done = if rotated {
+        false
+    } else {
+        rep.not_run(
+            "conformance.seal_retires",
+            "no epoch advance was driven in this run, so no address was superseded and \
+             there is nothing whose retirement could be observed",
+        );
+        true
+    };
+    let deadline = Instant::now() + cfg.barrier_timeout;
+
+    // A member sends its Report only AFTER its seal handshake, so all
+    // reports in + seal_done is normally the end of the run. If every
+    // report is in and no probe ever came, give it a bounded grace and
+    // then say so — waiting out the whole barrier would turn a reportable
+    // fact into a hang.
+    let mut probe_grace: Option<Instant> = None;
+    while Instant::now() < deadline {
+        if member_reports.len() >= live.len() {
+            if seal_done {
+                break;
+            }
+            let until =
+                *probe_grace.get_or_insert_with(|| Instant::now() + Duration::from_secs(30));
+            if Instant::now() >= until {
+                break;
+            }
+        }
+        let Ok((_s, msg)) = occ.mailbox.next_control(Duration::from_secs(5)).await else {
+            continue;
+        };
+        match msg {
+            Control::Report { key_id, body } => {
+                member_reports.insert(key_id, body);
+            }
+            Control::SealProbe {
+                key_id,
+                superseded_epoch,
+            } if seal_probe.is_none() => {
+                let gid = occ.group_id();
+                let (Some(live_a), Some(old_a)) = (
+                    occ.table.send_address(&cfg.scope, &gid, &key_id),
+                    occ.table
+                        .address_at(&cfg.scope, &gid, superseded_epoch, &key_id),
+                ) else {
+                    rep.not_run(
+                        "conformance.seal_retires",
+                        format!(
+                            "this node's own table holds no live+superseded pair for                              {key_id} at epoch {superseded_epoch}"
+                        ),
+                    );
+                    seal_done = true;
+                    continue;
+                };
+                let Some(peer_key) = peer_transport_ed25519(&cfg.mesh_dir, &key_id) else {
+                    rep.not_run(
+                        "conformance.seal_retires",
+                        format!("{key_id} published no transport key, so it cannot be dialled"),
+                    );
+                    seal_done = true;
+                    continue;
+                };
+                // BEFORE. Both must answer, or the after-reading proves
+                // nothing.
+                let before_live = dialer.dial(&live_a, peer_key, dial_timeout).await;
+                let before_old = dialer.dial(&old_a, peer_key, dial_timeout).await;
+                seal_probe = Some((key_id.clone(), live_a, old_a, before_live, before_old));
+                let _ = send_control(
+                    &occ.transport,
+                    &key_id,
+                    &Control::SealGo {
+                        key_id: key_id.clone(),
+                    },
+                )
+                .await;
+            }
+            Control::Sealed {
+                key_id,
+                sealed,
+                unretired,
+            } => {
+                let Some((probe_id, live_a, old_a, before_live, before_old)) = seal_probe.clone()
+                else {
+                    continue;
+                };
+                if probe_id != key_id {
+                    continue;
+                }
+                let Some(peer_key) = peer_transport_ed25519(&cfg.mesh_dir, &key_id) else {
+                    continue;
+                };
+                // AFTER.
+                let after_live = dialer.dial(&live_a, peer_key, dial_timeout).await;
+                let after_old = dialer.dial(&old_a, peer_key, dial_timeout).await;
+                seal_done = true;
+                if before_live && before_old {
+                    rep.ran(
+                        "conformance.seal_retires",
+                        sealed > 0
+                            && unretired == 0
+                            && after_live
+                            && !after_old,
+                        serde_json::json!({
+                            "owner": key_id,
+                            "sealed": sealed,
+                            "unretired": unretired,
+                            "dial_live_before": before_live,
+                            "dial_superseded_before": before_old,
+                            "dial_live_after": after_live,
+                            "dial_superseded_after": after_old,
+                            "live_address": hex::encode(live_a.as_bytes()),
+                            "superseded_address": hex::encode(old_a.as_bytes()),
+                            "addresses_derived_by": "the DIALLER's own table, so a landed                                                      dial also proves cross-node derivation                                                      agreement",
+                            "convergence_secs": cfg.convergence.as_secs(),
+                            "dial_binding": dialer.binding_source(),
+                            "measured_by": "a DIFFERENT node than the one that sealed",
+                            "note": "the dial-side binding is installed by the harness: no \
+                                     transport verb dials a ScopeAddressTable::send_address \
+                                     result",
+                        }),
+                    );
+                } else {
+                    // DIAGNOSED, not shrugged at. A scope-derived
+                    // destination is registered with
+                    // `Destination::with_explicit_hash`, and an
+                    // explicit-hash destination CANNOT announce
+                    // (`AnnounceError::ExplicitHashCannotAnnounce`;
+                    // leviculum answers path requests for one with
+                    // silence, because a path response IS an announce and
+                    // an announce for a caller-supplied hash is
+                    // unverifiable). It therefore has no multi-hop RNS
+                    // path, and this topology puts a relay between the
+                    // dialler and the owner.
+                    //
+                    // So the peer-dials-it form of "the superseded address
+                    // finds nobody home" is not measurable today — not
+                    // because the seal failed, but because there is no
+                    // route to dial in the first place. The owner-side
+                    // half IS measured, by the member's own `scope.seal`
+                    // leg: table closed, transport retired
+                    // (`unretired == 0`), live address still answering.
+                    rep.not_run(
+                        "conformance.seal_retires",
+                        format!(
+                            "pre-seal dials did not establish (live={before_live}, \
+                             superseded={before_old}), so an after-reading would be \
+                             indistinguishable from a broken dial. DIAGNOSIS: a \
+                             scope-derived destination is an explicit-hash destination, \
+                             which cannot announce, so no multi-hop RNS path to it can \
+                             exist and this topology relays between dialler and owner. \
+                             The owner-side half of the claim is measured by that \
+                             member's `scope.seal` leg instead."
+                        ),
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if !seal_done {
+        rep.not_run(
+            "conformance.seal_retires",
+            "no member offered a seal probe before the barrier expired — either no member \
+             crossed the epoch advance, or the handshake did not complete",
+        );
+    }
+    if member_reports.len() == live.len() {
+        rep.ran(
+            "mesh.member_reports",
+            true,
+            serde_json::json!({ "reports": member_reports }),
+        );
+    } else {
+        rep.not_run(
+            "mesh.member_reports",
+            format!(
+                "only {} of {} members reported before the barrier expired",
+                member_reports.len(),
+                live.len()
+            ),
+        );
+    }
+    Ok(())
+}
+
+/// Admit a member from a base64 KeyPackage.
+///
+/// Returns `(welcome, commit, epoch)`: the Welcome goes to the joiner,
+/// the Commit goes to every existing member so they advance in step.
+///
+/// Edge exposes no KeyPackage byte codec — `mint_cohort_key_material`
+/// hands back an openmls `KeyPackage` by value and `add_member` takes
+/// one by value, so a cross-process join has to do the tls-codec hop
+/// itself. Recorded as a DX finding; done here rather than worked around.
+async fn admit(
+    group: &CohortGroup,
+    key_id: &str,
+    kp_b64: &str,
+) -> Result<(Vec<u8>, Vec<u8>, u64), String> {
+    use openmls::prelude::{
+        tls_codec::Deserialize as _, MlsMessageBodyIn, MlsMessageIn, ProtocolVersion,
+    };
+    use openmls_traits::OpenMlsProvider as _;
+
+    let raw = B64
+        .decode(kp_b64)
+        .map_err(|e| format!("decode KeyPackage: {e}"))?;
+    let msg = MlsMessageIn::tls_deserialize(&mut raw.as_slice())
+        .map_err(|e| format!("KeyPackage wire decode: {e:?}"))?;
+    let MlsMessageBodyIn::KeyPackage(kp_in) = msg.extract() else {
+        return Err("the joiner did not send a KeyPackage".to_owned());
+    };
+    let provider = openmls_libcrux_crypto::Provider::default();
+    let kp = kp_in
+        .validate(provider.crypto(), ProtocolVersion::Mls10)
+        .map_err(|e| format!("KeyPackage validate: {e:?}"))?;
+    let commit = group
+        .add_member(key_id, kp)
+        .await
+        .map_err(|e| format!("add_member: {e}"))?;
+    let epoch = commit.epoch();
+    let (_e, commit_bytes, welcome) = commit.into_parts();
+    let welcome = welcome.ok_or_else(|| "add_member produced no Welcome".to_owned())?;
+    Ok((welcome, commit_bytes, epoch))
+}
+
+/// What happened to one inbound media frame.
+enum MediaOutcome {
+    /// Opened under the epoch's real keys.
+    Opened,
+    /// Parsed or AEAD-failed under keys we DO hold - a genuine fault.
+    Failed,
+    /// We hold no keys for that epoch yet. Not a loss: the commit is in
+    /// flight. Distinguished from `Failed` deliberately - collapsing the
+    /// two would score the make-before-break window as frame loss.
+    NoKeyYet,
+}
+
+/// Open one sealed chunk under the keys of the epoch its header names.
+fn open_media(
+    key_ring: &BTreeMap<u64, ([u8; 32], [u8; 32])>,
+    epoch: u64,
+    seq: u64,
+    payload: &[u8],
+    link_id: &[u8],
+    latency_us: &mut Vec<u128>,
+) -> MediaOutcome {
+    let Some((dek_bytes, transit)) = key_ring.get(&epoch) else {
+        return MediaOutcome::NoKeyYet;
+    };
+    let Ok(sealed) = SealedAvChunk::from_bytes(payload) else {
+        return MediaOutcome::Failed;
+    };
+    let dek = EpochDek::from_bytes(*dek_bytes);
+    let t0 = Instant::now();
+    match open_av_chunk(&sealed, transit, link_id, seq, &dek) {
+        Ok(plain) if !plain.is_empty() => {
+            latency_us.push(t0.elapsed().as_micros());
+            MediaOutcome::Opened
+        }
+        _ => MediaOutcome::Failed,
+    }
+}
+
+/// An in-progress blob reception.
+struct BlobRecv {
+    sha256: String,
+    expected_bytes: usize,
+    slots: Vec<Option<Vec<u8>>>,
+    started: Instant,
+}
+
+/// A cohort member: joins over the wire, installs addresses, receives.
+async fn run_subscriber(occ: Occurrence) -> Result<(), String> {
+    let rep = Arc::clone(&occ.reporter);
+    let cfg = &occ.cfg;
+    let publisher = cfg
+        .cohort_members
+        .first()
+        .cloned()
+        .ok_or("EDGE_COHORT_MEMBERS must name the publisher first")?;
+
+    let root_elapsed = match occ.await_rooting(std::slice::from_ref(&publisher)).await {
+        Ok(d) => d,
+        Err(e) => {
+            rep.not_run("mesh.rooting", e.clone());
+            return Err(e);
+        }
+    };
+    rep.ran(
+        "mesh.rooting",
+        true,
+        serde_json::json!({
+            "peer": publisher,
+            "converged_ms": root_elapsed.as_millis(),
+            "mechanism": "announce_attestation_rooting",
+        }),
+    );
+
+    // A late joiner waits before presenting its KeyPackage so its
+    // admission lands mid-stream.
+    if cfg.late_joiner.as_deref() == Some(cfg.node_id.as_str()) {
+        tokio_sleep(env_secs("EDGE_LATE_JOIN_DELAY_SECS", 5)).await;
+    }
+
+    // ── Real cross-process MLS join ──────────────────────────────────
+    let (material, kp) = mint_cohort_key_material(&cfg.node_id)
+        .map_err(|e| format!("mint_cohort_key_material: {e}"))?;
+    let kp_bytes = {
+        use openmls::prelude::tls_codec::Serialize as _;
+        openmls::prelude::MlsMessageOut::from(kp)
+            .tls_serialize_detached()
+            .map_err(|e| format!("serialize KeyPackage: {e:?}"))?
+    };
+    send_control(
+        &occ.transport,
+        &publisher,
+        &Control::KeyPackage {
+            key_id: cfg.node_id.clone(),
+            kp_b64: B64.encode(&kp_bytes),
+        },
+    )
+    .await
+    .map_err(|e| format!("send KeyPackage: {e}"))?;
+
+    let join_start = Instant::now();
+    let welcome = loop {
+        let (_s, msg) = occ
+            .mailbox
+            .next_control(cfg.barrier_timeout)
+            .await
+            .map_err(|e| format!("waiting for Welcome: {e}"))?;
+        if let Control::Welcome {
+            key_id,
+            welcome_b64,
+        } = msg
+        {
+            if key_id == cfg.node_id {
+                break B64
+                    .decode(&welcome_b64)
+                    .map_err(|e| format!("decode Welcome: {e}"))?;
+            }
+        }
+    };
+    let kv = Arc::new(open_sealed_kv(
+        &cfg.state_dir,
+        &cfg.state_dir.join("fed/ed25519.seed"),
+    )?);
+    let store = ScopeStateProvider::new(kv);
+    let group = CohortGroup::join(store, &cfg.community_id, material, &welcome, 16)
+        .await
+        .map_err(|e| format!("CohortGroup::join: {e}"))?;
+    rep.ran(
+        "cohort.join",
+        true,
+        serde_json::json!({
+            "epoch": group.epoch().await,
+            "members": group.member_count().await,
+            "elapsed_ms": join_start.elapsed().as_millis(),
+            "mechanism": "real_mls_welcome_over_rns",
+        }),
+    );
+
+    // ── Addresses ────────────────────────────────────────────────────
+    let installed = occ.install_addresses(&group).await?;
+    let own_hash = *installed.own_address.as_bytes();
+    rep.ran(
+        "scope.install",
+        true,
+        serde_json::json!({
+            "derived": installed.derived,
+            "epoch": installed.epoch,
+            "own_address": hex::encode(own_hash),
+            "registered_on_transport": occ.transport.inbound_scope(&own_hash).is_some(),
+            "agrees_with_table": occ
+                .table
+                .send_address(&cfg.scope, &occ.group_id(), &cfg.node_id)
+                .map(|a| *a.as_bytes() == own_hash),
+        }),
+    );
+    send_control(
+        &occ.transport,
+        &publisher,
+        &Control::Ready {
+            key_id: cfg.node_id.clone(),
+            epoch: installed.epoch,
+        },
+    )
+    .await
+    .map_err(|e| format!("send Ready: {e}"))?;
+
+    // ── Receive ──────────────────────────────────────────────────────
+    let mut stream_id_bytes = [0u8; 32];
+    stream_id_bytes.copy_from_slice(&Sha256::digest(cfg.community_id.as_bytes()));
+    let stream_id = StreamId(stream_id_bytes);
+
+    // A key RING, not a single key. Each epoch has its own record-plane
+    // exporter, so a frame must be opened under the keys of the epoch its
+    // header names - never under "the current" ones.
+    let mut key_ring: BTreeMap<u64, ([u8; 32], [u8; 32])> = BTreeMap::new();
+    {
+        let secret = *group
+            .record_secret()
+            .await
+            .map_err(|e| format!("record_secret: {e}"))?
+            .as_bytes();
+        let e = group.epoch().await;
+        key_ring.insert(e, epoch_keys(&secret, &stream_id, e)?);
+    }
+    // Frames that arrived under an epoch whose commit has not landed yet.
+    // THIS is the make-before-break window from the receive side: the
+    // publisher advances and sends under the new epoch before every member
+    // has applied the commit, and those frames must be held, not dropped.
+    // Bounded by MAX_DEFERRED so a wrong-epoch flood cannot grow it
+    // without limit.
+    let mut deferred: Vec<(u64, u64, Vec<u8>)> = Vec::new();
+    let mut deferred_dropped = 0usize;
+
+    let mut seen: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
+    let mut opened = 0usize;
+    let mut open_failed = 0usize;
+    let mut recv_lat: Vec<u128> = Vec::new();
+    let mut first_frame_at: Option<Duration> = None;
+    let mut stream_end_frames: Option<usize> = None;
+    let mut epochs_seen: std::collections::BTreeSet<u64> = std::collections::BTreeSet::new();
+    let mut blob_state: Option<BlobRecv> = None;
+    let mut blob_result: Option<serde_json::Value> = None;
+    // Chunks that arrived before their announcement. Control and data
+    // are separate channels, so nothing orders them.
+    let mut blob_early: Vec<(usize, Vec<u8>)> = Vec::new();
+    let mut blob_early_dropped = 0usize;
+    let mut early_replayed = 0usize;
+    // A node admitted mid-stream cannot have received the frames that
+    // preceded its own admission, so the zero-loss criterion — which is
+    // about members present ACROSS the advance — does not apply to it.
+    let joined_mid_stream = cfg.late_joiner.as_deref() == Some(cfg.node_id.as_str());
+    // Bounded settle grace once the stream and the blob have both been
+    // announced complete, so a run always terminates.
+    let mut settle_deadline: Option<Instant> = None;
+
+    let recv_start = Instant::now();
+    let deadline = Instant::now() + cfg.barrier_timeout;
+    while Instant::now() < deadline {
+        // Control first — a commit changes the keys the media path uses.
+        {
+            let mut rx = occ.mailbox.control.lock().await;
+            let got = rx.try_recv().ok();
+            drop(rx);
+            if let Some((_s, msg)) = got {
+                match msg {
+                    Control::Commit {
+                        epoch: e,
+                        commit_b64,
+                    } => {
+                        let bytes = B64
+                            .decode(&commit_b64)
+                            .map_err(|er| format!("decode commit: {er}"))?;
+                        group
+                            .apply_remote_commit(&bytes)
+                            .await
+                            .map_err(|er| format!("apply_remote_commit: {er}"))?;
+                        let _ = occ.advance_addresses(&group).await?;
+                        let secret = *group
+                            .record_secret()
+                            .await
+                            .map_err(|er| format!("record_secret: {er}"))?
+                            .as_bytes();
+                        let now_epoch = group.epoch().await;
+                        key_ring.insert(now_epoch, epoch_keys(&secret, &stream_id, now_epoch)?);
+                        tracing::info!(epoch = e, "applied a remote commit and advanced addresses");
+                        // Drain what arrived ahead of the commit.
+                        let held = std::mem::take(&mut deferred);
+                        for (seq, ep, payload) in held {
+                            match open_media(
+                                &key_ring,
+                                ep,
+                                seq,
+                                &payload,
+                                cfg.node_id.as_bytes(),
+                                &mut recv_lat,
+                            ) {
+                                MediaOutcome::Opened => {
+                                    opened += 1;
+                                    seen.insert(seq);
+                                }
+                                MediaOutcome::Failed => open_failed += 1,
+                                MediaOutcome::NoKeyYet => deferred.push((seq, ep, payload)),
+                            }
+                        }
+                    }
+                    Control::StreamEnd { frames_sent } => {
+                        stream_end_frames = Some(frames_sent);
+                    }
+                    Control::BlobStart {
+                        sha256,
+                        bytes,
+                        chunks,
+                    } => {
+                        let mut recv = BlobRecv {
+                            sha256,
+                            expected_bytes: bytes,
+                            slots: vec![None; chunks],
+                            started: Instant::now(),
+                        };
+                        // Replay whatever outran the announcement.
+                        early_replayed = blob_early.len();
+                        for (i, payload) in std::mem::take(&mut blob_early) {
+                            if let Some(slot) = recv.slots.get_mut(i) {
+                                *slot = Some(payload);
+                            }
+                        }
+                        blob_state = Some(recv);
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Media.
+        let media_msg = {
+            let mut rx = occ.mailbox.media.lock().await;
+            let m = rx.try_recv().ok();
+            drop(rx);
+            m
+        };
+        if let Some((_s, header, payload)) = media_msg {
+            let seq = header
+                .get("seq")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(u64::MAX);
+            let hdr_epoch = header
+                .get("epoch")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            epochs_seen.insert(hdr_epoch);
+            if first_frame_at.is_none() {
+                first_frame_at = Some(recv_start.elapsed());
+            }
+            match open_media(
+                &key_ring,
+                hdr_epoch,
+                seq,
+                &payload,
+                cfg.node_id.as_bytes(),
+                &mut recv_lat,
+            ) {
+                MediaOutcome::Opened => {
+                    opened += 1;
+                    seen.insert(seq);
+                }
+                MediaOutcome::Failed => open_failed += 1,
+                MediaOutcome::NoKeyYet => {
+                    // Held, not lost - the commit for this epoch has not
+                    // reached us yet.
+                    if deferred.len() < MAX_DEFERRED {
+                        deferred.push((seq, hdr_epoch, payload));
+                    } else {
+                        deferred_dropped += 1;
+                    }
+                }
+            }
+        }
+
+        // Blob.
+        let blob_msg = {
+            let mut rx = occ.mailbox.blob.lock().await;
+            let m = rx.try_recv().ok();
+            drop(rx);
+            m
+        };
+        if let Some((_s, header, payload)) = blob_msg {
+            let i = usize::try_from(
+                header
+                    .get("i")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(u64::MAX),
+            )
+            .unwrap_or(usize::MAX);
+            if blob_state.is_none() {
+                // The announcement has not been processed yet. Hold it.
+                if blob_early.len() < MAX_DEFERRED {
+                    blob_early.push((i, payload));
+                } else {
+                    blob_early_dropped += 1;
+                }
+            } else if let Some(recv) = blob_state.as_mut() {
+                if let Some(slot) = recv.slots.get_mut(i) {
+                    *slot = Some(payload);
+                }
+                if recv.slots.iter().all(Option::is_some) {
+                    let mut buf = Vec::with_capacity(recv.expected_bytes);
+                    for s in recv.slots.iter().flatten() {
+                        buf.extend_from_slice(s);
+                    }
+                    let got = hex::encode(Sha256::digest(&buf));
+                    blob_result = Some(serde_json::json!({
+                        "chunks": recv.slots.len(),
+                        "bytes": buf.len(),
+                        "expected_bytes": recv.expected_bytes,
+                        "sha256_matches": got == recv.sha256,
+                        "completion_ms": recv.started.elapsed().as_millis(),
+                        "chunks_arrived_before_announcement": early_replayed,
+                        "early_chunks_dropped_over_budget": blob_early_dropped,
+                    }));
+                    blob_state = None;
+                }
+            }
+        }
+
+        // Done when the stream ended, every announced frame arrived, and
+        // the blob completed.
+        if stream_end_frames.is_some() {
+            let all_in = stream_end_frames.is_some_and(|total| seen.len() >= total);
+            if all_in && blob_result.is_some() && !joined_mid_stream {
+                break;
+            }
+            // The grace starts at StreamEnd, NOT at blob completion. A
+            // blob that never completes must still end the run and be
+            // REPORTED as incomplete rather than wait out the whole
+            // barrier — the previous shape only started the clock once
+            // the blob had already finished, so an incomplete one hung.
+            let settle =
+                *settle_deadline.get_or_insert_with(|| Instant::now() + Duration::from_secs(30));
+            if Instant::now() >= settle {
+                break;
+            }
+        }
+        tokio_sleep(Duration::from_millis(5)).await;
+    }
+
+    // ── Report ───────────────────────────────────────────────────────
+    let expected = stream_end_frames;
+    let (delivery_ok, delivery_detail) = match expected {
+        Some(total) => {
+            let missing: Vec<u64> = (0..total as u64).filter(|s| !seen.contains(s)).collect();
+            #[allow(clippy::cast_precision_loss)]
+            let ratio = if total == 0 {
+                None
+            } else {
+                Some(seen.len() as f64 / total as f64)
+            };
+            (
+                missing.is_empty(),
+                serde_json::json!({
+                    "frames_announced": total,
+                    "frames_opened": opened,
+                    "distinct_seqs": seen.len(),
+                    "delivery_ratio": ratio,
+                    "missing_seqs": missing,
+                    "open_failures": open_failed,
+                    "still_deferred_awaiting_commit": deferred.len(),
+                    "deferred_dropped_over_budget": deferred_dropped,
+                    "epochs_observed": epochs_seen.iter().copied().collect::<Vec<u64>>(),
+                    "time_to_first_frame_ms": first_frame_at.map(|d| d.as_millis()),
+                    "open_latency": latency_json(&mut recv_lat.clone()),
+                }),
+            )
+        }
+        None => (false, serde_json::json!({})),
+    };
+
+    if expected.is_none() {
+        rep.not_run(
+            "conformance.rotation_frame_loss",
+            "the publisher never announced StreamEnd, so no delivery ratio could be computed",
+        );
+        rep.not_run(
+            "perf.receive",
+            "the publisher never announced StreamEnd, so nothing bounds what should have arrived",
+        );
+    } else if joined_mid_stream {
+        // THE honest arm. This node was admitted at the rotation, so the
+        // frames before it are not losses. Scoring it against zero-loss
+        // would be scoring the wrong node; saying nothing would hide that
+        // a member's numbers were dropped.
+        rep.not_run(
+            "conformance.rotation_frame_loss",
+            "this node was admitted mid-stream; the zero-loss criterion is about members \
+             present ACROSS the advance, and pre-admission frames are not losses",
+        );
+        rep.ran("perf.receive", !seen.is_empty() && open_failed == 0, {
+            let mut d = delivery_detail.clone();
+            if let Some(o) = d.as_object_mut() {
+                o.insert("joined_mid_stream".to_owned(), serde_json::json!(true));
+                o.insert(
+                    "scored_on".to_owned(),
+                    serde_json::json!("frames received after admission open cleanly"),
+                );
+            }
+            d
+        });
+    } else {
+        rep.ran(
+            "conformance.rotation_frame_loss",
+            delivery_ok && epochs_seen.len() > 1,
+            {
+                let mut d = delivery_detail.clone();
+                if let Some(o) = d.as_object_mut() {
+                    o.insert(
+                        "crossed_an_epoch_advance".to_owned(),
+                        serde_json::json!(epochs_seen.len() > 1),
+                    );
+                }
+                d
+            },
+        );
+        rep.ran("perf.receive", delivery_ok, delivery_detail);
+    }
+
+    match blob_result.clone() {
+        Some(b) => rep.ran(
+            "conformance.member_can_fetch",
+            b.get("sha256_matches").and_then(serde_json::Value::as_bool) == Some(true),
+            b,
+        ),
+        None => rep.not_run(
+            "conformance.member_can_fetch",
+            "the blob did not complete within the barrier",
+        ),
+    }
+
+    // ── Seal handshake ───────────────────────────────────────────────
+    //
+    // Only the OWNER of an address can retire it, so this node seals and
+    // the PUBLISHER takes the before/after network reading. The order is
+    // strict: probe → publisher dials → SealGo → seal → Sealed →
+    // publisher dials again. Anything else and the two readings would not
+    // bracket the seal.
+    let gid = occ.group_id();
+    match occ
+        .table
+        .live_epochs(&cfg.scope, &gid)
+        .and_then(|e| e.previous)
+    {
+        None => rep.not_run(
+            "scope.seal",
+            "this node holds no superseded epoch — it did not cross an epoch advance, so \
+             there is nothing to retire",
+        ),
+        Some(previous) => {
+            let handshake = async {
+                send_control(
+                    &occ.transport,
+                    &publisher,
+                    &Control::SealProbe {
+                        key_id: cfg.node_id.clone(),
+                        superseded_epoch: previous,
+                    },
+                )
+                .await
+                .map_err(|e| format!("send SealProbe: {e}"))?;
+                // Wait for the publisher's before-reading to be taken.
+                let until = Instant::now() + Duration::from_secs(90);
+                loop {
+                    if Instant::now() >= until {
+                        return Err("no SealGo from the publisher".to_owned());
+                    }
+                    if let Ok((_s, Control::SealGo { key_id })) =
+                        occ.mailbox.next_control(Duration::from_secs(5)).await
+                    {
+                        if key_id == cfg.node_id {
+                            break;
+                        }
+                    }
+                }
+                // The convergence window is what makes a seal legitimate;
+                // sealing before it elapses would cut off a straggler.
+                tokio_sleep(cfg.convergence + Duration::from_secs(1)).await;
+                let outcome = occ.lifecycle.seal_due(Instant::now());
+                send_control(
+                    &occ.transport,
+                    &publisher,
+                    &Control::Sealed {
+                        key_id: cfg.node_id.clone(),
+                        sealed: outcome.sealed,
+                        unretired: outcome.unretired,
+                    },
+                )
+                .await
+                .map_err(|e| format!("send Sealed: {e}"))?;
+                Ok::<_, String>((outcome, previous))
+            }
+            .await;
+
+            match handshake {
+                Ok((outcome, prev_epoch)) => {
+                    let old = occ
+                        .table
+                        .address_at(&cfg.scope, &gid, prev_epoch, &cfg.node_id);
+                    let live_addr = occ.table.send_address(&cfg.scope, &gid, &cfg.node_id);
+                    rep.ran(
+                        "scope.seal",
+                        outcome.sealed > 0
+                            && outcome.unretired == 0
+                            && old.is_none()
+                            && live_addr.as_ref().is_some_and(|a| {
+                                occ.transport.inbound_scope(a.as_bytes()).is_some()
+                            }),
+                        serde_json::json!({
+                            "superseded_epoch": prev_epoch,
+                            "sealed": outcome.sealed,
+                            "unretired": outcome.unretired,
+                            "superseded_still_in_table": old.is_some(),
+                            "live_still_answers": live_addr
+                                .as_ref()
+                                .map(|a| occ.transport.inbound_scope(a.as_bytes()).is_some()),
+                            "convergence_secs": cfg.convergence.as_secs(),
+                        }),
+                    );
+                }
+                Err(e) => rep.not_run("scope.seal", e),
+            }
+        }
+    }
+
+    // Hand the numbers back to the publisher so one place has the mesh
+    // view. Failure to deliver the report is not a silent success.
+    let (_any, all_ok) = rep.verdict();
+    let _ = send_control(
+        &occ.transport,
+        &publisher,
+        &Control::Report {
+            key_id: cfg.node_id.clone(),
+            body: serde_json::json!({
+                "all_legs_ran_and_passed": all_ok,
+                "frames_opened": opened,
+                "blob": blob_result,
+            }),
+        },
+    )
+    .await;
+    Ok(())
+}
+
+/// A relay: a real transit node on the mesh. It carries ciphertext and
+/// holds no cohort secret — which is exactly what makes the refusal leg
+/// meaningful for it too.
+async fn run_relay(occ: Occurrence) -> Result<(), String> {
+    let rep = Arc::clone(&occ.reporter);
+    let cfg = &occ.cfg;
+    let peers: Vec<String> = cfg
+        .expect
+        .iter()
+        .filter(|k| *k != &cfg.node_id)
+        .cloned()
+        .collect();
+    match occ.await_rooting(&peers).await {
+        Ok(d) => rep.ran(
+            "mesh.rooting",
+            true,
+            serde_json::json!({
+                "peers": peers.len(),
+                "converged_ms": d.as_millis(),
+                "transit_node": true,
+                "mechanism": "announce_attestation_rooting",
+            }),
+        ),
+        Err(e) => {
+            rep.not_run("mesh.rooting", e.clone());
+            return Err(e);
+        }
+    }
+    // A relay holds no cohort state, so it must derive no address.
+    let derived = occ
+        .table
+        .send_address(&cfg.scope, &occ.group_id(), &cfg.node_id)
+        .is_some();
+    rep.ran(
+        "conformance.relay_holds_no_cohort_address",
+        !derived,
+        serde_json::json!({
+            "derived_an_address": derived,
+            "why": "a relay is not in the cohort roster, so no exporter secret reaches it",
+        }),
+    );
+    // Stay up for the whole run so the mesh has its transit path.
+    tokio_sleep(cfg.barrier_timeout).await;
+    Ok(())
+}
+
+/// A real node on the mesh that is NOT in the cohort.
+///
+/// Its whole job is to make the refusal assertion falsifiable: it is
+/// rooted, reachable, and receives the same ciphertext, and it must
+/// still be unable to open it or to name a cohort-scoped address.
+async fn run_nonmember(occ: Occurrence) -> Result<(), String> {
+    let rep = Arc::clone(&occ.reporter);
+    let cfg = &occ.cfg;
+    let publisher = cfg
+        .cohort_members
+        .first()
+        .cloned()
+        .ok_or("EDGE_COHORT_MEMBERS must name the publisher first")?;
+
+    match occ.await_rooting(std::slice::from_ref(&publisher)).await {
+        Ok(d) => rep.ran(
+            "mesh.rooting",
+            true,
+            serde_json::json!({
+                "peer": publisher,
+                "converged_ms": d.as_millis(),
+                "mechanism": "announce_attestation_rooting",
+            }),
+        ),
+        Err(e) => {
+            rep.not_run("mesh.rooting", e.clone());
+            return Err(e);
+        }
+    }
+
+    // (a) It cannot derive any cohort-scoped address — it has no
+    //     exporter secret, so the table holds nothing for it.
+    let no_address = occ
+        .table
+        .send_address(&cfg.scope, &occ.group_id(), &cfg.node_id)
+        .is_none();
+
+    // (b) It cannot open ciphertext it is handed. Wait for a real media
+    //     frame (it is on the mesh; the harness addresses one to it) and
+    //     try, with a key it derives from material it actually holds.
+    let mut tried = 0usize;
+    let mut opened = 0usize;
+    let deadline = Instant::now() + Duration::from_secs(60);
+    while Instant::now() < deadline && tried == 0 {
+        let msg = {
+            let mut rx = occ.mailbox.media.lock().await;
+            let m = rx.try_recv().ok();
+            drop(rx);
+            m
+        };
+        if let Some((_s, header, payload)) = msg {
+            tried += 1;
+            let seq = header
+                .get("seq")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0);
+            if let Ok(sealed) = SealedAvChunk::from_bytes(&payload) {
+                // The best a non-member can do: guess. It has no cohort
+                // record secret, so it has neither the transit key nor
+                // the DEK.
+                let guess = [0u8; 32];
+                let dek = EpochDek::from_bytes([0u8; 32]);
+                if open_av_chunk(&sealed, &guess, cfg.node_id.as_bytes(), seq, &dek).is_ok() {
+                    opened += 1;
+                }
+            }
+        }
+        tokio_sleep(Duration::from_millis(50)).await;
+    }
+
+    if tried == 0 {
+        rep.not_run(
+            "conformance.nonmember_cannot_fetch",
+            "no cohort ciphertext reached the non-member, so the refusal could not be tested \
+             — a leg that refuses nothing proves nothing",
+        );
+    } else {
+        rep.ran(
+            "conformance.nonmember_cannot_fetch",
+            no_address && opened == 0,
+            serde_json::json!({
+                "derived_a_scoped_address": !no_address,
+                "ciphertext_frames_offered": tried,
+                "frames_opened": opened,
+                "why": "no cohort exporter secret ⇒ no derived address and no AEAD key",
+            }),
+        );
+    }
+    // Stay on the mesh for the rest of the run. A non-member that exits
+    // mid-stream is not just unrealistic — it makes the publisher pay a
+    // transport timeout on every remaining send to it, which would
+    // silently corrupt the fan-out throughput number.
+    tokio_sleep(cfg.barrier_timeout).await;
+    Ok(())
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// main
+// ═══════════════════════════════════════════════════════════════════
+
+fn main() -> std::process::ExitCode {
+    // No `tracing_subscriber` init: it is a dev-dependency, and a
+    // `[[bin]]` compiles against `[dependencies]` only. The JSONL on
+    // stdout is the instrument; `tracing` events compile and are
+    // available to any consumer that installs a subscriber.
+    //
+    // Reticulum needs a genuine multi-thread runtime.
+    let rt = match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => {
+            eprintln!("{{\"fatal\":\"tokio runtime: {e}\"}}");
+            return std::process::ExitCode::FAILURE;
+        }
+    };
+
+    rt.block_on(async {
+        let cfg = match Config::from_env() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("{{\"fatal\":\"config: {e}\"}}");
+                return std::process::ExitCode::FAILURE;
+            }
+        };
+        let reporter = Arc::new(Reporter::new(
+            &cfg.node_id,
+            cfg.role.as_str(),
+            cfg.results.clone(),
+        ));
+        let role = cfg.role;
+
+        let occ = match stand_up(cfg, Arc::clone(&reporter)).await {
+            Ok(o) => o,
+            Err(e) => {
+                reporter.not_run("mesh.standup", e);
+                return std::process::ExitCode::FAILURE;
+            }
+        };
+        reporter.ran(
+            "mesh.standup",
+            true,
+            serde_json::json!({
+                "role": role.as_str(),
+                "in_cohort": role.in_cohort(),
+                "peers_in_roster": occ.roster.len(),
+                "transport_dest_hash": hex::encode(occ.transport.local_dest_hash()),
+                "interfaces": occ.transport.interface_specs().len(),
+            }),
+        );
+
+        let outcome = match role {
+            Role::Publisher => run_publisher(occ).await,
+            Role::Relay => run_relay(occ).await,
+            Role::Subscriber => run_subscriber(occ).await,
+            Role::NonMember => run_nonmember(occ).await,
+        };
+        if let Err(e) = outcome {
+            reporter.not_run("mesh.role_completion", e);
+        }
+
+        let (any, all_ok) = reporter.verdict();
+        // A run with no legs is a failure, not a pass. So is any leg that
+        // did not run.
+        if any && all_ok {
+            std::process::ExitCode::SUCCESS
+        } else {
+            std::process::ExitCode::FAILURE
+        }
+    })
+}

--- a/src/blob_swarm/mod.rs
+++ b/src/blob_swarm/mod.rs
@@ -61,9 +61,16 @@
 //! - Stream-based chunk delivery (FSD §10.5.1 live-stream surface).
 //!   v3.4.0-pre1 ships sealed-blob fetch only.
 
+pub mod scope;
+
 use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+
+pub use scope::{
+    admit_blob_serve, BlobRecipient, BlobScopeRouter, ContentScope, ScopeRouteRefusal,
+    ServeAdmission, ServeRefusal,
+};
 
 /// Operator knobs for the swarm scheduler. Defaults match the
 /// CIRISEdge#55 TL;DR (in-flight cap 4 per peer, EWMA alpha 0.3,
@@ -219,6 +226,23 @@ pub enum SwarmError {
     /// from "the swarm broke."
     #[error("invalid manifest for blob {0}: {1}")]
     InvalidManifest(String, String),
+    /// CIRISEdge#499 — the blob's scope could not be resolved to an address
+    /// for ANY holder, so the fetch never started. A separate variant from
+    /// [`Self::NoHolders`] on purpose: holders exist, we simply must not ask
+    /// them at the federation address, and folding the two would report a
+    /// privacy gate as a federation-wide miss.
+    ///
+    /// Never a fallback. There is deliberately no arm of the scheduler that
+    /// degrades an unroutable scoped fetch onto the federation address — that
+    /// degradation IS the defect #499 removes.
+    #[error("scope routing failed for every holder of blob {blob_sha}: {reason}")]
+    ScopeUnroutable {
+        /// Hex-encoded overall blob SHA-256.
+        blob_sha: String,
+        /// The first refusal observed, rendered. Every holder's refusal is
+        /// logged; this carries the leading one for the error surface.
+        reason: String,
+    },
 }
 
 /// Distinct outcomes from a [`BlobChunkVerifier::verify_and_store`]
@@ -303,6 +327,30 @@ pub trait BlobChunkSource: Send + Sync + 'static {
         blob_sha256: [u8; 32],
         chunk_sha256: [u8; 32],
     ) -> Result<Option<Vec<u8>>, ChunkSourceRefusal>;
+
+    /// CIRISEdge#499 — the SCOPE this blob's content lives in, so the
+    /// responder can decide whether the address a request arrived on
+    /// entitles the requester to it.
+    ///
+    /// **Edge never infers a blob's scope.** Content classification is
+    /// the persist-backed consumer's, exactly as SHA verification is
+    /// (CIRISPersist#145 §10.1.1) — this method is the seam, not a
+    /// decision edge makes. `None` means *undeterminable*, and is NEVER
+    /// read as `Public`: on a scope-native node it refuses the serve
+    /// ([`ServeRefusal::ScopeUndeterminable`]).
+    ///
+    /// The default returns `None`, which keeps every existing
+    /// implementation compiling AND keeps its behaviour byte-identical:
+    /// the scope gate is armed only where a
+    /// [`ScopeAddressTable`](crate::scope_addressing::ScopeAddressTable)
+    /// is installed, and a deployment with no table admits every serve
+    /// regardless of what this returns. A consumer that installs an
+    /// address table MUST override this or its blob plane fails closed —
+    /// which is the correct order of operations: derive addresses only
+    /// once you can say what they are for.
+    fn chunk_scope(&self, _blob_sha256: [u8; 32]) -> Option<ContentScope> {
+        None
+    }
 }
 
 /// Refusal reasons surfaced by a [`BlobChunkSource::read_chunk`]
@@ -453,13 +501,57 @@ impl SwarmScheduler {
     /// - **Holder list.** The caller queries persist's
     ///   `BlobStorage::list_holders(blob_sha256)` and passes the
     ///   result. The scheduler does not call persist directly.
-    #[allow(clippy::too_many_lines)] // the driver loop is the load-bearing composition site
-    #[allow(clippy::cast_possible_truncation)] // assembled blob size is bounded by AV-13 family caps
     pub async fn fetch_blob(
         &self,
         blob_sha256: [u8; 32],
         manifest: ChunkManifestLite,
         holders: Vec<String>,
+    ) -> Result<Vec<u8>, SwarmError> {
+        // CIRISEdge#499 — a caller that cannot say what scope the blob is gets
+        // `None`, and the router's `None` semantics are exactly right for it:
+        //
+        //  - on a node with no address table (every deployment today) it routes
+        //    to the federation address, so this call is byte-identical to
+        //    pre-#499;
+        //  - on a scope-native node it is REFUSED, because a caller that cannot
+        //    name the scope cannot be given an address that respects it, and
+        //    guessing "public" is the one default this stack must never adopt.
+        //
+        // Scope-aware callers use [`Self::fetch_blob_scoped`].
+        self.fetch_blob_scoped(blob_sha256, manifest, holders, None)
+            .await
+    }
+
+    /// CIRISEdge#499 — drive a swarm fetch of a blob whose content scope is
+    /// KNOWN, requesting every chunk at the address that scope requires.
+    ///
+    /// `content_scope` is the blob's declared scope (from the persist-backed
+    /// consumer that owns content classification — edge never infers it), or
+    /// `None` when it could not be determined.
+    ///
+    /// Routing happens ONCE, up front, for every holder, and BEFORE a single
+    /// byte moves. That ordering is the point: a per-dispatch resolution could
+    /// leave the scheduler half-way through a fetch when it discovers a holder
+    /// is unaddressable, having already put scoped request bytes on the
+    /// federation address for the holders it got to first. Resolving the whole
+    /// holder set first makes the fetch all-or-nothing with respect to context.
+    ///
+    /// A holder that cannot be routed is DROPPED from the candidate set with a
+    /// logged reason, exactly like a demoted peer — never silently retried at
+    /// the federation address. If no holder survives, the fetch fails with
+    /// [`SwarmError::ScopeUnroutable`].
+    ///
+    /// # Errors
+    /// Every error [`Self::fetch_blob`] returns, plus
+    /// [`SwarmError::ScopeUnroutable`].
+    #[allow(clippy::too_many_lines)] // the driver loop is the load-bearing composition site
+    #[allow(clippy::cast_possible_truncation)] // assembled blob size is bounded by AV-13 family caps
+    pub async fn fetch_blob_scoped(
+        &self,
+        blob_sha256: [u8; 32],
+        manifest: ChunkManifestLite,
+        holders: Vec<String>,
+        content_scope: Option<ContentScope>,
     ) -> Result<Vec<u8>, SwarmError> {
         let blob_hex = hex::encode(blob_sha256);
 
@@ -471,9 +563,22 @@ impl SwarmScheduler {
             return Err(SwarmError::NoHolders(blob_hex));
         }
 
-        // Per-peer state, fetch-scoped.
-        let mut peers: HashMap<String, PeerState> = holders
-            .iter()
+        // CIRISEdge#499 — resolve every holder to an address BEFORE dispatch.
+        // The router reads its table from the transport, so "is this node
+        // scope-native" has one source of truth (see `Edge::blob_scope_router`).
+        let scope_router = self.edge.blob_scope_router();
+        let routes =
+            resolve_holder_routes(&scope_router, content_scope.as_ref(), &holders, &blob_hex)
+                .map_err(|reason| SwarmError::ScopeUnroutable {
+                    blob_sha: blob_hex.clone(),
+                    reason,
+                })?;
+
+        // Per-peer state, fetch-scoped. Keyed on the routable holders only —
+        // an unroutable holder is not a candidate, so `pick_peer` can never
+        // select one and no dispatch can reach it.
+        let mut peers: HashMap<String, PeerState> = routes
+            .keys()
             .map(|k| (k.clone(), PeerState::default()))
             .collect();
 
@@ -507,7 +612,7 @@ impl SwarmScheduler {
                 let Some(chunk_sha) = pending.pop_front() else {
                     break;
                 };
-                self.dispatch_chunk_fetch(&peer, blob_sha256, chunk_sha, &tx);
+                self.dispatch_chunk_fetch(&routes, &peer, blob_sha256, chunk_sha, &tx);
                 if let Some(state) = peers.get_mut(&peer) {
                     state.in_flight = state.in_flight.saturating_add(1);
                 }
@@ -531,6 +636,7 @@ impl SwarmScheduler {
             let remaining = pending.len() + total_in_flight;
             if remaining > 0 && remaining <= self.config.endgame_threshold {
                 self.maybe_endgame_dispatch(
+                    &routes,
                     blob_sha256,
                     &chunk_bytes,
                     &manifest,
@@ -683,6 +789,7 @@ impl SwarmScheduler {
     /// `chunk_sha`, forwarding the result over `tx`.
     fn dispatch_chunk_fetch(
         &self,
+        routes: &HashMap<String, BlobRecipient>,
         peer_key_id: &str,
         blob_sha256: [u8; 32],
         chunk_sha: [u8; 32],
@@ -690,12 +797,27 @@ impl SwarmScheduler {
     ) {
         let edge = self.edge.clone();
         let peer = peer_key_id.to_string();
+        // CIRISEdge#499 — the pre-resolved address for this holder. Absent only
+        // if a caller reached here with a peer that was never routed, which
+        // `peers` being built FROM `routes` makes unreachable; the `else` is
+        // defensive and loud rather than a silent federation-address dispatch.
+        let Some(recipient) = routes.get(peer_key_id).cloned() else {
+            tracing::error!(
+                holder = %peer,
+                "swarm dispatch reached an UNROUTED holder — refusing to fall back to \
+                 the federation address (CIRISEdge#499)",
+            );
+            return;
+        };
         let timeout = self.config.per_request_timeout;
         let tx = tx.clone();
         let started_at = Instant::now();
         tokio::spawn(async move {
+            // `fetch_blob_chunk_scoped` delegates verbatim to the unscoped
+            // `fetch_blob_chunk` for a federation route, so the public-content
+            // path is byte-identical to pre-#499.
             let result = match edge
-                .fetch_blob_chunk(&peer, blob_sha256, chunk_sha, timeout)
+                .fetch_blob_chunk_scoped(&recipient, blob_sha256, chunk_sha, timeout)
                 .await
             {
                 Ok(crate::ChunkResult::Bytes(bytes)) => FetchResultBody::Bytes(bytes),
@@ -719,8 +841,17 @@ impl SwarmScheduler {
     /// `chunk_bytes`), if a holder with capacity exists, dispatch a
     /// duplicate request. First response wins via the
     /// `chunk_bytes.contains_key` check on the verifier path.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "CIRISEdge#499 added the pre-resolved `routes` map; every other \
+                  argument is pre-existing scheduler state this endgame pass must \
+                  read or mutate. Bundling them into a struct would put the \
+                  scheduler's mutable loop state behind an indirection for one \
+                  call site and hide which fields this pass actually touches."
+    )]
     fn maybe_endgame_dispatch(
         &self,
+        routes: &HashMap<String, BlobRecipient>,
         blob_sha256: [u8; 32],
         chunk_bytes: &HashMap<[u8; 32], Vec<u8>>,
         manifest: &ChunkManifestLite,
@@ -741,7 +872,7 @@ impl SwarmScheduler {
                 .map(|(k, _)| k.clone())
                 .next();
             if let Some(peer) = candidate {
-                self.dispatch_chunk_fetch(&peer, blob_sha256, *chunk_sha, tx);
+                self.dispatch_chunk_fetch(routes, &peer, blob_sha256, *chunk_sha, tx);
                 if let Some(state) = peers.get_mut(&peer) {
                     state.in_flight = state.in_flight.saturating_add(1);
                 }
@@ -756,6 +887,56 @@ impl SwarmScheduler {
             }
         }
     }
+}
+
+/// CIRISEdge#499 — resolve every holder to the address this content's SCOPE
+/// requires, dropping (loudly) the ones that cannot be addressed for it.
+///
+/// Pure and free-standing so the scope decision is testable without standing up
+/// a live edge handle: this is where the privacy-relevant choice lives, so it is
+/// the part that must be cheap to assert on and cheap to mutation-test.
+///
+/// Returns `Err(reason)` — the FIRST refusal, rendered — when no holder survives.
+/// There is deliberately no arm that returns a federation route for content that
+/// asked for a scoped one: a partial degradation would put scoped request bytes
+/// on the public address for whichever holders resolved first, which is the exact
+/// context collapse the routing exists to prevent.
+fn resolve_holder_routes(
+    scope_router: &BlobScopeRouter,
+    content_scope: Option<&ContentScope>,
+    holders: &[String],
+    blob_hex: &str,
+) -> Result<HashMap<String, BlobRecipient>, String> {
+    let mut routes: HashMap<String, BlobRecipient> = HashMap::with_capacity(holders.len());
+    let mut first_refusal: Option<String> = None;
+    for holder in holders {
+        match scope_router.route(content_scope, holder) {
+            Ok(recipient) => {
+                routes.insert(holder.clone(), recipient);
+            }
+            Err(refusal) => {
+                // Loud, never a bare `continue` (CIRISEdge#425). One line per
+                // unroutable holder; the holder set is caller-supplied and small
+                // (persist's `list_holders`), so this is bounded.
+                tracing::warn!(
+                    blob_sha = %blob_hex,
+                    holder = %holder,
+                    reason = refusal.reason_tag(),
+                    "blob holder DROPPED from the swarm candidate set — no address for \
+                     this content's scope. NOT retried at the federation address: {refusal}",
+                );
+                if first_refusal.is_none() {
+                    first_refusal = Some(refusal.to_string());
+                }
+            }
+        }
+    }
+    if routes.is_empty() {
+        return Err(
+            first_refusal.unwrap_or_else(|| "no holder could be routed for this scope".to_owned())
+        );
+    }
+    Ok(routes)
 }
 
 /// Pick the peer with lowest EWMA-RTT that has capacity. Untimed
@@ -932,6 +1113,207 @@ mod tests {
         peers.insert("a".into(), a);
         peers.insert("b".into(), b);
         assert!(pick_peer(&peers, 4).is_none());
+    }
+
+    // ── CIRISEdge#499: holder routing ────────────────────────────────
+
+    mod scope_native_holder_routing {
+        use super::*;
+        use crate::cohort_scope::CohortScope;
+        use crate::scope_addressing::{MemberAddress, ScopeAddressTable, StubDeriver};
+
+        const ALICE: &str = "ed25519:alice";
+        const BOB: &str = "ed25519:bob";
+
+        fn neighbourhood() -> CohortScope {
+            CohortScope::Cohort {
+                cohort_id: "neighbourhood".to_owned(),
+            }
+        }
+
+        /// alice + bob are members of community group `com-1`; mallory is not.
+        fn table() -> Arc<ScopeAddressTable> {
+            let t = ScopeAddressTable::new(Arc::new(StubDeriver));
+            t.install_group(&neighbourhood(), "com-1", 3, &[0xB2; 32], &[ALICE, BOB])
+                .expect("install com-1");
+            Arc::new(t)
+        }
+
+        fn community_blob() -> ContentScope {
+            ContentScope::Group {
+                scope: neighbourhood(),
+                group_id: "com-1".to_owned(),
+            }
+        }
+
+        fn holders(names: &[&str]) -> Vec<String> {
+            names.iter().map(|s| (*s).to_owned()).collect()
+        }
+
+        #[test]
+        fn a_cohort_scoped_blob_routes_every_member_to_its_own_derived_address() {
+            let t = table();
+            let scope_router = BlobScopeRouter::new(Some(Arc::clone(&t)));
+
+            let routes = resolve_holder_routes(
+                &scope_router,
+                Some(&community_blob()),
+                &holders(&[ALICE, BOB]),
+                "deadbeef",
+            )
+            .expect("both holders are members");
+
+            assert_eq!(routes.len(), 2);
+            for member in [ALICE, BOB] {
+                let got = routes[member]
+                    .scoped_address()
+                    .expect("a community blob must not ride the federation address")
+                    .as_bytes();
+                let want = t
+                    .send_address(&neighbourhood(), "com-1", member)
+                    .expect("table has the member");
+                assert_eq!(
+                    got,
+                    want.as_bytes(),
+                    "the routed address must be BYTE-EXACT with the table's derivation \
+                     — edge reproduces CIRISVerify#259's bytes, it does not transform them",
+                );
+            }
+            assert_ne!(
+                routes[ALICE].scoped_address().map(MemberAddress::as_bytes),
+                routes[BOB].scoped_address().map(MemberAddress::as_bytes),
+                "per-member, never a shared group hash (unicast-ambiguous in RNS)",
+            );
+        }
+
+        #[test]
+        fn a_public_blob_routes_every_holder_to_the_federation_address() {
+            // The no-regression case on a SCOPE-NATIVE node: installing a table
+            // must not move public content off the federation address.
+            let scope_router = BlobScopeRouter::new(Some(table()));
+            let routes = resolve_holder_routes(
+                &scope_router,
+                Some(&ContentScope::Federation),
+                &holders(&[ALICE, BOB, "ed25519:mallory"]),
+                "deadbeef",
+            )
+            .expect("public content always routes");
+
+            assert_eq!(
+                routes.len(),
+                3,
+                "including the non-member — public is public"
+            );
+            for r in routes.values() {
+                assert!(!r.is_scoped());
+                assert!(r.scoped_address().is_none());
+            }
+        }
+
+        #[test]
+        fn a_legacy_node_routes_everything_to_the_federation_address() {
+            // The no-regression case on a node with NO table — i.e. every
+            // production deployment today. `None` scope is what the pre-#499
+            // `fetch_blob` entry point supplies.
+            let scope_router = BlobScopeRouter::default();
+            let routes =
+                resolve_holder_routes(&scope_router, None, &holders(&[ALICE, BOB]), "deadbeef")
+                    .expect("legacy nodes route unconditionally");
+            assert_eq!(routes.len(), 2);
+            for r in routes.values() {
+                assert!(!r.is_scoped(), "byte-identical to pre-#499");
+            }
+        }
+
+        #[test]
+        fn an_unroutable_holder_is_dropped_and_the_routable_ones_survive() {
+            let scope_router = BlobScopeRouter::new(Some(table()));
+            let routes = resolve_holder_routes(
+                &scope_router,
+                Some(&community_blob()),
+                &holders(&[ALICE, "ed25519:mallory", BOB]),
+                "deadbeef",
+            )
+            .expect("two of three holders are members");
+
+            assert_eq!(routes.len(), 2);
+            assert!(routes.contains_key(ALICE) && routes.contains_key(BOB));
+            assert!(
+                !routes.contains_key("ed25519:mallory"),
+                "a non-member holder must be DROPPED, never federation-routed — a \
+                 partial degradation would put scoped request bytes on the public \
+                 address",
+            );
+        }
+
+        #[test]
+        fn a_blob_no_holder_can_be_addressed_for_fails_with_a_named_reason() {
+            let scope_router = BlobScopeRouter::new(Some(table()));
+            let err = resolve_holder_routes(
+                &scope_router,
+                Some(&community_blob()),
+                &holders(&["ed25519:mallory", "ed25519:trudy"]),
+                "deadbeef",
+            )
+            .expect_err("no holder is a member");
+            assert!(
+                err.contains("HOLDER") || err.contains("holder"),
+                "the refusal must NAME why, not just fail: {err}",
+            );
+
+            // The trap: a refusal test that passes by refusing everything.
+            assert!(
+                resolve_holder_routes(
+                    &scope_router,
+                    Some(&community_blob()),
+                    &holders(&[ALICE]),
+                    "deadbeef",
+                )
+                .is_ok(),
+                "a legitimate member must still route under the identical call",
+            );
+        }
+
+        #[test]
+        fn an_undeterminable_scope_is_refused_on_a_scope_native_node_only() {
+            let native = BlobScopeRouter::new(Some(table()));
+            let err = resolve_holder_routes(&native, None, &holders(&[ALICE, BOB]), "deadbeef")
+                .expect_err("unknown scope on a scope-native node");
+            assert!(
+                err.contains("UNDETERMINABLE"),
+                "the refusal must name the undeterminable scope: {err}",
+            );
+
+            // ...and the same node still routes a blob whose scope IS known,
+            // both scoped and public.
+            assert!(resolve_holder_routes(
+                &native,
+                Some(&community_blob()),
+                &holders(&[ALICE]),
+                "deadbeef"
+            )
+            .is_ok());
+            assert!(resolve_holder_routes(
+                &native,
+                Some(&ContentScope::Federation),
+                &holders(&[ALICE]),
+                "deadbeef"
+            )
+            .is_ok());
+
+            // On a legacy node the SAME input is not a refusal at all.
+            assert!(
+                resolve_holder_routes(
+                    &BlobScopeRouter::default(),
+                    None,
+                    &holders(&[ALICE]),
+                    "deadbeef"
+                )
+                .is_ok(),
+                "arming the gate on a node that cannot derive addresses would break \
+                 every existing deployment without moving a single byte",
+            );
+        }
     }
 
     #[test]

--- a/src/blob_swarm/scope.rs
+++ b/src/blob_swarm/scope.rs
@@ -1,0 +1,1018 @@
+//! Scope-native addressing for the blob / content plane (CIRISEdge#499).
+//!
+//! # The defect this closes
+//!
+//! Before this module, [`SwarmScheduler::fetch_blob`] and the inbound
+//! `BlobChunkFetch` responder had **zero** scope awareness: a community's
+//! blob was requested from, and served at, the node's single federation
+//! address regardless of the content's scope. The record layer was
+//! scope-private; the address the bytes moved over was not. An observer
+//! sitting on the fabric therefore correlated a family flow, a community
+//! flow and a public flow to one endpoint — the same context collapse
+//! #499 removed from the message and A/V planes, one plane over.
+//!
+//! Per <https://ciris.ai/contextual-integrity/>, privacy is appropriate
+//! *flow*, and a scoped blob moving over an unscoped address is an
+//! inappropriate one **even when the bytes are sealed**: the ciphertext
+//! is not the leak, the endpoint correlation is.
+//!
+//! # Two halves, one rule
+//!
+//! Both halves reduce to the SAME already-owned predicate,
+//! [`CohortScope::allows_recipient_scope`] (CIRISEdge#48-A). This module
+//! invents no scope rule of its own — it only changes what the
+//! *recipient scope* input is made of:
+//!
+//! - **Send** ([`BlobScopeRouter::route`]) — resolve the holder's
+//!   scope-derived address ABOVE the transport and hand the send path a
+//!   [`BlobRecipient`], which cannot name a wrong address because the
+//!   only way to build one is to have resolved it. This is the
+//!   `ResolvedRecipient` pattern (CIRISEdge#396/#402) applied to the blob
+//!   plane. `Transport::send` grows NO scope parameter (it has 10
+//!   implementors, including HTTP and packet radio) and the transport
+//!   parses no scope: the caller already knows the content's scope, so it
+//!   hands down an address rather than a question.
+//!
+//! - **Serve** ([`admit_blob_serve`]) — the recipient scope is no longer
+//!   a directory-recorded *claim* but a **cryptographic fact**. A frame
+//!   that arrived on a scope-derived address carries an
+//!   [`InboundAddress`], and holding one proves the sender possessed the
+//!   group's MLS `exporter_secret`, which binds `(group_id, epoch)` per
+//!   RFC 9420 §8.5. That is why the gate is cheap and why it can sit
+//!   ahead of the body parse: the admission fact is a hash-map probe the
+//!   transport already performed, not something the responder derives
+//!   from anything the requester said.
+//!
+//! # Fail-closed, and the exact shape of "closed"
+//!
+//! A blob whose scope cannot be determined is NOT served — [`ServeAdmission`]
+//! is `#[must_use]` and its refusal arm carries a named
+//! [`ServeRefusal`], mirroring the [`ApplyOutcome`] choke-point pattern
+//! (CIRISEdge#425). There is no arm that refuses silently and no arm a
+//! caller can drop on the floor.
+//!
+//! **But fail-closed is armed, not unconditional.** Both halves are gated
+//! on whether a [`ScopeAddressTable`] is installed
+//! ([`BlobScopeRouter::is_scope_native`]). A deployment with no table —
+//! which per `scope_addressing`'s module docs is EVERY production
+//! deployment until the MLS exporter label is specified upstream —
+//! behaves exactly as it did before this module existed:
+//! [`BlobRoute::Federation`] on send, [`ServeAdmission::Admit`] on serve.
+//! Scope-native addressing is strictly additive. Refusing every blob on a
+//! node that has no way to derive an address would not be fail-closed, it
+//! would be fail-broken.
+//!
+//! [`SwarmScheduler::fetch_blob`]: super::SwarmScheduler::fetch_blob
+//! [`ApplyOutcome`]: crate::replication::summary::ApplyOutcome
+
+use std::sync::Arc;
+
+use crate::cohort_scope::CohortScope;
+use crate::scope_addressing::{InboundAddress, MemberAddress, ScopeAddressTable};
+
+// ─── What "this blob's scope" means to the addressing layer ─────────
+
+/// The scope a blob's CONTENT lives in, in the form the addressing layer
+/// needs it: the cohort scope plus the opaque MLS group id whose
+/// `exporter_secret` derives that group's member addresses.
+///
+/// Two fields rather than one because [`CohortScope`] alone cannot
+/// address anything. `Family` names a *kind* of scope; it does not say
+/// WHICH family, and a node may hold several. The group id is what the
+/// [`ScopeAddressTable`] is keyed by. Edge does **not** interpret
+/// `group_id` — it is the MLS group's identifier as the scope-privacy
+/// layer names it, carried through opaquely.
+///
+/// Obtained from [`BlobChunkSource::chunk_scope`](super::BlobChunkSource::chunk_scope),
+/// i.e. from the persist-backed consumer that owns content classification.
+/// Edge never infers a blob's scope; `None` from that call is the
+/// undeterminable case and is refused, not guessed.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ContentScope {
+    /// Public / federation-scoped content. Rides the node's federation
+    /// address exactly as it did pre-#499. This is NOT a scope-derived
+    /// route and deliberately has no group: `Public` content is reachable
+    /// by construction, and deriving a private address for it would be a
+    /// contradiction (see [`ScopeRouteRefusal::PublicIsNotScoped`]).
+    Federation,
+    /// Content bound to a scoped MLS group. Addresses for this content's
+    /// flows are derived from that group's `exporter_secret`.
+    Group {
+        /// The cohort scope. `Public` here is refused at routing time —
+        /// public content must be declared [`ContentScope::Federation`].
+        scope: CohortScope,
+        /// The opaque MLS group id. Edge does not interpret it.
+        group_id: String,
+    },
+}
+
+impl ContentScope {
+    /// The cohort scope this content declares, for the #48-A predicate.
+    #[must_use]
+    pub fn cohort_scope(&self) -> &CohortScope {
+        match self {
+            Self::Federation => &CohortScope::Public,
+            Self::Group { scope, .. } => scope,
+        }
+    }
+
+    /// The MLS group id, or `None` for federation-scoped content.
+    #[must_use]
+    pub fn group_id(&self) -> Option<&str> {
+        match self {
+            Self::Federation => None,
+            Self::Group { group_id, .. } => Some(group_id),
+        }
+    }
+}
+
+// ─── SEND: the resolved-recipient funnel ────────────────────────────
+
+/// Where a blob request's bytes are addressed. Private to the crate: the
+/// only way a caller learns the route is through [`BlobRecipient`], and
+/// the only way to build one of those is to have resolved it.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum BlobRoute {
+    /// The node's federation address, reached by `key_id` through the
+    /// ordinary `Transport::send` path. Byte-identical to pre-#499.
+    Federation,
+    /// A scope-derived per-member address.
+    Scoped(MemberAddress),
+}
+
+/// Proof that a holder's address for a blob's scope HAS BEEN RESOLVED —
+/// the key the blob send path requires.
+///
+/// Constructible ONLY via [`BlobScopeRouter::route`], so possessing one
+/// is proof that the content's scope was determined and an address was
+/// derived for it (or that the content is federation-scoped and the
+/// federation address is correct). Holding a raw `&str` peer id grants no
+/// such right: issuing a scoped fetch to it is unrepresentable without
+/// first routing.
+///
+/// This is the blob plane's [`ResolvedRecipient`], and it is a separate
+/// type on purpose — that one is the *consent* projection's authorization
+/// (may I send to this peer at all), this one is the *addressing*
+/// resolution (which of this peer's addresses is correct for this
+/// content). Folding them would make one type mean two checks, and a
+/// caller that satisfied one would silently appear to have satisfied the
+/// other.
+///
+/// [`ResolvedRecipient`]: crate::replication::resolved_state::ResolvedRecipient
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct BlobRecipient {
+    peer_key_id: String,
+    route: BlobRoute,
+}
+
+impl BlobRecipient {
+    /// The holder this authorization addresses.
+    #[must_use]
+    pub fn peer_key_id(&self) -> &str {
+        &self.peer_key_id
+    }
+
+    /// The scope-derived address, or `None` for a federation route.
+    ///
+    /// Returns a [`MemberAddress`], which has no public byte constructor:
+    /// a caller cannot fabricate one and cannot turn arbitrary bytes into
+    /// one. The bytes are readable (`as_bytes`) because the transport has
+    /// to hand them to a Reticulum `Destination`; they are not writable.
+    #[must_use]
+    pub fn scoped_address(&self) -> Option<&MemberAddress> {
+        match &self.route {
+            BlobRoute::Federation => None,
+            BlobRoute::Scoped(addr) => Some(addr),
+        }
+    }
+
+    /// `true` iff this recipient is addressed at a scope-derived address
+    /// rather than the federation address.
+    #[must_use]
+    pub fn is_scoped(&self) -> bool {
+        matches!(self.route, BlobRoute::Scoped(_))
+    }
+}
+
+/// Why a blob request could not be routed. Every variant is a REFUSAL,
+/// never a fallback: there is deliberately no arm that shrugs and uses
+/// the federation address, because that is precisely the context collapse
+/// this module exists to remove.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ScopeRouteRefusal {
+    /// The content's scope could not be determined on a node that IS
+    /// scope-native (a [`ScopeAddressTable`] is installed). Refused rather
+    /// than defaulted: "unclassified means public" is the single most
+    /// expensive default this stack could adopt, and it is not edge's to
+    /// choose — `chunk_scope` is the consumer's declaration and its `None`
+    /// means *unknown*, not *public*.
+    #[error(
+        "blob scope routing: content scope is UNDETERMINABLE and this node is \
+         scope-native — refusing to fall back to the federation address \
+         (CIRISEdge#499). Wire BlobChunkSource::chunk_scope to report the blob's \
+         scope; a None answer is never read as Public."
+    )]
+    ScopeUndeterminable,
+    /// The content is group-scoped but no [`ScopeAddressTable`] is
+    /// installed, so no address can be derived. Fail-closed: sending a
+    /// scoped blob over the federation address is the defect.
+    #[error(
+        "blob scope routing: content is scoped to '{scope_kind}' group '{group_id}' \
+         but NO scope address table is installed — no derived address exists, and \
+         the federation address is not an acceptable substitute (CIRISEdge#499)"
+    )]
+    NoAddressTable {
+        /// [`CohortScope::kind_token`] of the content's scope.
+        scope_kind: &'static str,
+        /// The MLS group id the content is bound to.
+        group_id: String,
+    },
+    /// A table is installed but this holder has no derived address in the
+    /// content's group — it is not a member at any live epoch, or it was
+    /// excluded at a rotation seal. Either way we cannot address it for
+    /// this content, and must not address it for this content.
+    #[error(
+        "blob scope routing: holder '{peer_key_id}' has NO derived address in \
+         '{scope_kind}' group '{group_id}' (not a member at any live epoch, or \
+         excluded at a rotation seal) — this holder cannot be asked for this \
+         blob (CIRISEdge#499)"
+    )]
+    HolderNotInGroup {
+        /// The holder we could not address.
+        peer_key_id: String,
+        /// [`CohortScope::kind_token`] of the content's scope.
+        scope_kind: &'static str,
+        /// The MLS group id the content is bound to.
+        group_id: String,
+    },
+    /// The content declared [`ContentScope::Group`] with a `Public`
+    /// cohort scope. Refused for exactly the reason
+    /// `ReticulumTransport::register_scoped_destination` refuses to
+    /// register a `Public` scoped destination: a derived per-member
+    /// address is not a discovery address, and pairing "public" with a
+    /// private derived address is a contradiction, not a configuration.
+    /// Public content is [`ContentScope::Federation`].
+    #[error(
+        "blob scope routing: content declared group '{group_id}' at Public scope — \
+         a derived per-member address is not a discovery address; public content \
+         must be declared ContentScope::Federation (CIRISEdge#499)"
+    )]
+    PublicIsNotScoped {
+        /// The group id the caller paired with `Public`.
+        group_id: String,
+    },
+}
+
+impl ScopeRouteRefusal {
+    /// Stable, low-cardinality tag for log throttling and metric detail.
+    /// Never contains a peer id or a group id — those ride the bounded
+    /// record, not the label (unbounded label cardinality explodes
+    /// downstream metric storage).
+    #[must_use]
+    pub const fn reason_tag(&self) -> &'static str {
+        match self {
+            Self::ScopeUndeterminable => "blob_scope_undeterminable",
+            Self::NoAddressTable { .. } => "blob_no_address_table",
+            Self::HolderNotInGroup { .. } => "blob_holder_not_in_group",
+            Self::PublicIsNotScoped { .. } => "blob_public_is_not_scoped",
+        }
+    }
+}
+
+/// Resolves a blob's scope to the address its bytes must move over.
+///
+/// Sits **above** the transport by construction: it holds only the
+/// address table (a pure lookup structure) and produces a
+/// [`BlobRecipient`]. It cannot send, so it cannot be the place a send
+/// decision leaks into the transport.
+///
+/// Every method is synchronous and takes no lock across anything — the
+/// table's own methods are synchronous by design (CIRISEdge#217: a guard
+/// held across an `.await` on a transport path is what produced the real
+/// hangs), and this type adds no state of its own.
+#[derive(Clone, Default)]
+pub struct BlobScopeRouter {
+    table: Option<Arc<ScopeAddressTable>>,
+}
+
+impl BlobScopeRouter {
+    /// A router over an installed table. `None` — the production state
+    /// until the MLS exporter label is specified upstream — yields a
+    /// router that routes everything to the federation address, i.e.
+    /// exactly pre-#499 behaviour.
+    #[must_use]
+    pub fn new(table: Option<Arc<ScopeAddressTable>>) -> Self {
+        Self { table }
+    }
+
+    /// `true` iff a [`ScopeAddressTable`] is installed, i.e. iff this node
+    /// can derive scoped addresses at all.
+    ///
+    /// This is THE arming condition for both halves of the gate. It is a
+    /// deployment fact, not a policy knob: a node with no table has no
+    /// scope-derived address to send from, to send to, or to be reached
+    /// on, so a scope gate over it could only ever refuse everything.
+    #[must_use]
+    pub fn is_scope_native(&self) -> bool {
+        self.table.is_some()
+    }
+
+    /// Resolve `peer_key_id` to the address this content's bytes must
+    /// move over.
+    ///
+    /// `content` is the blob's declared scope, or `None` when the
+    /// consumer could not determine it.
+    ///
+    /// # Errors
+    ///
+    /// Every arm of [`ScopeRouteRefusal`]. There is no arm that silently
+    /// degrades to the federation address for scoped content.
+    pub fn route(
+        &self,
+        content: Option<&ContentScope>,
+        peer_key_id: &str,
+    ) -> Result<BlobRecipient, ScopeRouteRefusal> {
+        let federation = || BlobRecipient {
+            peer_key_id: peer_key_id.to_owned(),
+            route: BlobRoute::Federation,
+        };
+
+        let Some(content) = content else {
+            // Undeterminable scope. On a node that cannot derive addresses
+            // at all there is nothing to refuse INTO — refusing here would
+            // break every existing deployment's blob plane without moving
+            // a single byte off the federation address (there is no other
+            // address). On a scope-native node it is a hard refusal.
+            return if self.is_scope_native() {
+                Err(ScopeRouteRefusal::ScopeUndeterminable)
+            } else {
+                Ok(federation())
+            };
+        };
+
+        let (scope, group_id) = match content {
+            // Public content rides the federation address — byte-identical
+            // to pre-#499, on scope-native nodes and legacy nodes alike.
+            ContentScope::Federation => return Ok(federation()),
+            ContentScope::Group { scope, group_id } => (scope, group_id),
+        };
+
+        if matches!(scope, CohortScope::Public) {
+            return Err(ScopeRouteRefusal::PublicIsNotScoped {
+                group_id: group_id.clone(),
+            });
+        }
+
+        let Some(table) = self.table.as_ref() else {
+            return Err(ScopeRouteRefusal::NoAddressTable {
+                scope_kind: scope.kind_token(),
+                group_id: group_id.clone(),
+            });
+        };
+
+        // The one derivation-adjacent call in this module, and it is a
+        // LOOKUP, not a derivation: `send_address` never calls the deriver
+        // (that is the invariant `scope_addressing`'s
+        // `lookup_never_calls_the_deriver` test pins). Address derivation
+        // is CIRISVerify#259's; edge reproduces its bytes, never its math.
+        match table.send_address(scope, group_id, peer_key_id) {
+            Some(address) => Ok(BlobRecipient {
+                peer_key_id: peer_key_id.to_owned(),
+                route: BlobRoute::Scoped(address),
+            }),
+            None => Err(ScopeRouteRefusal::HolderNotInGroup {
+                peer_key_id: peer_key_id.to_owned(),
+                scope_kind: scope.kind_token(),
+                group_id: group_id.clone(),
+            }),
+        }
+    }
+}
+
+// ─── SERVE: admission ahead of the parse ────────────────────────────
+
+/// Why a blob chunk was not served. Each variant is ONE code branch, per
+/// the CIRISEdge#433 rule that a refusal reason is the BRANCH and never a
+/// disjunction — folding "we could not tell what this blob is" into "you
+/// reached us on the wrong address" would send an operator to look in the
+/// wrong place.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServeRefusal {
+    /// The responder could not determine the blob's scope, so it cannot
+    /// know whether this requester is entitled to it. Fail-closed.
+    ScopeUndeterminable,
+    /// The blob's scope does not admit the scope the request ARRIVED on.
+    /// The canonical case: family-scoped content requested over the
+    /// federation address — the requester proved nothing about family
+    /// membership by reaching a public endpoint.
+    ArrivalScopeInsufficient {
+        /// [`CohortScope::kind_token`] of the content's scope.
+        content_kind: &'static str,
+        /// [`CohortScope::kind_token`] of the scope the request arrived on.
+        arrival_kind: &'static str,
+    },
+    /// The arrival scope matched, but the request arrived on an address
+    /// derived from a DIFFERENT group's `exporter_secret`.
+    ///
+    /// Its own branch because the scope predicate genuinely cannot see
+    /// this: `Family` vs `Family` is a match to
+    /// [`CohortScope::allows_recipient_scope`], and yet possession of one
+    /// family's group secret proves nothing whatsoever about another
+    /// family's. Serving across that boundary would answer on authority
+    /// the requester never demonstrated.
+    GroupMismatch {
+        /// [`CohortScope::kind_token`] of the content's scope.
+        content_kind: &'static str,
+    },
+}
+
+impl ServeRefusal {
+    /// Stable, low-cardinality tag for log throttling and metric detail.
+    /// Carries no group id, peer id or blob hash — those ride the bounded
+    /// record.
+    #[must_use]
+    pub const fn reason_tag(&self) -> &'static str {
+        match self {
+            Self::ScopeUndeterminable => "blob_serve_scope_undeterminable",
+            Self::ArrivalScopeInsufficient { .. } => "blob_serve_arrival_scope_insufficient",
+            Self::GroupMismatch { .. } => "blob_serve_group_mismatch",
+        }
+    }
+
+    /// The withhold-ledger reason for this branch (CIRISEdge#433).
+    #[must_use]
+    pub const fn withhold_reason(&self) -> crate::observability::WithholdReason {
+        match self {
+            Self::ScopeUndeterminable => {
+                crate::observability::WithholdReason::BlobScopeUndeterminable
+            }
+            Self::ArrivalScopeInsufficient { .. } => {
+                crate::observability::WithholdReason::BlobArrivalScopeInsufficient
+            }
+            Self::GroupMismatch { .. } => {
+                crate::observability::WithholdReason::BlobArrivalGroupMismatch
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ServeRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ScopeUndeterminable => f.write_str(
+                "blob scope could not be determined, so entitlement cannot be \
+                 evaluated — refusing (CIRISEdge#499)",
+            ),
+            Self::ArrivalScopeInsufficient {
+                content_kind,
+                arrival_kind,
+            } => write!(
+                f,
+                "blob is scoped '{content_kind}' but the request arrived on a \
+                 '{arrival_kind}' address — reaching that address proves no \
+                 '{content_kind}' group-secret possession (CIRISEdge#499)"
+            ),
+            Self::GroupMismatch { content_kind } => write!(
+                f,
+                "request arrived on a '{content_kind}'-scoped address derived from a \
+                 DIFFERENT group's exporter_secret — possession of one group's secret \
+                 proves nothing about another's (CIRISEdge#499)"
+            ),
+        }
+    }
+}
+
+/// Whether an inbound blob-chunk request may be answered.
+///
+/// `#[must_use]` with a payload-carrying refusal arm, mirroring
+/// [`ApplyOutcome`](crate::replication::summary::ApplyOutcome)
+/// (CIRISEdge#425): the responder cannot drop this on the floor, and a
+/// refusal always arrives with a named reason to book and log. A bare
+/// `bool` would have made "refused" and "refused for a reason nobody can
+/// see" the same value — the exact silent-refusal class #423–#429 spent
+/// four cuts removing.
+#[must_use = "a serve admission carries a refusal reason the responder must book and log — do not drop it"]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServeAdmission {
+    /// Answer the request.
+    Admit,
+    /// Do not answer; book and log this reason, then reply with a typed
+    /// miss (`MissReason::PolicyDenied`).
+    Refuse(ServeRefusal),
+}
+
+impl ServeAdmission {
+    /// `true` iff the request may be answered.
+    #[must_use]
+    pub fn is_admitted(&self) -> bool {
+        matches!(self, Self::Admit)
+    }
+}
+
+/// The serve decision: may a peer that reached us on `arrival` be handed
+/// a chunk of content scoped `content`?
+///
+/// # The rule, and whose rule it is
+///
+/// The predicate is [`CohortScope::allows_recipient_scope`] — edge's
+/// EXISTING CIRISEdge#48-A recipient-determination rule, unchanged. What
+/// #499 changes is only the *provenance of the recipient scope input*:
+///
+/// - **Before**: the recipient's scope was a directory-recorded claim.
+/// - **Now**: it is the scope of the address the request physically
+///   arrived on. `Some(arrival)` exists only because a destination hash
+///   matched the [`ScopeAddressTable`]'s reverse index, and those hashes
+///   are derived from the group's MLS `exporter_secret` — so arrival is
+///   proof of group-secret possession, binding `(group_id, epoch)` per
+///   RFC 9420 §8.5.
+///
+/// A request that arrived on the federation address (`arrival == None`)
+/// is treated as `CohortScope::Public`, which is not a downgrade or an
+/// assumption — it is the literal truth about what reaching a public
+/// discovery address demonstrates, namely nothing beyond reachability.
+///
+/// Group identity is checked SEPARATELY from scope because the #48-A
+/// predicate structurally cannot see it (see
+/// [`ServeRefusal::GroupMismatch`]).
+///
+/// # Arming
+///
+/// `scope_native == false` ⇒ [`ServeAdmission::Admit`] unconditionally.
+/// See the module docs: a node with no address table has no scope-derived
+/// address for anyone to arrive on, so every request would arrive as
+/// `None` and a gate would refuse all non-public content on every
+/// existing deployment. Additive, not disruptive.
+pub fn admit_blob_serve(
+    scope_native: bool,
+    arrival: Option<&InboundAddress>,
+    content: Option<&ContentScope>,
+) -> ServeAdmission {
+    if !scope_native {
+        return ServeAdmission::Admit;
+    }
+
+    let Some(content) = content else {
+        return ServeAdmission::Refuse(ServeRefusal::ScopeUndeterminable);
+    };
+
+    // What the requester actually PROVED by the address it reached.
+    // `None` — the federation address — proves reachability and nothing
+    // else, which is exactly `Public`.
+    let arrival_scope = arrival.map_or(&CohortScope::Public, |a| a.group().scope());
+    let content_scope = content.cohort_scope();
+
+    if !content_scope.allows_recipient_scope(arrival_scope) {
+        return ServeAdmission::Refuse(ServeRefusal::ArrivalScopeInsufficient {
+            content_kind: content_scope.kind_token(),
+            arrival_kind: arrival_scope.kind_token(),
+        });
+    }
+
+    // Scope matched. If the content names a group, the arrival must name
+    // the SAME group: the exporter_secret that derived the arrival address
+    // belongs to exactly one group, and possession of it says nothing
+    // about any other. `Federation` content names no group and needs no
+    // such check — `(Public, _) => true` already admitted it above.
+    if let Some(group_id) = content.group_id() {
+        let arrival_group = arrival.map(|a| a.group().group_id());
+        if arrival_group != Some(group_id) {
+            return ServeAdmission::Refuse(ServeRefusal::GroupMismatch {
+                content_kind: content_scope.kind_token(),
+            });
+        }
+    }
+
+    ServeAdmission::Admit
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scope_addressing::StubDeriver;
+
+    const ALICE: &str = "ed25519:alice";
+    const BOB: &str = "ed25519:bob";
+    const MEMBERS: [&str; 2] = [ALICE, BOB];
+
+    fn cohort(id: &str) -> CohortScope {
+        CohortScope::Cohort {
+            cohort_id: id.to_owned(),
+        }
+    }
+
+    /// A table with one family group `fam-1` and one community group
+    /// `com-1`, each holding alice + bob.
+    fn table() -> Arc<ScopeAddressTable> {
+        let t = ScopeAddressTable::new(Arc::new(StubDeriver));
+        t.install_group(&CohortScope::Family, "fam-1", 1, &[0xA1; 32], &MEMBERS)
+            .expect("family install");
+        t.install_group(&cohort("neighbourhood"), "com-1", 1, &[0xB2; 32], &MEMBERS)
+            .expect("community install");
+        Arc::new(t)
+    }
+
+    fn family_content() -> ContentScope {
+        ContentScope::Group {
+            scope: CohortScope::Family,
+            group_id: "fam-1".to_owned(),
+        }
+    }
+
+    fn community_content() -> ContentScope {
+        ContentScope::Group {
+            scope: cohort("neighbourhood"),
+            group_id: "com-1".to_owned(),
+        }
+    }
+
+    /// Resolve the `InboundAddress` a peer would arrive on for a group.
+    fn arrival_for(t: &ScopeAddressTable, scope: &CohortScope, group: &str) -> InboundAddress {
+        let addr = t
+            .send_address(scope, group, ALICE)
+            .expect("alice has an address");
+        t.accepts_inbound(addr.as_bytes())
+            .expect("her own address is accepted inbound")
+    }
+
+    // ── SEND: routing ────────────────────────────────────────────────
+
+    #[test]
+    fn scoped_content_routes_to_the_derived_address_not_the_federation_one() {
+        let t = table();
+        let router = BlobScopeRouter::new(Some(Arc::clone(&t)));
+
+        let recipient = router
+            .route(Some(&family_content()), BOB)
+            .expect("bob is a member of fam-1");
+
+        assert!(
+            recipient.is_scoped(),
+            "a family-scoped blob must NOT be requested at the federation address",
+        );
+        assert_eq!(recipient.peer_key_id(), BOB);
+        assert_eq!(
+            recipient.scoped_address().map(MemberAddress::as_bytes),
+            t.send_address(&CohortScope::Family, "fam-1", BOB)
+                .as_ref()
+                .map(MemberAddress::as_bytes),
+            "the routed address must be exactly the table's derived bytes — no \
+             edge-side transformation",
+        );
+    }
+
+    #[test]
+    fn two_scopes_route_the_same_holder_to_unrelated_addresses() {
+        // The whole point of the cut: one peer, two contexts, two
+        // addresses — so an observer cannot correlate the family flow and
+        // the community flow to one endpoint.
+        let t = table();
+        let router = BlobScopeRouter::new(Some(t));
+
+        let fam = router.route(Some(&family_content()), BOB).expect("family");
+        let com = router
+            .route(Some(&community_content()), BOB)
+            .expect("community");
+
+        assert_ne!(
+            fam.scoped_address().map(MemberAddress::as_bytes),
+            com.scoped_address().map(MemberAddress::as_bytes),
+            "same holder, two scopes, one address = the context collapse #499 removes",
+        );
+    }
+
+    #[test]
+    fn federation_content_keeps_the_unscoped_route_on_a_scope_native_node() {
+        let router = BlobScopeRouter::new(Some(table()));
+        let r = router
+            .route(Some(&ContentScope::Federation), BOB)
+            .expect("public content always routes");
+        assert!(!r.is_scoped());
+        assert!(r.scoped_address().is_none());
+    }
+
+    #[test]
+    fn a_node_with_no_table_behaves_exactly_as_before() {
+        // The no-regression case. Every input that a legacy deployment can
+        // actually produce must yield the federation route.
+        let router = BlobScopeRouter::default();
+        assert!(!router.is_scope_native());
+
+        for content in [None, Some(&ContentScope::Federation)] {
+            let r = router.route(content, BOB).expect("legacy route");
+            assert!(
+                !r.is_scoped() && r.scoped_address().is_none(),
+                "a deployment with no installed address table must be byte-identical \
+                 to pre-#499",
+            );
+        }
+    }
+
+    #[test]
+    fn scoped_content_on_a_node_with_no_table_is_refused_not_downgraded() {
+        let router = BlobScopeRouter::default();
+        let err = router
+            .route(Some(&family_content()), BOB)
+            .expect_err("no table, no derived address");
+        assert_eq!(
+            err,
+            ScopeRouteRefusal::NoAddressTable {
+                scope_kind: "family",
+                group_id: "fam-1".to_owned(),
+            },
+            "the one thing that must NEVER happen is a silent fall back to the \
+             federation address",
+        );
+    }
+
+    #[test]
+    fn undeterminable_scope_is_refused_on_a_scope_native_node() {
+        let router = BlobScopeRouter::new(Some(table()));
+        assert_eq!(
+            router.route(None, BOB).expect_err("unknown scope"),
+            ScopeRouteRefusal::ScopeUndeterminable,
+        );
+        // ...and the legitimate route still works, so the refusal is not
+        // "refuse everything" wearing a reason.
+        assert!(router.route(Some(&family_content()), BOB).is_ok());
+    }
+
+    #[test]
+    fn a_non_member_holder_is_refused() {
+        let router = BlobScopeRouter::new(Some(table()));
+        let err = router
+            .route(Some(&family_content()), "ed25519:mallory")
+            .expect_err("mallory is not in fam-1");
+        assert_eq!(
+            err,
+            ScopeRouteRefusal::HolderNotInGroup {
+                peer_key_id: "ed25519:mallory".to_owned(),
+                scope_kind: "family",
+                group_id: "fam-1".to_owned(),
+            },
+        );
+        assert!(
+            router.route(Some(&family_content()), BOB).is_ok(),
+            "a member is still routable — the refusal is holder-specific",
+        );
+    }
+
+    #[test]
+    fn a_group_declared_at_public_scope_is_refused() {
+        // Mirrors `register_scoped_destination` refusing a Public scoped
+        // destination: a derived per-member address is not a discovery
+        // address.
+        let router = BlobScopeRouter::new(Some(table()));
+        let err = router
+            .route(
+                Some(&ContentScope::Group {
+                    scope: CohortScope::Public,
+                    group_id: "fam-1".to_owned(),
+                }),
+                BOB,
+            )
+            .expect_err("public + group is a contradiction");
+        assert_eq!(
+            err,
+            ScopeRouteRefusal::PublicIsNotScoped {
+                group_id: "fam-1".to_owned()
+            },
+        );
+    }
+
+    #[test]
+    fn a_sealed_out_holder_stops_being_routable_at_the_seal() {
+        let t = table();
+        let router = BlobScopeRouter::new(Some(Arc::clone(&t)));
+        assert!(router.route(Some(&family_content()), BOB).is_ok());
+
+        t.remove_member(&CohortScope::Family, "fam-1", BOB);
+        assert!(
+            matches!(
+                router.route(Some(&family_content()), BOB),
+                Err(ScopeRouteRefusal::HolderNotInGroup { .. })
+            ),
+            "a removed member must be refused, never silently federation-routed",
+        );
+        assert!(
+            router.route(Some(&family_content()), ALICE).is_ok(),
+            "removing bob must not deafen alice",
+        );
+    }
+
+    #[test]
+    fn reason_tags_are_distinct_and_low_cardinality() {
+        let tags = [
+            ScopeRouteRefusal::ScopeUndeterminable.reason_tag(),
+            ScopeRouteRefusal::NoAddressTable {
+                scope_kind: "family",
+                group_id: "g".into(),
+            }
+            .reason_tag(),
+            ScopeRouteRefusal::HolderNotInGroup {
+                peer_key_id: "p".into(),
+                scope_kind: "family",
+                group_id: "g".into(),
+            }
+            .reason_tag(),
+            ScopeRouteRefusal::PublicIsNotScoped {
+                group_id: "g".into(),
+            }
+            .reason_tag(),
+        ];
+        let uniq: std::collections::HashSet<_> = tags.iter().collect();
+        assert_eq!(uniq.len(), tags.len(), "one tag per branch");
+        for t in tags {
+            assert!(
+                !t.contains("ed25519") && !t.contains("fam-1"),
+                "a tag must never carry an id — it is a metric label",
+            );
+        }
+    }
+
+    // ── SERVE: admission ─────────────────────────────────────────────
+
+    #[test]
+    fn a_scoped_blob_is_served_to_a_peer_arriving_on_the_matching_address() {
+        let t = table();
+        let arrival = arrival_for(&t, &CohortScope::Family, "fam-1");
+        assert_eq!(
+            admit_blob_serve(true, Some(&arrival), Some(&family_content())),
+            ServeAdmission::Admit,
+        );
+    }
+
+    #[test]
+    fn a_scoped_blob_is_not_served_to_a_peer_arriving_on_the_federation_address() {
+        // THE headline refusal. `None` arrival == the federation address.
+        let admission = admit_blob_serve(true, None, Some(&family_content()));
+        assert_eq!(
+            admission,
+            ServeAdmission::Refuse(ServeRefusal::ArrivalScopeInsufficient {
+                content_kind: "family",
+                arrival_kind: "public",
+            }),
+        );
+        assert!(!admission.is_admitted());
+
+        // The trap this repo has been bitten by twice: a refusal test that
+        // passes by refusing everything. Assert a LEGITIMATE serve still
+        // succeeds under the identical gate.
+        let t = table();
+        let arrival = arrival_for(&t, &CohortScope::Family, "fam-1");
+        assert!(
+            admit_blob_serve(true, Some(&arrival), Some(&family_content())).is_admitted(),
+            "the gate must still admit the legitimate fetch",
+        );
+        assert!(
+            admit_blob_serve(true, None, Some(&ContentScope::Federation)).is_admitted(),
+            "and must still admit public content on the federation address",
+        );
+    }
+
+    #[test]
+    fn public_content_is_served_on_every_arrival() {
+        // The no-regression case, restated at the gate: `(Public, _) => true`.
+        let t = table();
+        let fam = arrival_for(&t, &CohortScope::Family, "fam-1");
+        let com = arrival_for(&t, &cohort("neighbourhood"), "com-1");
+        for arrival in [None, Some(&fam), Some(&com)] {
+            assert_eq!(
+                admit_blob_serve(true, arrival, Some(&ContentScope::Federation)),
+                ServeAdmission::Admit,
+            );
+        }
+    }
+
+    #[test]
+    fn undeterminable_scope_is_never_served_on_a_scope_native_node() {
+        let t = table();
+        let arrival = arrival_for(&t, &CohortScope::Family, "fam-1");
+        for a in [None, Some(&arrival)] {
+            assert_eq!(
+                admit_blob_serve(true, a, None),
+                ServeAdmission::Refuse(ServeRefusal::ScopeUndeterminable),
+                "an unknown scope is refused even to a proven group member — we \
+                 cannot know it is THEIR content",
+            );
+        }
+        // ...and a determinable blob still serves.
+        assert!(admit_blob_serve(true, Some(&arrival), Some(&family_content())).is_admitted());
+    }
+
+    #[test]
+    fn a_different_groups_address_does_not_unlock_same_scope_content() {
+        // `allows_recipient_scope` sees Family vs Family and says yes; the
+        // group check is what stops one family reading another's blob.
+        let t = ScopeAddressTable::new(Arc::new(StubDeriver));
+        t.install_group(&CohortScope::Family, "fam-1", 1, &[0xA1; 32], &MEMBERS)
+            .expect("fam-1");
+        t.install_group(&CohortScope::Family, "fam-2", 1, &[0xC3; 32], &MEMBERS)
+            .expect("fam-2");
+
+        let other_family = arrival_for(&t, &CohortScope::Family, "fam-2");
+        assert_eq!(
+            admit_blob_serve(true, Some(&other_family), Some(&family_content())),
+            ServeAdmission::Refuse(ServeRefusal::GroupMismatch {
+                content_kind: "family"
+            }),
+            "possession of fam-2's exporter_secret proves nothing about fam-1",
+        );
+
+        let own_family = arrival_for(&t, &CohortScope::Family, "fam-1");
+        assert!(
+            admit_blob_serve(true, Some(&own_family), Some(&family_content())).is_admitted(),
+            "the legitimate member is still served",
+        );
+    }
+
+    #[test]
+    fn a_community_address_does_not_unlock_family_content() {
+        let t = table();
+        let com = arrival_for(&t, &cohort("neighbourhood"), "com-1");
+        assert_eq!(
+            admit_blob_serve(true, Some(&com), Some(&family_content())),
+            ServeAdmission::Refuse(ServeRefusal::ArrivalScopeInsufficient {
+                content_kind: "family",
+                arrival_kind: "cohort",
+            }),
+        );
+    }
+
+    #[test]
+    fn a_different_cohort_id_does_not_unlock_community_content() {
+        let t = ScopeAddressTable::new(Arc::new(StubDeriver));
+        t.install_group(&cohort("neighbourhood"), "com-1", 1, &[0xB2; 32], &MEMBERS)
+            .expect("com-1");
+        t.install_group(&cohort("book-club"), "com-2", 1, &[0xD4; 32], &MEMBERS)
+            .expect("com-2");
+
+        let other = arrival_for(&t, &cohort("book-club"), "com-2");
+        assert_eq!(
+            admit_blob_serve(true, Some(&other), Some(&community_content())),
+            ServeAdmission::Refuse(ServeRefusal::ArrivalScopeInsufficient {
+                content_kind: "cohort",
+                arrival_kind: "cohort",
+            }),
+            "CohortScope::allows_recipient_scope compares cohort_id — a different \
+             community is refused at the scope predicate, before the group check",
+        );
+
+        let own = arrival_for(&t, &cohort("neighbourhood"), "com-1");
+        assert!(admit_blob_serve(true, Some(&own), Some(&community_content())).is_admitted());
+    }
+
+    #[test]
+    fn the_gate_is_disarmed_when_no_table_is_installed() {
+        // The no-regression case at the gate. A legacy node cannot produce
+        // a non-`None` arrival, so every request would otherwise be
+        // refused for all non-public content.
+        for content in [
+            None,
+            Some(&family_content()),
+            Some(&ContentScope::Federation),
+        ] {
+            assert_eq!(
+                admit_blob_serve(false, None, content),
+                ServeAdmission::Admit,
+                "a deployment with no address table must serve exactly as pre-#499",
+            );
+        }
+    }
+
+    #[test]
+    fn serve_refusal_reason_tags_are_distinct() {
+        let tags = [
+            ServeRefusal::ScopeUndeterminable.reason_tag(),
+            ServeRefusal::ArrivalScopeInsufficient {
+                content_kind: "family",
+                arrival_kind: "public",
+            }
+            .reason_tag(),
+            ServeRefusal::GroupMismatch {
+                content_kind: "family",
+            }
+            .reason_tag(),
+        ];
+        let uniq: std::collections::HashSet<_> = tags.iter().collect();
+        assert_eq!(uniq.len(), tags.len(), "one tag per branch (CIRISEdge#433)");
+    }
+
+    #[test]
+    fn every_serve_refusal_books_its_own_withhold_reason() {
+        // #433: the reason is the BRANCH, not a disjunction.
+        let reasons = [
+            ServeRefusal::ScopeUndeterminable.withhold_reason(),
+            ServeRefusal::ArrivalScopeInsufficient {
+                content_kind: "family",
+                arrival_kind: "public",
+            }
+            .withhold_reason(),
+            ServeRefusal::GroupMismatch {
+                content_kind: "family",
+            }
+            .withhold_reason(),
+        ];
+        let uniq: std::collections::HashSet<_> = reasons.iter().collect();
+        assert_eq!(uniq.len(), reasons.len());
+    }
+}

--- a/src/cohort_addressing.rs
+++ b/src/cohort_addressing.rs
@@ -1,0 +1,310 @@
+//! Cohort → scoped-address wiring (CIRISEdge#499).
+//!
+//! The join between [`crate::mls::CohortGroup`] (which holds the MLS
+//! group and therefore the epoch secret) and
+//! [`crate::scope_addressing::ScopeAddressTable`] (which holds the
+//! derived addresses). It is a separate module rather than a method on
+//! either because each has a property worth not breaking:
+//!
+//! - `scope_addressing` is **entirely synchronous** — no `async fn`, no
+//!   `.await` anywhere — so a lock guard cannot be held across a
+//!   suspension point even by accident (CIRISEdge#217). Adding an
+//!   `async` installer there would end that guarantee for the sake of
+//!   one function.
+//! - `mls::cohort_group` deliberately does not reach into transport
+//!   concerns; addressing is one.
+//!
+//! So the async part lives here, and it is the ONLY async in the path:
+//! read the secret, then call the table's sync verbs.
+//!
+//! # The secret never outlives the call
+//!
+//! [`CohortSecret`] is borrowed for the duration of an install and
+//! dropped; what persists in the table is only the 16-byte public
+//! addresses derived from it. That is the same discipline
+//! `ScopeAddressTable` already documents for `exporter_secret`.
+//!
+//! # Rotation
+//!
+//! MLS epochs advance per-member at slightly different wall-clock
+//! moments, so an epoch bump must never be a hard cutover. The two
+//! verbs here map onto the table's three phases:
+//!
+//! ```text
+//! join a cohort        → install_cohort_addresses   (phase 0: the only epoch)
+//! epoch advanced       → advance_cohort_addresses   (phase 1 + 2: install_next, activate_next)
+//! convergence elapsed  → ScopeAddressTable::seal_rotation (phase 3, caller's timing)
+//! ```
+//!
+//! Sealing is deliberately NOT done here. Phases 1 and 2 are driven by
+//! a fact this module can observe — the group's epoch changed — but
+//! phase 3 is a *timing* decision about how long stragglers get, and
+//! guessing it here would either strand slow peers or hold a superseded
+//! address open indefinitely.
+
+use crate::cohort_scope::CohortScope;
+use crate::mls::{CohortGroup, CohortGroupError};
+use crate::scope_addressing::{ScopeAddressError, ScopeAddressTable};
+
+/// Why a cohort's addresses could not be installed.
+#[derive(Debug, thiserror::Error)]
+pub enum CohortAddressError {
+    /// The group's exporter secret could not be derived — corrupted
+    /// group state.
+    #[error("cohort exporter: {0}")]
+    Exporter(#[from] CohortGroupError),
+    /// The address table refused the install.
+    #[error("scope address table: {0}")]
+    Table(#[from] ScopeAddressError),
+}
+
+/// Install a cohort's scoped addresses at its CURRENT epoch.
+///
+/// Call once, after joining or creating the group. The group id in the
+/// table is the `community_id`, and the members are the group's own
+/// roster — so the table's view cannot drift from MLS's without the
+/// roster itself changing.
+///
+/// # Errors
+/// [`CohortAddressError::Exporter`] on corrupted group state;
+/// [`CohortAddressError::Table`] if the community is already installed
+/// (use [`advance_cohort_addresses`] for a later epoch).
+pub async fn install_cohort_addresses(
+    table: &ScopeAddressTable,
+    scope: &CohortScope,
+    group: &CohortGroup,
+) -> Result<usize, CohortAddressError> {
+    let (epoch, members, secret) = read_epoch(group).await?;
+    Ok(table.install_group(
+        scope,
+        group.community_id(),
+        epoch,
+        secret.as_bytes(),
+        &members,
+    )?)
+}
+
+/// Move a cohort's addresses onto a NEW epoch, make-before-break.
+///
+/// Runs phases 1 and 2 together: the new epoch's addresses become
+/// reachable, then become the ones we send on, while the superseded
+/// epoch stays accepted for receive. A peer that advanced before us is
+/// answered the whole time, and a straggler that has not yet advanced
+/// keeps being addressed on the old epoch until the caller seals.
+///
+/// Both phases run against the SAME secret read, so the addresses
+/// installed and the addresses activated cannot come from two different
+/// epochs — which is the failure a naive `install_next(); activate();`
+/// pair would have if the group advanced between them.
+///
+/// # Errors
+/// [`CohortAddressError::Exporter`] on corrupted group state;
+/// [`CohortAddressError::Table`] if the community is not installed, or
+/// the epoch is already live.
+pub async fn advance_cohort_addresses(
+    table: &ScopeAddressTable,
+    scope: &CohortScope,
+    group: &CohortGroup,
+) -> Result<usize, CohortAddressError> {
+    let (epoch, members, secret) = read_epoch(group).await?;
+    let installed = table.install_next(
+        scope,
+        group.community_id(),
+        epoch,
+        secret.as_bytes(),
+        &members,
+    )?;
+    table.activate_next(scope, group.community_id())?;
+    Ok(installed)
+}
+
+/// Read `(epoch, roster, destination secret)` for the group's current
+/// epoch.
+///
+/// The three are read through separate locks rather than one, so a
+/// concurrent commit could in principle land between them. That is
+/// harmless *here* and worth stating: a torn read yields a
+/// `(secret, roster)` pair that is merely stale, and the table refuses
+/// a stale epoch on install (`AddressCollision` / the epoch checks)
+/// rather than silently mixing epochs. It is not a substitute for the
+/// group's own single-writer lock, which is what actually serializes
+/// commits.
+async fn read_epoch(
+    group: &CohortGroup,
+) -> Result<(u64, Vec<String>, crate::mls::CohortSecret), CohortGroupError> {
+    let epoch = group.epoch().await;
+    let members = group.member_key_ids().await;
+    // The DESTINATION plane secret specifically — never the record
+    // plane's, and never the A/V DEK seed. See
+    // `CohortGroup::destination_secret`.
+    let secret = group.destination_secret().await?;
+    Ok((epoch, members, secret))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mls::cohort_group::mint_cohort_key_material;
+    use crate::mls::{CohortGroup, ScopeStateProvider};
+    use crate::scope_addressing::ScopePrivacyDeriver;
+    use ciris_persist::encrypted_kv::XChaChaKvStore;
+    use std::sync::Arc;
+
+    fn store() -> ScopeStateProvider {
+        ScopeStateProvider::new(Arc::new(
+            XChaChaKvStore::open_in_memory(b"cohort-addressing-test").unwrap(),
+        ))
+    }
+
+    fn table() -> ScopeAddressTable {
+        ScopeAddressTable::new(Arc::new(ScopePrivacyDeriver))
+    }
+
+    fn scope() -> CohortScope {
+        CohortScope::Cohort {
+            cohort_id: "neighbourhood".to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn two_members_of_one_cohort_derive_each_others_addresses() {
+        // THE property the whole feature rests on. Both nodes hold the
+        // same MLS group, so both must compute the same 16 bytes for a
+        // given member — otherwise each addresses a hash the other
+        // never registered, and nothing errors anywhere: an RNS
+        // destination nobody registered is simply never delivered to.
+        let a = CohortGroup::create(store(), "c-addr", "node-a", 16)
+            .await
+            .unwrap();
+        let (material, kp) = mint_cohort_key_material("node-b").unwrap();
+        let add = a.add_member("node-b", kp).await.unwrap();
+        let b = CohortGroup::join(store(), "c-addr", material, add.welcome().unwrap(), 16)
+            .await
+            .unwrap();
+
+        let (ta, tb) = (table(), table());
+        install_cohort_addresses(&ta, &scope(), &a).await.unwrap();
+        install_cohort_addresses(&tb, &scope(), &b).await.unwrap();
+
+        for member in ["node-a", "node-b"] {
+            let from_a = ta.send_address(&scope(), "c-addr", member).unwrap();
+            let from_b = tb.send_address(&scope(), "c-addr", member).unwrap();
+            assert_eq!(
+                from_a.as_bytes(),
+                from_b.as_bytes(),
+                "both members must derive the SAME address for {member}",
+            );
+        }
+
+        // Per-member, not per-group: a shared hash would put both nodes
+        // under one RNS routing entry.
+        assert_ne!(
+            ta.send_address(&scope(), "c-addr", "node-a")
+                .unwrap()
+                .as_bytes(),
+            ta.send_address(&scope(), "c-addr", "node-b")
+                .unwrap()
+                .as_bytes(),
+        );
+    }
+
+    #[tokio::test]
+    async fn an_epoch_advance_re_addresses_without_deafening_the_old_epoch() {
+        let a = CohortGroup::create(store(), "c-rot", "node-a", 16)
+            .await
+            .unwrap();
+        let t = table();
+        install_cohort_addresses(&t, &scope(), &a).await.unwrap();
+        let before = *t
+            .send_address(&scope(), "c-rot", "node-a")
+            .unwrap()
+            .as_bytes();
+
+        let _rotated = a.rotate().await.unwrap();
+        advance_cohort_addresses(&t, &scope(), &a).await.unwrap();
+
+        let after = *t
+            .send_address(&scope(), "c-rot", "node-a")
+            .unwrap()
+            .as_bytes();
+        assert_ne!(before, after, "an epoch bump must move the address");
+
+        // Make-before-break: the OLD address is still accepted for
+        // receive, so a peer that has not yet advanced still reaches us.
+        assert!(
+            t.accepts_inbound(&before).is_some(),
+            "the superseded epoch must stay accepted until seal",
+        );
+        assert!(t.accepts_inbound(&after).is_some());
+
+        // ...and only stops after the caller seals.
+        t.seal_rotation(&scope(), "c-rot").unwrap();
+        assert!(
+            t.accepts_inbound(&before).is_none(),
+            "a sealed epoch is no longer ours",
+        );
+        assert!(t.accepts_inbound(&after).is_some());
+    }
+
+    #[tokio::test]
+    async fn a_different_cohort_yields_unrelated_addresses() {
+        // Unlinkability: the same node in two cohorts presents two
+        // addresses nothing correlates without the group secrets.
+        let one = CohortGroup::create(store(), "c-one", "node-a", 16)
+            .await
+            .unwrap();
+        let two = CohortGroup::create(store(), "c-two", "node-a", 16)
+            .await
+            .unwrap();
+        let t = table();
+        install_cohort_addresses(&t, &scope(), &one).await.unwrap();
+        install_cohort_addresses(&t, &scope(), &two).await.unwrap();
+
+        assert_ne!(
+            t.send_address(&scope(), "c-one", "node-a")
+                .unwrap()
+                .as_bytes(),
+            t.send_address(&scope(), "c-two", "node-a")
+                .unwrap()
+                .as_bytes(),
+            "one node in two cohorts must present unrelated addresses",
+        );
+    }
+
+    #[tokio::test]
+    async fn the_record_plane_secret_would_produce_different_addresses() {
+        // Guards the plane split from the inside: if this module ever
+        // reached for `record_secret` instead, every address would
+        // change and every peer would silently stop resolving us. The
+        // assertion is that the two planes are NOT interchangeable.
+        let g = CohortGroup::create(store(), "c-plane", "node-a", 16)
+            .await
+            .unwrap();
+        let t = table();
+        install_cohort_addresses(&t, &scope(), &g).await.unwrap();
+        let via_destination = *t
+            .send_address(&scope(), "c-plane", "node-a")
+            .unwrap()
+            .as_bytes();
+
+        let record = g.record_secret().await.unwrap();
+        let other = table();
+        other
+            .install_group(
+                &scope(),
+                "c-plane",
+                g.epoch().await,
+                record.as_bytes(),
+                &["node-a"],
+            )
+            .unwrap();
+        assert_ne!(
+            via_destination,
+            *other
+                .send_address(&scope(), "c-plane", "node-a")
+                .unwrap()
+                .as_bytes(),
+            "record and destination planes must not be interchangeable",
+        );
+    }
+}

--- a/src/cohort_addressing.rs
+++ b/src/cohort_addressing.rs
@@ -42,9 +42,8 @@
 //! guessing it here would either strand slow peers or hold a superseded
 //! address open indefinitely.
 
-use crate::cohort_scope::CohortScope;
 use crate::mls::{CohortGroup, CohortGroupError};
-use crate::scope_addressing::{ScopeAddressError, ScopeAddressTable};
+use crate::scope_lifecycle::ScopeGroupSnapshot;
 
 /// Why a cohort's addresses could not be installed.
 #[derive(Debug, thiserror::Error)]
@@ -53,102 +52,74 @@ pub enum CohortAddressError {
     /// group state.
     #[error("cohort exporter: {0}")]
     Exporter(#[from] CohortGroupError),
-    /// The address table refused the install.
-    #[error("scope address table: {0}")]
-    Table(#[from] ScopeAddressError),
 }
 
-/// Install a cohort's scoped addresses at its CURRENT epoch.
+/// **The adapter.** Reduce a community to the one shape the lifecycle
+/// takes.
 ///
-/// Call once, after joining or creating the group. The group id in the
-/// table is the `community_id`, and the members are the group's own
-/// roster — so the table's view cannot drift from MLS's without the
-/// roster itself changing.
+/// Identical in form to [`crate::av_addressing::snapshot`] — that is the
+/// point. Downstream writes the same two lines whether it is standing up
+/// a community or a call inside one:
+///
+/// ```ignore
+/// let snap = cohort_addressing::snapshot(&community).await?;
+/// lifecycle.install(&scope, &snap)?;
+/// ```
+///
+/// `async` only because a `CohortGroup`'s state lives behind the async
+/// mutex that gives it its single-writer property; the A/V twin is sync
+/// for the same reason inverted. That difference is exactly why the
+/// lifecycle takes a value rather than a trait — a common trait would
+/// have to be async and would not be `dyn`-safe.
+///
+/// The group id is namespaced (`cohort:{community_id}`) so a community
+/// and a call running inside it cannot collide in the table.
 ///
 /// # Errors
-/// [`CohortAddressError::Exporter`] on corrupted group state;
-/// [`CohortAddressError::Table`] if the community is already installed
-/// (use [`advance_cohort_addresses`] for a later epoch).
-pub async fn install_cohort_addresses(
-    table: &ScopeAddressTable,
-    scope: &CohortScope,
-    group: &CohortGroup,
-) -> Result<usize, CohortAddressError> {
-    let (epoch, members, secret) = read_epoch(group).await?;
-    Ok(table.install_group(
-        scope,
-        group.community_id(),
-        epoch,
-        secret.as_bytes(),
-        &members,
-    )?)
-}
-
-/// Move a cohort's addresses onto a NEW epoch, make-before-break.
-///
-/// Runs phases 1 and 2 together: the new epoch's addresses become
-/// reachable, then become the ones we send on, while the superseded
-/// epoch stays accepted for receive. A peer that advanced before us is
-/// answered the whole time, and a straggler that has not yet advanced
-/// keeps being addressed on the old epoch until the caller seals.
-///
-/// Both phases run against the SAME secret read, so the addresses
-/// installed and the addresses activated cannot come from two different
-/// epochs — which is the failure a naive `install_next(); activate();`
-/// pair would have if the group advanced between them.
-///
-/// # Errors
-/// [`CohortAddressError::Exporter`] on corrupted group state;
-/// [`CohortAddressError::Table`] if the community is not installed, or
-/// the epoch is already live.
-pub async fn advance_cohort_addresses(
-    table: &ScopeAddressTable,
-    scope: &CohortScope,
-    group: &CohortGroup,
-) -> Result<usize, CohortAddressError> {
-    let (epoch, members, secret) = read_epoch(group).await?;
-    let installed = table.install_next(
-        scope,
-        group.community_id(),
-        epoch,
-        secret.as_bytes(),
-        &members,
-    )?;
-    table.activate_next(scope, group.community_id())?;
-    Ok(installed)
-}
-
-/// Read `(epoch, roster, destination secret)` for the group's current
-/// epoch.
-///
-/// The three are read through separate locks rather than one, so a
-/// concurrent commit could in principle land between them. That is
-/// harmless *here* and worth stating: a torn read yields a
-/// `(secret, roster)` pair that is merely stale, and the table refuses
-/// a stale epoch on install (`AddressCollision` / the epoch checks)
-/// rather than silently mixing epochs. It is not a substitute for the
-/// group's own single-writer lock, which is what actually serializes
-/// commits.
-async fn read_epoch(
-    group: &CohortGroup,
-) -> Result<(u64, Vec<String>, crate::mls::CohortSecret), CohortGroupError> {
+/// [`CohortAddressError::Exporter`] on corrupted group state.
+pub async fn snapshot(group: &CohortGroup) -> Result<ScopeGroupSnapshot, CohortAddressError> {
+    // Three separate reads rather than one lock: a concurrent commit
+    // could in principle land between them, which is harmless HERE —
+    // a torn read yields a merely-stale (epoch, roster, secret), and the
+    // table refuses a stale epoch on install rather than mixing epochs.
+    // It is not a substitute for the group's own single-writer lock,
+    // which is what actually serializes commits.
     let epoch = group.epoch().await;
     let members = group.member_key_ids().await;
-    // The DESTINATION plane secret specifically — never the record
-    // plane's, and never the A/V DEK seed. See
-    // `CohortGroup::destination_secret`.
+    // The DESTINATION plane specifically — never the record plane's,
+    // and never the A/V DEK seed.
     let secret = group.destination_secret().await?;
-    Ok((epoch, members, secret))
+    Ok(ScopeGroupSnapshot {
+        group_id: format!("cohort:{}", group.community_id()),
+        epoch,
+        members,
+        destination_secret: *secret.as_bytes(),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cohort_scope::CohortScope;
     use crate::mls::cohort_group::mint_cohort_key_material;
     use crate::mls::{CohortGroup, ScopeStateProvider};
-    use crate::scope_addressing::ScopePrivacyDeriver;
+    use crate::scope_addressing::{MemberAddress, ScopeAddressTable, ScopePrivacyDeriver};
+    use crate::scope_lifecycle::{ScopeLifecycle, ScopedDestinationSink};
     use ciris_persist::encrypted_kv::XChaChaKvStore;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    #[derive(Default)]
+    struct Sink(Mutex<Vec<[u8; 16]>>);
+    impl ScopedDestinationSink for Sink {
+        fn register(&self, a: &MemberAddress, _s: &CohortScope) -> Result<(), String> {
+            self.0.lock().unwrap().push(*a.as_bytes());
+            Ok(())
+        }
+        fn retire(&self, _a: &MemberAddress, _s: &CohortScope) -> Result<(), String> {
+            Ok(())
+        }
+    }
 
     fn store() -> ScopeStateProvider {
         ScopeStateProvider::new(Arc::new(
@@ -156,8 +127,15 @@ mod tests {
         ))
     }
 
-    fn table() -> ScopeAddressTable {
-        ScopeAddressTable::new(Arc::new(ScopePrivacyDeriver))
+    fn node(own: &str) -> (ScopeLifecycle, Arc<ScopeAddressTable>) {
+        let table = Arc::new(ScopeAddressTable::new(Arc::new(ScopePrivacyDeriver)));
+        let life = ScopeLifecycle::new(
+            Arc::clone(&table),
+            Arc::new(Sink::default()),
+            own,
+            Duration::from_secs(300),
+        );
+        (life, table)
     }
 
     fn scope() -> CohortScope {
@@ -167,12 +145,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn two_members_of_one_cohort_derive_each_others_addresses() {
-        // THE property the whole feature rests on. Both nodes hold the
-        // same MLS group, so both must compute the same 16 bytes for a
-        // given member — otherwise each addresses a hash the other
-        // never registered, and nothing errors anywhere: an RNS
-        // destination nobody registered is simply never delivered to.
+    async fn two_members_of_one_community_derive_each_others_addresses() {
+        // THE property the feature rests on, driven through exactly the
+        // two lines downstream writes. If the two nodes disagree,
+        // nothing errors anywhere: an RNS destination nobody registered
+        // is simply never delivered to.
         let a = CohortGroup::create(store(), "c-addr", "node-a", 16)
             .await
             .unwrap();
@@ -182,27 +159,38 @@ mod tests {
             .await
             .unwrap();
 
-        let (ta, tb) = (table(), table());
-        install_cohort_addresses(&ta, &scope(), &a).await.unwrap();
-        install_cohort_addresses(&tb, &scope(), &b).await.unwrap();
+        let (life_a, table_a) = node("node-a");
+        let (life_b, table_b) = node("node-b");
+        life_a
+            .install(&scope(), &snapshot(&a).await.unwrap())
+            .unwrap();
+        life_b
+            .install(&scope(), &snapshot(&b).await.unwrap())
+            .unwrap();
 
+        let gid = format!("cohort:{}", a.community_id());
         for member in ["node-a", "node-b"] {
-            let from_a = ta.send_address(&scope(), "c-addr", member).unwrap();
-            let from_b = tb.send_address(&scope(), "c-addr", member).unwrap();
             assert_eq!(
-                from_a.as_bytes(),
-                from_b.as_bytes(),
+                table_a
+                    .send_address(&scope(), &gid, member)
+                    .unwrap()
+                    .as_bytes(),
+                table_b
+                    .send_address(&scope(), &gid, member)
+                    .unwrap()
+                    .as_bytes(),
                 "both members must derive the SAME address for {member}",
             );
         }
-
-        // Per-member, not per-group: a shared hash would put both nodes
-        // under one RNS routing entry.
+        // Per-member, never a shared group hash: a shared one puts both
+        // nodes under a single RNS routing entry.
         assert_ne!(
-            ta.send_address(&scope(), "c-addr", "node-a")
+            table_a
+                .send_address(&scope(), &gid, "node-a")
                 .unwrap()
                 .as_bytes(),
-            ta.send_address(&scope(), "c-addr", "node-b")
+            table_a
+                .send_address(&scope(), &gid, "node-b")
                 .unwrap()
                 .as_bytes(),
         );
@@ -210,45 +198,40 @@ mod tests {
 
     #[tokio::test]
     async fn an_epoch_advance_re_addresses_without_deafening_the_old_epoch() {
-        let a = CohortGroup::create(store(), "c-rot", "node-a", 16)
+        let g = CohortGroup::create(store(), "c-rot", "node-a", 16)
             .await
             .unwrap();
-        let t = table();
-        install_cohort_addresses(&t, &scope(), &a).await.unwrap();
-        let before = *t
-            .send_address(&scope(), "c-rot", "node-a")
-            .unwrap()
-            .as_bytes();
+        let (life, table) = node("node-a");
+        let first = life
+            .install(&scope(), &snapshot(&g).await.unwrap())
+            .unwrap();
 
-        let _rotated = a.rotate().await.unwrap();
-        advance_cohort_addresses(&t, &scope(), &a).await.unwrap();
+        let _commit = g.rotate().await.unwrap();
+        let t0 = std::time::Instant::now();
+        let second = life
+            .advance(&scope(), &snapshot(&g).await.unwrap(), t0)
+            .unwrap();
 
-        let after = *t
-            .send_address(&scope(), "c-rot", "node-a")
-            .unwrap()
-            .as_bytes();
-        assert_ne!(before, after, "an epoch bump must move the address");
-
-        // Make-before-break: the OLD address is still accepted for
-        // receive, so a peer that has not yet advanced still reaches us.
-        assert!(
-            t.accepts_inbound(&before).is_some(),
-            "the superseded epoch must stay accepted until seal",
-        );
-        assert!(t.accepts_inbound(&after).is_some());
-
-        // ...and only stops after the caller seals.
-        t.seal_rotation(&scope(), "c-rot").unwrap();
-        assert!(
-            t.accepts_inbound(&before).is_none(),
-            "a sealed epoch is no longer ours",
-        );
-        assert!(t.accepts_inbound(&after).is_some());
+        assert_ne!(first.own_address.as_bytes(), second.own_address.as_bytes());
+        // Make-before-break: the old address still answers until sealed.
+        assert!(table
+            .accepts_inbound(first.own_address.as_bytes())
+            .is_some());
+        assert!(table
+            .accepts_inbound(second.own_address.as_bytes())
+            .is_some());
+        life.seal_due(t0 + Duration::from_secs(300));
+        assert!(table
+            .accepts_inbound(first.own_address.as_bytes())
+            .is_none());
+        assert!(table
+            .accepts_inbound(second.own_address.as_bytes())
+            .is_some());
     }
 
     #[tokio::test]
-    async fn a_different_cohort_yields_unrelated_addresses() {
-        // Unlinkability: the same node in two cohorts presents two
+    async fn a_different_community_yields_unrelated_addresses() {
+        // Unlinkability: one node in two communities presents two
         // addresses nothing correlates without the group secrets.
         let one = CohortGroup::create(store(), "c-one", "node-a", 16)
             .await
@@ -256,55 +239,55 @@ mod tests {
         let two = CohortGroup::create(store(), "c-two", "node-a", 16)
             .await
             .unwrap();
-        let t = table();
-        install_cohort_addresses(&t, &scope(), &one).await.unwrap();
-        install_cohort_addresses(&t, &scope(), &two).await.unwrap();
-
+        let (life, table) = node("node-a");
+        life.install(&scope(), &snapshot(&one).await.unwrap())
+            .unwrap();
+        life.install(&scope(), &snapshot(&two).await.unwrap())
+            .unwrap();
         assert_ne!(
-            t.send_address(&scope(), "c-one", "node-a")
+            table
+                .send_address(&scope(), "cohort:c-one", "node-a")
                 .unwrap()
                 .as_bytes(),
-            t.send_address(&scope(), "c-two", "node-a")
+            table
+                .send_address(&scope(), "cohort:c-two", "node-a")
                 .unwrap()
                 .as_bytes(),
-            "one node in two cohorts must present unrelated addresses",
         );
     }
 
     #[tokio::test]
-    async fn the_record_plane_secret_would_produce_different_addresses() {
-        // Guards the plane split from the inside: if this module ever
-        // reached for `record_secret` instead, every address would
-        // change and every peer would silently stop resolving us. The
-        // assertion is that the two planes are NOT interchangeable.
+    async fn the_snapshot_carries_the_destination_plane_not_the_record_plane() {
+        // Guards the plane split from the inside. Note the two-member
+        // agreement test CANNOT catch this: both members would use the
+        // same wrong secret and still agree with each other.
         let g = CohortGroup::create(store(), "c-plane", "node-a", 16)
             .await
             .unwrap();
-        let t = table();
-        install_cohort_addresses(&t, &scope(), &g).await.unwrap();
-        let via_destination = *t
-            .send_address(&scope(), "c-plane", "node-a")
-            .unwrap()
-            .as_bytes();
-
-        let record = g.record_secret().await.unwrap();
-        let other = table();
-        other
-            .install_group(
-                &scope(),
-                "c-plane",
-                g.epoch().await,
-                record.as_bytes(),
-                &["node-a"],
-            )
-            .unwrap();
+        let snap = snapshot(&g).await.unwrap();
+        assert_eq!(
+            snap.destination_secret,
+            *g.destination_secret().await.unwrap().as_bytes(),
+        );
         assert_ne!(
-            via_destination,
-            *other
-                .send_address(&scope(), "c-plane", "node-a")
-                .unwrap()
-                .as_bytes(),
+            snap.destination_secret,
+            *g.record_secret().await.unwrap().as_bytes(),
             "record and destination planes must not be interchangeable",
+        );
+    }
+
+    #[tokio::test]
+    async fn the_group_id_namespaces_a_community_apart_from_a_call() {
+        // A community and an A/V call inside it are separate groups with
+        // separate secrets; their table ids must not collide either.
+        let g = CohortGroup::create(store(), "c-ns", "node-a", 16)
+            .await
+            .unwrap();
+        let snap = snapshot(&g).await.unwrap();
+        assert_eq!(snap.group_id, "cohort:c-ns");
+        assert!(
+            !snap.group_id.starts_with("av-stream:"),
+            "the two namespaces must be disjoint",
         );
     }
 }

--- a/src/contextual_integrity.rs
+++ b/src/contextual_integrity.rs
@@ -1,0 +1,385 @@
+//! What was delivered, and why — in the vocabulary of the commitment
+//! (<https://ciris.ai/contextual-integrity>).
+//!
+//! # Why this module exists
+//!
+//! Edge's design thesis is that **"the strongest flow rule is one the
+//! network cannot express breaking"**, and its serve path already
+//! enforces that: a record reaches a peer only after passing the
+//! projection filter, the consent gate, the capability restriction, the
+//! quarantine check, the accord relay gate, and — since CIRISEdge#499 —
+//! the scope-address admission.
+//!
+//! Every one of those gates enforces a *specific* commitment. But that
+//! attribution lived only in prose. A [`WithholdReason`] said what
+//! mechanism refused; nothing said **which promise to the data subject
+//! that mechanism keeps**. So "why was this withheld" could be answered
+//! in edge's vocabulary and not in the vocabulary the commitment is
+//! written in — which is the one an operator, an auditor, or a data
+//! subject actually asks in.
+//!
+//! This module is that attribution, and it is **total by compile
+//! error**.
+//!
+//! # Nissenbaum's five parameters, as edge's wire fields
+//!
+//! Contextual integrity defines privacy as **appropriate flow**, and a
+//! violation as a breach of context-relative norms across five
+//! parameters. Edge maps each onto a signed wire field:
+//!
+//! | parameter | edge's field |
+//! |---|---|
+//! | data subject | `subject_key_ids` |
+//! | sender | `attesting_key_id` |
+//! | recipient | `cohort_scope` · `subject_key_ids` · `delivery_mode` |
+//! | information type | `dimension` |
+//! | transmission principle | `consent:scope` |
+//!
+//! [`CiParameter`] is those five. [`parameter_of`] says which one each
+//! refusal defends.
+//!
+//! # The guard, and why it is a compile error
+//!
+//! [`parameter_of`] matches [`WithholdReason`] **exhaustively, with no
+//! wildcard**. `WithholdReason` is edge's own enum and is not
+//! `#[non_exhaustive]`, so adding a gate without saying which commitment
+//! it serves **fails the build**.
+//!
+//! That is deliberate, and it is the strongest form available here.
+//! Edge could not get this guard for persist's `AttestationFamily` —
+//! that enum is `#[non_exhaustive]`, so a downstream match must carry a
+//! wildcard and can never be exhaustive (see [`crate::family_gates`],
+//! which falls back to a loud-and-restrictive wildcard instead). Here
+//! the enum is edge's, so the compiler can hold the invariant directly:
+//! **a new way to withhold cannot enter this codebase anonymously.**
+//!
+//! # What this module is NOT
+//!
+//! It makes **no decisions**. Every verdict is still the gate's; this
+//! only names, after the fact, which commitment a verdict served.
+//! Re-deriving any gate's rule here would be a second implementation of
+//! it — the precise defect class this repo has spent the last several
+//! releases removing.
+
+use crate::observability::WithholdReason;
+
+/// One of the five parameters an information-flow norm is defined over
+/// (Nissenbaum; <https://ciris.ai/contextual-integrity>).
+///
+/// A flow is *appropriate* when it conforms on all five. A refusal is
+/// edge declining to participate in a flow that would not.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum CiParameter {
+    /// **Data subject** — who the claim is about. Edge's
+    /// `subject_key_ids`, which puts revocation at the wire level
+    /// rather than the application layer.
+    DataSubject,
+    /// **Sender** — who originated the claim. Edge's
+    /// `attesting_key_id`: every flow has a named, cryptographic
+    /// source, and a frame edge cannot attribute is dropped before any
+    /// handler sees it.
+    Sender,
+    /// **Recipient** — who may receive. Edge keeps three axes distinct
+    /// on purpose: `cohort_scope` (visibility), `subject_key_ids`
+    /// (revocation authority) and `delivery_mode` (active receipt).
+    /// Collapsing them is how "can see" quietly becomes "will be sent".
+    Recipient,
+    /// **Information type** — what is being claimed. Edge's `dimension`
+    /// namespace, whose prefixes carry objective, machine-checkable
+    /// admission tests rather than a human category.
+    InformationType,
+    /// **Transmission principle** — the rule the flow must follow:
+    /// retain, share, analyze, train, publish, with limits. Edge's
+    /// `consent:scope`, as a signed and revocable wire commitment.
+    /// CIRIS calls this the decisive differentiator, because it is the
+    /// parameter most systems leave in prose.
+    TransmissionPrinciple,
+}
+
+impl CiParameter {
+    /// A stable token, for logs and metrics.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::DataSubject => "data_subject",
+            Self::Sender => "sender",
+            Self::Recipient => "recipient",
+            Self::InformationType => "information_type",
+            Self::TransmissionPrinciple => "transmission_principle",
+        }
+    }
+
+    /// The commitment, in the words an operator or data subject would
+    /// use — not edge's mechanism vocabulary.
+    #[must_use]
+    pub fn commitment(self) -> &'static str {
+        match self {
+            Self::DataSubject => "a claim about you carries your revocation authority on the wire",
+            Self::Sender => "every claim has a named cryptographic source",
+            Self::Recipient => "a claim reaches only the context it was made in",
+            Self::InformationType => "what is claimed is what the namespace admits",
+            Self::TransmissionPrinciple => "the flow follows the rule its consent grant names",
+        }
+    }
+}
+
+/// Which commitment this refusal defends.
+///
+/// **Exhaustive, no wildcard, on purpose.** Adding a [`WithholdReason`]
+/// without attributing it here does not compile. See the module docs.
+#[must_use]
+// The arms are grouped by REASONING, not by value: three separate groups
+// map to `Recipient` because they defend it for three different reasons
+// (the consent-resolved send set, CC 4.2.1 accord carriage, and #499
+// scope-address admission), and each carries the comment that says which.
+// Collapsing them into one arm would satisfy the lint by deleting exactly
+// the attribution this module exists to record. The allow sits directly on
+// the function so nothing can be inserted between it and its target
+// (a displacement that has bitten this repo before).
+#[allow(clippy::match_same_arms)]
+pub fn parameter_of(reason: WithholdReason) -> CiParameter {
+    match reason {
+        // ── Recipient ───────────────────────────────────────────────
+        // The scope/consent-resolved send set IS the recipient axis:
+        // these are edge declining to move a claim outside the context
+        // it was made in.
+        WithholdReason::SendSetUnresolved
+        | WithholdReason::RecipientNotInSendSet
+        | WithholdReason::ConfigPaused => CiParameter::Recipient,
+
+        // CC 4.2.1 — "a node that never trusted the accord is simply
+        // not reached". Carriage narrowed to the accord's own roster is
+        // a recipient bound, not an information-type one: the dimension
+        // is admitted, the audience is not.
+        WithholdReason::AccordRelayRosterUnresolvable
+        | WithholdReason::AccordRelaySignerNotSeated
+        | WithholdReason::AccordRelayNoTrustEdge
+        | WithholdReason::AccordRelayUnresolved
+        | WithholdReason::AccordRelayObjectRootUnnamed
+        | WithholdReason::AccordRelayObjectRootDisagrees => CiParameter::Recipient,
+
+        // CIRISEdge#499 — arrival on a scope-derived address is the
+        // recipient's *demonstration* of context membership, replacing
+        // a directory claim about it. A peer that cannot demonstrate it
+        // is outside the context.
+        WithholdReason::BlobScopeUndeterminable
+        | WithholdReason::BlobArrivalScopeInsufficient
+        | WithholdReason::BlobArrivalGroupMismatch => CiParameter::Recipient,
+
+        // ── Transmission principle ──────────────────────────────────
+        // The serve capability and the per-record restriction are the
+        // grant's own terms: not "who may see" but "under what rule
+        // this may move". `infra:serve` is the capability the grant
+        // requires of a carrier; the restriction is the limit written
+        // into the grant itself.
+        WithholdReason::ServeCapabilityMissing
+        | WithholdReason::ServeCapabilityReadError
+        | WithholdReason::ServeCapabilityNotRooted
+        | WithholdReason::RecipientCapabilityRestriction => CiParameter::TransmissionPrinciple,
+
+        // ── Sender ──────────────────────────────────────────────────
+        // Every flow must have a named, rooted, non-quarantined source.
+        // A trust-root walk failure is "I cannot establish who this is
+        // from", which is a sender question even though it reads like
+        // infrastructure.
+        WithholdReason::LocalIdentityMissing
+        | WithholdReason::TrustRootWalkError
+        | WithholdReason::QuarantinedAuthor
+        | WithholdReason::QuarantineReadError => CiParameter::Sender,
+
+        // The row is not the type it claims, or its signed mirror does
+        // not bind its columns — so the named source is not established
+        // for the bytes on offer.
+        WithholdReason::AccordRelayObjectUnreadable | WithholdReason::AccordRelayMirrorUnbound => {
+            CiParameter::Sender
+        }
+
+        // ── Information type ────────────────────────────────────────
+        // Persist's classifier says this row is not on the family the
+        // gate exists for — a claim about WHAT this is, not who may
+        // have it.
+        WithholdReason::AccordRelayObjectNotAccord => CiParameter::InformationType,
+
+        // ── Data subject ────────────────────────────────────────────
+        // A record edge cannot fetch, serialize or hash cannot have its
+        // subject's revocation authority honoured on the wire, because
+        // the fields that carry it are unreadable. Fail closed rather
+        // than move bytes whose subject bindings we cannot read.
+        WithholdReason::EnvelopeUnfetchable
+        | WithholdReason::RowNotSerializable
+        | WithholdReason::RowHashUndecodable => CiParameter::DataSubject,
+    }
+}
+
+/// A delivery decision, in commitment terms.
+///
+/// The value a serve path can hand an operator, an audit log, or a
+/// downstream that must explain itself: **what happened, and which
+/// promise it kept**.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delivery {
+    /// The flow conformed on every parameter edge evaluates, and the
+    /// record was offered.
+    Delivered,
+    /// Edge declined to participate. Carries the mechanism that refused
+    /// AND the commitment that refusal defends, so the answer is
+    /// legible in both vocabularies at once.
+    Withheld {
+        /// The gate that refused — edge's mechanism vocabulary.
+        reason: WithholdReason,
+        /// The commitment it defends — the vocabulary the promise is
+        /// written in.
+        parameter: CiParameter,
+    },
+}
+
+impl Delivery {
+    /// Build a refusal, attributing it automatically. There is no way
+    /// to construct a `Withheld` whose parameter disagrees with its
+    /// reason.
+    #[must_use]
+    pub fn withheld(reason: WithholdReason) -> Self {
+        Self::Withheld {
+            reason,
+            parameter: parameter_of(reason),
+        }
+    }
+
+    /// Whether the record was offered.
+    #[must_use]
+    pub fn delivered(self) -> bool {
+        matches!(self, Self::Delivered)
+    }
+
+    /// One line, in the commitment's vocabulary — for an operator log
+    /// or a subject-facing explanation.
+    #[must_use]
+    pub fn explain(self) -> String {
+        match self {
+            Self::Delivered => "delivered: the flow conformed on every evaluated parameter".into(),
+            Self::Withheld { reason, parameter } => format!(
+                "withheld [{}] to keep the commitment that {} (gate: {})",
+                parameter.as_str(),
+                parameter.commitment(),
+                reason.as_str(),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every refusal edge can produce is attributed. The compiler
+    /// already guarantees totality — this pins that the mapping is
+    /// *reachable* and self-consistent, and that `withheld` cannot
+    /// disagree with `parameter_of`.
+    #[test]
+    fn every_withhold_reason_is_attributed_consistently() {
+        for reason in ALL_REASONS {
+            let d = Delivery::withheld(reason);
+            let Delivery::Withheld { parameter, .. } = d else {
+                panic!("withheld() must produce Withheld");
+            };
+            assert_eq!(
+                parameter,
+                parameter_of(reason),
+                "{} attributed inconsistently",
+                reason.as_str(),
+            );
+            assert!(!d.delivered());
+            assert!(
+                d.explain().contains(parameter.as_str()),
+                "the explanation must name the commitment it kept",
+            );
+        }
+    }
+
+    /// The five parameters are all live — not four with one aspirational.
+    /// If a parameter has no gate defending it, that is a hole in the
+    /// enforcement, and it should be visible here rather than implied by
+    /// the module's prose.
+    #[test]
+    fn all_five_parameters_have_at_least_one_gate_defending_them() {
+        use std::collections::BTreeSet;
+        let covered: BTreeSet<CiParameter> =
+            ALL_REASONS.iter().copied().map(parameter_of).collect();
+        for p in [
+            CiParameter::DataSubject,
+            CiParameter::Sender,
+            CiParameter::Recipient,
+            CiParameter::InformationType,
+            CiParameter::TransmissionPrinciple,
+        ] {
+            assert!(
+                covered.contains(&p),
+                "no gate defends the {} parameter — the commitment is prose, not enforcement",
+                p.as_str(),
+            );
+        }
+    }
+
+    /// The recipient axis carries the most gates, and that is expected
+    /// rather than accidental: it is the parameter edge's transport
+    /// layer is uniquely positioned to enforce, and the one CIRISEdge#499
+    /// spent this release closing. Pinned so a future refactor that
+    /// silently moves gates off it is visible.
+    #[test]
+    fn the_recipient_axis_is_the_most_defended() {
+        let counts = |p: CiParameter| {
+            ALL_REASONS
+                .iter()
+                .filter(|r| parameter_of(**r) == p)
+                .count()
+        };
+        let recipient = counts(CiParameter::Recipient);
+        for p in [
+            CiParameter::DataSubject,
+            CiParameter::Sender,
+            CiParameter::InformationType,
+            CiParameter::TransmissionPrinciple,
+        ] {
+            assert!(
+                recipient > counts(p),
+                "recipient ({recipient}) should out-gate {} ({})",
+                p.as_str(),
+                counts(p),
+            );
+        }
+    }
+
+    /// Every reason edge defines. Hand-listed because there is no
+    /// `strum`-style iteration on the enum — but `parameter_of`'s
+    /// exhaustive match is what actually guarantees totality, so a
+    /// reason missing from THIS list weakens the tests, never the
+    /// invariant.
+    const ALL_REASONS: [WithholdReason; 26] = [
+        WithholdReason::EnvelopeUnfetchable,
+        WithholdReason::LocalIdentityMissing,
+        WithholdReason::SendSetUnresolved,
+        WithholdReason::RecipientNotInSendSet,
+        WithholdReason::ServeCapabilityMissing,
+        WithholdReason::ServeCapabilityReadError,
+        WithholdReason::ServeCapabilityNotRooted,
+        WithholdReason::TrustRootWalkError,
+        WithholdReason::RecipientCapabilityRestriction,
+        WithholdReason::RowNotSerializable,
+        WithholdReason::RowHashUndecodable,
+        WithholdReason::ConfigPaused,
+        WithholdReason::QuarantinedAuthor,
+        WithholdReason::QuarantineReadError,
+        WithholdReason::AccordRelayRosterUnresolvable,
+        WithholdReason::AccordRelaySignerNotSeated,
+        WithholdReason::AccordRelayNoTrustEdge,
+        WithholdReason::AccordRelayUnresolved,
+        WithholdReason::AccordRelayObjectUnreadable,
+        WithholdReason::AccordRelayMirrorUnbound,
+        WithholdReason::AccordRelayObjectNotAccord,
+        WithholdReason::AccordRelayObjectRootUnnamed,
+        WithholdReason::AccordRelayObjectRootDisagrees,
+        WithholdReason::BlobScopeUndeterminable,
+        WithholdReason::BlobArrivalScopeInsufficient,
+        WithholdReason::BlobArrivalGroupMismatch,
+    ];
+}

--- a/src/contextual_integrity.rs
+++ b/src/contextual_integrity.rs
@@ -166,6 +166,20 @@ pub fn parameter_of(reason: WithholdReason) -> CiParameter {
         | WithholdReason::BlobArrivalScopeInsufficient
         | WithholdReason::BlobArrivalGroupMismatch => CiParameter::Recipient,
 
+        // CIRISEdge#499 (holdings plane) — "I hold this" is itself a
+        // flow, and before this cut a family-scoped holding's content id
+        // AND symbol ids were announced on a timer to every peer the
+        // cohort callback returned. All four defend the same commitment
+        // — a claim reaches only the context it was made in — and are
+        // four variants rather than one because each sends the operator
+        // somewhere different: fix the wiring, fix the declaration, fix
+        // the roster, or await a persist widening. Different remedies,
+        // same promise.
+        WithholdReason::HoldingScopeUndeterminable
+        | WithholdReason::HoldingScopePublicGroup
+        | WithholdReason::HoldingScopePeerNotInRoster
+        | WithholdReason::HoldingScopeProjectionUnsupported => CiParameter::Recipient,
+
         // ── Transmission principle ──────────────────────────────────
         // The serve capability and the per-record restriction are the
         // grant's own terms: not "who may see" but "under what rule
@@ -354,7 +368,7 @@ mod tests {
     /// exhaustive match is what actually guarantees totality, so a
     /// reason missing from THIS list weakens the tests, never the
     /// invariant.
-    const ALL_REASONS: [WithholdReason; 26] = [
+    const ALL_REASONS: [WithholdReason; 30] = [
         WithholdReason::EnvelopeUnfetchable,
         WithholdReason::LocalIdentityMissing,
         WithholdReason::SendSetUnresolved,
@@ -381,5 +395,9 @@ mod tests {
         WithholdReason::BlobScopeUndeterminable,
         WithholdReason::BlobArrivalScopeInsufficient,
         WithholdReason::BlobArrivalGroupMismatch,
+        WithholdReason::HoldingScopeUndeterminable,
+        WithholdReason::HoldingScopePublicGroup,
+        WithholdReason::HoldingScopePeerNotInRoster,
+        WithholdReason::HoldingScopeProjectionUnsupported,
     ];
 }

--- a/src/contextual_integrity.rs
+++ b/src/contextual_integrity.rs
@@ -180,6 +180,18 @@ pub fn parameter_of(reason: WithholdReason) -> CiParameter {
         | WithholdReason::HoldingScopePeerNotInRoster
         | WithholdReason::HoldingScopeProjectionUnsupported => CiParameter::Recipient,
 
+        // CIRISEdge#169 (LXMF propagation host) — serving as a propagation
+        // node means moving someone ELSE's claim on their behalf, so the
+        // recipient axis is where its two identity gates land. The mailbox
+        // is indexed BY destination, which makes "you may read only your
+        // own mail" structural rather than a filter; these two are what
+        // that structure says out loud when it refuses. Off-roster is a
+        // context this node does not carry into at all; a scope mismatch
+        // is a requester reaching for a context that is not theirs.
+        WithholdReason::LxmfDestinationNotServed | WithholdReason::LxmfMailboxScopeMismatch => {
+            CiParameter::Recipient
+        }
+
         // ── Transmission principle ──────────────────────────────────
         // The serve capability and the per-record restriction are the
         // grant's own terms: not "who may see" but "under what rule
@@ -190,6 +202,30 @@ pub fn parameter_of(reason: WithholdReason) -> CiParameter {
         | WithholdReason::ServeCapabilityReadError
         | WithholdReason::ServeCapabilityNotRooted
         | WithholdReason::RecipientCapabilityRestriction => CiParameter::TransmissionPrinciple,
+
+        // CIRISEdge#169 — a propagation node's TERMS OF CARRIAGE. Each of
+        // these is the node's published rule about how a flow may pass
+        // through it, refusing a flow that does not meet it:
+        //   * `LxmfPropagationDisabled` — this node does not carry
+        //     third-party mail at all (the default posture).
+        //   * `LxmfStampBelowCost` — the proof-of-work cost the node
+        //     ANNOUNCES is the price of carriage; an unpaid upload has not
+        //     met the offered rule.
+        //   * `LxmfFrameOversized` / `LxmfMailboxFull` — the size and
+        //     capacity ceilings the node commits to, refusing rather than
+        //     silently growing to accommodate a stranger.
+        //   * `LxmfRetentionExpired` — the bounded-retention promise
+        //     itself: "held, but only this long". This is the parameter
+        //     Nissenbaum describes as retain-with-limits, and it is the
+        //     whole reason edge will not quietly become a mailbox.
+        // None of these is a claim about WHO may receive — an on-roster
+        // recipient whose mail expires was refused by the clock, not by
+        // the audience.
+        WithholdReason::LxmfPropagationDisabled
+        | WithholdReason::LxmfStampBelowCost
+        | WithholdReason::LxmfFrameOversized
+        | WithholdReason::LxmfMailboxFull
+        | WithholdReason::LxmfRetentionExpired => CiParameter::TransmissionPrinciple,
 
         // ── Sender ──────────────────────────────────────────────────
         // Every flow must have a named, rooted, non-quarantined source.
@@ -208,11 +244,32 @@ pub fn parameter_of(reason: WithholdReason) -> CiParameter {
             CiParameter::Sender
         }
 
+        // CIRISEdge#169 — a `/get` on a link whose remote identity edge
+        // could not resolve. Deliberately NOT `Recipient`, though it is a
+        // request to receive: what actually failed is attribution, and
+        // this is the same commitment the E3 unattributed-frame drop
+        // keeps — a frame edge cannot attribute gets no service. Reading
+        // it as a recipient gate would misfile the remedy (identify the
+        // link, not amend the roster).
+        WithholdReason::LxmfRequesterUnidentified => CiParameter::Sender,
+
         // ── Information type ────────────────────────────────────────
         // Persist's classifier says this row is not on the family the
         // gate exists for — a claim about WHAT this is, not who may
         // have it.
         WithholdReason::AccordRelayObjectNotAccord => CiParameter::InformationType,
+
+        // CIRISEdge#169 — "these bytes are not what this endpoint
+        // admits". `LxmfWireUnparseable` is malformed input;
+        // `LxmfPeerSyncUnsupported` is the crate's own distinction —
+        // a well-formed MULTI-message upload is the node-to-node
+        // `/offer` sync form, i.e. a message for an endpoint edge does
+        // not serve (leviculum#209), not a broken one. Two variants
+        // because the operator goes somewhere different for each, one
+        // parameter because both answer WHAT rather than WHO.
+        WithholdReason::LxmfWireUnparseable | WithholdReason::LxmfPeerSyncUnsupported => {
+            CiParameter::InformationType
+        }
 
         // ── Data subject ────────────────────────────────────────────
         // A record edge cannot fetch, serialize or hash cannot have its
@@ -368,7 +425,7 @@ mod tests {
     /// exhaustive match is what actually guarantees totality, so a
     /// reason missing from THIS list weakens the tests, never the
     /// invariant.
-    const ALL_REASONS: [WithholdReason; 30] = [
+    const ALL_REASONS: [WithholdReason; 40] = [
         WithholdReason::EnvelopeUnfetchable,
         WithholdReason::LocalIdentityMissing,
         WithholdReason::SendSetUnresolved,
@@ -399,5 +456,15 @@ mod tests {
         WithholdReason::HoldingScopePublicGroup,
         WithholdReason::HoldingScopePeerNotInRoster,
         WithholdReason::HoldingScopeProjectionUnsupported,
+        WithholdReason::LxmfPropagationDisabled,
+        WithholdReason::LxmfDestinationNotServed,
+        WithholdReason::LxmfRequesterUnidentified,
+        WithholdReason::LxmfMailboxScopeMismatch,
+        WithholdReason::LxmfStampBelowCost,
+        WithholdReason::LxmfWireUnparseable,
+        WithholdReason::LxmfPeerSyncUnsupported,
+        WithholdReason::LxmfFrameOversized,
+        WithholdReason::LxmfMailboxFull,
+        WithholdReason::LxmfRetentionExpired,
     ];
 }

--- a/src/contextual_integrity.rs
+++ b/src/contextual_integrity.rs
@@ -191,16 +191,28 @@ pub fn parameter_of(reason: WithholdReason) -> CiParameter {
         // CIRISEdge#499 (holdings plane) — "I hold this" is itself a
         // flow, and before this cut a family-scoped holding's content id
         // AND symbol ids were announced on a timer to every peer the
-        // cohort callback returned. All four defend the same commitment
-        // — a claim reaches only the context it was made in — and are
-        // four variants rather than one because each sends the operator
-        // somewhere different: fix the wiring, fix the declaration, fix
-        // the roster, or await a persist widening. Different remedies,
-        // same promise.
+        // cohort callback returned. All of these defend the same
+        // commitment — a claim reaches only the context it was made in —
+        // and are separate variants rather than one because each sends
+        // the operator somewhere different: fix the declaration, fix the
+        // roster, or await a persist widening. Different remedies, same
+        // promise.
+        //
+        // CIRISPersist#744 adds the two verdict-side arms. Both are the
+        // RECIPIENT axis because they are persist answering "who may be
+        // told", not a claim about the publisher: `RecipientSetUnresolved`
+        // is persist declining to name the audience ("I cannot judge"),
+        // and `RecipientReadError` is that same question left unanswered
+        // by a fault. Neither is a statement about the peer — which is
+        // exactly why they are not folded into `PeerNotInRoster` — but
+        // both are edge refusing to move a claim it cannot bound to a
+        // context, which is the recipient commitment.
         WithholdReason::HoldingScopeUndeterminable
         | WithholdReason::HoldingScopePublicGroup
         | WithholdReason::HoldingScopePeerNotInRoster
-        | WithholdReason::HoldingScopeProjectionUnsupported => CiParameter::Recipient,
+        | WithholdReason::HoldingScopeProjectionUnsupported
+        | WithholdReason::HoldingScopeRecipientSetUnresolved
+        | WithholdReason::HoldingScopeRecipientReadError => CiParameter::Recipient,
 
         // ── Transmission principle ──────────────────────────────────
         // The serve capability and the per-record restriction are the
@@ -222,6 +234,28 @@ pub fn parameter_of(reason: WithholdReason) -> CiParameter {
         | WithholdReason::TrustRootWalkError
         | WithholdReason::QuarantinedAuthor
         | WithholdReason::QuarantineReadError => CiParameter::Sender,
+
+        // CIRISPersist#744 (holdings plane) — the two PUBLISHER-side
+        // arms, and they are Sender for the reason the group above
+        // states rather than Recipient by default.
+        //
+        // `HoldingScopeAuthorityUnresolved` IS a trust-root walk failure:
+        // `holdings_authority` is `is_canonical_effective ||
+        // is_infra_attest_effective` over the publisher's key. It is the
+        // same question as `TrustRootWalkError` asked on the holdings
+        // plane — "I cannot establish who this is from" — so it takes the
+        // same attribution. Filing it under Recipient would say edge
+        // declined to reach a peer, when what actually happened is that
+        // edge could not establish its own publisher's standing.
+        //
+        // `HoldingScopeDirectoryMissing` is the wiring twin, and it sits
+        // here for the reason `LocalIdentityMissing` does: with no
+        // directory there is no verified state in which the publisher's
+        // authority class exists to be resolved. That call is also
+        // strictly first — the recipient verb TAKES the authority as an
+        // input — so the parameter that fails first is the sender's.
+        WithholdReason::HoldingScopeAuthorityUnresolved
+        | WithholdReason::HoldingScopeDirectoryMissing => CiParameter::Sender,
 
         // The row is not the type it claims, or its signed mirror does
         // not bind its columns — so the named source is not established

--- a/src/contextual_integrity.rs
+++ b/src/contextual_integrity.rs
@@ -53,6 +53,28 @@
 //! the enum is edge's, so the compiler can hold the invariant directly:
 //! **a new way to withhold cannot enter this codebase anonymously.**
 //!
+//! # Boundary: this attributes the SERVE side only
+//!
+//! Edge has two refusal mechanisms and they are not the same thing:
+//!
+//! - **Serve / emit** refusals go through [`WithholdReason`] and
+//!   `EdgeMetrics::inc_withhold` — a counted, attributed ledger. That is
+//!   what this module maps.
+//! - **Inbound / transport** refusals go through
+//!   `ReticulumTransport::drop_inbound` — a throttled WARN with a string
+//!   reason tag (CIRISEdge#425). It is log-only, carries no
+//!   [`WithholdReason`], and is therefore **not attributed here**.
+//!
+//! That asymmetry is real and is not an oversight to paper over: an
+//! inbound drop is edge declining to *accept* a frame it cannot
+//! attribute, which is a question about the Sender parameter, while
+//! everything below is edge declining to *make* a flow. The compile-time
+//! guard covers the second and says nothing about the first.
+//!
+//! Stated so the coverage is not overread. Typing the inbound reasons
+//! would extend the guard across both, and is the obvious next
+//! improvement rather than a defect being hidden.
+//!
 //! # What this module is NOT
 //!
 //! It makes **no decisions**. Every verdict is still the gate's; this

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1199,6 +1199,12 @@ pub struct Edge {
     /// `EdgeBindingsError::Unsupported`.
     #[cfg(feature = "_reticulum-module")]
     reticulum_transport: Option<Arc<crate::transport::reticulum::ReticulumTransport>>,
+    /// CIRISEdge#499 — the scope-address lifecycle, present only when the
+    /// operator opted in via [`EdgeBuilder::scope_native_addressing`] AND a
+    /// Reticulum transport is wired. `None` is the default and is
+    /// byte-identical to pre-#499 behaviour.
+    #[cfg(feature = "_reticulum-module")]
+    scope_lifecycle: Option<Arc<crate::scope_lifecycle::ScopeLifecycle>>,
     /// CIRISEdge#26 mutation surface (v0.15.1) — optional
     /// concrete-typed `Arc<dyn FederationDirectory>` retained so the
     /// UniFFI peer-mutation surface (`peer_add` / `peer_remove` /
@@ -1297,6 +1303,11 @@ pub struct EdgeBuilder {
     /// pushed into `transports` so listen+send fan-out is unchanged.
     #[cfg(feature = "_reticulum-module")]
     reticulum_transport: Option<Arc<crate::transport::reticulum::ReticulumTransport>>,
+    /// CIRISEdge#499 — the convergence window, when the operator has opted
+    /// into scope-native addressing. `None` (the default) leaves the address
+    /// table uninstalled and every scope-native path declining.
+    #[cfg(feature = "_reticulum-module")]
+    scope_native_convergence: Option<std::time::Duration>,
     /// CIRISEdge#34 (v0.14.0 wiring) — optionally pre-built
     /// reachability tracker so a Reticulum transport constructed BEFORE
     /// Edge (the pyo3 cohabitation init order) can share the same
@@ -1536,6 +1547,8 @@ impl Edge {
             events: None,
             #[cfg(feature = "_reticulum-module")]
             reticulum_transport: None,
+            #[cfg(feature = "_reticulum-module")]
+            scope_native_convergence: None,
             reachability: None,
             derived_schema: None,
             canonical_bootstrap_peers: Vec::new(),
@@ -3431,8 +3444,31 @@ impl Edge {
     ///
     /// Returns a router with no table — i.e. the pre-#499 federation-only
     /// behaviour — on HTTP-only deployments, on builds without the Reticulum
-    /// module, and on every deployment that has not installed a table (which is
-    /// all of them until CIRISVerify#259's MLS exporter label is specified).
+    /// module, and on any deployment that has not armed scope-native addressing
+    /// via [`EdgeBuilder::scope_native_addressing`] (the default).
+    /// CIRISEdge#499 — the scope-address lifecycle, when the operator armed it
+    /// with [`EdgeBuilder::scope_native_addressing`].
+    ///
+    /// This is how a host drives the plane: snapshot a group, install it,
+    /// advance it on every epoch change, and seal on a cadence.
+    ///
+    /// ```ignore
+    /// let life = edge.scope_lifecycle().expect("armed");
+    /// let snap = cohort_addressing::snapshot(&community).await?;  // or av_addressing::snapshot(&call)?
+    /// life.install(&scope, &snap)?;
+    /// // …on every epoch change:
+    /// life.advance(&scope, &snapshot(&community).await?, Instant::now())?;
+    /// // …and on a timer:
+    /// life.seal_due(Instant::now());
+    /// ```
+    ///
+    /// `None` when not armed, which is the default.
+    #[cfg(feature = "_reticulum-module")]
+    #[must_use]
+    pub fn scope_lifecycle(&self) -> Option<&Arc<crate::scope_lifecycle::ScopeLifecycle>> {
+        self.scope_lifecycle.as_ref()
+    }
+
     #[must_use]
     pub fn blob_scope_router(&self) -> crate::blob_swarm::BlobScopeRouter {
         #[cfg(feature = "_reticulum-module")]
@@ -3862,7 +3898,6 @@ impl Edge {
     /// [`EdgeBuilder::transport`] path). The Links UniFFI surface
     /// consults this; `None` → `EdgeBindingsError::Unsupported`.
     #[cfg(feature = "_reticulum-module")]
-    #[must_use]
     pub fn reticulum_transport(
         &self,
     ) -> Option<Arc<crate::transport::reticulum::ReticulumTransport>> {
@@ -6159,6 +6194,66 @@ async fn dispatch_inbound(
 // ─── Builder ────────────────────────────────────────────────────────
 
 impl EdgeBuilder {
+    /// CIRISEdge#499 — arm scope-native addressing, if the operator asked.
+    ///
+    /// Extracted from [`Self::build`] so the arming reads as one decision
+    /// rather than as a block inside a 130-line constructor.
+    ///
+    /// OPT-IN, and deliberately so. Scoped addressing is ONE HOP by
+    /// constitutional ruling (CIRISConstitution#91: CC 5.4.6 binds the
+    /// emission, so a scope-derived destination can never announce and no
+    /// transport node ever learns a path to it). Enabling it is a real
+    /// operator trade — unlinkable per-context addressing in exchange for
+    /// direct-link-only reach on scoped content — and a trade like that is
+    /// chosen, never inherited from a default.
+    ///
+    /// Installing the table ARMS every scope-native path at once: the
+    /// transport's `inbound_scope`, the blob router and serve gate, and the
+    /// swarm holdings gate all read their arming from this one handle, so
+    /// "which addresses I answer on" and "which I send to" cannot drift.
+    #[cfg(feature = "_reticulum-module")]
+    fn arm_scope_native(
+        convergence: Option<std::time::Duration>,
+        transport: Option<&Arc<crate::transport::reticulum::ReticulumTransport>>,
+        own_key_id: &str,
+    ) -> Result<Option<Arc<crate::scope_lifecycle::ScopeLifecycle>>, EdgeError> {
+        match (convergence, transport) {
+            (Some(convergence), Some(transport)) => {
+                let table = Arc::new(crate::scope_addressing::ScopeAddressTable::new(Arc::new(
+                    crate::scope_addressing::ScopePrivacyDeriver,
+                )));
+                // The transport owns the table (one source of truth) and is
+                // also the lifecycle's sink, so a registration and its table
+                // entry are made by the same object.
+                transport
+                    .install_scope_address_table(Arc::clone(&table))
+                    .map_err(|e| EdgeError::Config(format!("scope address table: {e}")))?;
+                tracing::info!(
+                    convergence_secs = convergence.as_secs(),
+                    "CIRISEdge#499 — scope-native addressing ARMED. Scoped destinations \
+                     are one-hop by CC 5.4.6 (CIRISConstitution#91): they never announce, \
+                     so scoped content reaches directly-attached peers only."
+                );
+                Ok(Some(Arc::new(crate::scope_lifecycle::ScopeLifecycle::new(
+                    table,
+                    Arc::clone(transport) as Arc<dyn crate::scope_lifecycle::ScopedDestinationSink>,
+                    own_key_id.to_owned(),
+                    convergence,
+                ))))
+            }
+            // Asked for, but no Reticulum transport to register on. Refused
+            // rather than silently ignored: a host that opted in and got the
+            // pre-#499 behaviour anyway would believe it had unlinkable
+            // addressing that it does not have.
+            (Some(_), None) => Err(EdgeError::Config(
+                "scope_native_addressing requires a Reticulum transport — the address \
+                 table has nowhere to register scoped destinations without one"
+                    .into(),
+            )),
+            (None, _) => Ok(None),
+        }
+    }
+
     /// Sovereign-mode convenience: load steward identity from
     /// filesystem seeds via `ciris-keyring`, open persist's
     /// SQLite-backed federation directory + edge outbound queue at
@@ -6281,6 +6376,45 @@ impl EdgeBuilder {
     /// additive variant. The typed handle is OPTIONAL — `link_open`
     /// returns `EdgeBindingsError::Unsupported` when no Reticulum
     /// transport is registered.
+    #[cfg(feature = "_reticulum-module")]
+    #[must_use]
+    /// CIRISEdge#499 — **arm scope-native addressing** with `convergence` as
+    /// the rotation window.
+    ///
+    /// Off by default. Calling this installs a [`ScopeAddressTable`] on the
+    /// Reticulum transport, which arms every scope-native path at once: the
+    /// transport's inbound admission, the blob router and serve gate, and the
+    /// swarm holdings gate all read their arming from that one handle, so
+    /// "which addresses I answer on" and "which I send to" cannot drift.
+    ///
+    /// # The trade you are making
+    ///
+    /// Scoped destinations are **one hop**. CC 5.4.6 binds the *emission*
+    /// (ruled: CIRISConstitution#91), so a scope-derived destination never
+    /// announces and no transport node ever learns a path to it. Scoped
+    /// content therefore reaches directly-attached peers only. In exchange,
+    /// this node presents an unlinkable address per context instead of one
+    /// `sha256(fed_pubkey)[..16]` everywhere.
+    ///
+    /// That is a genuine operational trade, which is why it is opt-in rather
+    /// than a default: a deployment that needs multi-hop reach for
+    /// cohort-scoped content should not inherit one-hop behaviour silently.
+    ///
+    /// `convergence` is how long a superseded epoch stays reachable after a
+    /// rotation — see [`DEFAULT_CONVERGENCE_WINDOW`]. Seal earlier and a peer
+    /// that has not re-keyed is cut off; later and a rotated-away address stays
+    /// live longer.
+    ///
+    /// After building, drive it through [`Edge::scope_lifecycle`].
+    ///
+    /// [`ScopeAddressTable`]: crate::scope_addressing::ScopeAddressTable
+    /// [`DEFAULT_CONVERGENCE_WINDOW`]: crate::scope_lifecycle::DEFAULT_CONVERGENCE_WINDOW
+    #[cfg(feature = "_reticulum-module")]
+    pub fn scope_native_addressing(mut self, convergence: std::time::Duration) -> Self {
+        self.scope_native_convergence = Some(convergence);
+        self
+    }
+
     #[cfg(feature = "_reticulum-module")]
     #[must_use]
     pub fn reticulum_transport(
@@ -6441,6 +6575,12 @@ impl EdgeBuilder {
         self
     }
 
+    // `build` wires ~30 subsystems into one value; the 100-line threshold is
+    // arbitrary for a constructor of that shape, and splitting it would spread
+    // one wiring decision across several functions. The allow sits DIRECTLY on
+    // the fn so nothing can be inserted between it and its target — a
+    // displacement this file has already produced twice today.
+    #[allow(clippy::too_many_lines)]
     pub fn build(self) -> Result<Edge, EdgeError> {
         let directory = self
             .directory
@@ -6521,6 +6661,13 @@ impl EdgeBuilder {
         // gracefully under the same back-pressure regime.
         let (verified_envelope_tx, _) =
             broadcast::channel(self.config.event_channel_capacity.max(1));
+        #[cfg(feature = "_reticulum-module")]
+        let scope_lifecycle = Self::arm_scope_native(
+            self.scope_native_convergence,
+            self.reticulum_transport.as_ref(),
+            &signer.key_id,
+        )?;
+
         let content_fetch_pending = Arc::new(std::sync::Mutex::new(HashMap::new()));
         // CIRISEdge#55 — sibling pending-map for chunk fetches.
         let blob_chunk_fetch_pending = Arc::new(std::sync::Mutex::new(HashMap::new()));
@@ -6581,6 +6728,8 @@ impl EdgeBuilder {
             reachability,
             #[cfg(feature = "_reticulum-module")]
             reticulum_transport: self.reticulum_transport,
+            #[cfg(feature = "_reticulum-module")]
+            scope_lifecycle,
             federation_directory: self.federation_directory,
             detector,
             canonical_peers,
@@ -8542,5 +8691,81 @@ mod baked_genesis_tests {
     #[test]
     fn default_config_enables_baked_genesis() {
         assert!(EdgeConfig::default().baked_canonical_genesis_enabled);
+    }
+}
+
+/// CIRISEdge#499 — the install path: arming, refusing, and staying off.
+///
+/// These build a real `Edge` rather than asserting on the builder, because
+/// the property that matters is that arming ACTUALLY INSTALLS the table —
+/// the single handle every scope-native path reads its arming from. A test
+/// that only checked the flag would pass with the install deleted.
+#[cfg(all(test, feature = "_reticulum-module"))]
+mod scope_native_install_tests {
+    use super::*;
+    use std::time::Duration;
+
+    async fn builder(dir: &std::path::Path, key_id: &str) -> EdgeBuilder {
+        // `from_keyring_seed_dir` READS a seed; it does not mint one.
+        let seeds = dir.join("seeds");
+        std::fs::create_dir_all(&seeds).expect("seed dir");
+        let mut seed = [0u8; 32];
+        for (i, b) in seed.iter_mut().enumerate() {
+            *b = u8::try_from(i).expect("in range") ^ 0x5a;
+        }
+        std::fs::write(seeds.join("ed25519.seed"), seed).expect("write seed");
+
+        EdgeBuilder::from_keyring_seed_dir(key_id, seeds, dir.join("edge.sqlite"))
+            .await
+            .expect("builder")
+    }
+
+    #[tokio::test]
+    async fn off_by_default_leaves_every_scope_native_path_declining() {
+        // The pre-#499 posture, and the one an existing deployment inherits
+        // by upgrading. Arming is an operator decision because scoped
+        // addressing is ONE HOP by CC 5.4.6 (CIRISConstitution#91) — a
+        // deployment must not acquire direct-link-only reach silently.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let edge = builder(tmp.path(), "edge-default")
+            .await
+            .transport(Arc::new(crate::transport::NullTransport))
+            .build()
+            .expect("build");
+
+        assert!(
+            edge.scope_lifecycle().is_none(),
+            "scope-native addressing must be OFF unless asked for",
+        );
+        assert!(
+            !edge.blob_scope_router().is_scope_native(),
+            "the blob router must stay federation-only when unarmed",
+        );
+    }
+
+    #[tokio::test]
+    async fn arming_without_a_transport_is_refused_not_silently_ignored() {
+        // THE safety property of this seam. A host that asked for unlinkable
+        // addressing and got the federation-only path anyway would believe it
+        // had a guarantee it does not have — the worst failure available here,
+        // because it is invisible and it is a privacy claim.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // A transport IS configured — just not a Reticulum one. This is the
+        // dangerous shape: a host with working delivery that believes it also
+        // has unlinkable addressing.
+        let Err(err) = builder(tmp.path(), "edge-no-transport")
+            .await
+            .transport(Arc::new(crate::transport::NullTransport))
+            .scope_native_addressing(Duration::from_secs(300))
+            .build()
+        else {
+            panic!("arming without a Reticulum transport must be refused");
+        };
+
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("scope_native_addressing") && msg.contains("Reticulum transport"),
+            "the refusal must name what is missing and why, got: {msg}",
+        );
     }
 }

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -3169,6 +3169,141 @@ impl Edge {
         }
     }
 
+    /// CIRISEdge#499 — fetch a chunk from a holder at the address its
+    /// content's SCOPE requires.
+    ///
+    /// The scope-native sibling of [`Self::fetch_blob_chunk`]. It takes a
+    /// [`BlobRecipient`], which is constructible only by
+    /// [`BlobScopeRouter::route`](crate::blob_swarm::BlobScopeRouter::route):
+    /// holding one is proof that the content's scope was determined and an
+    /// address resolved for it. There is no overload that takes a bare peer id
+    /// and a scope — that would let a caller name a scope the address does not
+    /// match, which is exactly the mistake the newtype exists to make
+    /// unrepresentable.
+    ///
+    /// The correlation half (the pending-map keyed by
+    /// `(blob_sha256, chunk_sha256)`, the timeout, the cleanup on every exit)
+    /// is IDENTICAL to [`Self::fetch_blob_chunk`] and shared with it. Only the
+    /// send differs:
+    ///
+    /// - [`BlobRoute::Federation`] — delegates to the unscoped path verbatim,
+    ///   so public content is byte-identical to pre-#499.
+    /// - `Scoped` — signs the same `BlobChunkFetch` and ships it to the
+    ///   derived destination via
+    ///   [`ReticulumTransport::send_to_scoped_destination`].
+    ///
+    /// # Fail-closed
+    ///
+    /// A scoped route on a node with no Reticulum transport (HTTP-only, or a
+    /// build without the module) is an ERROR, never a downgrade: HTTP has no
+    /// scope-derived destination plane, so serving the request there would put
+    /// the scoped blob back on the federation endpoint and re-collapse the
+    /// context. The caller sees a typed refusal and can pick another holder.
+    ///
+    /// [`BlobRecipient`]: crate::blob_swarm::BlobRecipient
+    /// [`BlobRoute::Federation`]: crate::blob_swarm::scope::BlobRoute::Federation
+    /// [`ReticulumTransport::send_to_scoped_destination`]: crate::transport::reticulum::ReticulumTransport::send_to_scoped_destination
+    ///
+    /// # Errors
+    /// Every error [`Self::fetch_blob_chunk`] returns, plus
+    /// [`EdgeError::Config`] when a scoped route cannot be shipped on this
+    /// node's transports.
+    pub async fn fetch_blob_chunk_scoped(
+        &self,
+        recipient: &crate::blob_swarm::BlobRecipient,
+        blob_sha256: [u8; 32],
+        chunk_sha256: [u8; 32],
+        timeout: std::time::Duration,
+    ) -> Result<ChunkResult, EdgeError> {
+        let Some(address) = recipient.scoped_address() else {
+            // Federation route — the unscoped path, verbatim.
+            return self
+                .fetch_blob_chunk(recipient.peer_key_id(), blob_sha256, chunk_sha256, timeout)
+                .await;
+        };
+
+        let key = (blob_sha256, chunk_sha256);
+        let (tx, rx) = oneshot::channel();
+        {
+            let mut pending = self
+                .blob_chunk_fetch_pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            pending.insert(key, tx);
+        }
+
+        let forget = |edge: &Self| {
+            let mut pending = edge
+                .blob_chunk_fetch_pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            pending.remove(&key);
+        };
+
+        let fetch = crate::messages::BlobChunkFetch {
+            blob_sha256,
+            chunk_sha256,
+            response_hint: None,
+        };
+
+        // Build + sign exactly as the unscoped path does — the ENVELOPE is
+        // unchanged by scope-native addressing, only the address it rides.
+        let envelope_bytes = match self
+            .build_signed_envelope_with_cohort_scope(recipient.peer_key_id(), &fetch, None, None)
+            .await
+        {
+            Ok(b) => b,
+            Err(e) => {
+                forget(self);
+                return Err(e);
+            }
+        };
+
+        #[cfg(feature = "_reticulum-module")]
+        let sent = match self.reticulum_transport.as_ref() {
+            Some(transport) => transport
+                .send_to_scoped_destination(recipient.peer_key_id(), address, &envelope_bytes)
+                .await
+                .map(|_| ())
+                .map_err(|e| EdgeError::Config(format!("scope-native blob fetch send: {e}"))),
+            None => Err(EdgeError::Config(format!(
+                "scope-native blob fetch: holder '{}' resolved to a scope-derived \
+                 address but this node has no Reticulum transport. HTTP and packet \
+                 radio have no scope-derived destination plane, and shipping this \
+                 request on the federation endpoint would re-collapse the context the \
+                 address exists to separate — refusing (CIRISEdge#499)",
+                recipient.peer_key_id()
+            ))),
+        };
+        #[cfg(not(feature = "_reticulum-module"))]
+        let sent = {
+            let _ = &envelope_bytes;
+            Err::<(), EdgeError>(EdgeError::Config(format!(
+                "scope-native blob fetch: holder '{}' resolved to a scope-derived \
+                 address but this build has no Reticulum module — refusing rather \
+                 than falling back to the federation address (CIRISEdge#499)",
+                recipient.peer_key_id()
+            )))
+        };
+        if let Err(e) = sent {
+            forget(self);
+            return Err(e);
+        }
+
+        match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(result)) => Ok(result),
+            Ok(Err(_)) => Err(EdgeError::Config(
+                "fetch_blob_chunk_scoped channel closed before response".into(),
+            )),
+            Err(_) => {
+                forget(self);
+                Err(EdgeError::Config(format!(
+                    "fetch_blob_chunk_scoped timeout after {timeout:?}"
+                )))
+            }
+        }
+    }
+
     /// CIRISEdge#55 — test-only sibling of
     /// [`Self::complete_pending_fetch_for_test`]: inject a fake
     /// `BlobChunkBody` / `BlobChunkMiss` outcome into the pending-chunk
@@ -3278,8 +3413,40 @@ impl Edge {
             self.canonical_peers.clone(),
             self.blob_chunk_source.as_ref(),
             self.swarm_runtime.get().as_ref(),
+            &self.blob_scope_router(),
         )
         .await;
+    }
+
+    /// CIRISEdge#499 — the blob plane's scope-address resolver.
+    ///
+    /// Derived from the Reticulum transport's installed
+    /// [`ScopeAddressTable`](crate::scope_addressing::ScopeAddressTable) rather
+    /// than held as a second copy on `Edge`. That is deliberate: the table is
+    /// also what registers the node's scoped destinations and what resolves
+    /// inbound arrivals, so a second install path would let "which addresses do
+    /// I answer on" and "which addresses do I send to" drift apart — and the
+    /// failure would be silent (an RNS hash nobody registered is simply never
+    /// delivered to). One `OnceLock`, one truth.
+    ///
+    /// Returns a router with no table — i.e. the pre-#499 federation-only
+    /// behaviour — on HTTP-only deployments, on builds without the Reticulum
+    /// module, and on every deployment that has not installed a table (which is
+    /// all of them until CIRISVerify#259's MLS exporter label is specified).
+    #[must_use]
+    pub fn blob_scope_router(&self) -> crate::blob_swarm::BlobScopeRouter {
+        #[cfg(feature = "_reticulum-module")]
+        {
+            crate::blob_swarm::BlobScopeRouter::new(
+                self.reticulum_transport
+                    .as_ref()
+                    .and_then(|t| t.scope_address_table().cloned()),
+            )
+        }
+        #[cfg(not(feature = "_reticulum-module"))]
+        {
+            crate::blob_swarm::BlobScopeRouter::default()
+        }
     }
 
     /// CIRISEdge#208 — install a runtime override for the
@@ -3919,6 +4086,15 @@ impl Edge {
         // Clone of the `Arc<OnceLock<Arc<FountainSwarmRuntime>>>`; the
         // OnceLock load inside the dispatch is a cheap atomic.
         let swarm_runtime = self.swarm_runtime.clone();
+        // CIRISEdge#499 — the handle the blob scope gate reads its address table
+        // from. Captured as the TRANSPORT, not as a pre-built router, because
+        // `install_scope_address_table` may fire after `run` starts (the MLS
+        // layer installs as soon as the first group is joined): resolving per
+        // frame means a table installed mid-run arms the gate on the next frame,
+        // where a router built once here would stay disarmed until restart.
+        // Cost is an `Arc` clone plus a `OnceLock` load per frame.
+        #[cfg(feature = "_reticulum-module")]
+        let blob_scope_transport = self.reticulum_transport.clone();
         // CIRISEdge#119 v3.5.1 — opt-in replication routing. When the
         // OnceLock has been populated by
         // `Edge::install_replication_routing`, the inbound loop
@@ -3970,6 +4146,14 @@ impl Edge {
                     let delegation_trust_roots_clone = delegation_trust_roots.clone();
                     let blob_chunk_source_clone = blob_chunk_source.clone();
                     let swarm_runtime_clone = swarm_runtime.clone();
+                    #[cfg(feature = "_reticulum-module")]
+                    let blob_scope_router = crate::blob_swarm::BlobScopeRouter::new(
+                        blob_scope_transport
+                            .as_ref()
+                            .and_then(|t| t.scope_address_table().cloned()),
+                    );
+                    #[cfg(not(feature = "_reticulum-module"))]
+                    let blob_scope_router = crate::blob_swarm::BlobScopeRouter::default();
                     tokio::spawn(async move {
                         dispatch_inbound(
                             frame,
@@ -4004,6 +4188,7 @@ impl Edge {
                             delegation_trust_roots_clone,
                             blob_chunk_source_clone.as_ref(),
                             swarm_runtime_clone.get().as_ref(),
+                            &blob_scope_router,
                         ).await;
                     });
                 }
@@ -4218,6 +4403,20 @@ static INBOUND_VERIFY_REJECT_LOG: std::sync::OnceLock<crate::log_throttle::LogTh
 fn inbound_unroutable_crpl_log() -> &'static crate::log_throttle::LogThrottle {
     INBOUND_UNROUTABLE_CRPL_LOG.get_or_init(|| {
         crate::log_throttle::LogThrottle::new(5, std::time::Duration::from_secs(60), 16)
+    })
+}
+
+/// CIRISEdge#499 — a `BlobChunkFetch` withheld on scope admission. Keyed on the
+/// refusal's `reason_tag` (a three-value closed set, never attacker-chosen), so
+/// a flood from one gate collapses to a suppressed-count while each DISTINCT
+/// gate still gets a voice. The withhold COUNTER is deliberately unthrottled —
+/// a metric that under-counts is a metric that lies (CIRISEdge#433).
+static BLOB_SCOPE_WITHHELD_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+
+fn blob_scope_withheld_log() -> &'static crate::log_throttle::LogThrottle {
+    BLOB_SCOPE_WITHHELD_LOG.get_or_init(|| {
+        crate::log_throttle::LogThrottle::new(3, std::time::Duration::from_secs(300), 16)
     })
 }
 
@@ -4505,6 +4704,7 @@ fn first_bytes_hex(bytes: &[u8]) -> String {
         delegation_trust_roots,
         blob_chunk_source,
         swarm_runtime,
+        blob_scope_router,
     ),
     fields(
         transport_id = %frame.transport.0,
@@ -4589,9 +4789,19 @@ async fn dispatch_inbound(
     // (verify still runs) but no runtime hook fires — same posture as
     // `blob_chunk_source` for the chunked-blob swarm.
     swarm_runtime: Option<&Arc<crate::swarm::FountainSwarmRuntime>>,
+    // CIRISEdge#499 — the blob plane's scope-address resolver, read from the
+    // transport's installed table so there is exactly ONE source of truth for
+    // "is this node scope-native". Default (no table) leaves the blob serve gate
+    // DISARMED, i.e. byte-identical to pre-#499.
+    blob_scope_router: &crate::blob_swarm::BlobScopeRouter,
 ) {
     let received_at = frame.received_at;
     let transport = frame.transport;
+    // CIRISEdge#499 — the receive-side ADMISSION FACT, resolved by the transport
+    // ahead of any parse (see `InboundFrame::arrival_scope`). Captured here, at
+    // the top, so every serve gate below reads the same value and none of them
+    // can accidentally re-derive it from something the requester said.
+    let arrival_scope = frame.arrival_scope.clone();
     // CIRISEdge#28 (v0.19.0) — count the bytes consumed by the
     // listener side regardless of verify outcome (the wire spent the
     // bytes; observability covers them).
@@ -5005,22 +5215,172 @@ async fn dispatch_inbound(
                 use crate::messages::{
                     BlobChunkBody, BlobChunkMiss as BlobChunkMissBody, MissReason,
                 };
-                let (response_kind, response_envelope_bytes) = match source
-                    .read_chunk(req.blob_sha256, req.chunk_sha256)
-                {
-                    Ok(Some(bytes)) => {
-                        // AV-13 size gate on outbound: refuse to
-                        // emit a chunk that exceeds the ceiling
-                        // (the peer would drop it anyway, but the
-                        // wire surface should never propose an
-                        // oversize body).
-                        if bytes.len() > max_content_body_bytes {
+
+                // CIRISEdge#499 — SCOPE ADMISSION, ahead of the read.
+                //
+                // The requester's entitlement is judged on the address the frame
+                // physically ARRIVED on, never on anything it claimed: an
+                // `arrival_scope` exists only because the destination hash
+                // matched the scope table's reverse index, and those hashes are
+                // derived from the group's MLS `exporter_secret` (RFC 9420 §8.5
+                // binds `(group_id, epoch)`), so holding one IS proof of
+                // group-secret possession. `None` means the federation address,
+                // which proves reachability and nothing more.
+                //
+                // The content's scope comes from the persist-backed consumer
+                // (`chunk_scope`); edge never infers it, and a `None` is
+                // refused rather than read as Public.
+                //
+                // Ordered BEFORE `read_chunk` so an unentitled request never
+                // touches the store — a refusal that still performed the read
+                // would leak timing and burn IO on a peer we will not answer.
+                //
+                // `chunk_scope` is consulted ONLY on a scope-native node. On a
+                // node with no address table the gate admits unconditionally, so
+                // calling it would be a consumer round-trip whose answer cannot
+                // change the outcome — and "byte-identical to pre-#499" has to
+                // mean the responder makes the same calls, not just reaches the
+                // same verdict.
+                let scope_native = blob_scope_router.is_scope_native();
+                let content_scope = if scope_native {
+                    source.chunk_scope(req.blob_sha256)
+                } else {
+                    None
+                };
+                let admission = crate::blob_swarm::admit_blob_serve(
+                    scope_native,
+                    arrival_scope.as_ref(),
+                    content_scope.as_ref(),
+                );
+                let scope_refusal = match admission {
+                    crate::blob_swarm::ServeAdmission::Admit => None,
+                    // Never a bare `continue` (CIRISEdge#425): the refusal is
+                    // BOOKED unthrottled (a metric that under-counts is a metric
+                    // that lies) and SPOKEN under the shared serve throttle, then
+                    // answered with a typed miss so the fetcher fails over to
+                    // another holder instead of hanging.
+                    crate::blob_swarm::ServeAdmission::Refuse(reason) => {
+                        metrics.inc_withhold(
+                            reason.withhold_reason(),
+                            &envelope.signing_key_id,
+                            reason.reason_tag(),
+                        );
+                        if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                            blob_scope_withheld_log().check(reason.reason_tag())
+                        {
                             tracing::warn!(
-                                transport = ?transport,
-                                chunk_size = bytes.len(),
-                                max = max_content_body_bytes,
-                                "BlobChunkFetch responder: chunk exceeds AV-13 ceiling, replying NotHeld",
+                                event = "edge.blob_chunk_fetch.scope_withheld",
+                                peer_key_id = %envelope.signing_key_id,
+                                blob_sha256 = %hex::encode(&req.blob_sha256[..8]),
+                                reason = reason.reason_tag(),
+                                arrival_scope = arrival_scope
+                                    .as_ref()
+                                    .map_or("federation", |a| a.group().scope().kind_token()),
+                                suppressed_prev,
+                                "BlobChunkFetch WITHHELD on scope admission — {reason} \
+                                 (CIRISEdge#499)",
                             );
+                        }
+                        Some(reason)
+                    }
+                };
+
+                let (response_kind, response_envelope_bytes) = if scope_refusal.is_some() {
+                    // A scope refusal is a POLICY denial on the wire: the bytes
+                    // are not gone federation-wide, this node simply will not
+                    // serve them to this requester, so the scheduler's
+                    // `PolicyDenied` reaction (demote this responder, retry
+                    // elsewhere) is exactly right. The precise branch stays
+                    // LOCAL, in the withhold ledger — the wire reason must not
+                    // tell an unentitled peer which gate it failed.
+                    let miss = BlobChunkMissBody {
+                        blob_sha256: req.blob_sha256,
+                        chunk_sha256: req.chunk_sha256,
+                        reason: MissReason::PolicyDenied,
+                    };
+                    match build_chunk_response_envelope(
+                        MessageType::BlobChunkMiss,
+                        &envelope.signing_key_id,
+                        signer,
+                        &miss,
+                        body_sha256,
+                    )
+                    .await
+                    {
+                        Ok(bytes) => (MessageType::BlobChunkMiss, Some(bytes)),
+                        Err(e) => {
+                            tracing::warn!(
+                                error = %e,
+                                "BlobChunkFetch responder: failed to build scope-refusal envelope",
+                            );
+                            (MessageType::BlobChunkMiss, None)
+                        }
+                    }
+                } else {
+                    match source.read_chunk(req.blob_sha256, req.chunk_sha256) {
+                        Ok(Some(bytes)) => {
+                            // AV-13 size gate on outbound: refuse to
+                            // emit a chunk that exceeds the ceiling
+                            // (the peer would drop it anyway, but the
+                            // wire surface should never propose an
+                            // oversize body).
+                            if bytes.len() > max_content_body_bytes {
+                                tracing::warn!(
+                                    transport = ?transport,
+                                    chunk_size = bytes.len(),
+                                    max = max_content_body_bytes,
+                                    "BlobChunkFetch responder: chunk exceeds AV-13 ceiling, replying NotHeld",
+                                );
+                                let miss = BlobChunkMissBody {
+                                    blob_sha256: req.blob_sha256,
+                                    chunk_sha256: req.chunk_sha256,
+                                    reason: MissReason::NotHeld,
+                                };
+                                match build_chunk_response_envelope(
+                                    MessageType::BlobChunkMiss,
+                                    &envelope.signing_key_id,
+                                    signer,
+                                    &miss,
+                                    body_sha256,
+                                )
+                                .await
+                                {
+                                    Ok(bytes) => (MessageType::BlobChunkMiss, Some(bytes)),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            error = %e,
+                                            "BlobChunkFetch responder: failed to build miss envelope",
+                                        );
+                                        (MessageType::BlobChunkMiss, None)
+                                    }
+                                }
+                            } else {
+                                let body = BlobChunkBody {
+                                    blob_sha256: req.blob_sha256,
+                                    chunk_sha256: req.chunk_sha256,
+                                    bytes,
+                                };
+                                match build_chunk_response_envelope(
+                                    MessageType::BlobChunkBody,
+                                    &envelope.signing_key_id,
+                                    signer,
+                                    &body,
+                                    body_sha256,
+                                )
+                                .await
+                                {
+                                    Ok(bytes) => (MessageType::BlobChunkBody, Some(bytes)),
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            error = %e,
+                                            "BlobChunkFetch responder: failed to build body envelope",
+                                        );
+                                        (MessageType::BlobChunkBody, None)
+                                    }
+                                }
+                            }
+                        }
+                        Ok(None) => {
                             let miss = BlobChunkMissBody {
                                 blob_sha256: req.blob_sha256,
                                 chunk_sha256: req.chunk_sha256,
@@ -5044,79 +5404,30 @@ async fn dispatch_inbound(
                                     (MessageType::BlobChunkMiss, None)
                                 }
                             }
-                        } else {
-                            let body = BlobChunkBody {
+                        }
+                        Err(refusal) => {
+                            let miss = BlobChunkMissBody {
                                 blob_sha256: req.blob_sha256,
                                 chunk_sha256: req.chunk_sha256,
-                                bytes,
+                                reason: refusal.to_miss_reason(),
                             };
                             match build_chunk_response_envelope(
-                                MessageType::BlobChunkBody,
+                                MessageType::BlobChunkMiss,
                                 &envelope.signing_key_id,
                                 signer,
-                                &body,
+                                &miss,
                                 body_sha256,
                             )
                             .await
                             {
-                                Ok(bytes) => (MessageType::BlobChunkBody, Some(bytes)),
+                                Ok(bytes) => (MessageType::BlobChunkMiss, Some(bytes)),
                                 Err(e) => {
                                     tracing::warn!(
                                         error = %e,
-                                        "BlobChunkFetch responder: failed to build body envelope",
+                                        "BlobChunkFetch responder: failed to build refusal envelope",
                                     );
-                                    (MessageType::BlobChunkBody, None)
+                                    (MessageType::BlobChunkMiss, None)
                                 }
-                            }
-                        }
-                    }
-                    Ok(None) => {
-                        let miss = BlobChunkMissBody {
-                            blob_sha256: req.blob_sha256,
-                            chunk_sha256: req.chunk_sha256,
-                            reason: MissReason::NotHeld,
-                        };
-                        match build_chunk_response_envelope(
-                            MessageType::BlobChunkMiss,
-                            &envelope.signing_key_id,
-                            signer,
-                            &miss,
-                            body_sha256,
-                        )
-                        .await
-                        {
-                            Ok(bytes) => (MessageType::BlobChunkMiss, Some(bytes)),
-                            Err(e) => {
-                                tracing::warn!(
-                                    error = %e,
-                                    "BlobChunkFetch responder: failed to build miss envelope",
-                                );
-                                (MessageType::BlobChunkMiss, None)
-                            }
-                        }
-                    }
-                    Err(refusal) => {
-                        let miss = BlobChunkMissBody {
-                            blob_sha256: req.blob_sha256,
-                            chunk_sha256: req.chunk_sha256,
-                            reason: refusal.to_miss_reason(),
-                        };
-                        match build_chunk_response_envelope(
-                            MessageType::BlobChunkMiss,
-                            &envelope.signing_key_id,
-                            signer,
-                            &miss,
-                            body_sha256,
-                        )
-                        .await
-                        {
-                            Ok(bytes) => (MessageType::BlobChunkMiss, Some(bytes)),
-                            Err(e) => {
-                                tracing::warn!(
-                                    error = %e,
-                                    "BlobChunkFetch responder: failed to build refusal envelope",
-                                );
-                                (MessageType::BlobChunkMiss, None)
                             }
                         }
                     }
@@ -7866,6 +8177,7 @@ mod inbound_ingest_tests {
             received_at: chrono::Utc::now(),
             source_key_id: source.map(crate::transport::SourceKeyId::transport_authenticated),
             link_key_id: None,
+            arrival_scope: None,
         }
     }
 
@@ -7934,6 +8246,7 @@ mod inbound_ingest_tests {
             received_at: chrono::Utc::now(),
             source_key_id: None,
             link_key_id: link.map(str::to_string),
+            arrival_scope: None,
         };
 
         // (a) Key + link → admitted on the link's transport identity.
@@ -7982,6 +8295,7 @@ mod inbound_ingest_tests {
             received_at: chrono::Utc::now(),
             source_key_id: None,
             link_key_id: Some("fresh-peer".into()),
+            arrival_scope: None,
         };
         assert!(
             bootstrap_carve_out_source(&junk).is_none(),
@@ -8012,6 +8326,7 @@ mod inbound_ingest_tests {
                 received_at: chrono::Utc::now(),
                 source_key_id: None,
                 link_key_id: link.clone(),
+                arrival_scope: None,
             };
             // Some(link) exactly when kind is a bootstrap kind AND a link exists.
             let expected = link.filter(|_| kind.is_bootstrap());

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -7190,17 +7190,36 @@ async fn emit_delivery_attestation(
         .map_err(|e| EdgeError::Persist(format!("attestation classical sign: {e}")))?;
     att.signature_classical_base64 = encode_signature_base64(&ed25519_sig);
 
-    // Optional PQC ML-DSA-65 over `canonical || classical_sig` per
-    // persist's AV-33 bound-signature convention (FSD §3.2.1).
-    if let Some(pqc) = signer.pqc.as_ref() {
-        let mut bound = canonical.clone();
-        bound.extend_from_slice(&ed25519_sig);
-        let pqc_sig = pqc
-            .sign(&bound)
-            .await
-            .map_err(|e| EdgeError::Persist(format!("attestation pqc sign: {e}")))?;
-        att.signature_pqc_base64 = Some(encode_signature_base64(&pqc_sig));
-    }
+    // MANDATORY PQC ML-DSA-65 over `canonical || classical_sig`, per persist's
+    // AV-33 bound-signature convention (FSD §3.2.1).
+    //
+    // This was `if let Some(pqc)` — optional — and that made edge a producer of
+    // hybrid-pending rows whenever its signer happened to be classical-only.
+    // Persist rejects those at admission under the Strict policy, so the defect
+    // surfaced as a REMOTE failure at the far end of an emit, with nothing
+    // local naming the cause.
+    //
+    // Refused HERE instead, and refused rather than degraded: no classical-only
+    // path may exist, not merely be superseded. A node that cannot sign hybrid
+    // must not emit an attestation at all — emitting one it knows will be
+    // rejected is a delivery gap dressed as an emission, and FSD §3.2's
+    // "missing-attestation-as-delivery-gap" is observable at the steward end
+    // EITHER WAY. Better the gap be loud and local than silent and remote.
+    let Some(pqc) = signer.pqc.as_ref() else {
+        return Err(EdgeError::Config(format!(
+            "delivery attestation for {} requires a PQC signer: persist's Strict \
+             policy rejects hybrid-pending rows, so emitting one would fail at \
+             admission with nothing local naming the cause (CIRISEdge#458)",
+            signer.key_id
+        )));
+    };
+    let mut bound = canonical.clone();
+    bound.extend_from_slice(&ed25519_sig);
+    let pqc_sig = pqc
+        .sign(&bound)
+        .await
+        .map_err(|e| EdgeError::Persist(format!("attestation pqc sign: {e}")))?;
+    att.signature_pqc_base64 = Some(encode_signature_base64(&pqc_sig));
 
     // Wrap in a typed envelope. Destination is the **original
     // announcement sender** (envelope.signing_key_id) — the federation

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -3290,7 +3290,11 @@ impl Edge {
         };
         #[cfg(not(feature = "_reticulum-module"))]
         let sent = {
-            let _ = &envelope_bytes;
+            // `address` is only dialled on the Reticulum arm; bind it here so
+            // the reticulum-free build does not warn on it. Deliberately NOT
+            // renamed to `_address` at the binding: the name documents what
+            // the resolved value IS on the arm that uses it.
+            let _ = (&envelope_bytes, address);
             Err::<(), EdgeError>(EdgeError::Config(format!(
                 "scope-native blob fetch: holder '{}' resolved to a scope-derived \
                  address but this build has no Reticulum module — refusing rather \

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -6387,18 +6387,28 @@ impl EdgeBuilder {
     /// swarm holdings gate all read their arming from that one handle, so
     /// "which addresses I answer on" and "which I send to" cannot drift.
     ///
-    /// # The trade you are making
+    /// # What one hop actually costs, which depends on the other flag
     ///
-    /// Scoped destinations are **one hop**. CC 5.4.6 binds the *emission*
-    /// (ruled: CIRISConstitution#91), so a scope-derived destination never
-    /// announces and no transport node ever learns a path to it. Scoped
-    /// content therefore reaches directly-attached peers only. In exchange,
-    /// this node presents an unlinkable address per context instead of one
-    /// `sha256(fed_pubkey)[..16]` everywhere.
+    /// Scoped destinations are **one hop**: CC 5.4.6 binds the *emission*
+    /// (ruled at CIRISConstitution#91), so a scope-derived destination never
+    /// announces and no transport node learns a path to it.
     ///
-    /// That is a genuine operational trade, which is why it is opt-in rather
-    /// than a default: a deployment that needs multi-hop reach for
-    /// cohort-scoped content should not inherit one-hop behaviour silently.
+    /// Whether that is a cost at all depends on
+    /// [`ReticulumTransportConfig::federation_visible`] — the wizard's
+    /// *"allow me to be visible to the federation so I can use the mesh"*
+    /// question, which is the opt-in that actually decides this node's reach:
+    ///
+    /// - **Not federation-visible.** The node is point-to-point anyway. Scoped
+    ///   addressing costs it **nothing it had**, and gives it an unlinkable
+    ///   address per context instead of one `sha256(fed_pubkey)[..16]`
+    ///   everywhere. There is no trade here, only a gain.
+    /// - **Federation-visible.** The node has mesh reach on the federation
+    ///   plane, and arming this moves *scoped* flows off that plane onto
+    ///   one-hop delivery. That is the real trade, and it is why this stays a
+    ///   separate decision rather than riding the visibility flag.
+    ///
+    /// So this is opt-in because the second case exists, not because
+    /// unlinkable addressing is exotic.
     ///
     /// `convergence` is how long a superseded epoch stays reachable after a
     /// rotation — see [`DEFAULT_CONVERGENCE_WINDOW`]. Seal earlier and a peer

--- a/src/family_gates.rs
+++ b/src/family_gates.rs
@@ -1,0 +1,255 @@
+//! Which edge gates apply to an Attestation family — total, by
+//! construction (CIRISPersist#742 / CIRISEdge#499).
+//!
+//! # The recurrence this exists to end
+//!
+//! Edge conditions serve-path behaviour on the Attestation *family* in
+//! more than one place: the E3 trace gate keys on
+//! [`AttestationFamily::Trace`], the CC 4.2.1 relay gate keys on
+//! [`AttestationFamily::Accord`]. Each fold onto persist's classifier
+//! was correct in isolation and each lived at its own call site, so
+//! "which gates apply to family F" was never written down anywhere —
+//! it was the union of two independent `matches!` expressions a reader
+//! had to find.
+//!
+//! That shape has now bitten twice in one week, once in each repo:
+//!
+//! - persist's `FAMILY_DIMS` claimed one representative per decided
+//!   family and was missing the three newest, so its dominance
+//!   invariant swept a corpus that read as total while never seeing
+//!   `accord:*`, `moderation:*`, or `provenance:build_manifest:*`.
+//! - edge's projection sweep fanned the Attestation plane across
+//!   exactly ONE dimension (`trust:example:v1`) while claiming to be
+//!   total over the plane — the same defect, one layer out.
+//!
+//! Both are the same class: **a check that could not observe the thing
+//! it ruled out.** The fix is not another assertion. It is to make the
+//! mapping a single total function whose *unknown* case is loud and
+//! restrictive rather than silent and permissive.
+//!
+//! # Why edge cannot use persist's guard
+//!
+//! Persist closed its version with a compile error — an exhaustive
+//! `match` over [`AttestationFamily`] with no wildcard, so adding a
+//! family fails the build until someone names its representative. That
+//! guard is real and it **does not transfer downstream**:
+//!
+//! - [`AttestationFamily`] is `#[non_exhaustive]`, so a match in any
+//!   other crate MUST carry a wildcard arm and can never be exhaustive.
+//! - `FAMILY_DIMS` and `all_planes()` live inside persist's own
+//!   `#[cfg(test)]` module, so there is nothing for edge to reuse.
+//!
+//! So edge cannot be *told at compile time* that persist grew a family.
+//! What edge can do is decide what happens when it meets one, and make
+//! that the safe direction — which is what [`gates_for`] does.
+//!
+//! # The wildcard is the whole design
+//!
+//! An unknown family gets **every gate applied** and sets
+//! [`FamilyGates::unknown_family`]. A row edge cannot classify is
+//! therefore withheld rather than served, and says so. That inverts the
+//! failure mode: the old shape let a newly-decided family route
+//! *ungated* until someone noticed, and the new shape makes it
+//! *over-gated* and noisy until someone teaches edge about it.
+//!
+//! Over-gating is a visible, reversible bug — someone reports that a
+//! family will not replicate. Under-gating is an invisible,
+//! unrecoverable one: rows that should not have been carried already
+//! were. Given the two, edge takes the loud one.
+//!
+//! This module holds **no projection rules**. Which cohort tiers a
+//! family reaches is persist's (`projection_for`, CIRISPersist#713),
+//! and edge reads it per-row with the row's real dimension, so routing
+//! was always total on that axis. What is edge's own — and what is
+//! written down here — is which of *edge's* gates each family passes
+//! through.
+
+use ciris_persist::federation::namespace::{attestation_family, AttestationFamily};
+
+/// The edge-side gates that apply to one Attestation family.
+///
+/// Every field is "does this gate run", never "what does it decide" —
+/// the decisions stay at the gates. This type answers only *which*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FamilyGates {
+    /// The E3 trace gate: the row is only served to a peer holding the
+    /// serve capability, and is withheld entirely while trace is
+    /// paused. Keys on [`AttestationFamily::Trace`].
+    pub requires_serve_capability: bool,
+    /// The CC 4.2.1 relay gate (CIRISPersist#731/#733): carriage is
+    /// narrowed to the accord's own roster. Keys on
+    /// [`AttestationFamily::Accord`].
+    pub accord_relay_gated: bool,
+    /// **This build could not classify the dimension's family.**
+    ///
+    /// Set only by the wildcard arm, which means persist has decided a
+    /// family this edge build predates. Every other field is `true`
+    /// alongside it: the row is maximally gated and will in practice be
+    /// withheld. Callers should log it once per dimension rather than
+    /// per row — it is a "this build is behind" signal, not a per-row
+    /// fault.
+    pub unknown_family: bool,
+}
+
+impl FamilyGates {
+    /// Every gate on. The wildcard's value, and the safe default.
+    const MAXIMAL_UNKNOWN: Self = Self {
+        requires_serve_capability: true,
+        accord_relay_gated: true,
+        unknown_family: true,
+    };
+
+    /// No family-conditioned gate. Note this is not "ungated" — the
+    /// projection filter, the consent gate, and the author-quarantine
+    /// gate apply to every row regardless of family and are not
+    /// represented here.
+    const NONE: Self = Self {
+        requires_serve_capability: false,
+        accord_relay_gated: false,
+        unknown_family: false,
+    };
+}
+
+/// Which edge gates apply to `dimension`'s family.
+///
+/// Total over every possible input: an unrecognised or malformed
+/// dimension classifies through persist's [`attestation_family`] like
+/// any other, and anything this build does not know reaches the
+/// wildcard and is maximally gated.
+#[must_use]
+pub fn gates_for(dimension: &str) -> FamilyGates {
+    match attestation_family(dimension) {
+        // The E3 capability gate. `trace:*` is the one family whose
+        // rows are withheld wholesale while trace is paused.
+        AttestationFamily::Trace => FamilyGates {
+            requires_serve_capability: true,
+            ..FamilyGates::NONE
+        },
+        // CC 4.2.1 — a node that never trusted the accord "is simply
+        // not reached". Projection says who may HOLD; this gate says
+        // who may CARRY.
+        AttestationFamily::Accord => FamilyGates {
+            accord_relay_gated: true,
+            ..FamilyGates::NONE
+        },
+        // Families edge carries under the common gates only. Named
+        // individually rather than folded into the wildcard, because
+        // the wildcard means "this build does not know" and these are
+        // known.
+        AttestationFamily::Consent
+        | AttestationFamily::Scores
+        | AttestationFamily::Capacity
+        | AttestationFamily::ContentClass
+        | AttestationFamily::SubstrateHealth => FamilyGates::NONE,
+        // FORCED by `#[non_exhaustive]`, and deliberately the
+        // restrictive arm. See the module docs: over-gating is visible
+        // and reversible, under-gating is neither.
+        _ => FamilyGates::MAXIMAL_UNKNOWN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One representative per family edge knows about. Kept beside the
+    /// match so the two drift together or not at all.
+    const REPRESENTATIVES: &[(&str, &str)] = &[
+        ("trace:reasoning:v1", "Trace"),
+        ("accord:human_dignity:v1", "Accord"),
+        ("consent:share:v1", "Consent"),
+        ("scores:alignment:v1", "Scores"),
+        ("capacity:relay_delivery:v1", "Capacity"),
+        ("content_class:nsfw:v1", "ContentClass"),
+        ("transport:reachability:v1", "SubstrateHealth"),
+    ];
+
+    #[test]
+    fn every_known_representative_classifies_and_is_not_the_unknown_arm() {
+        // Catches the drift edge CAN see: persist renaming a stem, or a
+        // representative that stops classifying, would silently fall
+        // into the wildcard and start being maximally gated. That is
+        // safe but wrong, and it should be loud rather than mysterious.
+        for (dimension, family) in REPRESENTATIVES {
+            let gates = gates_for(dimension);
+            assert!(
+                !gates.unknown_family,
+                "{dimension} (expected family {family}) fell through to the unknown \
+                 arm — persist likely renamed the stem, and edge is now maximally \
+                 gating a family it used to know",
+            );
+        }
+    }
+
+    #[test]
+    fn the_two_family_conditioned_gates_land_on_exactly_their_families() {
+        assert_eq!(
+            gates_for("trace:reasoning:v1"),
+            FamilyGates {
+                requires_serve_capability: true,
+                accord_relay_gated: false,
+                unknown_family: false,
+            },
+        );
+        assert_eq!(
+            gates_for("accord:human_dignity:v1"),
+            FamilyGates {
+                requires_serve_capability: false,
+                accord_relay_gated: true,
+                unknown_family: false,
+            },
+        );
+        // ...and on nothing else. A gate that quietly widened to a
+        // second family would change carriage for that family with no
+        // other signal.
+        for (dimension, _) in REPRESENTATIVES {
+            let gates = gates_for(dimension);
+            if !dimension.starts_with("trace:") {
+                assert!(
+                    !gates.requires_serve_capability,
+                    "{dimension} is not E3-gated"
+                );
+            }
+            if !dimension.starts_with("accord:") {
+                assert!(!gates.accord_relay_gated, "{dimension} is not relay-gated");
+            }
+        }
+    }
+
+    #[test]
+    fn an_unclassifiable_dimension_is_maximally_gated_not_ungated() {
+        // THE property. A family this build predates, or a malformed
+        // dimension, must end up withheld rather than served. The old
+        // shape — two independent `matches!` at two call sites — gave
+        // the opposite: an unknown family matched NEITHER, so every
+        // family-conditioned gate was skipped and the row went out
+        // ungated.
+        for dimension in [
+            "",
+            "not-a-namespace",
+            "someday:persist:decides:this:v1",
+            "accordion:not:accord:v1",
+        ] {
+            let gates = gates_for(dimension);
+            assert_eq!(
+                gates,
+                FamilyGates::MAXIMAL_UNKNOWN,
+                "{dimension:?} must be maximally gated, not silently ungated",
+            );
+            assert!(gates.unknown_family, "and must SAY it could not classify");
+        }
+    }
+
+    #[test]
+    fn a_near_miss_prefix_does_not_inherit_a_families_gates() {
+        // `accordion:` starts with `accord` as a string but is not the
+        // `accord:` family. Edge must not hand-roll prefix matching —
+        // this pins that `gates_for` goes through persist's classifier,
+        // where the stem boundary is defined.
+        assert!(gates_for("accordion:not:accord:v1").unknown_family);
+        assert_ne!(
+            gates_for("accordion:not:accord:v1"),
+            gates_for("accord:human_dignity:v1"),
+        );
+    }
+}

--- a/src/family_gates.rs
+++ b/src/family_gates.rs
@@ -57,6 +57,41 @@
 //! unrecoverable one: rows that should not have been carried already
 //! were. Given the two, edge takes the loud one.
 //!
+//! # What this changes today: NOTHING. The protection is latent.
+//!
+//! Stated plainly because the first version of this module claimed
+//! otherwise. Every `AttestationFamily` variant that exists at this pin
+//! is named in [`gates_for`] — including `Unknown`, which persist
+//! returns for any dimension with no family and which is emphatically
+//! NOT the unknown-family case. So no constructible input reaches the
+//! wildcard, and `gates_for` is **behaviourally identical** to the two
+//! inline `matches!` expressions it replaced.
+//!
+//! The value is entirely in the future: when persist decides family
+//! number ten, an inline `matches!` silently returns `false` and routes
+//! it ungated, while this fold routes it through the wildcard and
+//! withholds it loudly. Wiring it now is what puts the protection in
+//! the path *before* it is needed, not a behaviour change.
+//!
+//! **The wildcard arm therefore has no test, and cannot have one.** No
+//! constructible input reaches it, and asserting on
+//! `FamilyGates::MAXIMAL_UNKNOWN` directly is a compile-time constant
+//! that proves nothing at run time — clippy says so, and it is right.
+//! A test asserting a constant would manufacture the appearance of
+//! coverage over the one arm that has none, which is worse than the
+//! honest gap. The arm is held by review and by this paragraph.
+//!
+//! Two corrections are baked into that paragraph, both found by wiring
+//! this module rather than by testing it:
+//!
+//! - It sat with **zero callers** while its own docs and commit message
+//!   said it had replaced the inline checks. Mutation-verified tests on
+//!   a unit nothing calls is a green board over a dead protection.
+//! - It conflated `Unknown` with unknown-family, which maximally gated
+//!   `trust:*` and every other unclassified dimension. That reddened 13
+//!   unrelated tests the moment it was wired — and would have withheld
+//!   most of the corpus had it shipped inert-but-wired.
+//!
 //! This module holds **no projection rules**. Which cohort tiers a
 //! family reaches is persist's (`projection_for`, CIRISPersist#713),
 //! and edge reads it per-row with the row's real dimension, so routing
@@ -117,6 +152,13 @@ impl FamilyGates {
 /// any other, and anything this build does not know reaches the
 /// wildcard and is maximally gated.
 #[must_use]
+// The arms are grouped by MEANING, not by value. `Unknown` shares
+// `FamilyGates::NONE` with the plain families, but the two say different
+// things — "persist maps this to no family" versus "a decided family with no
+// edge-side gate" — and the comments on each are the record of a bug that
+// came from conflating exactly those. Merging them to satisfy the lint would
+// delete that distinction, which is the one this module got wrong once.
+#[allow(clippy::match_same_arms)]
 pub fn gates_for(dimension: &str) -> FamilyGates {
     match attestation_family(dimension) {
         // The E3 capability gate. `trace:*` is the one family whose
@@ -140,10 +182,32 @@ pub fn gates_for(dimension: &str) -> FamilyGates {
         | AttestationFamily::Scores
         | AttestationFamily::Capacity
         | AttestationFamily::ContentClass
-        | AttestationFamily::SubstrateHealth => FamilyGates::NONE,
-        // FORCED by `#[non_exhaustive]`, and deliberately the
-        // restrictive arm. See the module docs: over-gating is visible
-        // and reversible, under-gating is neither.
+        | AttestationFamily::SubstrateHealth
+        | AttestationFamily::Moderation
+        | AttestationFamily::ProvenanceBuildManifest => FamilyGates::NONE,
+
+        // `Unknown` is NOT the unknown-family case, and conflating the two
+        // was a real bug in this module — invisible for as long as it had no
+        // callers, and it maximally-gated 13 test paths the moment it was
+        // wired.
+        //
+        // Persist returns `Unknown` for any dimension its registry maps to no
+        // family at all: `trust:*`, `objection:*`, and every ordinary
+        // dimension outside the nine decided families. Those are not
+        // mysteries — they are simply not family-gated, and gating them would
+        // withhold most of the corpus.
+        //
+        // The case this module exists for is a variant added by a persist
+        // NEWER than this build, which `#[non_exhaustive]` makes reachable
+        // and which no name here can match. That is the wildcard below, and
+        // separating it from `Unknown` is what makes the wildcard mean what
+        // its doc says.
+        AttestationFamily::Unknown => FamilyGates::NONE,
+        // FORCED by `#[non_exhaustive]`, and now genuinely reserved for a
+        // family decided by a persist newer than this build — every family
+        // this build knows about, INCLUDING `Unknown`, is named above.
+        // Deliberately the restrictive arm: over-gating is visible and
+        // reversible, under-gating is neither.
         _ => FamilyGates::MAXIMAL_UNKNOWN,
     }
 }
@@ -216,40 +280,91 @@ mod tests {
         }
     }
 
+    /// The test that would have caught this module being DEAD CODE.
+    ///
+    /// Every other test here calls `gates_for` directly, so all four stayed
+    /// green — and mutation-verified — while the serve path still used its own
+    /// inline `matches!` and nothing called this module at all. A
+    /// mutation-verified unit with no callers is a green board over a dead
+    /// protection, and it is the exact trap this repo keeps hitting.
+    ///
+    /// So this asserts through the CALL SITES instead: the two public
+    /// predicates the serve path actually consults must agree with
+    /// `gates_for`, including on the unknown case. Re-inlining a `matches!`
+    /// at either site reds this.
     #[test]
-    fn an_unclassifiable_dimension_is_maximally_gated_not_ungated() {
-        // THE property. A family this build predates, or a malformed
-        // dimension, must end up withheld rather than served. The old
-        // shape — two independent `matches!` at two call sites — gave
-        // the opposite: an unknown family matched NEITHER, so every
-        // family-conditioned gate was skipped and the row went out
-        // ungated.
+    fn the_serve_paths_predicates_read_this_module_and_not_a_local_matches() {
+        use crate::replication::accord_relay_gate::AccordRelayGate;
+
         for dimension in [
+            "accord:human_dignity:v1",
+            "trace:reasoning:v1",
+            "consent:share:v1",
+            "trust:example:v1",
+            "objection:halt:v1",
+        ] {
+            let expected = gates_for(dimension);
+            assert_eq!(
+                AccordRelayGate::dimension_is_gated(dimension),
+                expected.accord_relay_gated,
+                "the relay gate's pre-filter must read gates_for for {dimension:?} \
+                 — an inline matches! returns false on an unknown family and CARRIES it",
+            );
+        }
+
+        // HONEST LIMIT: with `Unknown` correctly mapped to NONE, `gates_for`
+        // and the inline `matches!` it replaced are behaviourally IDENTICAL
+        // at this pin — every existing variant is named, so they cannot
+        // disagree on any constructible input. This test therefore guards the
+        // WIRING (that the serve path reads one shared fold) and cannot, by
+        // construction, detect a re-inline by behaviour alone. The protection
+        // is latent: it bites when persist adds a family, not today.
+    }
+
+    #[test]
+    fn a_dimension_with_no_family_is_not_family_gated() {
+        // REGRESSION TEST for a real bug in this module, which was invisible
+        // for as long as it had no callers.
+        //
+        // Persist returns `AttestationFamily::Unknown` for any dimension its
+        // registry maps to no family — `trust:*`, `objection:*`, and most of
+        // the corpus. The first version of `gates_for` let `Unknown` fall to
+        // the wildcard and be MAXIMALLY gated, conflating "no family" with
+        // "a family I have never heard of". Wiring the module turned 13
+        // unrelated tests red, which is what surfaced it.
+        //
+        // Those dimensions are not mysteries. They are simply not
+        // family-gated, and gating them would withhold most of what this node
+        // carries.
+        for dimension in [
+            "trust:example:v1",
+            "objection:halt:v1",
             "",
             "not-a-namespace",
-            "someday:persist:decides:this:v1",
-            "accordion:not:accord:v1",
         ] {
             let gates = gates_for(dimension);
+            assert!(
+                !gates.unknown_family,
+                "{dimension:?} classifies as Unknown, which is a KNOWN answer",
+            );
             assert_eq!(
                 gates,
-                FamilyGates::MAXIMAL_UNKNOWN,
-                "{dimension:?} must be maximally gated, not silently ungated",
+                FamilyGates::NONE,
+                "{dimension:?} has no family, so no family-conditioned gate applies",
             );
-            assert!(gates.unknown_family, "and must SAY it could not classify");
         }
     }
 
     #[test]
     fn a_near_miss_prefix_does_not_inherit_a_families_gates() {
         // `accordion:` starts with `accord` as a string but is not the
-        // `accord:` family. Edge must not hand-roll prefix matching —
-        // this pins that `gates_for` goes through persist's classifier,
-        // where the stem boundary is defined.
-        assert!(gates_for("accordion:not:accord:v1").unknown_family);
+        // `accord:` family. Pins that `gates_for` goes through persist's
+        // classifier, where the stem boundary is defined, rather than
+        // hand-rolling a prefix match.
         assert_ne!(
             gates_for("accordion:not:accord:v1"),
             gates_for("accord:human_dignity:v1"),
         );
+        assert!(!gates_for("accordion:not:accord:v1").accord_relay_gated);
     }
 }

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1077,7 +1077,8 @@ impl PyEdge {
                     transport: tid,
                     received_at: chrono::Utc::now(),
                     source_key_id: None,
-                    link_key_id: None, // CIRISEdge#402
+                    link_key_id: None,   // CIRISEdge#402
+                    arrival_scope: None, // CIRISEdge#499 — injected frame, federation arrival
                 };
                 inner
                     .dispatch_inbound_observed_outcome_for_test(frame)

--- a/src/field_conformance.rs
+++ b/src/field_conformance.rs
@@ -273,9 +273,49 @@ fn check_cohort_scope_projection() -> Result<(), String> {
     // is a function of this value, so an unhandled cell would be a routing hole.
     // `authority_for` on a benign dimension gives a concrete AuthorityClass.
     let authority = authority_for("trust:example:v1").class;
+    // CIRISPersist#742 — the Attestation plane's projection varies by
+    // FAMILY, so sweeping it at one dimension is not sweeping the plane.
+    // Persist found exactly this in its own corpus (`FAMILY_DIMS` claimed
+    // "one representative per decided family" and was missing the three
+    // newest, so its dominance invariant read as total while never seeing
+    // them). Edge had the sharper version: ONE dimension, `trust:example:v1`,
+    // standing in for every family edge actually routes.
+    //
+    // Persist's fix was a compile error — an exhaustive match over
+    // `AttestationFamily` with no wildcard, so a new family fails the build
+    // until someone names its representative. **That guard does not transfer
+    // to edge.** `AttestationFamily` is `#[non_exhaustive]`, so a downstream
+    // match MUST carry a wildcard arm and can never be exhaustive; and
+    // `FAMILY_DIMS` / `all_planes()` live inside persist's own
+    // `#[cfg(test)]` module, so there is nothing to reuse. Edge's fallback is
+    // this list plus `family_representatives_still_classify_as_intended`
+    // below, which catches the drift edge CAN see (a representative that
+    // stops classifying) even though it cannot catch a family edge has never
+    // heard of.
     for plane in [
         Plane::Attestation {
             dimension: "trust:example:v1",
+        },
+        Plane::Attestation {
+            dimension: "accord:human_dignity:v1",
+        },
+        Plane::Attestation {
+            dimension: "moderation:allegation:v1",
+        },
+        Plane::Attestation {
+            dimension: "provenance:build_manifest:v1",
+        },
+        Plane::Attestation {
+            dimension: "consent:share:v1",
+        },
+        Plane::Attestation {
+            dimension: "trace:reasoning:v1",
+        },
+        Plane::Attestation {
+            dimension: "scores:alignment:v1",
+        },
+        Plane::Attestation {
+            dimension: "capacity:relay_delivery:v1",
         },
         Plane::KeyRecord,
         Plane::TransportDestination,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ mod sas_wordlist;
 // hash, derived on membership/epoch change and read (never derived) on
 // the packet path, with the three-phase epoch rotation that keeps the
 // receive accept-set a superset of the send-set (CIRISEdge#492 shape).
+pub mod cohort_addressing;
 pub mod scope_addressing;
 // v6.0.0 (CIRISEdge#175) — CC 1.13.3.4 substrate.
 pub mod scope_privacy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ mod sas_wordlist;
 // receive accept-set a superset of the send-set (CIRISEdge#492 shape).
 pub mod av_addressing;
 pub mod cohort_addressing;
+pub mod contextual_integrity;
 pub mod family_gates;
 pub mod scope_addressing;
 pub mod scope_lifecycle;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,6 +103,7 @@ mod sas_wordlist;
 // receive accept-set a superset of the send-set (CIRISEdge#492 shape).
 pub mod cohort_addressing;
 pub mod scope_addressing;
+pub mod scope_lifecycle;
 // v6.0.0 (CIRISEdge#175) — CC 1.13.3.4 substrate.
 pub mod scope_privacy;
 pub mod swarm;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ mod sas_wordlist;
 // the packet path, with the three-phase epoch rotation that keeps the
 // receive accept-set a superset of the send-set (CIRISEdge#492 shape).
 pub mod cohort_addressing;
+pub mod family_gates;
 pub mod scope_addressing;
 pub mod scope_lifecycle;
 // v6.0.0 (CIRISEdge#175) — CC 1.13.3.4 substrate.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,6 +101,7 @@ mod sas_wordlist;
 // hash, derived on membership/epoch change and read (never derived) on
 // the packet path, with the three-phase epoch rotation that keeps the
 // receive accept-set a superset of the send-set (CIRISEdge#492 shape).
+pub mod av_addressing;
 pub mod cohort_addressing;
 pub mod family_gates;
 pub mod scope_addressing;

--- a/src/mls/cohort_group.rs
+++ b/src/mls/cohort_group.rs
@@ -77,12 +77,20 @@
 //! # Relationship to `transport::realtime_av_mls`
 //!
 //! Same ciphersuite (`0x004D` X-Wing), same provider, same commit
-//! patterns — but a **different** exporter label
-//! ([`COHORT_SECRET_LABEL`] vs the A/V module's
-//! `ciris-realtime-av-epoch-dek-seed-v1`), so a cohort secret and an
-//! A/V DEK seed can never collide even if some future deployment
-//! points both at one group. RFC 9420 makes exporter derivations
-//! label-domain-separated; this module relies on that.
+//! patterns — but **different** exporter labels. This module exports
+//! under CIRISVerify's scope-privacy labels
+//! ([`crate::scope_privacy::DESTINATION_EXPORTER_LABEL`] and
+//! [`crate::scope_privacy::RECORD_EXPORTER_LABEL`], v13.5.0); the A/V
+//! module exports under `ciris-realtime-av-epoch-dek-seed-v1`. So a
+//! cohort secret and an A/V DEK seed can never collide even if some
+//! future deployment points both at one group. RFC 9420 makes exporter
+//! derivations label-domain-separated; this module relies on that.
+//!
+//! Verify refused the DEK-seed label for scope-privacy inputs
+//! explicitly and on the record: it protects payload confidentiality,
+//! and deriving a routing identifier that appears in the clear on the
+//! wire from that material would collapse two secrets §8.5 exists to
+//! keep independent.
 //!
 //! Per the workstream file boundary this module does **not** import
 //! from `crate::transport::*`. The few helpers it needs from there —
@@ -131,16 +139,12 @@ pub const CIPHERSUITE_ID: u16 = 0x004D;
 /// The openmls enum value [`CIPHERSUITE_ID`] maps to.
 const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519;
 
-/// Exporter label for the cohort epoch secret.
-///
-/// **Domain-separated** from the A/V path's
-/// `ciris-realtime-av-epoch-dek-seed-v1`. RFC 9420 §8.5 derives
-/// exporters as a function of the label, so two consumers of the same
-/// group's exporter that use different labels get unrelated secrets.
-/// The cohort secret feeds `scope_privacy`'s `k_record_id` /
-/// `k_symbol` (CEWP `SCOPE_PRIVACY.md` §2.2); the A/V one feeds a
-/// media DEK. They must never be the same bytes.
-pub const COHORT_SECRET_LABEL: &str = "ciris-cohort-mls-epoch-exporter-v1";
+// The exporter labels for cohort secrets are NOT defined here. They are
+// CIRISVerify's (`RECORD_EXPORTER_LABEL` / `DESTINATION_EXPORTER_LABEL`,
+// v13.5.0), re-exported through `crate::scope_privacy` and used
+// verbatim — a label is a cross-impl wire fact, and an edge-local one
+// would put two owners on it. This module previously defined its own
+// `COHORT_SECRET_LABEL`; it was retired when verify settled the family.
 
 /// Length of a [`CohortSecret`], in bytes.
 pub const COHORT_SECRET_LEN: usize = 32;
@@ -340,7 +344,9 @@ pub enum CohortGroupError {
 // ─── The cohort epoch secret ────────────────────────────────────────
 
 /// The current epoch's MLS exporter secret for a cohort, derived
-/// under [`COHORT_SECRET_LABEL`].
+/// under one of CIRISVerify's scope-privacy exporter labels — see
+/// [`CohortGroup::destination_secret`] and
+/// [`CohortGroup::record_secret`].
 ///
 /// This is the `exporter_secret` the `community` / `affiliations`
 /// scopes were missing: 32 bytes bound to *this* group at *this*
@@ -783,19 +789,37 @@ impl CohortGroupInner {
         }
     }
 
-    /// Derive this epoch's cohort exporter secret.
-    fn exporter(&self) -> Result<CohortSecret, CohortGroupError> {
+    /// Derive this epoch's cohort secret under one of CIRISVerify's
+    /// scope-privacy exporter labels (CIRISVerify#259, v13.5.0).
+    ///
+    /// `label` is [`crate::scope_privacy::RECORD_EXPORTER_LABEL`] or
+    /// [`crate::scope_privacy::DESTINATION_EXPORTER_LABEL`] — never an
+    /// edge-local string. Both the label and the context are
+    /// cross-impl wire facts: two members of one cohort derive the
+    /// same bytes only if they export under the same `(label,
+    /// context, length)`, so verify owns all three and edge reproduces
+    /// them.
+    fn scope_secret(&self, label: &str) -> Result<CohortSecret, CohortGroupError> {
         let bytes = self
             .group
             .export_secret(
                 self.provider.crypto(),
-                COHORT_SECRET_LABEL,
-                // Context = the community id. The group id already
-                // commits to it (see `cohort_group_id`), so this is
-                // belt-and-braces: it means a snapshot restored under
-                // the WRONG community namespace produces a different
-                // secret rather than a silently-shared one.
-                self.community_id.as_bytes(),
+                label,
+                // EXPORTER_CONTEXT is EMPTY, per verify: the exporter
+                // already binds (group_id, epoch) via RFC 9420 §8.5, so
+                // a context adds nothing and is "one less thing to
+                // diverge on". This deliberately replaces edge's
+                // earlier `community_id`-as-context: that was
+                // belt-and-braces against a snapshot restored under the
+                // wrong namespace, but a non-empty context edge chose
+                // for itself would make edge derive different bytes
+                // from every other implementation — trading a local
+                // safety margin for a silent cross-impl split. The
+                // namespace check now lives where it can be enforced
+                // without touching the wire: `join` refuses a Welcome
+                // whose group id is not the one derived for the
+                // community (CIRISEdge#500).
+                crate::scope_privacy::EXPORTER_CONTEXT,
                 COHORT_SECRET_LEN,
             )
             .map_err(|e| CohortGroupError::ExportFailed(format!("{e:?}")))?;
@@ -1179,11 +1203,42 @@ impl CohortGroup {
     /// `exporter_secret` the `community` / `affiliations` scopes need
     /// (CIRISEdge#499).
     ///
-    /// Derived under [`COHORT_SECRET_LABEL`], domain-separated from
-    /// the A/V media-key label, with the `community_id` as exporter
-    /// context.
-    pub async fn current_exporter(&self) -> Result<CohortSecret, CohortGroupError> {
-        self.inner.lock().await.exporter()
+    /// The **destination** plane secret — the input to
+    /// `k_destination` / `derive_destination`, and therefore to every
+    /// scoped Reticulum address this node presents in the cohort.
+    ///
+    /// Derived under [`crate::scope_privacy::DESTINATION_EXPORTER_LABEL`],
+    /// which is deliberately distinct from the record plane's label:
+    /// the two secrets go to different subsystems, and sharing one PRK
+    /// would mean a compromise yielding the record secret
+    /// *retroactively deanonymizes all routing* — an adversary
+    /// recomputes and links every address the node ever presented,
+    /// collapsing exactly the unlinkability scope-native addressing
+    /// exists to buy.
+    ///
+    /// # Errors
+    /// [`CohortGroupError::ExportFailed`] on a corrupted group state.
+    pub async fn destination_secret(&self) -> Result<CohortSecret, CohortGroupError> {
+        self.inner
+            .lock()
+            .await
+            .scope_secret(crate::scope_privacy::DESTINATION_EXPORTER_LABEL)
+    }
+
+    /// The **record** plane secret — the input to `k_record_id` /
+    /// `k_symbol`, derived under
+    /// [`crate::scope_privacy::RECORD_EXPORTER_LABEL`].
+    ///
+    /// Independent of [`Self::destination_secret`] by construction; see
+    /// there for why the separation is load-bearing rather than tidy.
+    ///
+    /// # Errors
+    /// [`CohortGroupError::ExportFailed`] on a corrupted group state.
+    pub async fn record_secret(&self) -> Result<CohortSecret, CohortGroupError> {
+        self.inner
+            .lock()
+            .await
+            .scope_secret(crate::scope_privacy::RECORD_EXPORTER_LABEL)
     }
 
     /// Add a member from a KeyPackage that member published, advance
@@ -1540,8 +1595,8 @@ mod tests {
         // everything except the secret would derive a different scoped
         // address and be silently unreachable (CIRISEdge#499).
         assert_eq!(
-            b.current_exporter().await.unwrap().as_bytes(),
-            a.current_exporter().await.unwrap().as_bytes(),
+            b.destination_secret().await.unwrap().as_bytes(),
+            a.destination_secret().await.unwrap().as_bytes(),
             "joiner must derive the SAME cohort secret as the founder",
         );
         let mut roster = b.member_key_ids().await;
@@ -1578,7 +1633,7 @@ mod tests {
                     .is_some(),
                 "the snapshot the head names must exist before join returns",
             );
-            (epoch, *b.current_exporter().await.unwrap().as_bytes())
+            (epoch, *b.destination_secret().await.unwrap().as_bytes())
         };
 
         // Crash, then reload. Membership peers already committed to
@@ -1589,7 +1644,7 @@ mod tests {
             .expect("a joined group reloads");
         assert_eq!(reloaded.epoch().await, epoch_at_join);
         assert_eq!(
-            *reloaded.current_exporter().await.unwrap().as_bytes(),
+            *reloaded.destination_secret().await.unwrap().as_bytes(),
             secret_at_join,
         );
         // And it can still take part: applying the founder's next
@@ -1598,8 +1653,8 @@ mod tests {
         let new_epoch = reloaded.apply_remote_commit(rotate.commit()).await.unwrap();
         assert_eq!(new_epoch, a.epoch().await);
         assert_eq!(
-            reloaded.current_exporter().await.unwrap().as_bytes(),
-            a.current_exporter().await.unwrap().as_bytes(),
+            reloaded.destination_secret().await.unwrap().as_bytes(),
+            a.destination_secret().await.unwrap().as_bytes(),
         );
     }
 
@@ -1640,7 +1695,7 @@ mod tests {
             .await
             .unwrap();
         let own_epoch = own.epoch().await;
-        let own_secret = *own.current_exporter().await.unwrap().as_bytes();
+        let own_secret = *own.destination_secret().await.unwrap().as_bytes();
 
         let err = CohortGroup::join(store_b.clone(), "c-existing", material, &welcome, 16)
             .await
@@ -1657,7 +1712,7 @@ mod tests {
             .expect("pre-existing group survives a refused join");
         assert_eq!(reloaded.epoch().await, own_epoch);
         assert_eq!(
-            *reloaded.current_exporter().await.unwrap().as_bytes(),
+            *reloaded.destination_secret().await.unwrap().as_bytes(),
             own_secret
         );
     }
@@ -1879,30 +1934,98 @@ mod tests {
         let g = CohortGroup::create(store, "c-exp", "node-a", 4)
             .await
             .unwrap();
-        let s0 = g.current_exporter().await.unwrap();
-        let s0b = g.current_exporter().await.unwrap();
+        let s0 = g.destination_secret().await.unwrap();
+        let s0b = g.destination_secret().await.unwrap();
         assert_eq!(s0.as_bytes(), s0b.as_bytes());
 
         let _ = g.rotate().await.unwrap();
-        let s1 = g.current_exporter().await.unwrap();
+        let s1 = g.destination_secret().await.unwrap();
         assert_ne!(s0.as_bytes(), s1.as_bytes());
     }
 
     #[tokio::test]
+    async fn the_two_scope_planes_derive_independent_secrets() {
+        // CIRISVerify v13.5.0 gives the record plane and the
+        // destination plane their OWN exporter labels, and that
+        // separation is load-bearing rather than tidy: sharing one PRK
+        // would mean a compromise yielding the record secret
+        // retroactively deanonymizes all routing — an adversary
+        // recomputes and links every address the node ever presented.
+        // If these two ever came back equal, that property is gone and
+        // nothing else in the stack would notice.
+        let g = CohortGroup::create(open_store(), "c-planes", "node-a", 4)
+            .await
+            .unwrap();
+        let dest = *g.destination_secret().await.unwrap().as_bytes();
+        let record = *g.record_secret().await.unwrap().as_bytes();
+        assert_ne!(
+            dest, record,
+            "record and destination planes must not share a PRK",
+        );
+
+        // Each is deterministic within an epoch...
+        assert_eq!(*g.destination_secret().await.unwrap().as_bytes(), dest);
+        assert_eq!(*g.record_secret().await.unwrap().as_bytes(), record);
+
+        // ...and both move when the epoch does, or rotation would not
+        // re-address the group.
+        let _rotated = g.rotate().await.unwrap();
+        assert_ne!(*g.destination_secret().await.unwrap().as_bytes(), dest);
+        assert_ne!(*g.record_secret().await.unwrap().as_bytes(), record);
+    }
+
+    #[tokio::test]
+    async fn the_exporter_context_is_verifys_empty_value_not_the_community_id() {
+        // The context is a cross-impl wire fact: two members agree only
+        // under the same (label, context, length). Edge previously used
+        // `community_id` as the context — a local safety margin that
+        // would have made edge derive different bytes from every other
+        // implementation. Verify specifies EMPTY, so that is what this
+        // pins, by deriving the same secret a bare export_secret call
+        // under verify's constants produces.
+        let g = CohortGroup::create(open_store(), "c-context", "node-a", 4)
+            .await
+            .unwrap();
+        let via_accessor = *g.destination_secret().await.unwrap().as_bytes();
+
+        let inner = g.inner.lock().await;
+        let direct = inner
+            .group
+            .export_secret(
+                inner.provider.crypto(),
+                crate::scope_privacy::DESTINATION_EXPORTER_LABEL,
+                crate::scope_privacy::EXPORTER_CONTEXT,
+                COHORT_SECRET_LEN,
+            )
+            .unwrap();
+        assert_eq!(
+            via_accessor.as_slice(),
+            direct.as_slice(),
+            "the accessor must export under verify's exact (label, context, length)",
+        );
+        assert!(
+            crate::scope_privacy::EXPORTER_CONTEXT.is_empty(),
+            "verify specifies an EMPTY exporter context",
+        );
+    }
+
+    #[tokio::test]
     async fn exporter_is_domain_separated_from_the_av_label() {
-        // The cohort label must NOT be the A/V one. Asserted on the
-        // constant (the A/V string is duplicated here rather than
+        // Neither scope-privacy label may be the A/V DEK-seed label —
+        // verify refused that input explicitly. Asserted on the
+        // constants (the A/V string is duplicated here rather than
         // imported — `crate::transport::*` is off-limits for this
         // workstream) and behaviourally: exporting the same group
         // under the A/V label yields different bytes.
         const AV_LABEL: &str = "ciris-realtime-av-epoch-dek-seed-v1";
-        assert_ne!(COHORT_SECRET_LABEL, AV_LABEL);
+        assert_ne!(crate::scope_privacy::DESTINATION_EXPORTER_LABEL, AV_LABEL);
+        assert_ne!(crate::scope_privacy::RECORD_EXPORTER_LABEL, AV_LABEL);
 
         let store = open_store();
         let g = CohortGroup::create(store, "c-label", "node-a", 4)
             .await
             .unwrap();
-        let cohort = g.current_exporter().await.unwrap();
+        let cohort = g.destination_secret().await.unwrap();
 
         let inner = g.inner.lock().await;
         let av = inner
@@ -2058,14 +2181,14 @@ mod tests {
             let g = CohortGroup::create(store.clone(), "c-exp-rt", "node-a", 8)
                 .await
                 .unwrap();
-            *g.current_exporter().await.unwrap().as_bytes()
+            *g.destination_secret().await.unwrap().as_bytes()
         };
         let reloaded = CohortGroup::load(store, "c-exp-rt", 8)
             .await
             .unwrap()
             .unwrap();
         assert_eq!(
-            *reloaded.current_exporter().await.unwrap().as_bytes(),
+            *reloaded.destination_secret().await.unwrap().as_bytes(),
             before
         );
     }
@@ -2256,8 +2379,8 @@ mod tests {
 
         // Both sides derive the same exporter for the same epoch —
         // the property that makes a cohort secret a *shared* secret.
-        let shared = *a.current_exporter().await.unwrap().as_bytes();
-        assert_eq!(*b.current_exporter().await.unwrap().as_bytes(), shared);
+        let shared = *a.destination_secret().await.unwrap().as_bytes();
+        assert_eq!(*b.destination_secret().await.unwrap().as_bytes(), shared);
 
         // …and node-b's applied epoch survives a restart, exporter
         // included. A Welcome-joined group persists exactly like a
@@ -2270,7 +2393,7 @@ mod tests {
             .expect("joined group must reload");
         assert_eq!(b_reloaded.epoch().await, new_epoch);
         assert_eq!(
-            *b_reloaded.current_exporter().await.unwrap().as_bytes(),
+            *b_reloaded.destination_secret().await.unwrap().as_bytes(),
             shared
         );
     }
@@ -2371,13 +2494,13 @@ mod tests {
         let g = groups.open("c-evict").await.unwrap();
         let _ = g.rotate().await.unwrap();
         let epoch = g.epoch().await;
-        let secret = *g.current_exporter().await.unwrap().as_bytes();
+        let secret = *g.destination_secret().await.unwrap().as_bytes();
         drop(g);
 
         assert!(groups.evict("c-evict").await);
         let back = groups.open("c-evict").await.unwrap();
         assert_eq!(back.epoch().await, epoch);
-        assert_eq!(*back.current_exporter().await.unwrap().as_bytes(), secret);
+        assert_eq!(*back.destination_secret().await.unwrap().as_bytes(), secret);
     }
 
     #[tokio::test]
@@ -2390,8 +2513,8 @@ mod tests {
         assert_eq!(a.epoch().await, 1);
         assert_eq!(b.epoch().await, 0);
         assert_ne!(
-            a.current_exporter().await.unwrap().as_bytes(),
-            b.current_exporter().await.unwrap().as_bytes()
+            a.destination_secret().await.unwrap().as_bytes(),
+            b.destination_secret().await.unwrap().as_bytes()
         );
     }
 }

--- a/src/mls/mod.rs
+++ b/src/mls/mod.rs
@@ -36,9 +36,7 @@ pub mod scope_state;
 pub mod welcome_wrap;
 
 pub use archive_mode::{ArchiveMode, ArchiveModeError, DEFAULT_ROTATE_FORWARD_WINDOW_DAYS};
-pub use cohort_group::{
-    CohortCommit, CohortGroup, CohortGroupError, CohortGroups, CohortSecret, COHORT_SECRET_LABEL,
-};
+pub use cohort_group::{CohortCommit, CohortGroup, CohortGroupError, CohortGroups, CohortSecret};
 pub use scope_state::{ScopeStateProvider, ScopeStateProviderError};
 pub use welcome_wrap::{
     unwrap_welcome, wrap_welcome, FederationDirectoryEntry, WelcomeWrapError, WrappedWelcome,

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -437,6 +437,33 @@ pub enum WithholdReason {
     /// fail-closed anyway, so a future persist widening surfaces as a NAMED
     /// withhold rather than as an allow.
     HoldingScopeProjectionUnsupported,
+    /// CIRISPersist#744 (swarm holdings plane) — the gate is ARMED (a scope
+    /// address table is installed) but no `FederationDirectory` is wired, so
+    /// neither `holdings_authority` nor `resolve_projection_recipients` can be
+    /// asked. A WIRING fault, not a policy decision. Refused rather than
+    /// falling back to the pre-#744 hard-coded `ProducerSteward`, which would
+    /// resurrect the under-advertisement defect invisibly.
+    HoldingScopeDirectoryMissing,
+    /// CIRISPersist#744 (swarm holdings plane) — persist's `holdings_authority`
+    /// errored: the accord-co-scrub trust-root walk over the PUBLISHER's key
+    /// could not be completed. Never folded into a `ProducerSteward` default —
+    /// a read that failed is not a statement that the publisher is a plain
+    /// producer (the #425 Exhibit C split, on the authority axis).
+    HoldingScopeAuthorityUnresolved,
+    /// CIRISPersist#744 (swarm holdings plane) — persist's
+    /// `resolve_projection_recipients` returned `set_resolvable: false`:
+    /// **"I cannot judge"** this record's recipient set. Its own variant,
+    /// never folded into [`Self::HoldingScopePeerNotInRoster`] — persist keeps
+    /// the two bools separate precisely so an admission of ignorance is not
+    /// reported as an accusation about the peer, and the remedies differ (fix
+    /// a roster table or a group registration vs. fix a membership list).
+    HoldingScopeRecipientSetUnresolved,
+    /// CIRISPersist#744 (swarm holdings plane) — persist's
+    /// `resolve_projection_recipients` returned `Err`. Distinct from
+    /// [`Self::HoldingScopeRecipientSetUnresolved`], which is a VERDICT persist
+    /// reached deliberately; this is an infrastructure fault. Persist retains
+    /// the `Result` for exactly this split.
+    HoldingScopeRecipientReadError,
 }
 
 impl WithholdReason {
@@ -474,6 +501,10 @@ impl WithholdReason {
             Self::HoldingScopeUndeterminable => "holding_scope_undeterminable",
             Self::HoldingScopePublicGroup => "holding_scope_public_group",
             Self::HoldingScopePeerNotInRoster => "holding_scope_peer_not_in_roster",
+            Self::HoldingScopeDirectoryMissing => "holding_scope_directory_missing",
+            Self::HoldingScopeAuthorityUnresolved => "holding_scope_authority_unresolved",
+            Self::HoldingScopeRecipientSetUnresolved => "holding_scope_recipient_set_unresolved",
+            Self::HoldingScopeRecipientReadError => "holding_scope_recipient_read_error",
             Self::HoldingScopeProjectionUnsupported => "holding_scope_projection_unsupported",
         }
     }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -336,23 +336,55 @@ pub enum WithholdReason {
     /// says *"we never ran the check"*, which is a wiring/timing fact, not a
     /// statement about the signer or the root.
     AccordRelayUnresolved,
-    /// CIRISPersist#731 — an `accord:*` row whose SIGNED bytes could not be read
-    /// at all: no `attestation_envelope`, no `row` mirror, or a mirror that does
-    /// not deserialize as persist's
-    /// [`RowMirror`](ciris_persist::federation::envelope::RowMirror). The gate
-    /// cannot learn WHO signed it or WHICH accord it acts under, so it is
-    /// withheld — LOUD and named, never a silent `continue` (CIRISEdge#425/#433).
-    /// A malformed or pre-v31 unstamped row, not a trust statement.
+    /// CIRISPersist#731 — the wire value is not an
+    /// [`Attestation`](ciris_persist::federation::Attestation) at all: it does
+    /// not deserialize into persist's row type, so there is no row to hand the
+    /// relay verb and nothing to ask. Withheld — LOUD and named, never a silent
+    /// `continue` (CIRISEdge#425/#433). A producer/serialization fault, not a
+    /// trust statement.
     AccordRelayObjectUnreadable,
-    /// CIRISPersist#731 — the row's signed bytes parsed, but **nothing in them
-    /// names the accord this object acts under**, so "which root?" has no
-    /// object-derived answer and the carriage question cannot be asked. The
-    /// permissive failure #731 is about is precisely what happens if this is
-    /// answered from construction state instead, so it refuses. See
-    /// [`AccordRelaySubject`](crate::replication::accord_relay_gate::AccordRelaySubject)
-    /// — an UPSTREAM gap (persist owns which field of an `accord:*` row names its
-    /// root), not a local misconfiguration.
+    /// CIRISPersist#733 — the row deserialized, but its signed
+    /// [`RowMirror`](ciris_persist::federation::envelope::RowMirror) is ABSENT
+    /// (a pre-#643 unstamped row) or DIVERGES from the typed columns, so the
+    /// columns assert nothing: persist's
+    /// [`check_row_column_binding`](ciris_persist::federation::admission::check_row_column_binding)
+    /// refuses it and its own relay verb treats that as *"I cannot judge"*.
+    ///
+    /// Never folded into [`Self::AccordRelayObjectUnreadable`]: a DIVERGENCE is a
+    /// security event (a relay rewriting a signed row's identity, verb, signer or
+    /// subject while the signature still verifies — CIRISPersist#643's whole
+    /// class), while a missing mirror is a producer-vintage problem. Different
+    /// findings, different remedies.
+    AccordRelayMirrorUnbound,
+    /// CIRISPersist#733 — persist's own classifier says the row is not on the
+    /// `accord:*` family at all
+    /// ([`AccordRootClaim::NotAccord`](ciris_persist::federation::trust_root::AccordRootClaim)),
+    /// so it "is not this predicate's to judge" and the verb refuses it.
+    /// Structurally unreachable through the serve path (the `accord:*` early-out
+    /// runs persist's own `attestation_family` first) and booked anyway, so a
+    /// classifier disagreement surfaces as a NAMED withhold rather than as an
+    /// allow.
+    AccordRelayObjectNotAccord,
+    /// CIRISPersist#733 — the row is on the `accord:*` family and **nothing in
+    /// it names the accord this object acts under**: no signed `accord_root`
+    /// key, and not the one dimension whose fallback rule persist defines. A
+    /// pre-#733 row or an unadopted producer's. "Which root?" has no
+    /// object-derived answer, and answering it from construction state instead
+    /// is precisely the permissive failure #731 reports — so it refuses. The
+    /// durable narrowing #733 accepted, not a local misconfiguration.
     AccordRelayObjectRootUnnamed,
+    /// CIRISPersist#733 — **ONE ARTIFACT ASSERTING TWO ACCORDS**: the row's
+    /// signed `accord_root` key and the drill-dimension rule name DIFFERENT
+    /// roots. Neither is preferred (preferring the key lets an emitter relabel a
+    /// heartbeat's accord; preferring the column makes the new field
+    /// decorative), so the row is refused rather than resolved.
+    ///
+    /// Reachable at RELAY even though persist's write door refuses the same
+    /// shape: that door protects rows this node ADMITS, and relaying is exactly
+    /// when a node handles rows it never admitted. Its own variant, never folded
+    /// into [`Self::AccordRelayObjectRootUnnamed`] — "names none" sends an
+    /// operator to add a key, "names two" sends them to remove one.
+    AccordRelayObjectRootDisagrees,
 }
 
 impl WithholdReason {
@@ -380,7 +412,10 @@ impl WithholdReason {
             Self::AccordRelayNoTrustEdge => "accord_relay_no_trust_edge",
             Self::AccordRelayUnresolved => "accord_relay_unresolved",
             Self::AccordRelayObjectUnreadable => "accord_relay_object_unreadable",
+            Self::AccordRelayMirrorUnbound => "accord_relay_mirror_unbound",
+            Self::AccordRelayObjectNotAccord => "accord_relay_object_not_accord",
             Self::AccordRelayObjectRootUnnamed => "accord_relay_object_root_unnamed",
+            Self::AccordRelayObjectRootDisagrees => "accord_relay_object_root_disagrees",
         }
     }
 }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -437,6 +437,85 @@ pub enum WithholdReason {
     /// fail-closed anyway, so a future persist widening surfaces as a NAMED
     /// withhold rather than as an allow.
     HoldingScopeProjectionUnsupported,
+
+    // ── CIRISEdge#169 — the LXMF propagation HOST serve path ────────────
+    //
+    // These ten are the refusal taxonomy of
+    // [`crate::transport::lxmf_serve`]: this node acting as an LXMF
+    // propagation node, holding and serving THIRD-PARTY mail. They are
+    // defined unconditionally rather than under the serve path's own
+    // `cfg`, because the withhold taxonomy is a stable operator-facing
+    // vocabulary: a snapshot's reason set must not change shape with the
+    // build's feature flags, and cfg-gating variants would fork
+    // `parameter_of`'s exhaustive match across feature combinations —
+    // the proper-subset build hazard this repo keeps re-learning. A
+    // default build simply never constructs them.
+    /// #169 — a propagation request arrived and this node does NOT operate
+    /// as a propagation node ([`crate::transport::lxmf_serve::PropagationAudience::Disabled`],
+    /// the default). Serving strangers' mail is an explicit operator act,
+    /// so the OFF state is a named refusal rather than an unhandled path:
+    /// an operator who believes they enabled propagation and sees this
+    /// reason is looking at the answer.
+    LxmfPropagationDisabled,
+    /// #169 — the destination is not one this node holds mail for. Fires
+    /// on BOTH legs of the same roster (`detail` names which): an upload
+    /// whose recipient is off-roster, and a `/get` from a requester who is
+    /// off-roster. One condition, one remedy — put the destination on the
+    /// roster — so one reason.
+    LxmfDestinationNotServed,
+    /// #169 — a `/get` arrived on a link whose remote identity edge could
+    /// not resolve, so there is no destination to scope the mailbox to.
+    /// Fail-closed: an unattributed request is never answered with mail,
+    /// because "whose mailbox is this" has no answer.
+    LxmfRequesterUnidentified,
+    /// #169 — the requester asked for a transient ID that is parked for a
+    /// DIFFERENT destination. This is the cross-recipient mailbox probe
+    /// the per-destination index exists to defeat; it is reported rather
+    /// than merely omitted, because it is the one `/get` miss that is
+    /// evidence of an attack rather than of a race.
+    LxmfMailboxScopeMismatch,
+    /// #169 — an upload's proof-of-work propagation stamp did not meet the
+    /// cost this node advertises in its
+    /// [`PropagationNodeAnnounce`](leviculum_lxmf::PropagationNodeAnnounce).
+    /// The advertised cost IS the node's published term of carriage; an
+    /// upload that has not paid it has not met the rule it was offered.
+    LxmfStampBelowCost,
+    /// #169 — the bytes do not decode as the LXMF propagation wire this
+    /// endpoint speaks (`detail` names the leg: `/get` request body or
+    /// upload envelope). Distinct from [`Self::LxmfPeerSyncUnsupported`]:
+    /// these bytes are malformed, those are well-formed and for another
+    /// endpoint.
+    LxmfWireUnparseable,
+    /// #169 — a well-formed MULTI-message upload: the node-to-node
+    /// `/offer` peer-sync form, which `leviculum-lxmf` deliberately does
+    /// not implement (leviculum#209) and reports as
+    /// `PropagationError::MultipleMessages`. Its own reason because the
+    /// remedy is not "fix your client" but "you have pointed a peer sync
+    /// at a node that serves clients only".
+    LxmfPeerSyncUnsupported,
+    /// #169 — a byte or count ceiling refused carriage before any work was
+    /// done (`detail` names which: request body, upload envelope, the
+    /// transient-ID list in one request, or the per-response transfer
+    /// cap). A propagation node serves strangers by definition, so every
+    /// buffer it fills on their behalf has an explicit ceiling, and
+    /// hitting one is an event.
+    LxmfFrameOversized,
+    /// #169 — the mailbox is at a retention ceiling (total bytes, messages
+    /// for this destination, or distinct destinations) and the upload was
+    /// REFUSED rather than admitted by evicting. Refusing is the security
+    /// property: a node that evicted to admit would let an attacker flush
+    /// a victim's pending mail with junk uploads, turning a capacity bound
+    /// into a censorship lever. Contrast
+    /// [`crate::transport::store_and_forward`], which DOES evict
+    /// oldest-first — it queues this node's OWN outbound envelopes, where
+    /// there is no third party to censor.
+    LxmfMailboxFull,
+    /// #169 — a parked message reached the retention window without being
+    /// collected and was evicted undelivered. The bounded-retention
+    /// promise kept, and kept LOUDLY: a propagation node that dropped
+    /// third-party mail silently would be indistinguishable from one that
+    /// never received it.
+    LxmfRetentionExpired,
 }
 
 impl WithholdReason {
@@ -475,6 +554,16 @@ impl WithholdReason {
             Self::HoldingScopePublicGroup => "holding_scope_public_group",
             Self::HoldingScopePeerNotInRoster => "holding_scope_peer_not_in_roster",
             Self::HoldingScopeProjectionUnsupported => "holding_scope_projection_unsupported",
+            Self::LxmfPropagationDisabled => "lxmf_propagation_disabled",
+            Self::LxmfDestinationNotServed => "lxmf_destination_not_served",
+            Self::LxmfRequesterUnidentified => "lxmf_requester_unidentified",
+            Self::LxmfMailboxScopeMismatch => "lxmf_mailbox_scope_mismatch",
+            Self::LxmfStampBelowCost => "lxmf_stamp_below_cost",
+            Self::LxmfWireUnparseable => "lxmf_wire_unparseable",
+            Self::LxmfPeerSyncUnsupported => "lxmf_peer_sync_unsupported",
+            Self::LxmfFrameOversized => "lxmf_frame_oversized",
+            Self::LxmfMailboxFull => "lxmf_mailbox_full",
+            Self::LxmfRetentionExpired => "lxmf_retention_expired",
         }
     }
 }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -336,6 +336,28 @@ pub enum WithholdReason {
     /// says *"we never ran the check"*, which is a wiring/timing fact, not a
     /// statement about the signer or the root.
     AccordRelayUnresolved,
+    /// CIRISEdge#499 (blob plane) — an inbound `BlobChunkFetch` was refused
+    /// because the responder could not determine the blob's SCOPE, so it could
+    /// not evaluate whether this requester is entitled to it. Fail-closed, and
+    /// its own branch: "I do not know what this content is" is a wiring fact
+    /// (`BlobChunkSource::chunk_scope` unwired or returning `None`) with an
+    /// operator remedy, not a statement about the requester.
+    BlobScopeUndeterminable,
+    /// CIRISEdge#499 (blob plane) — the blob's scope does not admit the scope
+    /// the request ARRIVED on, per the #48-A
+    /// [`allows_recipient_scope`](crate::cohort_scope::CohortScope::allows_recipient_scope)
+    /// predicate. The canonical case: family-scoped content requested over the
+    /// federation address, where reaching a public discovery endpoint proves
+    /// nothing about family membership. This is the gate working as designed.
+    BlobArrivalScopeInsufficient,
+    /// CIRISEdge#499 (blob plane) — the arrival SCOPE matched but the request
+    /// arrived on an address derived from a DIFFERENT group's MLS
+    /// `exporter_secret`. Its own branch because the scope predicate
+    /// structurally cannot see it (`Family` vs `Family` is a match), and yet
+    /// possession of one family's group secret proves nothing about another's —
+    /// folding this into [`Self::BlobArrivalScopeInsufficient`] would report a
+    /// cross-group access attempt as an ordinary scope mismatch.
+    BlobArrivalGroupMismatch,
 }
 
 impl WithholdReason {
@@ -362,6 +384,9 @@ impl WithholdReason {
             Self::AccordRelaySignerNotSeated => "accord_relay_signer_not_seated",
             Self::AccordRelayNoTrustEdge => "accord_relay_no_trust_edge",
             Self::AccordRelayUnresolved => "accord_relay_unresolved",
+            Self::BlobScopeUndeterminable => "blob_scope_undeterminable",
+            Self::BlobArrivalScopeInsufficient => "blob_arrival_scope_insufficient",
+            Self::BlobArrivalGroupMismatch => "blob_arrival_group_mismatch",
         }
     }
 }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -407,6 +407,36 @@ pub enum WithholdReason {
     /// folding this into [`Self::BlobArrivalScopeInsufficient`] would report a
     /// cross-group access attempt as an ordinary scope mismatch.
     BlobArrivalGroupMismatch,
+    /// CIRISEdge#499 (swarm holdings plane) — the publisher could not determine
+    /// a held content's SCOPE on a scope-native node, so it cannot know which
+    /// peers are entitled to learn the holding exists. Fail-closed, and its own
+    /// branch: "I do not know what this content is" is a wiring fact
+    /// ([`FountainHoldingsSource::content_scope`](crate::swarm::FountainHoldingsSource::content_scope)
+    /// unwired or returning `None`) with an operator remedy, not a statement
+    /// about any peer.
+    HoldingScopeUndeterminable,
+    /// CIRISEdge#499 (swarm holdings plane) — the host declared a scope GROUP at
+    /// `Public` cohort scope. A private roster paired with a public audience is a
+    /// contradiction, not a configuration, and is refused before any roster
+    /// lookup — never folded into [`Self::HoldingScopePeerNotInRoster`], which
+    /// would send an operator to edit a membership list instead of the
+    /// declaration.
+    HoldingScopePublicGroup,
+    /// CIRISEdge#499 (swarm holdings plane) — persist's
+    /// `projection_for(Plane::FountainContent, …)` bound this holding's audience
+    /// to the record's OWN roster (`Cohort` over a named group, or the
+    /// structurally-invisible `SelfOwn`) and the peer holds no derived address in
+    /// that group at any live epoch. **The leak this cut closes**: before it, a
+    /// family- or community-scoped holding — content id AND symbol ids — was
+    /// announced on a timer to every peer the cohort callback returned.
+    HoldingScopePeerNotInRoster,
+    /// CIRISEdge#499 (swarm holdings plane) — the projection named an audience
+    /// KIND the publisher has no peer-set mechanism for on this plane
+    /// (`Capability` / `Subject`, which `Plane::FountainContent` has no cell for
+    /// today). Structurally unreachable against persist v37's table and booked
+    /// fail-closed anyway, so a future persist widening surfaces as a NAMED
+    /// withhold rather than as an allow.
+    HoldingScopeProjectionUnsupported,
 }
 
 impl WithholdReason {
@@ -441,6 +471,10 @@ impl WithholdReason {
             Self::BlobScopeUndeterminable => "blob_scope_undeterminable",
             Self::BlobArrivalScopeInsufficient => "blob_arrival_scope_insufficient",
             Self::BlobArrivalGroupMismatch => "blob_arrival_group_mismatch",
+            Self::HoldingScopeUndeterminable => "holding_scope_undeterminable",
+            Self::HoldingScopePublicGroup => "holding_scope_public_group",
+            Self::HoldingScopePeerNotInRoster => "holding_scope_peer_not_in_roster",
+            Self::HoldingScopeProjectionUnsupported => "holding_scope_projection_unsupported",
         }
     }
 }

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -336,6 +336,23 @@ pub enum WithholdReason {
     /// says *"we never ran the check"*, which is a wiring/timing fact, not a
     /// statement about the signer or the root.
     AccordRelayUnresolved,
+    /// CIRISPersist#731 — an `accord:*` row whose SIGNED bytes could not be read
+    /// at all: no `attestation_envelope`, no `row` mirror, or a mirror that does
+    /// not deserialize as persist's
+    /// [`RowMirror`](ciris_persist::federation::envelope::RowMirror). The gate
+    /// cannot learn WHO signed it or WHICH accord it acts under, so it is
+    /// withheld — LOUD and named, never a silent `continue` (CIRISEdge#425/#433).
+    /// A malformed or pre-v31 unstamped row, not a trust statement.
+    AccordRelayObjectUnreadable,
+    /// CIRISPersist#731 — the row's signed bytes parsed, but **nothing in them
+    /// names the accord this object acts under**, so "which root?" has no
+    /// object-derived answer and the carriage question cannot be asked. The
+    /// permissive failure #731 is about is precisely what happens if this is
+    /// answered from construction state instead, so it refuses. See
+    /// [`AccordRelaySubject`](crate::replication::accord_relay_gate::AccordRelaySubject)
+    /// — an UPSTREAM gap (persist owns which field of an `accord:*` row names its
+    /// root), not a local misconfiguration.
+    AccordRelayObjectRootUnnamed,
 }
 
 impl WithholdReason {
@@ -362,6 +379,8 @@ impl WithholdReason {
             Self::AccordRelaySignerNotSeated => "accord_relay_signer_not_seated",
             Self::AccordRelayNoTrustEdge => "accord_relay_no_trust_edge",
             Self::AccordRelayUnresolved => "accord_relay_unresolved",
+            Self::AccordRelayObjectUnreadable => "accord_relay_object_unreadable",
+            Self::AccordRelayObjectRootUnnamed => "accord_relay_object_root_unnamed",
         }
     }
 }

--- a/src/replication/accord_relay_gate.rs
+++ b/src/replication/accord_relay_gate.rs
@@ -18,7 +18,7 @@
 //! over-delivers, and **this predicate is what narrows carriage back to exactly
 //! that set.**
 //!
-//! ## WHICH accord? The OBJECT says — never the host (CIRISPersist#731)
+//! ## WHICH accord? The OBJECT says — and PERSIST reads it (CIRISPersist#733)
 //!
 //! Until v17.10.0 this gate judged every `accord:*` row against ONE root the
 //! host named at construction (`ReplicationRuntimeConfig::accord_relay_root`).
@@ -31,24 +31,61 @@
 //! > belongs to a **different** accord. The predicate cannot detect this,
 //! > because it was never given the object.
 //!
-//! So the nominated root is **gone**. Both arguments to persist's predicate are
-//! now read out of the object's own **signature-covered** bytes — see
-//! [`AccordRelaySubject`] — and the cache is keyed by the PAIR, because the
-//! same signer under two different roots has two different correct verdicts and
-//! a signer-keyed cache would reintroduce exactly the confusion the verb fix
-//! removed.
+//! Edge's first answer to that (v17.10.0) was to read the root out of the row
+//! ITSELF — a hand-rolled [`RowMirror`](ciris_persist::federation::envelope::RowMirror)
+//! walk plus an `accord:lifecycle:v1` special case, which meant edge held a rule
+//! about **which field of an `accord:*` row names its accord**. That rule was
+//! never edge's, and persist v37.0.0 (CIRISPersist#733) took it:
+//! [`accord_root_claim`] reads the claim off a row, a signed
+//! [`accord_root`](ciris_persist::federation::envelope::paths::ACCORD_ROOT)
+//! envelope key carries it on every dimension, and
+//! [`may_relay_accord_attestation`] is the **taking verb** — hand it the row and
+//! it answers, nominating nothing.
+//!
+//! **So the hand-parsing is gone.** What edge keeps is a CACHE KEY, which is a
+//! local concern — and even that is derived through [`accord_root_claim`] rather
+//! than by re-reading the row, so there is exactly one reading of *"which
+//! root?"* in the process. The key is the PAIR `(root, signer)`: the same signer
+//! under two different roots has two different correct verdicts, and a
+//! signer-keyed cache would rebuild #731 *behind* the fixed verb, where it is
+//! harder to see.
 //!
 //! ## Zero trust logic here
 //!
 //! The whole verdict is persist's — [`may_relay_accord_participation`] for an
-//! [`AccordParticipation`], [`may_relay_accord_object`] for an `accord:*`
-//! attestation whose signed bytes named its root. Seated signer AND a live
-//! `delegates_to(self → root)`. This module resolves, caches, and enforces; it
-//! decides nothing. It does not re-derive seating, roster membership, or edge
-//! existence, and the family classification of a dimension is persist's
-//! [`attestation_family`](ciris_persist::federation::namespace::attestation_family)
+//! [`AccordParticipation`], [`may_relay_accord_attestation`] for an `accord:*`
+//! attestation. Seated signer AND a live `delegates_to(self → root)`. This
+//! module resolves, caches, and enforces; it decides nothing. It does not
+//! re-derive seating, roster membership, edge existence, **or which accord a row
+//! belongs to**, and the family classification of a dimension is persist's
+//! [`attestation_family`]
 //! (the same fold `attestation_requires_serve` took in v17.7.0), never an
 //! edge-side `"accord:"` prefix match.
+//!
+//! ## The two persist predicates edge calls for ATTRIBUTION, and why
+//!
+//! [`may_relay_accord_attestation`] returns a three-bool [`RelayVerdict`], and
+//! it collapses FOUR distinct *"I cannot judge"* causes into
+//! `roster_resolvable: false` — an absent/divergent row mirror, a not-`accord:*`
+//! row, [`AccordRootClaim::Unnamed`] and [`AccordRootClaim::Disagrees`]. Persist
+//! keeps those apart in its own table; edge must too, because each is a
+//! different thing for an operator to go fix, and the #425 withhold-ledger
+//! discipline is that a refusal names ONE branch.
+//!
+//! There is no way to recover them from the verdict, so edge asks persist's own
+//! two pure functions —
+//! [`check_row_column_binding`]
+//! and [`accord_root_claim`], **the very two the verb runs internally**, in the
+//! same order — and maps each to its own [`RelayRefusal`]. This is not a second
+//! definition of anything: both callers call one body, which is the property
+//! #733 was written to establish.
+//!
+//! It also protects the CACHE. The key's root half can come from an unsigned
+//! column on the drill-dimension fallback, so keying before the binding gate has
+//! run would let a forged row park an *unjudgeable* verdict on a LEGITIMATE
+//! `(root, signer)` pair for a whole TTL — a fail-closed denial of the kill
+//! switch plane, cheap to repeat. Running the binding gate FIRST, and refusing
+//! without caching, means every key half is signature-covered by construction.
 //!
 //! ## The three-way verdict is kept three-way
 //!
@@ -78,8 +115,9 @@
 //! ## Fail CLOSED, in every direction
 //!
 //! A cache miss, an expired entry, an invalidated entry, a resolver error, an
-//! absent directory, an absent local identity, an unreadable object, an object
-//! that names no root, and `roster_resolvable == false` all refuse.
+//! absent directory, an absent local identity, a row that will not deserialize,
+//! a row whose signed mirror is absent or diverges, a row that names no root, a
+//! row that names two, and `roster_resolvable == false` all refuse.
 //! [`RelayRefusal::Unresolved`] is deliberately distinct from every decided
 //! refusal, so a refusal *because we never ran the predicate* can never be read
 //! as a refusal *because we decided* — the distinction a fail-safe default
@@ -105,23 +143,14 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-use ciris_persist::federation::admission::envelope_dimension;
-use ciris_persist::federation::envelope::{paths, RowMirror};
+use ciris_persist::federation::admission::check_row_column_binding;
 use ciris_persist::federation::namespace::{attestation_family, AttestationFamily};
 use ciris_persist::federation::trust_root::{
-    may_relay_accord_object, may_relay_accord_participation, RelayVerdict,
-    ACCORD_HEARTBEAT_DIMENSION,
+    accord_root_claim, may_relay_accord_attestation, may_relay_accord_participation,
+    AccordRootClaim, RelayVerdict,
 };
-use ciris_persist::federation::FederationDirectory;
+use ciris_persist::federation::{Attestation, FederationDirectory};
 use ciris_verify_core::accord_live_quorum::AccordParticipation;
-
-/// The row column holding the SIGNED envelope. persist publishes the member
-/// names INSIDE the envelope ([`paths`] / [`ciris_persist::federation::envelope::row_paths`])
-/// but the column that holds it is a schema name on
-/// [`Attestation`](ciris_persist::federation::Attestation), so it is spelled
-/// here — the one string this module owns, and the same one
-/// `attestation_requires_serve` and the quarantine consult already read.
-const ATTESTATION_ENVELOPE: &str = "attestation_envelope";
 
 /// How long one resolved [`RelayVerdict`] stays usable before the gate
 /// re-resolves it.
@@ -175,18 +204,53 @@ pub enum RelayRefusal {
     /// `delegates_to(self → root)` could exist. A WIRING fault
     /// (`ReplicationRuntimeConfig::local_key_id`), not a policy decision.
     NoLocalIdentity,
-    /// CIRISPersist#731 — the object's SIGNED bytes could not be read: no
-    /// `attestation_envelope`, no `row` mirror, or a mirror that is not
-    /// persist's [`RowMirror`]. Neither the signer nor the root is knowable, so
-    /// there is no question to ask. Fail-closed and LOUD (CIRISEdge#425) — a
-    /// malformed row, never a silent `continue`.
+    /// The wire value is not an [`Attestation`] at all — it does not
+    /// deserialize into persist's row type, so there is no row to hand the verb
+    /// and nothing to ask. Fail-closed and LOUD (CIRISEdge#425) — a malformed
+    /// row, never a silent `continue`. Reachable only from the direct-fetch
+    /// path, whose bytes come off the wire; the advertise and subject-Pull sites
+    /// hold a typed row and serialize it themselves.
     ObjectUnreadable,
-    /// CIRISPersist#731 — the object parsed, but **nothing in its signed bytes
-    /// names the accord it acts under**. Answering "which root?" from
-    /// construction state is the exact permissive failure #731 reports, so this
-    /// refuses instead. See [`AccordRelaySubject::of_attestation`]: an UPSTREAM
-    /// gap, not a local misconfiguration.
+    /// CIRISPersist#733, persist's first *"cannot judge"* row — the row's signed
+    /// [`RowMirror`](ciris_persist::federation::envelope::RowMirror) is ABSENT
+    /// (a pre-#643 unstamped row) or DIVERGES from the typed columns, so the
+    /// columns assert nothing and the row never passed a persist door. Distinct
+    /// from [`Self::ObjectUnreadable`]: that row is not an attestation, this one
+    /// is an attestation whose unsigned half has been edited. A divergence is a
+    /// SECURITY event (a relay rewriting a signed row's identity, verb, signer
+    /// or subject); a missing mirror is a producer-vintage problem. Different
+    /// findings, different remedies, so never folded.
+    MirrorUnbound,
+    /// [`AccordRootClaim::NotAccord`] — persist says this row is not on the
+    /// `accord:*` family at all, so it "is not this predicate's to judge" and
+    /// the verb refuses it. Unreachable through
+    /// `FederationDirectoryReplicationBridge::accord_relay_withholds`, whose
+    /// `attestation_is_accord` early-out already used persist's own
+    /// [`attestation_family`] classifier — and kept anyway so a DIRECT caller of
+    /// the public entry point below fails CLOSED with a name, rather than
+    /// falling through to an allow.
+    ObjectNotAccord,
+    /// [`AccordRootClaim::Unnamed`] — the row IS on the `accord:*` family and
+    /// **nothing in it names the accord it acts under**: no signed
+    /// [`accord_root`](ciris_persist::federation::envelope::paths::ACCORD_ROOT)
+    /// key, and not the one dimension whose fallback rule persist defines. A
+    /// pre-#733 row or an unadopted producer's. Answering "which root?" from
+    /// construction state is the permissive failure #731 reports, so this
+    /// refuses instead — the durable narrowing #733 accepted, not a local
+    /// misconfiguration.
     ObjectRootUnnamed,
+    /// [`AccordRootClaim::Disagrees`] — **ONE ARTIFACT ASSERTING TWO ACCORDS**:
+    /// a drill row carrying both signals, whose signed `accord_root` key and
+    /// drill-dimension rule name different roots. Neither signal is preferred
+    /// (preferring the key lets an emitter relabel a heartbeat's accord;
+    /// preferring the column makes the new field decorative), so it refuses.
+    ///
+    /// **This is NOT dead code behind persist's write door.** That door protects
+    /// rows this node ADMITS; relaying is exactly when a node handles rows it
+    /// never admitted, which is the entire premise of this plane. Its own
+    /// variant, never folded into [`Self::ObjectRootUnnamed`] — "names no
+    /// accord" and "names two" send an operator to different places.
+    ObjectRootDisagrees,
 }
 
 impl RelayRefusal {
@@ -201,7 +265,10 @@ impl RelayRefusal {
             Self::Unresolved => "unresolved",
             Self::NoLocalIdentity => "no_local_identity",
             Self::ObjectUnreadable => "object_unreadable",
+            Self::MirrorUnbound => "mirror_unbound",
+            Self::ObjectNotAccord => "object_not_accord",
             Self::ObjectRootUnnamed => "object_root_unnamed",
+            Self::ObjectRootDisagrees => "object_root_disagrees",
         }
     }
 }
@@ -212,35 +279,42 @@ impl std::fmt::Display for RelayRefusal {
     }
 }
 
-/// CIRISPersist#731 — **the two facts a relay decision needs, both read out of
-/// the object's own signature-covered bytes**: which accord it acts under, and
+/// **The CACHE KEY, and nothing else**: which accord an object acts under, and
 /// who signed it.
 ///
-/// # Why this type exists at all
+/// # What this is NOT, post-#733
 ///
-/// It is the thing the pre-#731 gate did not have. `may_relay_accord_object`
-/// takes `(signer, root)` as parameters, and edge was passing a root the HOST
-/// named — so an object belonging to accord B, signed by a key seated on accord
-/// A, was judged against A and carried. Making the pair a value derived
-/// *from the object* is what removes the caller's ability to nominate.
+/// It is not edge's reading of the object. v17.10.0's version of this type
+/// walked the [`RowMirror`](ciris_persist::federation::envelope::RowMirror) by
+/// hand and carried an `accord:lifecycle:v1` special case, which made edge a
+/// second owner of *"which field names the accord"*. Persist v37.0.0 took that
+/// rule ([`accord_root_claim`]), so both constructors below now **consume**
+/// persist's answer rather than compute one.
 ///
-/// # Signed bytes only
+/// The pair still has to exist on edge's side because the verdict is CACHED and
+/// a cache needs a key. Both of persist's legs are root-relative
+/// (`active_roster_of(root)`, `delegates_to(self → root)`), so ONE signer has as
+/// many correct verdicts as there are roots: keying on the signer alone would
+/// serve accord A's answer for an accord B object — the cross-accord confusion
+/// #731 is about, rebuilt *behind* the fixed verb where it is harder to see,
+/// because the resolver would be reading the object correctly and the cache
+/// would be answering for a different one.
 ///
-/// Persist's scrub signature covers `JCS(attestation_envelope)` **and nothing
-/// else** — the top-level `attesting_key_id` / `attested_key_id` columns are
-/// unsigned copies, bound to the envelope only by `check_row_column_binding` at
-/// `put_attestation`. That binding is a receive-path admission gate; this is a
-/// SERVE-path carriage gate, so it reads the signed mirror
-/// ([`paths::ROW`] → [`RowMirror`], the seven members CIRISPersist#643 stamped
-/// inside the signature precisely so a relay could not rewrite them) rather
-/// than trusting a column a relay could have edited. Reading the unsigned copy
-/// would hand an attacker the choice of root, which is #731 rebuilt one field
-/// over.
+/// # Every half is signature-covered
+///
+/// [`Self::of_row`] runs
+/// [`check_row_column_binding`]
+/// BEFORE it reads anything, so the typed columns are proven equal to the signed
+/// mirror first. After that, `attesting_key_id` (which is the signer persist's
+/// own verb reads) and the drill-dimension fallback's `attested_key_id` are
+/// reading signed bytes. Keying without that proof would let a forged row park a
+/// verdict on a legitimate pair — see the module docs.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AccordRelaySubject {
-    /// The accord trust root the object acts under, from the object.
+    /// The accord trust root the object acts under, as [`accord_root_claim`]
+    /// read it off the object (or, for a participation, `family_key_id`).
     pub root_ref: String,
-    /// The key that signed the object, from the object.
+    /// The key that signed the object.
     pub signer_key_id: String,
 }
 
@@ -263,61 +337,69 @@ impl AccordRelaySubject {
         }
     }
 
-    /// The subject of an `accord:*` ATTESTATION row, from its signed envelope.
+    /// The subject of an `accord:*` attestation ROW — persist's two pure gates,
+    /// in persist's own order, and no edge parsing at all.
     ///
-    /// # Which field names the root, and why only one dimension qualifies
+    /// 1. [`check_row_column_binding`]
+    ///    — the same call [`may_relay_accord_attestation`] makes first, for the
+    ///    same reason: `attesting_key_id` and `attested_key_id` are UNSIGNED
+    ///    columns, and relaying is exactly when a node handles a row it never
+    ///    admitted, so nothing may be read off them until they are proven equal
+    ///    to the signed mirror.
+    /// 2. [`accord_root_claim`] — persist's ONE reading of *"which accord does
+    ///    this row claim?"*, shared with its write door.
     ///
-    /// The signer is unambiguous: [`RowMirror::attesting_key_id`], signed.
-    ///
-    /// The ROOT is not, and this is the honest part. `accord:*` is a whole
-    /// dimension FAMILY whose only registry rule is `accord_holder-only`
-    /// (CC 3.4.1 — it constrains the EMITTER's `identity_type`, and says nothing
-    /// about which accord a row belongs to). Persist's own fixtures show
-    /// `attested_key_id` carrying different things across the family: for
-    /// `accord:human_dignity:v1` it is the AGENT being scored, and for
-    /// `accord:invoke:notify:*` it is the self-attesting holder — neither is a
-    /// root.
-    ///
-    /// **Exactly one dimension has an upstream answer.** For
-    /// [`ACCORD_HEARTBEAT_DIMENSION`] persist's own trust-root fold resolves
-    /// drills as `list_attestations_for(root_ref)` filtered to that dimension —
-    /// i.e. persist *defines* an `accord:lifecycle:v1` row about X as a drill
-    /// about accord X. Reading `attested_key_id` as the root there consumes
-    /// persist's rule; asserting it for any other `accord:*` dimension would be
-    /// edge inventing one.
-    ///
-    /// So every other dimension yields [`RelayRefusal::ObjectRootUnnamed`] and
-    /// is REFUSED. That is a real narrowing of what this node will carry, and it
-    /// is the correct direction: the alternative is answering "which root?" from
-    /// construction state, which is the permissive failure #731 exists to close.
-    /// The gap belongs to persist — a taking verb for `accord:*` attestations,
-    /// the way [`may_relay_accord_participation`] is the one for participations.
+    /// Each non-[`AccordRootClaim::Named`] outcome maps to its own
+    /// [`RelayRefusal`], because the verb collapses all of them into
+    /// `roster_resolvable: false` and an operator needs to know WHICH.
     ///
     /// # Errors
     ///
-    /// [`RelayRefusal::ObjectUnreadable`] if the signed envelope or its
-    /// [`RowMirror`] cannot be read; [`RelayRefusal::ObjectRootUnnamed`] if it
-    /// can, but names no root.
-    pub fn of_attestation(canonical_json: &serde_json::Value) -> Result<Self, RelayRefusal> {
-        let envelope = canonical_json
-            .get(ATTESTATION_ENVELOPE)
-            .ok_or(RelayRefusal::ObjectUnreadable)?;
-        // The SIGNED mirror, through persist's own typed view of it. `RowMirror`
-        // is `deny_unknown_fields`, so this is the exact seven-member object the
-        // scrub signature covers — not a hand-spelled pointer walk that could
-        // drift from the vocabulary.
-        let mirror: RowMirror = envelope
-            .get(paths::ROW)
-            .and_then(|row| serde_json::from_value(row.clone()).ok())
-            .ok_or(RelayRefusal::ObjectUnreadable)?;
-        if envelope_dimension(envelope) != Some(ACCORD_HEARTBEAT_DIMENSION) {
-            return Err(RelayRefusal::ObjectRootUnnamed);
+    /// [`RelayRefusal::MirrorUnbound`], [`RelayRefusal::ObjectNotAccord`],
+    /// [`RelayRefusal::ObjectRootUnnamed`] or
+    /// [`RelayRefusal::ObjectRootDisagrees`] — one per row of persist's own
+    /// *"why this is 'I cannot judge'"* table.
+    pub fn of_row(row: &Attestation) -> Result<Self, RelayRefusal> {
+        if check_row_column_binding(row).is_err() {
+            return Err(RelayRefusal::MirrorUnbound);
         }
-        Ok(Self {
-            root_ref: mirror.attested_key_id,
-            signer_key_id: mirror.attesting_key_id,
-        })
+        match accord_root_claim(row) {
+            AccordRootClaim::Named { root_ref, .. } => Ok(Self {
+                root_ref,
+                // The signer persist's own verb passes to
+                // `may_relay_accord_object` — read from the same column, now
+                // proven equal to the signed mirror by step 1.
+                signer_key_id: row.attesting_key_id.clone(),
+            }),
+            AccordRootClaim::NotAccord => Err(RelayRefusal::ObjectNotAccord),
+            AccordRootClaim::Unnamed { .. } => Err(RelayRefusal::ObjectRootUnnamed),
+            AccordRootClaim::Disagrees { .. } => Err(RelayRefusal::ObjectRootDisagrees),
+        }
     }
+
+    /// [`Self::of_row`] for a wire value — the shape the serve paths carry.
+    ///
+    /// # Errors
+    ///
+    /// [`RelayRefusal::ObjectUnreadable`] if the value is not an
+    /// [`Attestation`]; otherwise [`Self::of_row`]'s.
+    pub fn of_attestation(canonical_json: &serde_json::Value) -> Result<Self, RelayRefusal> {
+        Self::of_row(&deserialize_row(canonical_json)?)
+    }
+}
+
+/// The ONE place a wire value becomes persist's row type.
+///
+/// Borrows rather than cloning: `serde_json` implements `Deserializer` for
+/// `&Value`, so this costs one walk and no copy of the envelope.
+///
+/// A failure is [`RelayRefusal::ObjectUnreadable`] — LOUD and withheld, never a
+/// silent pass (CIRISEdge#425). It is only genuinely reachable from the
+/// direct-fetch path, whose bytes come off the wire; the advertise and
+/// subject-Pull sites serialize a typed row they already hold, so their
+/// round-trip cannot fail.
+fn deserialize_row(canonical_json: &serde_json::Value) -> Result<Attestation, RelayRefusal> {
+    serde::Deserialize::deserialize(canonical_json).map_err(|_| RelayRefusal::ObjectUnreadable)
 }
 
 /// The gate's answer for one `accord:*` object. `#[must_use]` for the same
@@ -566,40 +648,53 @@ impl AccordRelayGate {
         }
     }
 
-    /// Resolve one already-derived subject through persist and cache it, unless
-    /// a fresh verdict is already held (cache-first — a hit costs one lock and
-    /// no directory read).
+    /// **The ONE async step**: hand the ROW to persist's taking verb
+    /// ([`may_relay_accord_attestation`]) and cache what it says, unless a fresh
+    /// verdict is already held (cache-first — a hit costs one lock and no
+    /// directory read). Returns the subject the verdict was filed under, so the
+    /// caller can [`Self::decide`] on it.
+    ///
+    /// Nothing here nominates a root or a signer: the verb is given the object.
+    /// [`AccordRelaySubject::of_row`] runs persist's own two pure gates purely to
+    /// name a refusal and to key the cache, and it is the same pair of calls the
+    /// verb makes internally — so a row this returns `Ok` for is exactly a row
+    /// the verb will judge on its merits.
     ///
     /// The cache lock is taken twice, briefly, and **never held across the
     /// `.await`** (CIRISEdge#217). A resolver error does NOT cache: a transient
     /// directory fault must not pin a subject refused past the fault — the next
     /// call re-resolves, and [`Self::decide`] refuses meanwhile as
     /// [`RelayRefusal::Unresolved`], which says exactly what happened.
-    pub async fn prime(&self, subject: &AccordRelaySubject, now: Instant) {
+    ///
+    /// # Errors
+    ///
+    /// [`AccordRelaySubject::of_row`]'s — a row persist cannot judge is refused
+    /// here, before any directory read and without caching anything.
+    pub async fn prime(
+        &self,
+        row: &Attestation,
+        now: Instant,
+    ) -> Result<AccordRelaySubject, RelayRefusal> {
+        let subject = AccordRelaySubject::of_row(row)?;
+        // No "I" ⇒ no `delegates_to(self → root)` to resolve. `decide` reports
+        // that as `NoLocalIdentity`; resolving would be meaningless.
         let Some(us) = self.self_key_id.as_deref() else {
-            return;
+            return Ok(subject);
         };
         let gen_at_miss = {
             let guard = self
                 .cache
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if guard.get_fresh(subject, now).is_some() {
-                return;
+            if guard.get_fresh(&subject, now).is_some() {
+                return Ok(subject);
             }
             // Snapshot the generation WITH the miss check, so an invalidation
             // during the `.await` below is detected at commit.
             guard.generation
         };
 
-        let verdict = match may_relay_accord_object(
-            &*self.directory,
-            us,
-            &subject.signer_key_id,
-            &subject.root_ref,
-        )
-        .await
-        {
+        let verdict = match may_relay_accord_attestation(&*self.directory, us, row).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(
@@ -609,31 +704,39 @@ impl AccordRelayGate {
                     "accord relay verdict resolve FAILED — carriage refused as `unresolved` \
                      until the next resolve (fail-closed, workstream F)"
                 );
-                return;
+                return Ok(subject);
             }
         };
         self.cache
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .commit(subject, verdict, gen_at_miss, now);
+            .commit(&subject, verdict, gen_at_miss, now);
+        Ok(subject)
     }
 
-    /// **The serve-path entry point for an `accord:*` attestation row**: derive
-    /// the subject from the row's SIGNED bytes, resolve, and decide.
+    /// [`Self::prime`] then [`Self::decide`], for a caller holding persist's row
+    /// type. The async resolve / pure-sync predicate split is preserved: this is
+    /// only the two in sequence.
+    pub async fn may_relay_row(&self, row: &Attestation, now: Instant) -> RelayDecision {
+        match self.prime(row, now).await {
+            Ok(subject) => self.decide(&subject, now),
+            Err(refusal) => RelayDecision::Refused(refusal),
+        }
+    }
+
+    /// **The serve-path entry point for an `accord:*` attestation row**, from
+    /// the wire value the three call sites carry.
     ///
-    /// The row is never trusted to tell the gate which root to use via anything
-    /// but its signed mirror, and a row that cannot name one is REFUSED with a
-    /// named leg rather than judged against a fallback (CIRISPersist#731).
+    /// Deserializes ONCE into persist's row type and delegates to
+    /// [`Self::may_relay_row`]; a value that is not an [`Attestation`] is
+    /// REFUSED as [`RelayRefusal::ObjectUnreadable`], never carried.
     pub async fn may_relay_attestation(
         &self,
         canonical_json: &serde_json::Value,
         now: Instant,
     ) -> RelayDecision {
-        match AccordRelaySubject::of_attestation(canonical_json) {
-            Ok(subject) => {
-                self.prime(&subject, now).await;
-                self.decide(&subject, now)
-            }
+        match deserialize_row(canonical_json) {
+            Ok(row) => self.may_relay_row(&row, now).await,
             Err(refusal) => RelayDecision::Refused(refusal),
         }
     }
@@ -733,6 +836,7 @@ impl AccordRelayGate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ciris_persist::federation::trust_root::{AccordRootSource, ACCORD_HEARTBEAT_DIMENSION};
     use ciris_persist::store::MemoryBackend;
 
     /// The three-bool verdict, spelled out at every call so a test's INPUT is
@@ -761,29 +865,74 @@ mod tests {
         }
     }
 
-    /// An `accord:*` attestation row in the SIGNED shape persist v31.0.0
-    /// (#643) stamps: the `row` mirror lives inside `attestation_envelope`,
-    /// which is what the scrub signature covers. The top-level columns are
-    /// written too — deliberately SKEWED in one test below, to prove the gate
-    /// reads the signed half.
-    fn accord_row(dimension: &str, attesting: &str, attested: &str) -> serde_json::Value {
+    /// A COMPLETE `accord:*` attestation row as a wire VALUE, in the shape
+    /// persist v31.0.0 (#643) stamps: the `row` mirror lives inside
+    /// `attestation_envelope` (what the scrub signature covers) and MIRRORS the
+    /// typed columns, so `check_row_column_binding` passes. `accord_root` is the
+    /// v37.0.0 (#733) signed key naming the row's own accord — `None` omits it,
+    /// which is how a pre-#733 row looks.
+    ///
+    /// Every field persist's `Attestation` requires is present: these tests
+    /// exercise the REAL deserialize the serve path performs, not a
+    /// hand-selected subset (CIRISEdge's "test the field's own input" scar —
+    /// a fixture the row type would reject proves nothing about a row type
+    /// that must accept it).
+    fn accord_row_value(
+        dimension: &str,
+        attesting: &str,
+        attested: &str,
+        accord_root: Option<&str>,
+    ) -> serde_json::Value {
+        let mut envelope = serde_json::json!({
+            "dimension": dimension,
+            "asserted_at": "2026-01-01T00:00:00Z",
+            "row": {
+                "attestation_id": "att-1",
+                "attesting_key_id": attesting,
+                "attestation_type": "scores",
+                "attested_key_id": attested,
+                "cohort_scope": "federation",
+            },
+        });
+        if let Some(root) = accord_root {
+            envelope["accord_root"] = serde_json::json!(root);
+        }
         serde_json::json!({
             "attestation_id": "att-1",
             "attesting_key_id": attesting,
             "attested_key_id": attested,
             "attestation_type": "scores",
-            "attestation_envelope": {
-                "dimension": dimension,
-                "asserted_at": "2026-01-01T00:00:00Z",
-                "row": {
-                    "attestation_id": "att-1",
-                    "attesting_key_id": attesting,
-                    "attestation_type": "scores",
-                    "attested_key_id": attested,
-                    "cohort_scope": "federation",
-                },
-            },
+            "asserted_at": "2026-01-01T00:00:00Z",
+            "attestation_envelope": envelope,
+            "original_content_hash": "0".repeat(64),
+            "scrub_signature_classical": "x".repeat(88),
+            "scrub_key_id": attesting,
+            "scrub_timestamp": "2026-01-01T00:00:00Z",
+            "persist_row_hash": "",
         })
+    }
+
+    /// [`accord_row_value`] as persist's row type — the argument the taking verb
+    /// takes.
+    fn accord_row(
+        dimension: &str,
+        attesting: &str,
+        attested: &str,
+        accord_root: Option<&str>,
+    ) -> Attestation {
+        serde_json::from_value(accord_row_value(
+            dimension,
+            attesting,
+            attested,
+            accord_root,
+        ))
+        .expect("the fixture is a well-formed persist Attestation")
+    }
+
+    /// A drill row: the one dimension whose fallback rule persist defines, so
+    /// `attested_key_id` IS the accord and no signed key is needed.
+    fn drill_row(attesting: &str, root: &str) -> Attestation {
+        accord_row(ACCORD_HEARTBEAT_DIMENSION, attesting, root, None)
     }
 
     // ── decision_of: the verdict → decision mapping ──────────────────────
@@ -839,89 +988,228 @@ mod tests {
         assert!(!decision_of(verdict(false, false, false)).may_relay());
     }
 
-    // ── AccordRelaySubject: the object names its own root (#731) ──────────
+    // ── AccordRelaySubject: persist reads the claim, edge keys on it ──────
 
-    /// The heartbeat/drill dimension is the ONE `accord:*` shape with an
-    /// upstream root rule (persist's trust-root fold resolves drills as
-    /// `list_attestations_for(root)` filtered to this dimension), so the signed
-    /// `attested_key_id` IS the accord.
+    /// REWRITTEN for CIRISPersist#733. This used to assert that EDGE's mirror
+    /// walk plus its `accord:lifecycle:v1` special case produced the pair. It
+    /// now asserts the delegation: persist's [`accord_root_claim`] carries the
+    /// drill-dimension fallback, edge consumes its answer, and the two agree by
+    /// CONSTRUCTION rather than by edge re-deriving the rule.
+    ///
+    /// Asserted against persist's claim directly, so a change to persist's rule
+    /// moves both sides of this test together — which is the point of having one
+    /// owner.
     #[test]
-    fn a_heartbeat_row_names_its_root_and_its_signer() {
-        let row = accord_row(ACCORD_HEARTBEAT_DIMENSION, "holder-a", "accord-x");
+    fn the_subject_is_exactly_what_persists_claim_says() {
+        let row = drill_row("holder-a", "accord-x");
         assert_eq!(
-            AccordRelaySubject::of_attestation(&row),
+            accord_root_claim(&row),
+            AccordRootClaim::Named {
+                root_ref: "accord-x".to_owned(),
+                source: AccordRootSource::HeartbeatDimensionRule,
+            },
+            "the drill fallback is PERSIST's rule and it is the one that answers"
+        );
+        assert_eq!(
+            AccordRelaySubject::of_row(&row),
             Ok(subject("accord-x", "holder-a")),
-            "both halves come from the SIGNED row mirror"
+            "edge's key is persist's root plus the signer persist's own verb reads"
         );
     }
 
-    /// **The signed half wins.** The unsigned top-level columns are bound to
-    /// the envelope by persist's `check_row_column_binding` at
-    /// `put_attestation` — a RECEIVE-path gate. This is a SERVE-path carriage
-    /// gate, so it must not depend on that binding having run: skew the columns
-    /// and the subject must be unmoved. Reading the unsigned copy would hand an
-    /// attacker the choice of root — CIRISPersist#731 rebuilt one field over.
+    /// REWRITTEN, and the property INVERTED — deliberately, because #733 moved
+    /// it.
+    ///
+    /// The old test skewed the unsigned columns and asserted the subject was
+    /// UNMOVED, because edge read the signed mirror and ignored the columns.
+    /// That was edge working around a receive-path gate it did not run. Persist
+    /// v37.0.0's verb runs
+    /// [`check_row_column_binding`]
+    /// ITSELF and treats its refusal as *"I cannot judge"*, so the correct
+    /// serve-path answer to a skewed row is not "re-read it from the mirror" —
+    /// it is **REFUSE**. Strictly stronger: the old behaviour would have carried
+    /// a row whose signed and unsigned halves disagree, on the strength of the
+    /// signed half alone.
     #[test]
-    fn the_unsigned_columns_cannot_move_the_subject() {
-        let mut row = accord_row(ACCORD_HEARTBEAT_DIMENSION, "holder-a", "accord-x");
-        row["attesting_key_id"] = serde_json::json!("attacker");
-        row["attested_key_id"] = serde_json::json!("accord-the-attacker-prefers");
+    fn a_row_whose_columns_diverge_from_its_signed_mirror_is_refused() {
+        let mut value = accord_row_value(ACCORD_HEARTBEAT_DIMENSION, "holder-a", "accord-x", None);
+        value["attesting_key_id"] = serde_json::json!("attacker");
+        value["attested_key_id"] = serde_json::json!("accord-the-attacker-prefers");
         assert_eq!(
-            AccordRelaySubject::of_attestation(&row),
+            AccordRelaySubject::of_attestation(&value),
+            Err(RelayRefusal::MirrorUnbound),
+            "columns that diverge from the signed mirror make the row UNJUDGEABLE — persist's \
+             own first `cannot judge` row, not a subject to be recovered from the mirror"
+        );
+        // …and the same row with its columns intact IS judgeable, so the
+        // refusal above is about the divergence and not about the fixture.
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&accord_row_value(
+                ACCORD_HEARTBEAT_DIMENSION,
+                "holder-a",
+                "accord-x",
+                None
+            )),
             Ok(subject("accord-x", "holder-a")),
-            "the scrub signature covers JCS(attestation_envelope) and NOTHING else — the \
-             top-level columns are unsigned and are not read here"
         );
     }
 
-    /// Every other `accord:*` dimension names no root, so it is refused with
-    /// its OWN leg rather than judged against a fallback. `accord_holder-only`
-    /// (CC 3.4.1) constrains the emitter's identity type and says nothing about
-    /// which accord a row belongs to; persist's own fixtures put a scored AGENT
-    /// in `attested_key_id` for `accord:human_dignity:v1` and the self-attesting
-    /// HOLDER for `accord:invoke:notify:*`.
+    /// REWRITTEN — this is the #733 WIDENING, and the old test asserted its
+    /// opposite.
+    ///
+    /// Edge used to refuse every non-drill `accord:*` dimension outright
+    /// (`ObjectRootUnnamed`), because nothing in such a row named its accord and
+    /// edge would not invent a rule. v37.0.0 added the signed `accord_root`
+    /// envelope key, so those rows CAN now name their accord — and the refusal
+    /// survives only for the ones that still do not.
     #[test]
-    fn a_non_heartbeat_accord_row_names_no_root_and_is_refused_distinctly() {
+    fn a_non_drill_row_names_its_accord_with_the_signed_key_or_is_refused() {
         for dim in [
             "accord:human_dignity:v1",
             "accord:invoke:notify:halt",
             "accord:halt:v1",
         ] {
             assert_eq!(
-                AccordRelaySubject::of_attestation(&accord_row(dim, "holder-a", "someone")),
+                AccordRelaySubject::of_row(&accord_row(dim, "holder-a", "some-agent", None)),
                 Err(RelayRefusal::ObjectRootUnnamed),
-                "{dim}: no signed field names the accord — refuse, do NOT fall back to a \
-                 host-nominated root (CIRISPersist#731)"
+                "{dim} with no `accord_root`: a pre-#733 row names no accord — refuse, never \
+                 fall back to a host-nominated root"
+            );
+            assert_eq!(
+                AccordRelaySubject::of_row(&accord_row(
+                    dim,
+                    "holder-a",
+                    "some-agent",
+                    Some("accord-x")
+                )),
+                Ok(subject("accord-x", "holder-a")),
+                "{dim} WITH the signed key: #733's general answer, on a dimension where \
+                 `attested_key_id` is the scored agent and never the root"
             );
         }
     }
 
-    /// An unreadable object is its own leg, distinct from "names no root":
-    /// one is a malformed row, the other a well-formed row with an upstream
-    /// vocabulary gap, and they send an operator to different places.
+    /// **THE DUAL-SIGNAL DISAGREEMENT, and it is NOT dead code.** A drill row
+    /// carrying BOTH signals that name different accords is refused — with its
+    /// own leg, never folded into "names no root".
+    ///
+    /// Persist's write door refuses this shape too, which is exactly why the
+    /// arm matters HERE: a write door protects rows this node ADMITS, and
+    /// relaying is the case where a node handles a row it never admitted. That
+    /// is the entire premise of the plane, and persist says so in
+    /// `may_relay_accord_attestation`'s own doc.
+    ///
+    /// Neither signal is preferred: preferring the key lets an emitter relabel a
+    /// heartbeat's accord, preferring the column makes the new field decorative.
+    /// One artifact asserting two accords is malformed, whichever you believe.
     #[test]
-    fn an_unreadable_row_is_its_own_refusal_leg() {
-        // No envelope at all.
+    fn a_row_naming_two_accords_is_refused_as_disagrees_never_as_unnamed() {
+        let row = accord_row(
+            ACCORD_HEARTBEAT_DIMENSION,
+            "holder-a",
+            "accord-from-the-column",
+            Some("accord-from-the-signed-key"),
+        );
+        assert_eq!(
+            accord_root_claim(&row),
+            AccordRootClaim::Disagrees {
+                envelope_root: "accord-from-the-signed-key".to_owned(),
+                attested_key_id: "accord-from-the-column".to_owned(),
+            },
+        );
+        let got = AccordRelaySubject::of_row(&row);
+        assert_eq!(
+            got,
+            Err(RelayRefusal::ObjectRootDisagrees),
+            "one artifact asserting TWO accords is its own finding"
+        );
+        assert_ne!(
+            got,
+            Err(RelayRefusal::ObjectRootUnnamed),
+            "`names two` is not `names none` — folding them sends an operator to add a key \
+             the row already has"
+        );
+        // Agreement is NOT a disagreement: the same two signals naming the same
+        // accord resolve, and the signed key is reported as the source.
+        assert_eq!(
+            AccordRelaySubject::of_row(&accord_row(
+                ACCORD_HEARTBEAT_DIMENSION,
+                "holder-a",
+                "accord-x",
+                Some("accord-x")
+            )),
+            Ok(subject("accord-x", "holder-a")),
+            "both signals agreeing turns the drill rule into a CHECK, not a refusal"
+        );
+    }
+
+    /// The two "we could not even get a row" legs, kept apart.
+    ///
+    /// REWRITTEN: all three inputs below used to land on `ObjectUnreadable`,
+    /// because edge parsed the envelope by hand and every shape it could not
+    /// walk looked the same. Now a value that is not an [`Attestation`] and a
+    /// well-formed [`Attestation`] whose signed mirror is missing are DIFFERENT
+    /// findings — fix the producer's serializer vs. re-mint a pre-#643 row — so
+    /// they get different legs.
+    #[test]
+    fn an_unreadable_value_and_an_unbound_mirror_are_different_legs() {
+        // Not an `Attestation` at all: no `attestation_id`, no signatures, no
+        // `asserted_at`. persist's row type refuses it, and so do we.
         assert_eq!(
             AccordRelaySubject::of_attestation(&serde_json::json!({ "attesting_key_id": "a" })),
             Err(RelayRefusal::ObjectUnreadable),
         );
-        // Envelope, but no signed `row` mirror (a pre-#643 unstamped row).
+        // A row that is missing only the SIGNATURE fields is still not a row.
         assert_eq!(
             AccordRelaySubject::of_attestation(&serde_json::json!({
+                "attestation_id": "att-1",
+                "attesting_key_id": "a",
+                "attested_key_id": "b",
+                "attestation_type": "scores",
+                "asserted_at": "2026-01-01T00:00:00Z",
                 "attestation_envelope": { "dimension": ACCORD_HEARTBEAT_DIMENSION },
             })),
             Err(RelayRefusal::ObjectUnreadable),
         );
-        // A `row` that is not persist's closed-member `RowMirror`.
+        // A COMPLETE row whose envelope carries no signed `row` mirror — a
+        // pre-#643 unstamped row. Deserializes fine; persist's binding gate
+        // refuses it.
+        let mut value = accord_row_value(ACCORD_HEARTBEAT_DIMENSION, "holder-a", "accord-x", None);
+        value["attestation_envelope"]
+            .as_object_mut()
+            .expect("envelope object")
+            .remove("row");
         assert_eq!(
-            AccordRelaySubject::of_attestation(&serde_json::json!({
-                "attestation_envelope": {
-                    "dimension": ACCORD_HEARTBEAT_DIMENSION,
-                    "row": { "attesting_key_id": "a", "not_a_mirror_member": 1 },
-                },
-            })),
-            Err(RelayRefusal::ObjectUnreadable),
+            AccordRelaySubject::of_attestation(&value),
+            Err(RelayRefusal::MirrorUnbound),
+            "an unstamped row is UNBOUND, not unreadable — the two send an operator to \
+             different places"
+        );
+        // …and a `row` that is not persist's closed-member mirror lands there
+        // too: the binding gate owns that judgement now, not an edge walk.
+        let mut value = accord_row_value(ACCORD_HEARTBEAT_DIMENSION, "holder-a", "accord-x", None);
+        value["attestation_envelope"]["row"] =
+            serde_json::json!({ "attesting_key_id": "a", "not_a_mirror_member": 1 });
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&value),
+            Err(RelayRefusal::MirrorUnbound),
+        );
+    }
+
+    /// [`AccordRootClaim::NotAccord`] fails CLOSED at the gate's public entry
+    /// point. It is unreachable through the bridge (whose `attestation_is_accord`
+    /// early-out is persist's own [`attestation_family`] classifier, and `under`
+    /// implies `starts_with`), but the arm must not be an allow: a direct caller
+    /// of a `pub` predicate is a caller.
+    #[test]
+    fn a_row_that_is_not_accord_at_all_fails_closed_with_its_own_leg() {
+        let row = accord_row("scores:reputation:v1", "holder-a", "someone", None);
+        assert_eq!(accord_root_claim(&row), AccordRootClaim::NotAccord);
+        assert_eq!(
+            AccordRelaySubject::of_row(&row),
+            Err(RelayRefusal::ObjectNotAccord),
+            "persist refuses a non-accord row as unjudgeable; edge must not turn that into \
+             a carriage grant"
         );
     }
 
@@ -1148,9 +1436,16 @@ mod tests {
     async fn priming_an_unheld_root_caches_a_cannot_judge_verdict() {
         let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
         let gate = AccordRelayGate::new(dir, Some("this-node".into()));
-        let s = subject("unheld-accord-root", "holder-a");
         let t0 = now();
-        gate.prime(&s, t0).await;
+        let s = gate
+            .prime(&drill_row("holder-a", "unheld-accord-root"), t0)
+            .await
+            .expect("a well-formed drill row is judgeable");
+        assert_eq!(
+            s,
+            subject("unheld-accord-root", "holder-a"),
+            "the verdict is filed under the pair persist read off the row"
+        );
         assert_eq!(
             gate.decide(&s, t0),
             RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
@@ -1264,8 +1559,11 @@ mod tests {
         // (B) seated signer, but this node has NOT granted the root. The leg a
         // bare `Global` projection runs straight over.
         assert_eq!(
-            gate.may_relay_attestation(&accord_row(ACCORD_HEARTBEAT_DIMENSION, seated, root), t0)
-                .await,
+            gate.may_relay_attestation(
+                &accord_row_value(ACCORD_HEARTBEAT_DIMENSION, seated, root, None),
+                t0
+            )
+            .await,
             RelayDecision::Refused(RelayRefusal::NoTrustEdge),
             "seated but un-granted: CC 4.2.1 — simply not reached"
         );
@@ -1273,8 +1571,11 @@ mod tests {
         // (C) signer NOT on the roster. The roster IS resolvable here, so this
         // must read as `signer_not_seated` and never as `cannot judge`.
         assert_eq!(
-            gate.may_relay_attestation(&accord_row(ACCORD_HEARTBEAT_DIMENSION, stranger, root), t0)
-                .await,
+            gate.may_relay_attestation(
+                &accord_row_value(ACCORD_HEARTBEAT_DIMENSION, stranger, root, None),
+                t0
+            )
+            .await,
             RelayDecision::Refused(RelayRefusal::SignerNotSeated),
         );
 
@@ -1283,7 +1584,12 @@ mod tests {
         // root THE OBJECT NAMES changed, and the REASON changes with it.
         assert_eq!(
             gate.may_relay_attestation(
-                &accord_row(ACCORD_HEARTBEAT_DIMENSION, seated, "some-other-accord"),
+                &accord_row_value(
+                    ACCORD_HEARTBEAT_DIMENSION,
+                    seated,
+                    "some-other-accord",
+                    None
+                ),
                 t0
             )
             .await,
@@ -1334,7 +1640,7 @@ mod tests {
         // The object says `accord-b`. The signer is seated on `accord-a`.
         let decision = gate
             .may_relay_attestation(
-                &accord_row(ACCORD_HEARTBEAT_DIMENSION, signer, "accord-b"),
+                &accord_row_value(ACCORD_HEARTBEAT_DIMENSION, signer, "accord-b", None),
                 t0,
             )
             .await;
@@ -1351,7 +1657,7 @@ mod tests {
         // leg after seating passes.)
         assert_eq!(
             gate.may_relay_attestation(
-                &accord_row(ACCORD_HEARTBEAT_DIMENSION, signer, "accord-a"),
+                &accord_row_value(ACCORD_HEARTBEAT_DIMENSION, signer, "accord-a", None),
                 t0,
             )
             .await,
@@ -1366,60 +1672,115 @@ mod tests {
         );
     }
 
-    /// **The serve-path entry point carries the object refusals through.**
+    /// **ALL FIVE object refusals, carried through the serve-path ENTRY POINT.**
     ///
-    /// [`AccordRelaySubject::of_attestation`] is unit-tested above, but that
-    /// proves only that the DERIVATION refuses; it says nothing about what
+    /// [`AccordRelaySubject::of_row`] is unit-tested above, but that proves only
+    /// that the DERIVATION refuses; it says nothing about what
     /// [`AccordRelayGate::may_relay_attestation`] does with an `Err`. Turning
-    /// that arm into an allow is a one-token edit, and without this test the
-    /// whole gate module stays green while every unreadable and rootless
-    /// `accord:*` row is carried. MUTATION-VERIFIED (see the module report):
-    /// `Err(_) => RelayDecision::Relay` reds exactly this test.
+    /// either `Err` arm into an allow is a one-token edit.
+    ///
+    /// # Every leg is asserted HERE, and that is the point
+    ///
+    /// This test originally covered two of the five, and a mutation run found
+    /// the hole the user's rule predicts: flipping the `Disagrees` arm to
+    /// `Named` left the entire suite green except the DERIVATION test, because
+    /// nothing asserted what the GATE would then do with the row — and what it
+    /// would do is resolve it against the envelope-named root and CARRY it if
+    /// the signer happened to be seated there. So the roster below seats the
+    /// signer on every root these rows name, which turns each refusal into a
+    /// claim that survives the seating leg: a mutation that stops refusing gets
+    /// `no_trust_edge` (or a relay), never the expected leg.
     ///
     /// The seated-signer half is asserted too, so this cannot pass by refusing
     /// everything.
     #[tokio::test]
-    async fn the_serve_entry_point_refuses_rows_it_cannot_judge() {
+    async fn the_serve_entry_point_refuses_every_row_it_cannot_judge() {
         let us = "e-node";
         let signer = "e-holder";
         let root = "e-accord";
+        let other = "e-other-accord";
         let backend = Arc::new(MemoryBackend::new());
-        for who in [us, signer, root] {
+        for who in [us, signer, root, other] {
             backend.put_public_key(key(who)).await.expect("register");
         }
+        // The signer is SEATED on both roots any row below names. So if a leg
+        // stopped refusing, the gate would reach persist's seating leg and pass
+        // it — the answer would change to `no_trust_edge`, and every assertion
+        // here would red. A roster that seated nobody would let a broken arm
+        // land on `signer_not_seated` and hide behind a fail-safe default.
         seed_family(&backend, root, &[signer]).await;
+        seed_family(&backend, other, &[signer]).await;
         let dir: Arc<dyn FederationDirectory> = backend;
         let gate = AccordRelayGate::new(dir, Some(us.to_owned()));
         let t0 = now();
 
-        // A row whose signed bytes name no accord.
+        // (1) Not an `Attestation` at all.
+        assert_eq!(
+            gate.may_relay_attestation(&serde_json::json!({ "attesting_key_id": signer }), t0)
+                .await,
+            RelayDecision::Refused(RelayRefusal::ObjectUnreadable),
+            "an unreadable value is withheld, not carried"
+        );
+
+        // (2) A row whose columns diverge from its signed mirror.
+        let mut skewed = accord_row_value(ACCORD_HEARTBEAT_DIMENSION, signer, root, None);
+        skewed["attested_key_id"] = serde_json::json!(other);
+        assert_eq!(
+            gate.may_relay_attestation(&skewed, t0).await,
+            RelayDecision::Refused(RelayRefusal::MirrorUnbound),
+            "an unbound row is withheld — and the signer is seated on BOTH roots here, so \
+             a gate that stopped refusing would have CARRIED it"
+        );
+
+        // (3) Not on the `accord:*` family at all.
         assert_eq!(
             gate.may_relay_attestation(
-                &accord_row("accord:human_dignity:v1", signer, "some-agent"),
+                &accord_row_value("scores:reputation:v1", signer, root, None),
+                t0
+            )
+            .await,
+            RelayDecision::Refused(RelayRefusal::ObjectNotAccord),
+        );
+
+        // (4) On the family, naming no accord.
+        assert_eq!(
+            gate.may_relay_attestation(
+                &accord_row_value("accord:human_dignity:v1", signer, "some-agent", None),
                 t0
             )
             .await,
             RelayDecision::Refused(RelayRefusal::ObjectRootUnnamed),
             "no root in the signed bytes ⇒ nothing to judge against ⇒ REFUSE, never carry"
         );
-        // A row that does not parse at all.
+
+        // (5) On the family, naming TWO. Both named roots seat this signer, so
+        // resolving either one instead of refusing reaches the trust-edge leg.
         assert_eq!(
-            gate.may_relay_attestation(&serde_json::json!({ "attesting_key_id": signer }), t0)
-                .await,
-            RelayDecision::Refused(RelayRefusal::ObjectUnreadable),
-            "an unreadable row is withheld, not carried"
+            gate.may_relay_attestation(
+                &accord_row_value(ACCORD_HEARTBEAT_DIMENSION, signer, root, Some(other)),
+                t0
+            )
+            .await,
+            RelayDecision::Refused(RelayRefusal::ObjectRootDisagrees),
+            "one artifact asserting two accords is withheld at the GATE, not merely \
+             classified as a disagreement by the derivation"
         );
+
         assert_eq!(
             gate.cached_len(),
             0,
-            "a row we could not read never reached the resolver, so it cached nothing"
+            "not one of the five reached the resolver, so nothing was cached — a row we \
+             cannot judge must not park a verdict on any (root, signer) pair"
         );
 
         // …and the gate is ALIVE: a well-formed drill by the seated signer gets
         // a real, resolved verdict (leg 2 — no trust edge is seeded here).
         assert_eq!(
-            gate.may_relay_attestation(&accord_row(ACCORD_HEARTBEAT_DIMENSION, signer, root), t0)
-                .await,
+            gate.may_relay_attestation(
+                &accord_row_value(ACCORD_HEARTBEAT_DIMENSION, signer, root, None),
+                t0
+            )
+            .await,
             RelayDecision::Refused(RelayRefusal::NoTrustEdge),
             "a judgeable row IS judged — the refusals above are about the object, not a \
              gate that refuses everything"
@@ -1465,9 +1826,10 @@ mod tests {
         let gate = AccordRelayGate::new(dir, Some("us".into()));
         let t0 = now();
         let s = subject("accord-root", "holder-a");
+        let row = drill_row("holder-a", "accord-root");
         // Prime a verdict (an empty directory yields cannot-judge; what is
         // under test is the CACHE lifecycle, not the verdict's value).
-        gate.prime(&s, t0).await;
+        gate.prime(&row, t0).await.expect("judgeable");
         assert_eq!(gate.cached_len(), 1);
         assert_eq!(
             gate.decide(&s, t0),
@@ -1484,15 +1846,96 @@ mod tests {
         );
 
         // A root-naming invalidation drops every signer under THAT root.
-        gate.prime(&s, t0).await;
-        gate.prime(&subject("accord-root", "holder-b"), t0).await;
-        gate.prime(&subject("other-root", "holder-a"), t0).await;
+        for r in [
+            &row,
+            &drill_row("holder-b", "accord-root"),
+            &drill_row("holder-a", "other-root"),
+        ] {
+            gate.prime(r, t0).await.expect("judgeable");
+        }
         assert_eq!(gate.cached_len(), 3);
         gate.invalidate("accord-root");
         assert_eq!(
             gate.cached_len(),
             1,
             "a change naming the ROOT falsifies every verdict under it — and only under it"
+        );
+    }
+
+    /// **THE REQUIRED #733 PAIR, at the gate.** A row whose SIGNED `accord_root`
+    /// key names accord B, signed by a holder seated only on accord A, on a node
+    /// that holds a real family for BOTH — so `cannot judge` is doing none of
+    /// the work here and the roster resolves either way.
+    ///
+    /// This is the shape #733 made possible and #731 made necessary: pre-#733
+    /// the row could only be judged if its DIMENSION happened to be the drill
+    /// one, and pre-#731 it was judged against whichever root the host had
+    /// nominated — which, for a signer seated on A, was an ALLOW.
+    ///
+    /// Both halves are asserted. The refusal half alone would be satisfied by a
+    /// gate that refuses everything; the twin — the same signer, the same
+    /// dimension, the same node, with only the row's named root changed to the
+    /// one it IS seated on — passes the seating leg and moves the refusal to the
+    /// trust-edge leg, which is the next one along. (The full allow, with a live
+    /// `delegates_to(self → root)` and a genuinely SERVED row, is
+    /// `bridge::tests::a_signed_accord_root_decides_which_roster_judges_the_row`
+    /// — a trust edge needs the bridge module's hybrid-signing fixtures.)
+    #[tokio::test]
+    async fn a_signed_accord_root_naming_another_accord_is_judged_against_that_one() {
+        let us = "sk-node";
+        let signer = "sk-holder-on-a";
+        let backend = Arc::new(MemoryBackend::new());
+        for who in [us, signer, "sk-other-holder", "accord-a", "accord-b"] {
+            backend.put_public_key(key(who)).await.expect("register");
+        }
+        seed_family(&backend, "accord-a", &[signer]).await;
+        seed_family(&backend, "accord-b", &["sk-other-holder"]).await;
+
+        let dir: Arc<dyn FederationDirectory> = backend;
+        let gate = AccordRelayGate::new(dir, Some(us.to_owned()));
+        let t0 = now();
+
+        // A NON-drill dimension, so the ONLY thing naming the accord is the
+        // signed `accord_root` key — the drill fallback cannot answer here, and
+        // `attested_key_id` is the scored agent.
+        assert_eq!(
+            gate.may_relay_attestation(
+                &accord_row_value(
+                    "accord:human_dignity:v1",
+                    signer,
+                    "some-scored-agent",
+                    Some("accord-b")
+                ),
+                t0
+            )
+            .await,
+            RelayDecision::Refused(RelayRefusal::SignerNotSeated),
+            "the row NAMES accord-b, so accord-b's roster judges it — and this signer holds \
+             no seat there. Judging it on accord-a's roster (where it IS seated) is the \
+             confidently-wrong allow #731 reports"
+        );
+
+        // THE POSITIVE TWIN — only the named root changed.
+        assert_eq!(
+            gate.may_relay_attestation(
+                &accord_row_value(
+                    "accord:human_dignity:v1",
+                    signer,
+                    "some-scored-agent",
+                    Some("accord-a")
+                ),
+                t0
+            )
+            .await,
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge),
+            "on the accord it NAMES and IS seated on, seating passes and the refusal moves \
+             to the trust-edge leg — so the refusal above is about the ROOT, not a gate \
+             that refuses every row it is shown"
+        );
+        assert_eq!(
+            gate.cached_len(),
+            2,
+            "two named roots, two cached verdicts for one signer"
         );
     }
 }

--- a/src/replication/accord_relay_gate.rs
+++ b/src/replication/accord_relay_gate.rs
@@ -144,7 +144,6 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use ciris_persist::federation::admission::check_row_column_binding;
-use ciris_persist::federation::namespace::{attestation_family, AttestationFamily};
 use ciris_persist::federation::trust_root::{
     accord_root_claim, may_relay_accord_attestation, may_relay_accord_participation,
     AccordRootClaim, RelayVerdict,
@@ -616,9 +615,17 @@ impl AccordRelayGate {
     /// decided family is additive policy rather than a build break — and
     /// `objection:*`, the reserved-prefix sibling, is deliberately NOT in this
     /// family (CIRISPersist#713).
+    ///
+    /// **Reads [`crate::family_gates::gates_for`], not a local `matches!`.**
+    /// That is the whole point of the fold: an inline
+    /// `matches!(.., Accord)` returns `false` for a family this build
+    /// predates, which SKIPS the relay gate and CARRIES the row — permissive
+    /// on exactly the case `#[non_exhaustive]` exists to warn about.
+    /// `gates_for`'s wildcard is maximally gated instead, so an unknown
+    /// family is withheld and says so.
     #[must_use]
     pub fn dimension_is_gated(dimension: &str) -> bool {
-        matches!(attestation_family(dimension), AttestationFamily::Accord)
+        crate::family_gates::gates_for(dimension).accord_relay_gated
     }
 
     /// **The PURE SYNC predicate** — the gate itself. No I/O, no `.await`, no

--- a/src/replication/accord_relay_gate.rs
+++ b/src/replication/accord_relay_gate.rs
@@ -146,7 +146,7 @@ use std::time::{Duration, Instant};
 use ciris_persist::federation::admission::check_row_column_binding;
 use ciris_persist::federation::trust_root::{
     accord_root_claim, may_relay_accord_attestation, may_relay_accord_participation,
-    AccordRootClaim, RelayVerdict,
+    AccordRootClaim, RelayRefusal as PersistRelayRefusal, RelayVerdict,
 };
 use ciris_persist::federation::{Attestation, FederationDirectory};
 use ciris_verify_core::accord_live_quorum::AccordParticipation;
@@ -442,16 +442,47 @@ impl RelayDecision {
 /// roster also leaves `signer_seated == false`, and reporting that as
 /// "not seated" is the collapse CIRISPersist#713 wrote a mutation to forbid.
 fn decision_of(verdict: RelayVerdict) -> RelayDecision {
-    if verdict.may_relay() {
-        return RelayDecision::Relay;
+    // v37.1.0 (CIRISPersist#743) — persist owns the ORDER now, via
+    // `RelayVerdict::refusal_reason`. Edge maps its three-variant answer onto
+    // its own richer refusal set and adds nothing.
+    //
+    // The order is load-bearing and was edge's to get wrong: `roster_resolvable`
+    // must be read BEFORE `signer_seated`, or *"I cannot judge"* collapses into
+    // *"the signer is not seated"* — an accusation substituted for an admission
+    // of ignorance, on a relay gate. Persist's own mutation for this is the
+    // cleanest demonstration in the substrate of why an equivalence test is not
+    // coverage: reversing the two checks left their
+    // `refusal_reason_is_none_exactly_when_may_relay_is_true` test GREEN,
+    // because reordering changes WHY it refuses, not WHETHER. Only an ordering
+    // test caught it.
+    //
+    // Edge held that ordering itself until now, which meant a second consumer
+    // reading the three bools in the obvious order would have got a
+    // confidently wrong attribution with nothing to catch it. It travels with
+    // the type from here.
+    match verdict.refusal_reason() {
+        None => RelayDecision::Relay,
+        Some(PersistRelayRefusal::RosterUnresolvable) => {
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable)
+        }
+        Some(PersistRelayRefusal::SignerNotSeated) => {
+            RelayDecision::Refused(RelayRefusal::SignerNotSeated)
+        }
+        Some(PersistRelayRefusal::NoEdgeToRoot) => {
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge)
+        }
+        // FORCED: persist's `RelayRefusal` is `#[non_exhaustive]`, so a
+        // downstream match can never be exhaustive (the same constraint that
+        // denies edge a compile-error guard on `AttestationFamily` — see
+        // `crate::family_gates`).
+        //
+        // A refusal reason this build cannot name maps to `Unresolved` —
+        // edge's own *"I cannot judge"* — and NOT to a seated/not-seated
+        // answer. That is the whole point of the ordering this delegation
+        // exists to inherit: when edge does not know why persist refused, the
+        // honest report is ignorance, never an accusation about the signer.
+        Some(_) => RelayDecision::Refused(RelayRefusal::Unresolved),
     }
-    if !verdict.roster_resolvable {
-        return RelayDecision::Refused(RelayRefusal::RosterUnresolvable);
-    }
-    if !verdict.signer_seated {
-        return RelayDecision::Refused(RelayRefusal::SignerNotSeated);
-    }
-    RelayDecision::Refused(RelayRefusal::NoTrustEdge)
 }
 
 /// One cached verdict for one `(root, signer)` pair.
@@ -1793,6 +1824,42 @@ mod tests {
              gate that refuses everything"
         );
         assert_eq!(gate.cached_len(), 1, "…and that one DID reach the resolver");
+    }
+
+    /// The ORDERING, not the equivalence.
+    ///
+    /// Persist showed why the distinction matters: reversing the two checks
+    /// left their `refusal_reason_is_none_exactly_when_may_relay_is_true` test
+    /// GREEN, because reordering changes WHY it refuses, not WHETHER. Shipping
+    /// on equivalence alone yields a verdict saying "the signer is not seated"
+    /// when the truth is "I cannot judge" — an accusation substituted for an
+    /// admission of ignorance, on a relay gate.
+    ///
+    /// So this asserts the attribution where BOTH legs are false. No
+    /// equivalence test can distinguish the two orderings on that input.
+    #[test]
+    fn cannot_judge_outranks_not_seated_when_both_legs_are_false() {
+        let both_false = RelayVerdict {
+            roster_resolvable: false,
+            signer_seated: false,
+            edge_exists: true,
+        };
+        assert_eq!(
+            decision_of(both_false),
+            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
+            "an unresolvable roster is 'I cannot judge' and must NOT be \
+             reported as 'the signer is not seated'",
+        );
+        // ...and the seated leg still reports itself when the roster DID
+        // resolve, so this cannot pass by always answering RosterUnresolvable.
+        assert_eq!(
+            decision_of(RelayVerdict {
+                roster_resolvable: true,
+                signer_seated: false,
+                edge_exists: true,
+            }),
+            RelayDecision::Refused(RelayRefusal::SignerNotSeated),
+        );
     }
 
     /// persist's participation verb reads `family_key_id` / `member_id` out of

--- a/src/replication/accord_relay_gate.rs
+++ b/src/replication/accord_relay_gate.rs
@@ -18,10 +18,31 @@
 //! over-delivers, and **this predicate is what narrows carriage back to exactly
 //! that set.**
 //!
+//! ## WHICH accord? The OBJECT says — never the host (CIRISPersist#731)
+//!
+//! Until v17.10.0 this gate judged every `accord:*` row against ONE root the
+//! host named at construction (`ReplicationRuntimeConfig::accord_relay_root`).
+//! That is the defect CIRISPersist#731 reports, and it failed in the
+//! **permissive** direction:
+//!
+//! > A caller that supplies the wrong `root_ref` gets a **confidently wrong**
+//! > answer […] pass a root this node happens to trust and whose roster happens
+//! > to seat the signer, and `may_relay()` returns `true` for an object that
+//! > belongs to a **different** accord. The predicate cannot detect this,
+//! > because it was never given the object.
+//!
+//! So the nominated root is **gone**. Both arguments to persist's predicate are
+//! now read out of the object's own **signature-covered** bytes — see
+//! [`AccordRelaySubject`] — and the cache is keyed by the PAIR, because the
+//! same signer under two different roots has two different correct verdicts and
+//! a signer-keyed cache would reintroduce exactly the confusion the verb fix
+//! removed.
+//!
 //! ## Zero trust logic here
 //!
-//! The whole verdict is persist's
-//! [`may_relay_accord_object`] — seated signer AND a live
+//! The whole verdict is persist's — [`may_relay_accord_participation`] for an
+//! [`AccordParticipation`], [`may_relay_accord_object`] for an `accord:*`
+//! attestation whose signed bytes named its root. Seated signer AND a live
 //! `delegates_to(self → root)`. This module resolves, caches, and enforces; it
 //! decides nothing. It does not re-derive seating, roster membership, or edge
 //! existence, and the family classification of a dimension is persist's
@@ -41,7 +62,7 @@
 //!
 //! ## Async resolver, sync gate (CIRISEdge#217)
 //!
-//! [`may_relay_accord_object`] is `async`; the replication serve path
+//! persist's predicates are `async`; the replication serve path
 //! ([`crate::replication::session`]) is synchronous, and the per-record serve
 //! gate it reaches through `fetch_envelope` runs once PER ENVELOPE inside a
 //! round's reply assembly — the shape that produced CIRISEdge#400 (a per-
@@ -57,11 +78,12 @@
 //! ## Fail CLOSED, in every direction
 //!
 //! A cache miss, an expired entry, an invalidated entry, a resolver error, an
-//! absent directory, an absent local identity, and `roster_resolvable == false`
-//! all refuse. [`RelayRefusal::Unresolved`] is deliberately distinct from every
-//! decided refusal, so a refusal *because we never ran the predicate* can never
-//! be read as a refusal *because we decided* — the distinction a fail-safe
-//! default otherwise hides.
+//! absent directory, an absent local identity, an unreadable object, an object
+//! that names no root, and `roster_resolvable == false` all refuse.
+//! [`RelayRefusal::Unresolved`] is deliberately distinct from every decided
+//! refusal, so a refusal *because we never ran the predicate* can never be read
+//! as a refusal *because we decided* — the distinction a fail-safe default
+//! otherwise hides.
 //!
 //! ## Deliberately NOT here: whether this node is BOUND by a halt
 //!
@@ -83,9 +105,23 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use ciris_persist::federation::admission::envelope_dimension;
+use ciris_persist::federation::envelope::{paths, RowMirror};
 use ciris_persist::federation::namespace::{attestation_family, AttestationFamily};
-use ciris_persist::federation::trust_root::{may_relay_accord_object, RelayVerdict};
+use ciris_persist::federation::trust_root::{
+    may_relay_accord_object, may_relay_accord_participation, RelayVerdict,
+    ACCORD_HEARTBEAT_DIMENSION,
+};
 use ciris_persist::federation::FederationDirectory;
+use ciris_verify_core::accord_live_quorum::AccordParticipation;
+
+/// The row column holding the SIGNED envelope. persist publishes the member
+/// names INSIDE the envelope ([`paths`] / [`ciris_persist::federation::envelope::row_paths`])
+/// but the column that holds it is a schema name on
+/// [`Attestation`](ciris_persist::federation::Attestation), so it is spelled
+/// here — the one string this module owns, and the same one
+/// `attestation_requires_serve` and the quarantine consult already read.
+const ATTESTATION_ENVELOPE: &str = "attestation_envelope";
 
 /// How long one resolved [`RelayVerdict`] stays usable before the gate
 /// re-resolves it.
@@ -115,28 +151,42 @@ pub const RELAY_VERDICT_TTL: Duration = Duration::from_secs(10);
 pub enum RelayRefusal {
     /// persist could not resolve the root's roster at all
     /// ([`RelayVerdict::roster_resolvable`] `== false`) — this node holds no
-    /// family under that root. **"I cannot judge", NOT "the signer is not
-    /// seated"**, and it refuses. Remedy: sync the root's family record.
+    /// family under the root **the object named**. **"I cannot judge", NOT "the
+    /// signer is not seated"**, and it refuses. Remedy: sync that root's family
+    /// record.
     RosterUnresolvable,
-    /// The roster resolved and `signer_key_id` holds no live seat on it
+    /// The roster resolved and the object's signer holds no live seat on it
     /// (revocation-folded). Trusting a root does not make every key naming it
-    /// authoritative.
+    /// authoritative — and, post-#731, a signer seated on some OTHER accord
+    /// lands here rather than being waved through against a nominated root.
     SignerNotSeated,
-    /// No live `delegates_to(self → root)`: this node never granted the root,
-    /// or has cut the edge. CC 4.2.1 — *"simply not reached"*. This is the leg
-    /// a bare `Global` projection runs straight over.
+    /// No live `delegates_to(self → root)`: this node never granted the root
+    /// the object named, or has cut the edge. CC 4.2.1 — *"simply not
+    /// reached"*. This is the leg a bare `Global` projection runs straight over.
     NoTrustEdge,
-    /// **We never ran the predicate**: no verdict is cached for this signer, or
-    /// the cached one expired / was invalidated, and the sync gate cannot
-    /// resolve. Deliberately distinct from every decided refusal above — a
-    /// refusal that reports itself as unresolved is the one an operator can act
-    /// on, and it keeps a green test from proving nothing when the surrounding
-    /// default already refuses.
+    /// **We never ran the predicate**: no verdict is cached for this
+    /// `(root, signer)` pair, or the cached one expired / was invalidated, and
+    /// the sync gate cannot resolve. Deliberately distinct from every decided
+    /// refusal above — a refusal that reports itself as unresolved is the one an
+    /// operator can act on, and it keeps a green test from proving nothing when
+    /// the surrounding default already refuses.
     Unresolved,
     /// The gate has no `self_key_id`, so there is no "I" whose
     /// `delegates_to(self → root)` could exist. A WIRING fault
     /// (`ReplicationRuntimeConfig::local_key_id`), not a policy decision.
     NoLocalIdentity,
+    /// CIRISPersist#731 — the object's SIGNED bytes could not be read: no
+    /// `attestation_envelope`, no `row` mirror, or a mirror that is not
+    /// persist's [`RowMirror`]. Neither the signer nor the root is knowable, so
+    /// there is no question to ask. Fail-closed and LOUD (CIRISEdge#425) — a
+    /// malformed row, never a silent `continue`.
+    ObjectUnreadable,
+    /// CIRISPersist#731 — the object parsed, but **nothing in its signed bytes
+    /// names the accord it acts under**. Answering "which root?" from
+    /// construction state is the exact permissive failure #731 reports, so this
+    /// refuses instead. See [`AccordRelaySubject::of_attestation`]: an UPSTREAM
+    /// gap, not a local misconfiguration.
+    ObjectRootUnnamed,
 }
 
 impl RelayRefusal {
@@ -150,6 +200,8 @@ impl RelayRefusal {
             Self::NoTrustEdge => "no_trust_edge",
             Self::Unresolved => "unresolved",
             Self::NoLocalIdentity => "no_local_identity",
+            Self::ObjectUnreadable => "object_unreadable",
+            Self::ObjectRootUnnamed => "object_root_unnamed",
         }
     }
 }
@@ -157,6 +209,114 @@ impl RelayRefusal {
 impl std::fmt::Display for RelayRefusal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+/// CIRISPersist#731 — **the two facts a relay decision needs, both read out of
+/// the object's own signature-covered bytes**: which accord it acts under, and
+/// who signed it.
+///
+/// # Why this type exists at all
+///
+/// It is the thing the pre-#731 gate did not have. `may_relay_accord_object`
+/// takes `(signer, root)` as parameters, and edge was passing a root the HOST
+/// named — so an object belonging to accord B, signed by a key seated on accord
+/// A, was judged against A and carried. Making the pair a value derived
+/// *from the object* is what removes the caller's ability to nominate.
+///
+/// # Signed bytes only
+///
+/// Persist's scrub signature covers `JCS(attestation_envelope)` **and nothing
+/// else** — the top-level `attesting_key_id` / `attested_key_id` columns are
+/// unsigned copies, bound to the envelope only by `check_row_column_binding` at
+/// `put_attestation`. That binding is a receive-path admission gate; this is a
+/// SERVE-path carriage gate, so it reads the signed mirror
+/// ([`paths::ROW`] → [`RowMirror`], the seven members CIRISPersist#643 stamped
+/// inside the signature precisely so a relay could not rewrite them) rather
+/// than trusting a column a relay could have edited. Reading the unsigned copy
+/// would hand an attacker the choice of root, which is #731 rebuilt one field
+/// over.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccordRelaySubject {
+    /// The accord trust root the object acts under, from the object.
+    pub root_ref: String,
+    /// The key that signed the object, from the object.
+    pub signer_key_id: String,
+}
+
+impl AccordRelaySubject {
+    /// The subject of an [`AccordParticipation`] — `family_key_id` (*"the accord
+    /// family this decision is for"*) and `member_id` (the seat), both inside
+    /// the bytes the holder's hybrid threshold signature covers
+    /// (`AccordParticipation::canonical_bytes`).
+    ///
+    /// This is the shape persist's [`may_relay_accord_participation`] was
+    /// written for, and [`AccordRelayGate::may_relay_participation`] calls that
+    /// verb rather than re-deriving the pair — this constructor exists for the
+    /// CACHE KEY, so a participation and an attestation under the same root
+    /// share one entry.
+    #[must_use]
+    pub fn of_participation(participation: &AccordParticipation) -> Self {
+        Self {
+            root_ref: participation.family_key_id.clone(),
+            signer_key_id: participation.member_id.clone(),
+        }
+    }
+
+    /// The subject of an `accord:*` ATTESTATION row, from its signed envelope.
+    ///
+    /// # Which field names the root, and why only one dimension qualifies
+    ///
+    /// The signer is unambiguous: [`RowMirror::attesting_key_id`], signed.
+    ///
+    /// The ROOT is not, and this is the honest part. `accord:*` is a whole
+    /// dimension FAMILY whose only registry rule is `accord_holder-only`
+    /// (CC 3.4.1 — it constrains the EMITTER's `identity_type`, and says nothing
+    /// about which accord a row belongs to). Persist's own fixtures show
+    /// `attested_key_id` carrying different things across the family: for
+    /// `accord:human_dignity:v1` it is the AGENT being scored, and for
+    /// `accord:invoke:notify:*` it is the self-attesting holder — neither is a
+    /// root.
+    ///
+    /// **Exactly one dimension has an upstream answer.** For
+    /// [`ACCORD_HEARTBEAT_DIMENSION`] persist's own trust-root fold resolves
+    /// drills as `list_attestations_for(root_ref)` filtered to that dimension —
+    /// i.e. persist *defines* an `accord:lifecycle:v1` row about X as a drill
+    /// about accord X. Reading `attested_key_id` as the root there consumes
+    /// persist's rule; asserting it for any other `accord:*` dimension would be
+    /// edge inventing one.
+    ///
+    /// So every other dimension yields [`RelayRefusal::ObjectRootUnnamed`] and
+    /// is REFUSED. That is a real narrowing of what this node will carry, and it
+    /// is the correct direction: the alternative is answering "which root?" from
+    /// construction state, which is the permissive failure #731 exists to close.
+    /// The gap belongs to persist — a taking verb for `accord:*` attestations,
+    /// the way [`may_relay_accord_participation`] is the one for participations.
+    ///
+    /// # Errors
+    ///
+    /// [`RelayRefusal::ObjectUnreadable`] if the signed envelope or its
+    /// [`RowMirror`] cannot be read; [`RelayRefusal::ObjectRootUnnamed`] if it
+    /// can, but names no root.
+    pub fn of_attestation(canonical_json: &serde_json::Value) -> Result<Self, RelayRefusal> {
+        let envelope = canonical_json
+            .get(ATTESTATION_ENVELOPE)
+            .ok_or(RelayRefusal::ObjectUnreadable)?;
+        // The SIGNED mirror, through persist's own typed view of it. `RowMirror`
+        // is `deny_unknown_fields`, so this is the exact seven-member object the
+        // scrub signature covers — not a hand-spelled pointer walk that could
+        // drift from the vocabulary.
+        let mirror: RowMirror = envelope
+            .get(paths::ROW)
+            .and_then(|row| serde_json::from_value(row.clone()).ok())
+            .ok_or(RelayRefusal::ObjectUnreadable)?;
+        if envelope_dimension(envelope) != Some(ACCORD_HEARTBEAT_DIMENSION) {
+            return Err(RelayRefusal::ObjectRootUnnamed);
+        }
+        Ok(Self {
+            root_ref: mirror.attested_key_id,
+            signer_key_id: mirror.attesting_key_id,
+        })
     }
 }
 
@@ -213,7 +373,7 @@ fn decision_of(verdict: RelayVerdict) -> RelayDecision {
     RelayDecision::Refused(RelayRefusal::NoTrustEdge)
 }
 
-/// One cached verdict for one signer, under this gate's root.
+/// One cached verdict for one `(root, signer)` pair.
 #[derive(Debug, Clone, Copy)]
 struct CachedVerdict {
     verdict: RelayVerdict,
@@ -221,6 +381,22 @@ struct CachedVerdict {
     /// CIRISEdge#217: this rides a replication/transport path that can run on
     /// persist's runtime thread).
     fetched_at: Instant,
+}
+
+/// The cache key. **`(root, signer)`, never the signer alone** — the heart of
+/// the CIRISPersist#731 fix.
+///
+/// Both of persist's legs are root-relative (`active_roster_of(root)` and
+/// `delegates_to(self → root)`), so ONE signer has as many correct verdicts as
+/// there are roots. A signer-keyed cache would let the verdict resolved for
+/// accord A be served for an object belonging to accord B — the same
+/// cross-accord confusion #731 is about, reintroduced *behind* the fixed verb,
+/// where it is harder to see: the resolver would be reading the object
+/// correctly and the cache would be answering for a different one.
+type CacheKey = (String, String);
+
+fn cache_key(subject: &AccordRelaySubject) -> CacheKey {
+    (subject.root_ref.clone(), subject.signer_key_id.clone())
 }
 
 /// The pure, directory-free verdict cache. Split out from [`AccordRelayGate`]
@@ -231,15 +407,15 @@ struct VerdictCache {
     /// Bumped by EVERY invalidation. An in-flight resolve snapshots it at the
     /// miss and commits only if it is unchanged — see [`Self::commit`].
     generation: u64,
-    by_signer: HashMap<String, CachedVerdict>,
+    by_subject: HashMap<CacheKey, CachedVerdict>,
 }
 
 impl VerdictCache {
-    /// The cached verdict for `signer` iff a FRESH one exists. `None` means
-    /// "no usable verdict", which the sync gate turns into
+    /// The cached verdict for this `(root, signer)` pair iff a FRESH one exists.
+    /// `None` means "no usable verdict", which the sync gate turns into
     /// [`RelayRefusal::Unresolved`] — never into an allow.
-    fn get_fresh(&self, signer: &str, now: Instant) -> Option<RelayVerdict> {
-        let entry = self.by_signer.get(signer)?;
+    fn get_fresh(&self, subject: &AccordRelaySubject, now: Instant) -> Option<RelayVerdict> {
+        let entry = self.by_subject.get(&cache_key(subject))?;
         (now.saturating_duration_since(entry.fetched_at) < RELAY_VERDICT_TTL)
             .then_some(entry.verdict)
     }
@@ -256,17 +432,25 @@ impl VerdictCache {
     /// conservative outcome in every race: the next call re-resolves against
     /// live state. Two concurrent misses with NO interleaved invalidation still
     /// race benignly — they write the same answer.
-    fn commit(&mut self, signer: &str, verdict: RelayVerdict, gen_at_miss: u64, now: Instant) {
+    fn commit(
+        &mut self,
+        subject: &AccordRelaySubject,
+        verdict: RelayVerdict,
+        gen_at_miss: u64,
+        now: Instant,
+    ) {
         if self.generation != gen_at_miss {
             return;
         }
         // Bound memory: a departed signer must not accumulate. The live set is
-        // naturally roster-sized, but the key is peer-supplied (the row's
-        // `attesting_key_id`), so an unbounded map would be a cheap DoS.
-        self.by_signer
+        // naturally roster-sized, but BOTH halves of the key are peer-supplied
+        // (the row's signed mirror), so an unbounded map would be a cheap DoS —
+        // and post-#731 the key is a PAIR, so the product of forged roots and
+        // forged signers is what an attacker would try to inflate.
+        self.by_subject
             .retain(|_, v| now.saturating_duration_since(v.fetched_at) < RELAY_VERDICT_TTL);
-        self.by_signer.insert(
-            signer.to_owned(),
+        self.by_subject.insert(
+            cache_key(subject),
             CachedVerdict {
                 verdict,
                 fetched_at: now,
@@ -274,42 +458,47 @@ impl VerdictCache {
         );
     }
 
-    /// Drop every entry a state change naming `key_id` could falsify: the
-    /// signer whose verdict it is. A change naming the ROOT falsifies every
-    /// entry (both legs are root-relative), so the caller widens that to
-    /// [`Self::invalidate_all`].
+    /// Drop every entry a state change naming `key_id` could falsify: any entry
+    /// whose ROOT is `key_id` (a roster change, a charter, our trust edge — both
+    /// of persist's legs are root-relative, so every signer under it goes) and
+    /// any entry whose SIGNER is `key_id` (a seat revocation), across every
+    /// root that signer appears under.
+    ///
+    /// Post-#731 this replaces the old `key_id == self.root_ref ⇒ clear
+    /// everything` special case, which only worked because there was exactly one
+    /// root. With the root now coming from each object, "entries under this
+    /// root" is a filter on the key's first half rather than the whole map.
     ///
     /// Bumps the generation unconditionally — including when nothing matched —
     /// so an in-flight resolve started before this call can never commit over
     /// it.
     fn invalidate(&mut self, key_id: &str) {
         self.generation = self.generation.wrapping_add(1);
-        self.by_signer.remove(key_id);
+        self.by_subject
+            .retain(|(root, signer), _| root != key_id && signer != key_id);
     }
 
-    /// Drop everything (a root-relative change, or a coarse "trust state moved"
-    /// signal). Bumps the generation for the same reason.
+    /// Drop everything (a coarse "trust state moved and we cannot cheaply say
+    /// whose" signal). Bumps the generation for the same reason.
     fn invalidate_all(&mut self) {
         self.generation = self.generation.wrapping_add(1);
-        self.by_signer.clear();
+        self.by_subject.clear();
     }
 }
 
-/// The `accord:*` relay gate (workstream F). Wraps persist's
-/// [`may_relay_accord_object`] with a TTL'd, apply-path-invalidated cache and a
-/// pure sync predicate; see the module docs.
+/// The `accord:*` relay gate (workstream F). Wraps persist's relay predicates
+/// with a TTL'd, apply-path-invalidated cache and a pure sync predicate; see the
+/// module docs.
 ///
-/// # The root is an INSTANCE parameter, supplied by the host
+/// # There is no root here — that is the CIRISPersist#731 fix
 ///
-/// CC 4.2.3 is explicit that the accord roster belongs to a root — *"another
-/// instantiation of this form names its own three"* — so `root_ref` is
-/// construction state, not a baked constant, and every cache key is
-/// `(this root, signer)`. An `accord:*` row carries NO field naming the root it
-/// acts under, and persist exposes no `accord_root_of(row)` resolver, so the
-/// value has to arrive from the wiring seam (for a single-instance fleet, the
-/// genesis accord family id). Deriving it inside edge — from `attested_key_id`,
-/// from a baked id, from anything — would be edge holding a rule about which
-/// root an object belongs to, which is persist's to own. See the report note.
+/// This type used to hold a `root_ref` the host named at construction, and
+/// judged every object against it. It holds none now: the root is read from each
+/// object's signed bytes ([`AccordRelaySubject`]), so a host cannot nominate one
+/// and an object belonging to a different accord cannot be waved through on a
+/// roster that happens to seat its signer. Installing the gate is an on/off
+/// wiring decision (`ReplicationRuntimeConfig::accord_relay_enforced`), not a
+/// choice of which accord to believe in.
 pub struct AccordRelayGate {
     directory: Arc<dyn FederationDirectory>,
     /// "I" — this node's federation `key_id`, the subject of leg 2's
@@ -317,34 +506,21 @@ pub struct AccordRelayGate {
     /// ([`RelayRefusal::NoLocalIdentity`]): a wiring fault, and a gate with no
     /// "I" cannot evaluate consent-scoped reach at all.
     self_key_id: Option<String>,
-    /// The accord trust root whose roster seats the signer and to which this
-    /// node's edge must run.
-    root_ref: String,
     cache: Mutex<VerdictCache>,
 }
 
 impl AccordRelayGate {
     /// Build a gate over `directory`, anchored at `self_key_id` (our federation
-    /// key), for the accord root `root_ref`. `None` for `self_key_id` holds the
-    /// gate fully closed.
+    /// key). `None` for `self_key_id` holds the gate fully closed.
+    ///
+    /// No root parameter: see the type doc (CIRISPersist#731).
     #[must_use]
-    pub fn new(
-        directory: Arc<dyn FederationDirectory>,
-        self_key_id: Option<String>,
-        root_ref: impl Into<String>,
-    ) -> Self {
+    pub fn new(directory: Arc<dyn FederationDirectory>, self_key_id: Option<String>) -> Self {
         Self {
             directory,
             self_key_id,
-            root_ref: root_ref.into(),
             cache: Mutex::new(VerdictCache::default()),
         }
-    }
-
-    /// The accord root this gate judges against.
-    #[must_use]
-    pub fn root_ref(&self) -> &str {
-        &self.root_ref
     }
 
     /// Is `dimension` in the `accord:*` family — i.e. is this gate the one that
@@ -368,11 +544,14 @@ impl AccordRelayGate {
     /// released before returning. Safe to call from the synchronous replication
     /// serve path (CIRISEdge#217), once per envelope.
     ///
+    /// Takes the OBJECT'S subject, so the verdict served is the one resolved for
+    /// this object's root — not for whichever root the host had in mind.
+    ///
     /// Fail-closed on every absence: no local identity, no cached verdict, an
     /// expired verdict, an invalidated verdict. It NEVER resolves — resolution
     /// is [`Self::prime`]'s job, so a per-envelope serve gate can never turn
     /// into a per-envelope trust walk (the CIRISEdge#400 regression).
-    pub fn decide(&self, signer_key_id: &str, now: Instant) -> RelayDecision {
+    pub fn decide(&self, subject: &AccordRelaySubject, now: Instant) -> RelayDecision {
         if self.self_key_id.is_none() {
             return RelayDecision::Refused(RelayRefusal::NoLocalIdentity);
         }
@@ -380,24 +559,23 @@ impl AccordRelayGate {
             .cache
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .get_fresh(signer_key_id, now);
+            .get_fresh(subject, now);
         match cached {
             Some(verdict) => decision_of(verdict),
             None => RelayDecision::Refused(RelayRefusal::Unresolved),
         }
     }
 
-    /// Resolve `signer_key_id`'s verdict through persist and cache it, unless a
-    /// fresh one is already held (cache-first — a hit costs one lock and no
-    /// directory read). The ONE async step, called from the async serve paths
-    /// before their sync [`Self::decide`].
+    /// Resolve one already-derived subject through persist and cache it, unless
+    /// a fresh verdict is already held (cache-first — a hit costs one lock and
+    /// no directory read).
     ///
     /// The cache lock is taken twice, briefly, and **never held across the
     /// `.await`** (CIRISEdge#217). A resolver error does NOT cache: a transient
-    /// directory fault must not pin a signer refused past the fault — the next
+    /// directory fault must not pin a subject refused past the fault — the next
     /// call re-resolves, and [`Self::decide`] refuses meanwhile as
     /// [`RelayRefusal::Unresolved`], which says exactly what happened.
-    pub async fn prime(&self, signer_key_id: &str, now: Instant) {
+    pub async fn prime(&self, subject: &AccordRelaySubject, now: Instant) {
         let Some(us) = self.self_key_id.as_deref() else {
             return;
         };
@@ -406,7 +584,7 @@ impl AccordRelayGate {
                 .cache
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            if guard.get_fresh(signer_key_id, now).is_some() {
+            if guard.get_fresh(subject, now).is_some() {
                 return;
             }
             // Snapshot the generation WITH the miss check, so an invalidation
@@ -417,16 +595,16 @@ impl AccordRelayGate {
         let verdict = match may_relay_accord_object(
             &*self.directory,
             us,
-            signer_key_id,
-            &self.root_ref,
+            &subject.signer_key_id,
+            &subject.root_ref,
         )
         .await
         {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(
-                    signer = signer_key_id,
-                    root = %self.root_ref,
+                    signer = %subject.signer_key_id,
+                    root = %subject.root_ref,
                     error = %e,
                     "accord relay verdict resolve FAILED — carriage refused as `unresolved` \
                      until the next resolve (fail-closed, workstream F)"
@@ -437,15 +615,81 @@ impl AccordRelayGate {
         self.cache
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .commit(signer_key_id, verdict, gen_at_miss, now);
+            .commit(subject, verdict, gen_at_miss, now);
     }
 
-    /// [`Self::prime`] then [`Self::decide`] — the convenience an ASYNC gate
-    /// site uses. The decision is still the pure sync predicate; this only
-    /// guarantees a resolution attempt has happened first.
-    pub async fn may_relay(&self, signer_key_id: &str, now: Instant) -> RelayDecision {
-        self.prime(signer_key_id, now).await;
-        self.decide(signer_key_id, now)
+    /// **The serve-path entry point for an `accord:*` attestation row**: derive
+    /// the subject from the row's SIGNED bytes, resolve, and decide.
+    ///
+    /// The row is never trusted to tell the gate which root to use via anything
+    /// but its signed mirror, and a row that cannot name one is REFUSED with a
+    /// named leg rather than judged against a fallback (CIRISPersist#731).
+    pub async fn may_relay_attestation(
+        &self,
+        canonical_json: &serde_json::Value,
+        now: Instant,
+    ) -> RelayDecision {
+        match AccordRelaySubject::of_attestation(canonical_json) {
+            Ok(subject) => {
+                self.prime(&subject, now).await;
+                self.decide(&subject, now)
+            }
+            Err(refusal) => RelayDecision::Refused(refusal),
+        }
+    }
+
+    /// **The entry point for an [`AccordParticipation`]** — persist's
+    /// [`may_relay_accord_participation`], which reads `family_key_id` and
+    /// `member_id` out of the holder's signed canonical bytes itself.
+    ///
+    /// The verb is called directly rather than fed a pair edge derived, so the
+    /// mapping object → `(root, signer)` has exactly one owner (persist).
+    /// [`AccordRelaySubject::of_participation`] supplies only the CACHE KEY, and
+    /// a test pins the two against each other.
+    ///
+    /// This is the plane CIRISPersist#731's verb was written for
+    /// ([`AccordQuorumEvidence`](ciris_persist::federation::accord_carriage::AccordQuorumEvidence),
+    /// the #474 cursor plane). Edge does not yet route that plane through this
+    /// gate — see the module report — so this is the gate's readiness for it,
+    /// not a live serve path.
+    pub async fn may_relay_participation(
+        &self,
+        participation: &AccordParticipation,
+        now: Instant,
+    ) -> RelayDecision {
+        let Some(us) = self.self_key_id.as_deref() else {
+            return RelayDecision::Refused(RelayRefusal::NoLocalIdentity);
+        };
+        let subject = AccordRelaySubject::of_participation(participation);
+        let gen_at_miss = {
+            let guard = self
+                .cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match guard.get_fresh(&subject, now) {
+                Some(verdict) => return decision_of(verdict),
+                None => guard.generation,
+            }
+        };
+        let verdict =
+            match may_relay_accord_participation(&*self.directory, us, participation).await {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        member = %participation.member_id,
+                        family = %participation.family_key_id,
+                        error = %e,
+                        "accord participation relay verdict resolve FAILED — carriage refused \
+                         as `unresolved` until the next resolve (fail-closed, workstream F)"
+                    );
+                    return RelayDecision::Refused(RelayRefusal::Unresolved);
+                }
+            };
+        self.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .commit(&subject, verdict, gen_at_miss, now);
+        decision_of(verdict)
     }
 
     /// Drop cached verdicts a state change naming `key_id` could falsify.
@@ -453,21 +697,17 @@ impl AccordRelayGate {
     /// revocation, or trust-edge tombstone takes effect before the TTL would
     /// expire; [`RELAY_VERDICT_TTL`] is the backstop if an event is missed.
     ///
-    /// Deliberately over-broad: `key_id` naming the ROOT (or the root's family)
-    /// drops EVERY entry, since both of persist's legs are root-relative.
-    /// Choosing invalidation keys is a cache concern, not a trust rule — being
-    /// too eager only costs a re-resolve, while being too narrow caches a
-    /// verdict past the event that falsified it.
+    /// Deliberately over-broad: `key_id` matching EITHER half of a cache key
+    /// drops that entry — as a ROOT it drops every signer under that root (both
+    /// of persist's legs are root-relative), as a SIGNER it drops that signer
+    /// under every root. Choosing invalidation keys is a cache concern, not a
+    /// trust rule — being too eager only costs a re-resolve, while being too
+    /// narrow caches a verdict past the event that falsified it.
     pub fn invalidate(&self, key_id: &str) {
-        let mut guard = self
-            .cache
+        self.cache
             .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if key_id == self.root_ref {
-            guard.invalidate_all();
-        } else {
-            guard.invalidate(key_id);
-        }
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .invalidate(key_id);
     }
 
     /// Drop every cached verdict — the coarse "trust state moved and we cannot
@@ -485,7 +725,7 @@ impl AccordRelayGate {
         self.cache
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .by_signer
+            .by_subject
             .len()
     }
 }
@@ -511,6 +751,39 @@ mod tests {
 
     fn now() -> Instant {
         Instant::now()
+    }
+
+    /// A `(root, signer)` subject, for the cache tests.
+    fn subject(root: &str, signer: &str) -> AccordRelaySubject {
+        AccordRelaySubject {
+            root_ref: root.to_owned(),
+            signer_key_id: signer.to_owned(),
+        }
+    }
+
+    /// An `accord:*` attestation row in the SIGNED shape persist v31.0.0
+    /// (#643) stamps: the `row` mirror lives inside `attestation_envelope`,
+    /// which is what the scrub signature covers. The top-level columns are
+    /// written too — deliberately SKEWED in one test below, to prove the gate
+    /// reads the signed half.
+    fn accord_row(dimension: &str, attesting: &str, attested: &str) -> serde_json::Value {
+        serde_json::json!({
+            "attestation_id": "att-1",
+            "attesting_key_id": attesting,
+            "attested_key_id": attested,
+            "attestation_type": "scores",
+            "attestation_envelope": {
+                "dimension": dimension,
+                "asserted_at": "2026-01-01T00:00:00Z",
+                "row": {
+                    "attestation_id": "att-1",
+                    "attesting_key_id": attesting,
+                    "attestation_type": "scores",
+                    "attested_key_id": attested,
+                    "cohort_scope": "federation",
+                },
+            },
+        })
     }
 
     // ── decision_of: the verdict → decision mapping ──────────────────────
@@ -566,22 +839,109 @@ mod tests {
         assert!(!decision_of(verdict(false, false, false)).may_relay());
     }
 
+    // ── AccordRelaySubject: the object names its own root (#731) ──────────
+
+    /// The heartbeat/drill dimension is the ONE `accord:*` shape with an
+    /// upstream root rule (persist's trust-root fold resolves drills as
+    /// `list_attestations_for(root)` filtered to this dimension), so the signed
+    /// `attested_key_id` IS the accord.
+    #[test]
+    fn a_heartbeat_row_names_its_root_and_its_signer() {
+        let row = accord_row(ACCORD_HEARTBEAT_DIMENSION, "holder-a", "accord-x");
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&row),
+            Ok(subject("accord-x", "holder-a")),
+            "both halves come from the SIGNED row mirror"
+        );
+    }
+
+    /// **The signed half wins.** The unsigned top-level columns are bound to
+    /// the envelope by persist's `check_row_column_binding` at
+    /// `put_attestation` — a RECEIVE-path gate. This is a SERVE-path carriage
+    /// gate, so it must not depend on that binding having run: skew the columns
+    /// and the subject must be unmoved. Reading the unsigned copy would hand an
+    /// attacker the choice of root — CIRISPersist#731 rebuilt one field over.
+    #[test]
+    fn the_unsigned_columns_cannot_move_the_subject() {
+        let mut row = accord_row(ACCORD_HEARTBEAT_DIMENSION, "holder-a", "accord-x");
+        row["attesting_key_id"] = serde_json::json!("attacker");
+        row["attested_key_id"] = serde_json::json!("accord-the-attacker-prefers");
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&row),
+            Ok(subject("accord-x", "holder-a")),
+            "the scrub signature covers JCS(attestation_envelope) and NOTHING else — the \
+             top-level columns are unsigned and are not read here"
+        );
+    }
+
+    /// Every other `accord:*` dimension names no root, so it is refused with
+    /// its OWN leg rather than judged against a fallback. `accord_holder-only`
+    /// (CC 3.4.1) constrains the emitter's identity type and says nothing about
+    /// which accord a row belongs to; persist's own fixtures put a scored AGENT
+    /// in `attested_key_id` for `accord:human_dignity:v1` and the self-attesting
+    /// HOLDER for `accord:invoke:notify:*`.
+    #[test]
+    fn a_non_heartbeat_accord_row_names_no_root_and_is_refused_distinctly() {
+        for dim in [
+            "accord:human_dignity:v1",
+            "accord:invoke:notify:halt",
+            "accord:halt:v1",
+        ] {
+            assert_eq!(
+                AccordRelaySubject::of_attestation(&accord_row(dim, "holder-a", "someone")),
+                Err(RelayRefusal::ObjectRootUnnamed),
+                "{dim}: no signed field names the accord — refuse, do NOT fall back to a \
+                 host-nominated root (CIRISPersist#731)"
+            );
+        }
+    }
+
+    /// An unreadable object is its own leg, distinct from "names no root":
+    /// one is a malformed row, the other a well-formed row with an upstream
+    /// vocabulary gap, and they send an operator to different places.
+    #[test]
+    fn an_unreadable_row_is_its_own_refusal_leg() {
+        // No envelope at all.
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&serde_json::json!({ "attesting_key_id": "a" })),
+            Err(RelayRefusal::ObjectUnreadable),
+        );
+        // Envelope, but no signed `row` mirror (a pre-#643 unstamped row).
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&serde_json::json!({
+                "attestation_envelope": { "dimension": ACCORD_HEARTBEAT_DIMENSION },
+            })),
+            Err(RelayRefusal::ObjectUnreadable),
+        );
+        // A `row` that is not persist's closed-member `RowMirror`.
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&serde_json::json!({
+                "attestation_envelope": {
+                    "dimension": ACCORD_HEARTBEAT_DIMENSION,
+                    "row": { "attesting_key_id": "a", "not_a_mirror_member": 1 },
+                },
+            })),
+            Err(RelayRefusal::ObjectUnreadable),
+        );
+    }
+
     // ── VerdictCache: freshness, fail-closed miss, invalidation ──────────
 
     #[test]
     fn a_miss_is_none_never_a_default() {
         let c = VerdictCache::default();
-        assert!(c.get_fresh("never-seen", now()).is_none());
+        assert!(c.get_fresh(&subject("root", "never-seen"), now()).is_none());
     }
 
     #[test]
     fn a_committed_verdict_is_a_cache_hit_within_the_ttl() {
         let mut c = VerdictCache::default();
         let t0 = now();
-        c.commit("holder-a", verdict(true, true, true), 0, t0);
+        let s = subject("root", "holder-a");
+        c.commit(&s, verdict(true, true, true), 0, t0);
         assert_eq!(
             c.get_fresh(
-                "holder-a",
+                &s,
                 t0 + RELAY_VERDICT_TTL
                     .checked_sub(Duration::from_millis(1))
                     .expect("the TTL is longer than 1ms")
@@ -595,10 +955,44 @@ mod tests {
     fn a_verdict_expires_at_the_ttl_and_the_gate_then_fails_closed() {
         let mut c = VerdictCache::default();
         let t0 = now();
-        c.commit("holder-a", verdict(true, true, true), 0, t0);
+        let s = subject("root", "holder-a");
+        c.commit(&s, verdict(true, true, true), 0, t0);
         assert!(
-            c.get_fresh("holder-a", t0 + RELAY_VERDICT_TTL).is_none(),
+            c.get_fresh(&s, t0 + RELAY_VERDICT_TTL).is_none(),
             "expired AT the TTL — an expired ALLOW must not keep relaying"
+        );
+    }
+
+    /// **THE CACHE-KEY PROPERTY (CIRISPersist#731).** One signer, two roots,
+    /// two OPPOSITE verdicts — and the cache must keep them apart. A
+    /// signer-keyed cache serves accord A's allow for an accord B object, which
+    /// is the cross-accord confusion #731 is about, reintroduced behind the
+    /// fixed verb where it is harder to see.
+    ///
+    /// MUTATION-VERIFIED (see the module report): reverting `CacheKey` to the
+    /// signer alone reds this test.
+    #[test]
+    fn one_signer_under_two_roots_holds_two_independent_verdicts() {
+        let mut c = VerdictCache::default();
+        let t0 = now();
+        let on_a = subject("accord-a", "holder-a");
+        let on_b = subject("accord-b", "holder-a");
+        // Seated on A, NOT seated on B — the same key, two truths.
+        c.commit(&on_a, verdict(true, true, true), c.generation, t0);
+        c.commit(&on_b, verdict(true, false, true), c.generation, t0);
+        assert_eq!(
+            c.get_fresh(&on_a, t0),
+            Some(verdict(true, true, true)),
+            "accord A's verdict"
+        );
+        assert_eq!(
+            c.get_fresh(&on_b, t0),
+            Some(verdict(true, false, true)),
+            "accord B's verdict is B's — NOT A's answer served under B's name"
+        );
+        assert!(
+            !decision_of(c.get_fresh(&on_b, t0).expect("cached")).may_relay(),
+            "and it still refuses for B"
         );
     }
 
@@ -606,14 +1000,41 @@ mod tests {
     fn invalidate_drops_the_named_signer_and_leaves_the_others() {
         let mut c = VerdictCache::default();
         let t0 = now();
-        c.commit("holder-a", verdict(true, true, true), c.generation, t0);
-        c.commit("holder-b", verdict(true, true, true), c.generation, t0);
+        let a = subject("root", "holder-a");
+        let b = subject("root", "holder-b");
+        c.commit(&a, verdict(true, true, true), c.generation, t0);
+        c.commit(&b, verdict(true, true, true), c.generation, t0);
         c.invalidate("holder-a");
-        assert!(c.get_fresh("holder-a", t0).is_none(), "holder-a dropped");
+        assert!(c.get_fresh(&a, t0).is_none(), "holder-a dropped");
         assert_eq!(
-            c.get_fresh("holder-b", t0),
+            c.get_fresh(&b, t0),
             Some(verdict(true, true, true)),
             "an unrelated signer's verdict survives a targeted invalidation"
+        );
+    }
+
+    /// The root half of the key is an invalidation handle too: a change naming
+    /// a ROOT drops every signer under THAT root, and leaves other roots alone.
+    /// (Pre-#731 this was `key_id == self.root_ref ⇒ clear the whole map`,
+    /// which only worked because there was exactly one root.)
+    #[test]
+    fn invalidating_a_root_drops_its_signers_and_spares_other_roots() {
+        let mut c = VerdictCache::default();
+        let t0 = now();
+        let a1 = subject("accord-a", "holder-1");
+        let a2 = subject("accord-a", "holder-2");
+        let b1 = subject("accord-b", "holder-1");
+        for s in [&a1, &a2, &b1] {
+            c.commit(s, verdict(true, true, true), c.generation, t0);
+        }
+        c.invalidate("accord-a");
+        assert!(c.get_fresh(&a1, t0).is_none());
+        assert!(c.get_fresh(&a2, t0).is_none());
+        assert_eq!(
+            c.get_fresh(&b1, t0),
+            Some(verdict(true, true, true)),
+            "accord B is untouched — both legs are root-relative, so only A's entries were \
+             falsified"
         );
     }
 
@@ -626,32 +1047,35 @@ mod tests {
     fn a_commit_that_raced_an_invalidation_is_dropped_not_clobbering_it() {
         let mut c = VerdictCache::default();
         let t0 = now();
+        let s = subject("root", "holder-a");
         // A resolve begins: snapshot the generation at the miss.
         let gen_at_miss = c.generation;
         // …an invalidation lands DURING the (awaited) resolve.
         c.invalidate("holder-a");
         // …and the in-flight resolve now tries to commit its stale answer.
-        c.commit("holder-a", verdict(true, true, true), gen_at_miss, t0);
+        c.commit(&s, verdict(true, true, true), gen_at_miss, t0);
         assert!(
-            c.get_fresh("holder-a", t0).is_none(),
+            c.get_fresh(&s, t0).is_none(),
             "the racing commit is DROPPED — the invalidation is not clobbered, and the \
              next call re-resolves against live state"
         );
         // A fresh resolve (snapshot taken after the invalidation) commits fine.
         let gen_now = c.generation;
-        c.commit("holder-a", verdict(true, true, true), gen_now, t0);
-        assert_eq!(c.get_fresh("holder-a", t0), Some(verdict(true, true, true)));
+        c.commit(&s, verdict(true, true, true), gen_now, t0);
+        assert_eq!(c.get_fresh(&s, t0), Some(verdict(true, true, true)));
     }
 
     #[test]
     fn invalidate_all_clears_every_entry() {
         let mut c = VerdictCache::default();
         let t0 = now();
-        c.commit("holder-a", verdict(true, true, true), c.generation, t0);
-        c.commit("holder-b", verdict(true, true, true), c.generation, t0);
+        let a = subject("root-a", "holder-a");
+        let b = subject("root-b", "holder-b");
+        c.commit(&a, verdict(true, true, true), c.generation, t0);
+        c.commit(&b, verdict(true, true, true), c.generation, t0);
         c.invalidate_all();
-        assert!(c.get_fresh("holder-a", t0).is_none());
-        assert!(c.get_fresh("holder-b", t0).is_none());
+        assert!(c.get_fresh(&a, t0).is_none());
+        assert!(c.get_fresh(&b, t0).is_none());
     }
 
     // ── The gate: fail-closed, and the family classifier ─────────────────
@@ -690,9 +1114,9 @@ mod tests {
     #[test]
     fn no_local_identity_refuses_every_object() {
         let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
-        let gate = AccordRelayGate::new(dir, None, "humanity-accord");
+        let gate = AccordRelayGate::new(dir, None);
         assert_eq!(
-            gate.decide("any-holder", now()),
+            gate.decide(&subject("humanity-accord", "any-holder"), now()),
             RelayDecision::Refused(RelayRefusal::NoLocalIdentity),
             "no `I` ⇒ no consent-scoped reach to evaluate ⇒ closed"
         );
@@ -705,9 +1129,9 @@ mod tests {
     #[test]
     fn an_unprimed_gate_refuses_as_unresolved_not_as_a_decision() {
         let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
-        let gate = AccordRelayGate::new(dir, Some("this-node".into()), "humanity-accord");
+        let gate = AccordRelayGate::new(dir, Some("this-node".into()));
         assert_eq!(
-            gate.decide("holder-a", now()),
+            gate.decide(&subject("humanity-accord", "holder-a"), now()),
             RelayDecision::Refused(RelayRefusal::Unresolved),
             "a cache miss is `unresolved` — never an allow, and never mis-reported as a \
              verdict we did not reach"
@@ -723,31 +1147,92 @@ mod tests {
     #[tokio::test]
     async fn priming_an_unheld_root_caches_a_cannot_judge_verdict() {
         let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
-        let gate = AccordRelayGate::new(dir, Some("this-node".into()), "unheld-accord-root");
+        let gate = AccordRelayGate::new(dir, Some("this-node".into()));
+        let s = subject("unheld-accord-root", "holder-a");
         let t0 = now();
+        gate.prime(&s, t0).await;
         assert_eq!(
-            gate.may_relay("holder-a", t0).await,
+            gate.decide(&s, t0),
             RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
             "persist reports `roster_resolvable: false` for a root we hold no family for"
         );
         assert_eq!(gate.cached_len(), 1, "the verdict was cached");
-        // The cached verdict is served by the SYNC predicate, unchanged.
-        assert_eq!(
-            gate.decide("holder-a", t0),
-            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
-        );
         // …and expires into `Unresolved` — an expired cannot-judge is not a
         // standing cannot-judge, it is "we no longer know".
         assert_eq!(
-            gate.decide("holder-a", t0 + RELAY_VERDICT_TTL),
+            gate.decide(&s, t0 + RELAY_VERDICT_TTL),
             RelayDecision::Refused(RelayRefusal::Unresolved),
         );
     }
 
+    /// A minimal registered key. persist requires every family member to be a
+    /// registered `federation_keys` row (members MUST be registered keys), and
+    /// `put_public_key` does not hybrid-verify the registration row, so
+    /// placeholders are the honest fixture here — nothing in these tests
+    /// verifies a signature.
+    fn key(key_id: &str) -> ciris_persist::federation::SignedKeyRecord {
+        use base64::Engine as _;
+        use ciris_persist::federation::types::{algorithm, identity_type};
+        use ciris_persist::federation::{KeyRecord, SignedKeyRecord};
+        let b64 = base64::engine::general_purpose::STANDARD;
+        let now = chrono::Utc::now();
+        SignedKeyRecord {
+            record: KeyRecord {
+                key_id: key_id.to_owned(),
+                pubkey_ed25519_base64: b64.encode([0u8; 32]),
+                pubkey_ml_dsa_65_base64: Some(b64.encode([0u8; 1952])),
+                algorithm: algorithm::HYBRID.to_owned(),
+                identity_type: identity_type::NODE.to_owned(),
+                identity_ref: format!("node-ref-{key_id}"),
+                valid_from: now,
+                valid_until: None,
+                registration_envelope: serde_json::json!({ "key_id": key_id }),
+                original_content_hash: "0".repeat(64),
+                scrub_signature_classical: "x".repeat(88),
+                scrub_signature_pqc: None,
+                scrub_key_id: key_id.to_owned(),
+                scrub_timestamp: now,
+                pqc_completed_at: None,
+                persist_row_hash: String::new(),
+                capability_roles: Vec::new(),
+                attestation_evidence: None,
+                consent_role: None,
+                additional_scrubs: Vec::new(),
+            },
+        }
+    }
+
+    /// Seed a keyless accord family (`put_family_local` — a family holds no key
+    /// and cannot sign its own declaration), the way persist's own
+    /// `seed_test_family` does.
+    async fn seed_family(backend: &MemoryBackend, root: &str, members: &[&str]) {
+        use ciris_persist::federation::types::{Family, FamilyMember};
+        let founded: chrono::DateTime<chrono::Utc> = "2020-01-01T00:00:00Z"
+            .parse()
+            .expect("pinned founding instant");
+        backend
+            .put_family_local(Family {
+                family_key_id: root.to_owned(),
+                family_name: root.to_owned(),
+                members: members
+                    .iter()
+                    .map(|m| FamilyMember {
+                        key_id: (*m).to_owned(),
+                        joined_at: founded,
+                        role: Some("founder".to_owned()),
+                    })
+                    .collect(),
+                founded_at: founded,
+                consensus_protocol: "quorum:2/3".to_owned(),
+                consensus_protocol_entrenched: true,
+                persist_row_hash: String::new(),
+            })
+            .await
+            .expect("seed the accord family (keyless, local door)");
+    }
+
     /// persist's refusal legs (B), (C) and (D), end to end through the REAL
-    /// resolver, over a keyless accord family seeded exactly the way persist's
-    /// own `seed_test_family` seeds one (`put_family_local` — a family holds no
-    /// key and cannot sign its own declaration).
+    /// resolver, over a keyless accord family.
     ///
     /// No trust edge is seeded here (that needs a hybrid-signed federation-tier
     /// attestation, whose fixture machinery lives in the bridge's test module),
@@ -758,44 +1243,6 @@ mod tests {
     /// indistinguishable from a gate that is dead.
     #[tokio::test]
     async fn the_refusal_legs_through_the_real_resolver() {
-        use ciris_persist::federation::types::{algorithm, identity_type, Family, FamilyMember};
-        use ciris_persist::federation::{KeyRecord, SignedKeyRecord};
-
-        /// A minimal registered key. persist requires every family member to be
-        /// a registered `federation_keys` row (members MUST be registered
-        /// keys), and `put_public_key` does not hybrid-verify the registration
-        /// row, so placeholders are the honest fixture here — nothing in this
-        /// test verifies a signature.
-        fn key(key_id: &str) -> SignedKeyRecord {
-            use base64::Engine as _;
-            let b64 = base64::engine::general_purpose::STANDARD;
-            let now = chrono::Utc::now();
-            SignedKeyRecord {
-                record: KeyRecord {
-                    key_id: key_id.to_owned(),
-                    pubkey_ed25519_base64: b64.encode([0u8; 32]),
-                    pubkey_ml_dsa_65_base64: Some(b64.encode([0u8; 1952])),
-                    algorithm: algorithm::HYBRID.to_owned(),
-                    identity_type: identity_type::NODE.to_owned(),
-                    identity_ref: format!("node-ref-{key_id}"),
-                    valid_from: now,
-                    valid_until: None,
-                    registration_envelope: serde_json::json!({ "key_id": key_id }),
-                    original_content_hash: "0".repeat(64),
-                    scrub_signature_classical: "x".repeat(88),
-                    scrub_signature_pqc: None,
-                    scrub_key_id: key_id.to_owned(),
-                    scrub_timestamp: now,
-                    pqc_completed_at: None,
-                    persist_row_hash: String::new(),
-                    capability_roles: Vec::new(),
-                    attestation_evidence: None,
-                    consent_role: None,
-                    additional_scrubs: Vec::new(),
-                },
-            }
-        }
-
         let root = "relay-accord-root";
         let seated = "relay-holder-a";
         let stranger = "relay-stranger";
@@ -808,34 +1255,17 @@ mod tests {
                 .await
                 .expect("register key");
         }
-        let founded: chrono::DateTime<chrono::Utc> = "2020-01-01T00:00:00Z"
-            .parse()
-            .expect("pinned founding instant");
-        backend
-            .put_family_local(Family {
-                family_key_id: root.to_owned(),
-                family_name: root.to_owned(),
-                members: vec![FamilyMember {
-                    key_id: seated.to_owned(),
-                    joined_at: founded,
-                    role: Some("founder".to_owned()),
-                }],
-                founded_at: founded,
-                consensus_protocol: "quorum:2/3".to_owned(),
-                consensus_protocol_entrenched: true,
-                persist_row_hash: String::new(),
-            })
-            .await
-            .expect("seed the accord family (keyless, local door)");
+        seed_family(&backend, root, &[seated]).await;
 
         let dir: Arc<dyn FederationDirectory> = backend;
-        let gate = AccordRelayGate::new(Arc::clone(&dir), Some(us.to_owned()), root);
+        let gate = AccordRelayGate::new(Arc::clone(&dir), Some(us.to_owned()));
         let t0 = now();
 
         // (B) seated signer, but this node has NOT granted the root. The leg a
         // bare `Global` projection runs straight over.
         assert_eq!(
-            gate.may_relay(seated, t0).await,
+            gate.may_relay_attestation(&accord_row(ACCORD_HEARTBEAT_DIMENSION, seated, root), t0)
+                .await,
             RelayDecision::Refused(RelayRefusal::NoTrustEdge),
             "seated but un-granted: CC 4.2.1 — simply not reached"
         );
@@ -843,64 +1273,226 @@ mod tests {
         // (C) signer NOT on the roster. The roster IS resolvable here, so this
         // must read as `signer_not_seated` and never as `cannot judge`.
         assert_eq!(
-            gate.may_relay(stranger, t0).await,
+            gate.may_relay_attestation(&accord_row(ACCORD_HEARTBEAT_DIMENSION, stranger, root), t0)
+                .await,
             RelayDecision::Refused(RelayRefusal::SignerNotSeated),
         );
 
-        // (D) a DIFFERENT root this node holds no family for — cannot judge,
-        // and distinctly so. Same signer, same node: only the root changed,
-        // and the REASON changes with it.
-        let blind = AccordRelayGate::new(dir, Some(us.to_owned()), "some-other-accord");
+        // (D) an object naming a DIFFERENT root this node holds no family for —
+        // cannot judge, and distinctly so. Same signer, same node: only the
+        // root THE OBJECT NAMES changed, and the REASON changes with it.
         assert_eq!(
-            blind.may_relay(seated, t0).await,
+            gate.may_relay_attestation(
+                &accord_row(ACCORD_HEARTBEAT_DIMENSION, seated, "some-other-accord"),
+                t0
+            )
+            .await,
             RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
         );
 
         // Cache expiry fails CLOSED, and reports that it no longer knows.
         assert_eq!(
-            gate.decide(seated, t0 + RELAY_VERDICT_TTL),
+            gate.decide(&subject(root, seated), t0 + RELAY_VERDICT_TTL),
             RelayDecision::Refused(RelayRefusal::Unresolved),
             "an expired verdict stops being a verdict until it is re-resolved"
         );
     }
 
-    /// The apply-path invalidation, at the gate's own surface: a cached ALLOW
+    /// **THE #731 REGRESSION TEST, at the gate.** A node that trusts BOTH
+    /// accords, a signer seated on A only, and an object belonging to B.
+    ///
+    /// The pre-#731 gate held `root_ref = "accord-a"` as construction state and
+    /// judged *every* object against it, so this object — which says `accord-b`
+    /// in its own signed bytes — resolved (seated on A ✓, edge to A ✓) and was
+    /// CARRIED. That is persist's *"confidently wrong answer in the permissive
+    /// direction"*.
+    ///
+    /// The trust edge (leg 2) is not seeded here — it needs a hybrid-signed
+    /// federation attestation — so this asserts the leg that DIFFERS between
+    /// the two roots: seating. Under B the signer is not seated, so the answer
+    /// changes from the old code's allow to `signer_not_seated`. The full
+    /// old-allows/new-refuses pair WITH a live edge, and the accompanying
+    /// "a legitimately-seated signer IS still served" half, is
+    /// `bridge::tests::an_object_belonging_to_another_accord_is_not_relayed_on_this_ones_roster`.
+    #[tokio::test]
+    async fn an_object_naming_another_root_is_judged_against_that_root() {
+        let us = "x-node";
+        let signer = "x-holder-on-a";
+        let backend = Arc::new(MemoryBackend::new());
+        for who in [us, signer, "some-other-holder", "accord-a", "accord-b"] {
+            backend.put_public_key(key(who)).await.expect("register");
+        }
+        // The node holds a family for BOTH accords — so "cannot judge" is not
+        // what is doing the work here; the roster resolves either way.
+        seed_family(&backend, "accord-a", &[signer]).await;
+        seed_family(&backend, "accord-b", &["some-other-holder"]).await;
+
+        let dir: Arc<dyn FederationDirectory> = backend;
+        let gate = AccordRelayGate::new(dir, Some(us.to_owned()));
+        let t0 = now();
+
+        // The object says `accord-b`. The signer is seated on `accord-a`.
+        let decision = gate
+            .may_relay_attestation(
+                &accord_row(ACCORD_HEARTBEAT_DIMENSION, signer, "accord-b"),
+                t0,
+            )
+            .await;
+        assert_eq!(
+            decision,
+            RelayDecision::Refused(RelayRefusal::SignerNotSeated),
+            "the verdict is resolved against the root THE OBJECT NAMES (`accord-b`), where \
+             this signer holds no seat — the pre-#731 gate judged it against the \
+             host-nominated `accord-a`, found a seat, and carried it"
+        );
+        // And the SAME signer, on an object naming the root it IS seated on,
+        // reaches the seating leg — so this is not a gate that refuses
+        // everything. (It stops at `no_trust_edge`, leg 2, which is the next
+        // leg after seating passes.)
+        assert_eq!(
+            gate.may_relay_attestation(
+                &accord_row(ACCORD_HEARTBEAT_DIMENSION, signer, "accord-a"),
+                t0,
+            )
+            .await,
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge),
+            "on its OWN accord the signer IS seated — seating passes and the refusal moves \
+             to the trust-edge leg, so the refusal above is about the ROOT, not a blanket no"
+        );
+        assert_eq!(
+            gate.cached_len(),
+            2,
+            "two roots, two entries — one signer does NOT collapse to one cached verdict"
+        );
+    }
+
+    /// **The serve-path entry point carries the object refusals through.**
+    ///
+    /// [`AccordRelaySubject::of_attestation`] is unit-tested above, but that
+    /// proves only that the DERIVATION refuses; it says nothing about what
+    /// [`AccordRelayGate::may_relay_attestation`] does with an `Err`. Turning
+    /// that arm into an allow is a one-token edit, and without this test the
+    /// whole gate module stays green while every unreadable and rootless
+    /// `accord:*` row is carried. MUTATION-VERIFIED (see the module report):
+    /// `Err(_) => RelayDecision::Relay` reds exactly this test.
+    ///
+    /// The seated-signer half is asserted too, so this cannot pass by refusing
+    /// everything.
+    #[tokio::test]
+    async fn the_serve_entry_point_refuses_rows_it_cannot_judge() {
+        let us = "e-node";
+        let signer = "e-holder";
+        let root = "e-accord";
+        let backend = Arc::new(MemoryBackend::new());
+        for who in [us, signer, root] {
+            backend.put_public_key(key(who)).await.expect("register");
+        }
+        seed_family(&backend, root, &[signer]).await;
+        let dir: Arc<dyn FederationDirectory> = backend;
+        let gate = AccordRelayGate::new(dir, Some(us.to_owned()));
+        let t0 = now();
+
+        // A row whose signed bytes name no accord.
+        assert_eq!(
+            gate.may_relay_attestation(
+                &accord_row("accord:human_dignity:v1", signer, "some-agent"),
+                t0
+            )
+            .await,
+            RelayDecision::Refused(RelayRefusal::ObjectRootUnnamed),
+            "no root in the signed bytes ⇒ nothing to judge against ⇒ REFUSE, never carry"
+        );
+        // A row that does not parse at all.
+        assert_eq!(
+            gate.may_relay_attestation(&serde_json::json!({ "attesting_key_id": signer }), t0)
+                .await,
+            RelayDecision::Refused(RelayRefusal::ObjectUnreadable),
+            "an unreadable row is withheld, not carried"
+        );
+        assert_eq!(
+            gate.cached_len(),
+            0,
+            "a row we could not read never reached the resolver, so it cached nothing"
+        );
+
+        // …and the gate is ALIVE: a well-formed drill by the seated signer gets
+        // a real, resolved verdict (leg 2 — no trust edge is seeded here).
+        assert_eq!(
+            gate.may_relay_attestation(&accord_row(ACCORD_HEARTBEAT_DIMENSION, signer, root), t0)
+                .await,
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge),
+            "a judgeable row IS judged — the refusals above are about the object, not a \
+             gate that refuses everything"
+        );
+        assert_eq!(gate.cached_len(), 1, "…and that one DID reach the resolver");
+    }
+
+    /// persist's participation verb reads `family_key_id` / `member_id` out of
+    /// the object, and edge's cache key must agree with what it read — else the
+    /// verdict would be filed under a pair the resolver did not use.
+    #[test]
+    fn the_participation_cache_key_is_what_persists_verb_reads() {
+        use ciris_verify_core::accord_live_quorum::{AccordParticipation, Vote};
+        use ciris_verify_core::threshold::ThresholdSignature;
+        let p = AccordParticipation {
+            family_key_id: "accord-q".to_owned(),
+            proposal_digest: "0".repeat(64),
+            member_id: "holder-q".to_owned(),
+            vote: Vote::Yes,
+            window_until: "2026-01-01T00:00:00Z".to_owned(),
+            signed_at: "2026-01-01T00:00:00Z".to_owned(),
+            signature: ThresholdSignature {
+                member_id: "holder-q".to_owned(),
+                ed25519_signature_base64: String::new(),
+                mldsa65_signature_base64: None,
+            },
+        };
+        assert_eq!(
+            AccordRelaySubject::of_participation(&p),
+            subject("accord-q", "holder-q"),
+            "the pair is (family_key_id, member_id) — the same two signature-covered fields \
+             `may_relay_accord_participation` reads"
+        );
+    }
+
+    /// The apply-path invalidation, at the gate's own surface: a cached verdict
     /// is dropped the moment a state change naming the signer (or the root)
     /// arrives, so the very next sync decision is `Unresolved` rather than the
-    /// stale grant.
+    /// stale one.
     #[tokio::test]
-    async fn invalidation_drops_a_cached_allow_before_the_ttl() {
+    async fn invalidation_drops_a_cached_verdict_before_the_ttl() {
         let dir: Arc<dyn FederationDirectory> = Arc::new(MemoryBackend::new());
-        let gate = AccordRelayGate::new(dir, Some("us".into()), "accord-root");
+        let gate = AccordRelayGate::new(dir, Some("us".into()));
         let t0 = now();
+        let s = subject("accord-root", "holder-a");
         // Prime a verdict (an empty directory yields cannot-judge; what is
         // under test is the CACHE lifecycle, not the verdict's value).
-        let _ = gate.may_relay("holder-a", t0).await;
+        gate.prime(&s, t0).await;
         assert_eq!(gate.cached_len(), 1);
         assert_eq!(
-            gate.decide("holder-a", t0),
+            gate.decide(&s, t0),
             RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
             "primed: the decision is the resolved verdict"
         );
 
         gate.invalidate("holder-a");
         assert_eq!(
-            gate.decide("holder-a", t0),
+            gate.decide(&s, t0),
             RelayDecision::Refused(RelayRefusal::Unresolved),
             "post-invalidation the gate reports `unresolved` — it no longer knows, and \
              says so instead of serving the dropped verdict"
         );
 
-        // A root-naming invalidation is the broad one: both legs are
-        // root-relative, so every entry goes.
-        let _ = gate.may_relay("holder-a", t0).await;
-        let _ = gate.may_relay("holder-b", t0).await;
-        assert_eq!(gate.cached_len(), 2);
+        // A root-naming invalidation drops every signer under THAT root.
+        gate.prime(&s, t0).await;
+        gate.prime(&subject("accord-root", "holder-b"), t0).await;
+        gate.prime(&subject("other-root", "holder-a"), t0).await;
+        assert_eq!(gate.cached_len(), 3);
         gate.invalidate("accord-root");
         assert_eq!(
             gate.cached_len(),
-            0,
-            "a change naming the ROOT falsifies every verdict under it"
+            1,
+            "a change naming the ROOT falsifies every verdict under it — and only under it"
         );
     }
 }

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1977,10 +1977,12 @@ impl FederationDirectoryReplicationBridge {
             .pointer("/attestation_envelope/dimension")
             .and_then(serde_json::Value::as_str)
             .unwrap_or("");
-        matches!(
-            namespace::attestation_family(dimension),
-            namespace::AttestationFamily::Trace
-        )
+        // Reads `family_gates::gates_for`, not a local `matches!`. An inline
+        // `matches!(.., Trace)` returns `false` for a family this build
+        // predates, which SKIPS the E3 `infra:serve` gate and SERVES the row.
+        // `gates_for`'s wildcard is maximally gated, so an unknown family is
+        // withheld rather than served.
+        crate::family_gates::gates_for(dimension).requires_serve_capability
     }
 
     /// v17.7.0 — the ONE reader of an attestation's `cohort_scope`.

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -568,12 +568,33 @@ impl FederationDirectoryReplicationBridge {
     /// reason: a `dimension.starts_with("accord:")` here would be a second
     /// owner for one wire fact. `objection:*` is deliberately NOT in this
     /// family (CIRISPersist#713 — the co-scrub argument covers `accord:` only).
+    /// CIRISEdge#505 / CIRISPersist#743 — is this row on the `accord:*`
+    /// family, in EITHER namespace?
+    ///
+    /// This read only the `dimension` until v37.1.0, and that was a live
+    /// under-gating hole: persist's own admission comment is explicit that the
+    /// family rides both namespaces — *"`accord:invoke:*` as a TYPE,
+    /// `accord:human_dignity:v1` as a `scores` DIMENSION"* — so every
+    /// `accord:invoke:*` row carried in the `attestation_type` namespace
+    /// skipped the CC 4.2.1 relay gate entirely. A false NEGATIVE: the gate
+    /// never carried something it should have refused once it looked, it
+    /// failed to look.
+    ///
+    /// Persist now owns the question (`is_accord_family`), so edge stops
+    /// spelling it. Edge widening the pre-filter itself would have put a
+    /// second reading of *"is this the accord family"* in this repo — the
+    /// exact drift CIRISPersist#731 and #733 spent two releases removing, and
+    /// it would re-break the moment a third namespace arm appears.
     fn attestation_is_accord(canonical_json: &serde_json::Value) -> bool {
-        let dimension = canonical_json
-            .pointer("/attestation_envelope/dimension")
-            .and_then(serde_json::Value::as_str)
-            .unwrap_or("");
-        crate::replication::accord_relay_gate::AccordRelayGate::dimension_is_gated(dimension)
+        ciris_persist::federation::trust_root::is_accord_family(
+            canonical_json
+                .pointer("/attestation_type")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or(""),
+            canonical_json
+                .pointer("/attestation_envelope/dimension")
+                .and_then(serde_json::Value::as_str),
+        )
     }
 
     /// Workstream F — does the relay gate WITHHOLD this row? `false` when no
@@ -7862,6 +7883,42 @@ mod tests {
                  and serve AGREE (no #429 advertised-then-unfetchable)"
             );
         }
+    }
+
+    /// CIRISEdge#505 — the pre-filter must see BOTH namespaces.
+    ///
+    /// Until v37.1.0 this read only the dimension, so an `accord:invoke:*` row
+    /// carried in the `attestation_type` namespace never reached the relay
+    /// gate at all — advertised, fetched and subject-pulled with no CC 4.2.1
+    /// carriage check. A false NEGATIVE: the gate failed to look.
+    #[test]
+    fn the_accord_pre_filter_sees_the_type_namespace_not_only_the_dimension() {
+        let by_dimension = serde_json::json!({
+            "attestation_type": "scores",
+            "attestation_envelope": { "dimension": "accord:human_dignity:v1" },
+        });
+        let by_type = serde_json::json!({
+            "attestation_type": "accord:invoke:notify:halt",
+            "attestation_envelope": { "dimension": "trust:example:v1" },
+        });
+        let neither = serde_json::json!({
+            "attestation_type": "scores",
+            "attestation_envelope": { "dimension": "trust:example:v1" },
+        });
+
+        assert!(FederationDirectoryReplicationBridge::attestation_is_accord(
+            &by_dimension
+        ));
+        assert!(
+            FederationDirectoryReplicationBridge::attestation_is_accord(&by_type),
+            "an accord:* row in the TYPE namespace must reach the relay gate — \
+             skipping it is the CIRISEdge#505 under-gating hole",
+        );
+        assert!(
+            !FederationDirectoryReplicationBridge::attestation_is_accord(&neither),
+            "and a non-accord row must still bypass the gate, so this cannot \
+             pass by gating everything",
+        );
     }
 
     /// **THE CIRISPersist#731 REGRESSION TEST.** One signer, two accords, a node

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -609,10 +609,23 @@ impl FederationDirectoryReplicationBridge {
             return false;
         }
         let now = std::time::Instant::now();
-        // CIRISPersist#731 — the gate derives BOTH the root and the signer from
-        // the row's own signature-covered bytes. Nothing on this path nominates
-        // a root, so an object belonging to another accord can no longer be
-        // waved through on a roster that happens to seat its signer.
+        // CIRISPersist#733 — the gate hands the ROW to persist's taking verb
+        // (`may_relay_accord_attestation`), which reads the accord and the signer
+        // out of it. Nothing on this path nominates a root, and edge parses none
+        // of it, so an object belonging to another accord can no longer be waved
+        // through on a roster that happens to seat its signer.
+        //
+        // The `&serde_json::Value` plumbing is deliberate. Two of the three call
+        // sites (advertise, subject-Pull) hold a typed `Attestation` and could
+        // pass it, but the DIRECT-FETCH site serves arbitrary stored bytes — a
+        // KeyRecord, a Family, an attestation — and can only ever hold a `Value`.
+        // Keeping one signature puts the deserialize-failure handling in exactly
+        // ONE place, so all three sites withhold identically by construction;
+        // plumbing the typed row would need a second, site-local failure branch
+        // that only the fetch path could reach, which is two behaviours. The
+        // `attestation_is_accord` early-out above bounds the cost: the
+        // deserialize runs only for rows persist's own classifier calls
+        // `accord:*`, and never for the non-attestations the fetch path carries.
         let Some(refusal) = gate
             .may_relay_attestation(canonical_json, now)
             .await
@@ -630,12 +643,19 @@ impl FederationDirectoryReplicationBridge {
             // this site.
             RelayRefusal::NoLocalIdentity => WithholdReason::LocalIdentityMissing,
             RelayRefusal::Unresolved => WithholdReason::AccordRelayUnresolved,
-            // #731 — the two OBJECT-shaped refusals, each its own ledger line:
-            // a malformed row and a well-formed row that names no accord are
-            // different findings (fix the producer vs. an upstream vocabulary
-            // gap), and folding them would hide the second behind the first.
+            // #733 — the FIVE object-shaped refusals, each its own ledger line.
+            // persist's relay verb collapses every one of them into
+            // `roster_resolvable: false`; edge does not, because they are five
+            // different things to go fix (fix the producer's serializer; re-mint
+            // a pre-#643 row or investigate a rewriting relay; a classifier
+            // disagreement; add the `accord_root` key; remove one of two). The
+            // gate derives them from persist's OWN `check_row_column_binding` +
+            // `accord_root_claim`, so naming them costs no second rule.
             RelayRefusal::ObjectUnreadable => WithholdReason::AccordRelayObjectUnreadable,
+            RelayRefusal::MirrorUnbound => WithholdReason::AccordRelayMirrorUnbound,
+            RelayRefusal::ObjectNotAccord => WithholdReason::AccordRelayObjectNotAccord,
             RelayRefusal::ObjectRootUnnamed => WithholdReason::AccordRelayObjectRootUnnamed,
+            RelayRefusal::ObjectRootDisagrees => WithholdReason::AccordRelayObjectRootDisagrees,
         };
         self.withhold(reason, peer_label, refusal.as_str());
         if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
@@ -4373,10 +4393,20 @@ mod tests {
     ///    excluded from the signed envelope by construction);
     /// 4. node B re-admits the bytes A SERVED — the lockstep property
     ///    itself: what edge passes on remains admissible at the next hop.
+    ///
+    /// `delegations` seeds `delegates_to(granter → delegate)` edges into BOTH
+    /// nodes' backends before the apply. v37.0.0 (CIRISPersist#734) made one
+    /// plane need them: a `LocationProof`'s `authority_key_id` must be the
+    /// subject itself or a LIVE delegate of it, because location is
+    /// self-knowledge and a third party's signature proves only that they
+    /// signed it. Every other E4 kind admits a distinct authority by design
+    /// (an authority legitimately speaks about parties who are not itself) and
+    /// passes `&[]`.
     async fn pin_e4_forward_path<T>(
         kind: EnvelopeKind,
         cohort: &[&str],
         registered_keys: &[(&str, &str)],
+        delegations: &[(&str, &str)],
         signed: &T,
         wrapper_fields_of: impl Fn(&T) -> (String, String, Option<String>),
         signing_envelope_of: impl Fn(&T) -> serde_json::Value,
@@ -4388,6 +4418,15 @@ mod tests {
         // Node A — the forwarding edge.
         let (backend_a, bridge_a) = make_bridge(&cohort);
         register_fixture_keys(&backend_a, registered_keys).await;
+        for (granter, delegate) in delegations {
+            seed_delegates_to(
+                &backend_a,
+                granter,
+                delegate,
+                &serde_json::json!(["infra:attest"]),
+            )
+            .await;
+        }
         let wire = serde_json::to_vec(signed).expect("signed wrapper serializes");
         let outcome = bridge_a.apply_envelope_bytes(kind, &wire, None).await;
         assert!(
@@ -4425,6 +4464,15 @@ mod tests {
         // Node B — re-admission of what A served IS the lockstep property.
         let (backend_b, bridge_b) = make_bridge(&cohort);
         register_fixture_keys(&backend_b, registered_keys).await;
+        for (granter, delegate) in delegations {
+            seed_delegates_to(
+                &backend_b,
+                granter,
+                delegate,
+                &serde_json::json!(["infra:attest"]),
+            )
+            .await;
+        }
         let outcome_b = bridge_b.apply_envelope_bytes(kind, &served, None).await;
         assert!(
             outcome_b.is_admitted(),
@@ -4442,6 +4490,7 @@ mod tests {
                 ("e4-authority", identity_type::AGENT),
                 ("e4-member", identity_type::AGENT),
             ],
+            &[], // an authority speaks about others BY DESIGN on this plane
             &signed,
             |s: &SignedFamily| {
                 (
@@ -4473,6 +4522,7 @@ mod tests {
                 ("e4-community", identity_type::AGENT),
                 ("e4-member", identity_type::USER),
             ],
+            &[],
             &signed,
             |s: &SignedCommunity| {
                 (
@@ -4510,6 +4560,7 @@ mod tests {
                 ("e4-family", identity_type::AGENT),
                 ("e4-member", identity_type::AGENT),
             ],
+            &[],
             &signed,
             |s: &SignedFamilyMembershipRevocation| {
                 (
@@ -4547,6 +4598,7 @@ mod tests {
                 ("e4-community", identity_type::AGENT),
                 ("e4-member", identity_type::AGENT),
             ],
+            &[],
             &signed,
             |s: &SignedCommunityMembershipRevocation| {
                 (
@@ -4585,6 +4637,14 @@ mod tests {
                 ("e4-authority", identity_type::AGENT),
                 ("e4-subject", identity_type::AGENT),
             ],
+            // CIRISPersist#734 — location is SELF-KNOWLEDGE, so a distinct
+            // `authority_key_id` is admissible only as a LIVE delegate of the
+            // subject. The edge is seeded on BOTH nodes, through the real
+            // `put_attestation` door, rather than collapsing the fixture to a
+            // self-authored proof: `authority_key_id` surviving byte-identical
+            // is what this test is about, and it proves nothing if the
+            // authority is the subject.
+            &[("e4-subject", "e4-authority")],
             &signed,
             |s: &SignedLocationProof| {
                 (
@@ -4976,6 +5036,12 @@ mod tests {
 
     /// Seed a fresh `accord:lifecycle:v1` scores row ABOUT `root` — the
     /// liveness leg of `trust_root_valid`.
+    /// A DRILL row. `accord:lifecycle:v1` is the one dimension whose root rule
+    /// persist defines for itself (`trust_root_valid` resolves drills as
+    /// `list_attestations_for(root)` filtered to it), so `attested_key_id` IS the
+    /// accord and no signed `accord_root` key is required — persist v37.0.0's
+    /// write door accepts this shape unchanged
+    /// (`AccordRootClaim::Named { source: HeartbeatDimensionRule }`).
     async fn seed_accord_lifecycle(backend: &MemoryBackend, attester: &str, root: &str) {
         let id = uuid::Uuid::new_v4().to_string();
         let envelope = serde_json::json!({
@@ -4988,6 +5054,36 @@ mod tests {
             "confidence": 0.9,
         });
         seed_raw_attestation(backend, &id, attester, root, "scores", envelope).await;
+    }
+
+    /// v37.0.0 (CIRISPersist#733) — an `accord:*` row on a NON-drill dimension,
+    /// naming its own accord with the SIGNED `accord_root` envelope key.
+    ///
+    /// `accord:human_dignity:v1` is the field shape that motivated the key:
+    /// `attested_key_id` there is the AGENT BEING SCORED, never a root, so before
+    /// #733 nothing on the row said which accord it acted under and edge's gate
+    /// refused every such row outright. The key is now REQUIRED at the write door
+    /// (`check_accord_root_binding`), which is why this fixture carries it — a
+    /// producer that omits it is refused at admission, and edge's fixtures are
+    /// producers in exactly that sense.
+    async fn seed_accord_scored(
+        backend: &MemoryBackend,
+        attester: &str,
+        scored: &str,
+        accord_root: &str,
+    ) {
+        let id = uuid::Uuid::new_v4().to_string();
+        let envelope = serde_json::json!({
+            "id": id,
+            "attesting_key_id": attester,
+            "attested_key_id": scored,
+            "attestation_type": "scores",
+            "dimension": "accord:human_dignity:v1",
+            "accord_root": accord_root,
+            "score": 1.0,
+            "confidence": 0.9,
+        });
+        seed_raw_attestation(backend, &id, attester, scored, "scores", envelope).await;
     }
 
     /// Seed a `withdraws` composer tombstoning `target_id` — the CEG un-trust
@@ -7946,41 +8042,68 @@ mod tests {
         );
     }
 
-    /// CIRISPersist#731, the OTHER object-shaped leg: an `accord:*` row whose
-    /// signed bytes name no accord at all is REFUSED — loudly, with its own
-    /// ledger line — instead of being judged against a fallback root.
+    /// **THE REQUIRED CIRISPersist#733 PAIR, end to end.** A row's SIGNED
+    /// `accord_root` key decides which roster judges it — and the answer is a
+    /// row genuinely SERVED or genuinely WITHHELD, not merely a refusal reason.
     ///
-    /// `accord:human_dignity:v1` is the field shape: persist's own fixtures put
-    /// the SCORED AGENT in `attested_key_id` there, so nothing in the row names
-    /// an accord. Pre-#731 such a row was checked against the host's nominated
-    /// root and carried whenever that root happened to seat its signer.
+    /// REWRITTEN from `an_accord_row_that_names_no_root_is_withheld_loudly`,
+    /// whose premise persist deleted. That test seeded an
+    /// `accord:human_dignity:v1` row carrying NO root and asserted the gate
+    /// withheld it as `accord_relay_object_root_unnamed`. As of v37.0.0 such a
+    /// row cannot exist in this node's store at all: `check_accord_root_binding`
+    /// runs inside `check_reserved_prefix_admission`, which every backend's
+    /// `put_attestation` and the promote door call, so an `accord:*` row that
+    /// names no accord is REFUSED at admission. The fixture stopped seeding, and
+    /// stamping a root into it would have turned it into the opposite assertion.
     ///
-    /// The allow half rides along: the SAME holder's drill still crosses, so
-    /// this proves a narrowing, not a dead gate.
+    /// The `Unnamed` leg is not lost — it moved to where it is still reachable.
+    /// A relaying node handles rows it never admitted, and persist's own note is
+    /// that the stored PRE-#733 corpus is what edge's enforcement flag covers, so
+    /// the leg lives in `accord_relay_gate::tests` on rows constructed rather
+    /// than seeded. What CAN be driven through the real store is the thing #733
+    /// actually added, which is this:
+    ///
+    /// | row | expectation |
+    /// |---|---|
+    /// | `accord:human_dignity:v1`, `accord_root: A`, signer seated on A | **SERVED** |
+    /// | the same, `accord_root: B`, same signer (seated only on A) | **WITHHELD** `accord_relay_signer_not_seated` |
+    ///
+    /// The node holds a real family for BOTH accords and a live
+    /// `delegates_to(local → root)` to BOTH, so neither `roster_unresolvable` nor
+    /// `no_trust_edge` can be doing the work: the ONLY difference between the two
+    /// rows is the accord their signed bytes name. And `attested_key_id` is the
+    /// SCORED AGENT in both, so nothing but the `accord_root` key could have
+    /// answered — which is precisely the dimension shape the drill fallback
+    /// cannot serve.
     #[tokio::test]
-    // One coherent scenario: seed + the rootless refusal + the allow half that
-    // proves the gate is not simply dead.
+    // One coherent scenario: two accords seeded with edges and rosters, plus
+    // both halves of the pair. Splitting it would put the ALLOW in a different
+    // test from the REFUSAL, and it is the pair that carries the property.
     #[allow(clippy::too_many_lines)]
-    async fn an_accord_row_that_names_no_root_is_withheld_loudly() {
+    async fn a_signed_accord_root_decides_which_roster_judges_the_row() {
         use crate::observability::WithholdReason;
         use crate::replication::accord_relay_gate::AccordRelayGate;
         use ciris_persist::federation::types::{Family, FamilyMember};
 
         let local = "this-node";
         let peer = "peer-consented";
-        let root = "humanity-accord-under-test";
-        let holder = "accord-holder-seated";
+        let accord_a = "accord-a-under-test";
+        let accord_b = "accord-b-under-test";
+        let holder = "accord-holder-on-a";
+        let b_holder = "accord-holder-on-b";
         let scored = "some-scored-agent";
         let (backend, bridge, metrics) = make_metered_bridge(&[
             local.to_string(),
             peer.to_string(),
-            root.to_string(),
+            accord_a.to_string(),
+            accord_b.to_string(),
             scored.to_string(),
         ]);
         for (k, it) in [
             (local, identity_type::NODE),
             (peer, identity_type::AGENT),
-            (root, identity_type::NODE),
+            (accord_a, identity_type::NODE),
+            (accord_b, identity_type::NODE),
             (scored, identity_type::AGENT),
         ] {
             backend
@@ -7991,57 +8114,55 @@ mod tests {
                 .expect("seed key");
         }
         seed_accord_holder_key(&backend, holder).await;
+        seed_accord_holder_key(&backend, b_holder).await;
         seed_consent_membership(&backend, local, peer).await;
 
+        // Two REAL rosters: the signer is seated on A and only on A.
         let founded: chrono::DateTime<chrono::Utc> = "2020-01-01T00:00:00Z"
             .parse()
             .expect("pinned founding instant");
-        backend
-            .put_family_local(Family {
-                family_key_id: root.to_owned(),
-                family_name: root.to_owned(),
-                members: vec![FamilyMember {
-                    key_id: holder.to_owned(),
-                    joined_at: founded,
-                    role: Some("founder".to_owned()),
-                }],
-                founded_at: founded,
-                consensus_protocol: "quorum:2/3".to_owned(),
-                consensus_protocol_entrenched: true,
-                persist_row_hash: String::new(),
-            })
-            .await
-            .expect("seed the accord family");
-        seed_delegates_to(
-            &backend,
-            local,
-            root,
-            &serde_json::json!(["infra:attest", "infra:serve"]),
-        )
-        .await;
+        for (root, member) in [(accord_a, holder), (accord_b, b_holder)] {
+            backend
+                .put_family_local(Family {
+                    family_key_id: root.to_owned(),
+                    family_name: root.to_owned(),
+                    members: vec![FamilyMember {
+                        key_id: member.to_owned(),
+                        joined_at: founded,
+                        role: Some("founder".to_owned()),
+                    }],
+                    founded_at: founded,
+                    consensus_protocol: "quorum:2/3".to_owned(),
+                    consensus_protocol_entrenched: true,
+                    persist_row_hash: String::new(),
+                })
+                .await
+                .expect("seed the accord family");
+        }
+        // CC 4.2.1 — OUR consent edge to BOTH roots, so leg 2 holds either way
+        // and cannot be what separates the two rows.
+        for root in [accord_a, accord_b] {
+            seed_delegates_to(
+                &backend,
+                local,
+                root,
+                &serde_json::json!(["infra:attest", "infra:serve"]),
+            )
+            .await;
+        }
 
-        // The drill (names its root) and a dignity score (names none).
-        seed_accord_lifecycle(&backend, holder, root).await;
-        let rootless_id = uuid::Uuid::new_v4().to_string();
-        seed_raw_attestation(
-            &backend,
-            &rootless_id,
-            holder,
-            scored,
-            "scores",
-            serde_json::json!({
-                "id": rootless_id,
-                "attesting_key_id": holder,
-                "attested_key_id": scored,
-                "attestation_type": "scores",
-                "dimension": "accord:human_dignity:v1",
-                "score": 1.0,
-                "confidence": 0.9,
-            }),
-        )
-        .await;
+        // The pair. Same signer, same dimension, same scored subject — only the
+        // SIGNED `accord_root` differs.
+        seed_accord_scored(&backend, holder, scored, accord_a).await;
+        seed_accord_scored(&backend, holder, scored, accord_b).await;
 
-        let drill_hash = locate_accord_hash(&bridge, root, holder).await;
+        let on_a = locate_accord_hash(&bridge, accord_a, holder).await;
+        let on_b = locate_accord_hash(&bridge, accord_b, holder).await;
+        assert_ne!(
+            on_a, on_b,
+            "the two rows are distinct on the wire — the `accord_root` key is inside the \
+             signed envelope, so it changes the content hash"
+        );
         let bridge = bridge
             .with_local_key_id(Some(local.to_string()))
             .with_accord_relay_gate(Some(Arc::new(AccordRelayGate::new(
@@ -8053,38 +8174,68 @@ mod tests {
             .list_envelope_refs_for_peer(EnvelopeKind::Attestation, Some(peer))
             .await;
 
-        // The allow half — a seated holder's drill under a trusted root crosses.
+        // THE POSITIVE TWIN — the row names the accord its signer is seated on,
+        // and this node granted that accord. persist's `may_relay` holds, so the
+        // row is advertised AND served. Without this half the refusal below
+        // could be satisfied by a gate that is simply dead (#435).
         assert!(
-            offer.iter().any(|r| r.envelope_hash == drill_hash),
-            "the root-naming drill by a seated holder is still carried"
+            offer.iter().any(|r| r.envelope_hash == on_a),
+            "a row naming the accord its signer IS seated on is ADVERTISED"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(EnvelopeKind::Attestation, &on_a, Some(peer))
+                .await
+                .is_some(),
+            "…and SERVED on the direct-fetch twin"
         );
 
-        // The rootless row is not in the offer, and the ledger says WHY with a
-        // reason of its own — not folded into `unresolved` (a timing fact) or
-        // `signer_not_seated` (a statement about the signer, which would be a
-        // confident lie: the signer is seated on the only accord we hold).
+        // THE REFUSAL — the same signer, on a row naming accord B.
+        assert!(
+            !offer.iter().any(|r| r.envelope_hash == on_b),
+            "a row naming accord B is judged on B's roster, where this signer holds no \
+             seat — withheld from the offer"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(EnvelopeKind::Attestation, &on_b, Some(peer))
+                .await
+                .is_none(),
+            "…and cannot be obtained by fetching a hash learned out-of-band"
+        );
+
+        // And the LEDGER names the right leg. Both rosters resolved and both
+        // edges are live, so `roster_unresolvable` and `no_trust_edge` would
+        // each be a confident lie pointing an operator at state that is fine.
         let snap = metrics.snapshot();
         assert!(
             snap.withholds_by_reason
-                .get(&WithholdReason::AccordRelayObjectRootUnnamed)
+                .get(&WithholdReason::AccordRelaySignerNotSeated)
                 .copied()
                 .unwrap_or(0)
                 >= 1,
-            "booked `accord_relay_object_root_unnamed`, got {:?}",
+            "booked `accord_relay_signer_not_seated`, got {:?}",
             snap.withholds_by_reason
         );
-        assert_eq!(
-            snap.withholds_by_reason
-                .get(&WithholdReason::AccordRelaySignerNotSeated)
-                .copied()
-                .unwrap_or(0),
-            0,
-            "the signer IS seated — saying otherwise would send an operator to the roster \
-             for a problem that lives in the row's vocabulary"
-        );
+        for quiet in [
+            WithholdReason::AccordRelayRosterUnresolvable,
+            WithholdReason::AccordRelayNoTrustEdge,
+            WithholdReason::AccordRelayObjectRootUnnamed,
+            WithholdReason::AccordRelayObjectRootDisagrees,
+            WithholdReason::AccordRelayMirrorUnbound,
+            WithholdReason::AccordRelayObjectUnreadable,
+            WithholdReason::AccordRelayObjectNotAccord,
+        ] {
+            assert_eq!(
+                snap.withholds_by_reason.get(&quiet).copied().unwrap_or(0),
+                0,
+                "{} must stay silent — the row named its accord, the roster resolved, and \
+                 our edge is live; the ONLY thing wrong is the seat",
+                quiet.as_str()
+            );
+        }
 
-        // And every row that DID cross still fetches — advertise and serve
-        // agree, so nothing was advertised-then-refused (#429).
+        // Advertise and serve AGREE — nothing was offered then refused (#429).
         for r in &offer {
             assert!(
                 bridge
@@ -8160,6 +8311,11 @@ mod tests {
     /// serving a grant the roster no longer supports. The TTL is the backstop;
     /// this is the event that must not wait for it.
     #[tokio::test]
+    // One invalidation lifecycle: seed + prime + the REFUSED apply that must
+    // not invalidate + the real roster change that must. Splitting it would
+    // separate "a refused apply changes nothing" from the admitted apply it is
+    // the control for, and the pair is what carries the property.
+    #[allow(clippy::too_many_lines)]
     async fn an_admitted_family_apply_invalidates_the_cached_relay_verdict() {
         use crate::replication::accord_relay_gate::{
             AccordRelayGate, AccordRelaySubject, RelayDecision, RelayRefusal,
@@ -8188,8 +8344,21 @@ mod tests {
             .with_local_key_id(Some(local.to_string()))
             .with_accord_relay_gate(Some(Arc::clone(&gate)));
 
-        // CIRISPersist#731 — the subject is the OBJECT's (root, signer) pair,
-        // not a root this test nominated at construction.
+        // CIRISPersist#733 — prime with a REAL ROW, seeded through persist's own
+        // write door and read back out of the store. The gate keys the verdict
+        // on the (root, signer) pair persist reads off that row, so the subject
+        // below is an EXPECTATION rather than an input: nothing here nominates
+        // a root, and a fixture the door would refuse could not stand in for a
+        // row the field produces.
+        seed_accord_lifecycle(&backend, holder, root).await;
+        let row = backend
+            .list_attestations_since(None, 100)
+            .await
+            .expect("list the seeded rows")
+            .into_iter()
+            .map(|s| s.attestation)
+            .find(|a| a.attesting_key_id == holder)
+            .expect("the seeded accord drill row");
         let subject = AccordRelaySubject {
             root_ref: root.to_owned(),
             signer_key_id: holder.to_owned(),
@@ -8197,7 +8366,11 @@ mod tests {
         // Prime a verdict: with no family seeded this is `cannot judge`, which
         // is a RESOLVED verdict — distinct from "we never ran".
         let t0 = std::time::Instant::now();
-        gate.prime(&subject, t0).await;
+        assert_eq!(
+            gate.prime(&row, t0).await,
+            Ok(subject.clone()),
+            "the verdict is filed under the pair persist read off the seeded row"
+        );
         assert_eq!(
             gate.decide(&subject, t0),
             RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
@@ -8258,7 +8431,7 @@ mod tests {
         // …and re-resolving now sees the roster: the signer IS seated (only our
         // consent edge is still missing), which proves the drop was real and
         // not merely a stale repeat.
-        gate.prime(&subject, t0).await;
+        gate.prime(&row, t0).await.expect("judgeable");
         assert_eq!(
             gate.decide(&subject, t0),
             RelayDecision::Refused(RelayRefusal::NoTrustEdge),

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -388,12 +388,16 @@ pub struct FederationDirectoryReplicationBridge {
     ///
     /// `Some` ENFORCES, fail-closed, on the advertise sweep and its direct-fetch
     /// twin. `None` leaves `accord:*` carriage exactly as it was before this
-    /// workstream (the projection row alone) — the gate needs the accord ROOT,
-    /// which is an instance parameter the host supplies, so installing it is a
-    /// deliberate fleet-floor wiring event (the AV-42
-    /// `RequireTransportBinding` shape), not something a bridge can default
-    /// itself into. That absence is a WIRING state, visible at construction;
-    /// every per-object decision the installed gate makes is fail-closed.
+    /// workstream (the projection row alone), so installing it stays a
+    /// deliberate fleet-floor wiring event (the AV-42 `RequireTransportBinding`
+    /// shape) rather than something a bridge defaults itself into. That absence
+    /// is a WIRING state, visible at construction; every per-object decision the
+    /// installed gate makes is fail-closed.
+    ///
+    /// CIRISPersist#731 — the gate no longer carries a nominated root. Which
+    /// accord an object belongs to is read from that object's signature-covered
+    /// bytes, so this is an ON/OFF choice, never a choice of which accord to
+    /// believe in.
     accord_relay_gate: Option<Arc<crate::replication::accord_relay_gate::AccordRelayGate>>,
 }
 
@@ -541,10 +545,10 @@ impl FederationDirectoryReplicationBridge {
 
     /// Workstream F — install the `accord:*` relay gate (builder). See the
     /// [`Self::accord_relay_gate`] field doc for why it is an `Option` and why
-    /// installing it is a deliberate wiring event: the gate is anchored at ONE
-    /// accord root, which CC 4.2.3 makes an instance parameter (*"another
-    /// instantiation of this form names its own three"*), and no `accord:*` row
-    /// carries a field naming the root it acts under.
+    /// installing it is a deliberate wiring event. Post-CIRISPersist#731 the
+    /// gate takes no root: CC 4.2.3 still makes the accord an instance
+    /// parameter (*"another instantiation of this form names its own three"*),
+    /// but it is the OBJECT that names its instance, not the host.
     #[must_use]
     pub fn with_accord_relay_gate(
         mut self,
@@ -552,18 +556,6 @@ impl FederationDirectoryReplicationBridge {
     ) -> Self {
         self.accord_relay_gate = gate;
         self
-    }
-
-    /// Workstream F — the `attesting_key_id` whose seat the relay predicate
-    /// asks about: the holder that emitted this partial-quorum object. Same
-    /// field the quarantine consult and the first-party carve read as the row's
-    /// AUTHOR, so "who signed it" has one spelling on this path. (The co-scrub
-    /// SET — `scrub_key_id` + `additional_scrubs` — is the quorum surface, and
-    /// arbitrating it is persist's, not a carriage question.)
-    fn attestation_signer(canonical_json: &serde_json::Value) -> Option<&str> {
-        canonical_json
-            .get("attesting_key_id")
-            .and_then(serde_json::Value::as_str)
     }
 
     /// Workstream F — is this row in the `accord:*` family, i.e. is its
@@ -616,18 +608,16 @@ impl FederationDirectoryReplicationBridge {
         if !Self::attestation_is_accord(canonical_json) {
             return false;
         }
-        // A row with no author cannot be judged and is not carried: the
-        // predicate's first argument does not exist.
-        let Some(signer) = Self::attestation_signer(canonical_json) else {
-            self.withhold(
-                WithholdReason::AccordRelayUnresolved,
-                peer_label,
-                "accord row has no attesting_key_id",
-            );
-            return true;
-        };
         let now = std::time::Instant::now();
-        let Some(refusal) = gate.may_relay(signer, now).await.refusal() else {
+        // CIRISPersist#731 — the gate derives BOTH the root and the signer from
+        // the row's own signature-covered bytes. Nothing on this path nominates
+        // a root, so an object belonging to another accord can no longer be
+        // waved through on a roster that happens to seat its signer.
+        let Some(refusal) = gate
+            .may_relay_attestation(canonical_json, now)
+            .await
+            .refusal()
+        else {
             return false;
         };
         let reason = match refusal {
@@ -640,22 +630,35 @@ impl FederationDirectoryReplicationBridge {
             // this site.
             RelayRefusal::NoLocalIdentity => WithholdReason::LocalIdentityMissing,
             RelayRefusal::Unresolved => WithholdReason::AccordRelayUnresolved,
+            // #731 — the two OBJECT-shaped refusals, each its own ledger line:
+            // a malformed row and a well-formed row that names no accord are
+            // different findings (fix the producer vs. an upstream vocabulary
+            // gap), and folding them would hide the second behind the first.
+            RelayRefusal::ObjectUnreadable => WithholdReason::AccordRelayObjectUnreadable,
+            RelayRefusal::ObjectRootUnnamed => WithholdReason::AccordRelayObjectRootUnnamed,
         };
         self.withhold(reason, peer_label, refusal.as_str());
         if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
             serve_gate_withheld_log().check(&format!("accord-relay:{peer_label}:{refusal}:{site}"))
         {
+            let subject =
+                crate::replication::accord_relay_gate::AccordRelaySubject::of_attestation(
+                    canonical_json,
+                )
+                .ok();
             tracing::warn!(
                 peer = peer_label,
-                signer,
-                root = gate.root_ref(),
+                signer = subject.as_ref().map(|s| s.signer_key_id.as_str()),
+                root = subject.as_ref().map(|s| s.root_ref.as_str()),
                 refusal = %refusal,
                 site,
                 suppressed_prev,
                 "accord:* row WITHHELD by the relay gate — this node may not carry it \
                  (CC 4.2.1 reach is consent-scoped; `roster_unresolvable` means I CANNOT \
-                 JUDGE, which is not `signer_not_seated`, and `unresolved` means the \
-                 verdict was never resolved rather than refused on its merits)"
+                 JUDGE, which is not `signer_not_seated`; `unresolved` means the verdict \
+                 was never resolved rather than refused on its merits; and \
+                 `object_root_unnamed` means the row's SIGNED bytes name no accord, so \
+                 there is nothing to judge it against — CIRISPersist#731)"
             );
         }
         true
@@ -667,11 +670,12 @@ impl FederationDirectoryReplicationBridge {
     /// trust-edge tombstone must take effect before [`RELAY_VERDICT_TTL`](crate::replication::accord_relay_gate::RELAY_VERDICT_TTL)
     /// would expire; the TTL is the backstop if an event is ever missed.
     ///
-    /// Deliberately over-broad on the key: any id the applied record NAMES
-    /// drops that id's verdict, and an id equal to the gate's root drops every
-    /// verdict (both of persist's legs are root-relative). Choosing invalidation
-    /// keys is a cache concern, never a trust rule — over-eager costs a
-    /// re-resolve, too-narrow caches a verdict past the event that falsified it.
+    /// Deliberately over-broad on the key: any id the applied record NAMES drops
+    /// every cached verdict whose ROOT or whose SIGNER is that id (both of
+    /// persist's legs are root-relative, so a root drops all its signers).
+    /// Choosing invalidation keys is a cache concern, never a trust rule —
+    /// over-eager costs a re-resolve, too-narrow caches a verdict past the event
+    /// that falsified it.
     fn invalidate_accord_relay(&self, key_ids: &[&str]) {
         let Some(gate) = self.accord_relay_gate.as_ref() else {
             return;
@@ -7544,14 +7548,22 @@ mod tests {
             .expect("seed accord-holder key");
     }
 
-    /// Locate the advertised hash of the `accord:*` row authored by `signer`,
-    /// through the PEER-BLIND view (which the relay gate does not touch), so a
-    /// test can then drive the per-peer advertise + fetch gates at that exact
-    /// hash.
+    /// Locate the advertised hash of the `accord:*` row whose SIGNED subject is
+    /// `(root, signer)`, through the PEER-BLIND view (which the relay gate does
+    /// not touch), so a test can then drive the per-peer advertise + fetch gates
+    /// at that exact hash.
+    ///
+    /// CIRISPersist#731 — matched on the same
+    /// [`AccordRelaySubject`](crate::replication::accord_relay_gate::AccordRelaySubject)
+    /// the gate itself derives, so a test always aims at the row the gate will
+    /// actually judge. (It previously matched the UNSIGNED top-level
+    /// `attesting_key_id` column, which is not what the gate reads.)
     async fn locate_accord_hash(
         bridge: &FederationDirectoryReplicationBridge,
+        root: &str,
         signer: &str,
     ) -> [u8; 32] {
+        use crate::replication::accord_relay_gate::AccordRelaySubject;
         for r in bridge.list_envelope_refs(EnvelopeKind::Attestation).await {
             let bytes = bridge
                 .fetch_envelope_bytes(EnvelopeKind::Attestation, &r.envelope_hash)
@@ -7562,12 +7574,13 @@ mod tests {
             };
             let inner = v.get("attestation").unwrap_or(&v);
             if FederationDirectoryReplicationBridge::attestation_is_accord(inner)
-                && FederationDirectoryReplicationBridge::attestation_signer(inner) == Some(signer)
+                && AccordRelaySubject::of_attestation(inner)
+                    .is_ok_and(|s| s.root_ref == root && s.signer_key_id == signer)
             {
                 return r.envelope_hash;
             }
         }
-        panic!("the seeded accord row by {signer} appears in the local view");
+        panic!("the seeded accord row by {signer} under {root} appears in the local view");
     }
 
     /// Workstream F, the whole property in one scenario — and deliberately BOTH
@@ -7663,14 +7676,13 @@ mod tests {
         seed_accord_lifecycle(&backend, unseated, root).await;
         seed_advertised_attestation(&backend, producer).await;
 
-        let seated_hash = locate_accord_hash(&bridge, seated).await;
-        let unseated_hash = locate_accord_hash(&bridge, unseated).await;
+        let seated_hash = locate_accord_hash(&bridge, root, seated).await;
+        let unseated_hash = locate_accord_hash(&bridge, root, unseated).await;
         let bridge = bridge
             .with_local_key_id(Some(local.to_string()))
             .with_accord_relay_gate(Some(Arc::new(AccordRelayGate::new(
                 backend.clone(),
                 Some(local.to_string()),
-                root,
             ))));
 
         let offer = bridge
@@ -7754,6 +7766,340 @@ mod tests {
         }
     }
 
+    /// **THE CIRISPersist#731 REGRESSION TEST.** One signer, two accords, a node
+    /// that validly trusts BOTH — and the object decides which roster it is
+    /// judged against.
+    ///
+    /// | | row | old gate (`root_ref = accord-a`) | new gate |
+    /// |---|---|---|---|
+    /// | allow half | drill about `accord-a` by a holder seated on A | relayed | **relayed** |
+    /// | the defect | drill about `accord-b` by that same holder | **RELAYED** | **withheld** `accord_relay_signer_not_seated` |
+    ///
+    /// The old gate never looked at the object. It asked *"is this signer seated
+    /// on the root the HOST named, and do we have an edge to it?"* — both true —
+    /// and carried a `accord-b` object on `accord-a`'s roster. persist's finding
+    /// exactly: *"a confidently wrong answer […] in the permissive direction"*.
+    ///
+    /// Both halves are asserted on purpose. A gate that refused everything would
+    /// satisfy the refusal half alone, so the allow half is what proves the
+    /// refusal is about the ROOT rather than the gate being dead (#435).
+    ///
+    /// `accord-b` gets a REAL family (seating someone else), so the refusal is
+    /// `signer_not_seated` — the roster resolved fine — and not the weaker
+    /// `roster_unresolvable`, which a node simply missing B's family record
+    /// would produce and which would leave the cross-accord property untested.
+    #[tokio::test]
+    // One coherent scenario: two accords seeded + the allow half + the defect
+    // half. Splitting it would put the ALLOW in a different test from the
+    // REFUSAL, and it is the pair that carries the property.
+    #[allow(clippy::too_many_lines)]
+    async fn an_object_belonging_to_another_accord_is_not_relayed_on_this_ones_roster() {
+        use crate::observability::WithholdReason;
+        use crate::replication::accord_relay_gate::AccordRelayGate;
+        use ciris_persist::federation::types::{Family, FamilyMember};
+
+        let local = "this-node";
+        let peer = "peer-consented";
+        let accord_a = "accord-alpha";
+        let accord_b = "accord-beta";
+        let holder = "holder-seated-on-a-only";
+        let b_holder = "holder-seated-on-b";
+        let cohort = [
+            local.to_string(),
+            peer.to_string(),
+            accord_a.to_string(),
+            accord_b.to_string(),
+        ];
+        let (backend, bridge, metrics) = make_metered_bridge(&cohort);
+
+        for (k, it) in [
+            (local, identity_type::NODE),
+            (peer, identity_type::AGENT),
+            (accord_a, identity_type::NODE),
+            (accord_b, identity_type::NODE),
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, it),
+                })
+                .await
+                .expect("seed key");
+        }
+        seed_accord_holder_key(&backend, holder).await;
+        seed_accord_holder_key(&backend, b_holder).await;
+        seed_consent_membership(&backend, local, peer).await;
+
+        let founded: chrono::DateTime<chrono::Utc> = "2020-01-01T00:00:00Z"
+            .parse()
+            .expect("pinned founding instant");
+        let member = |k: &str| FamilyMember {
+            key_id: k.to_owned(),
+            joined_at: founded,
+            role: Some("founder".to_owned()),
+        };
+        // TWO real accords. `holder` sits on A only; B seats someone else, so
+        // B's roster RESOLVES — "cannot judge" is not what does the work here.
+        for (root, seat) in [(accord_a, holder), (accord_b, b_holder)] {
+            backend
+                .put_family_local(Family {
+                    family_key_id: root.to_owned(),
+                    family_name: root.to_owned(),
+                    members: vec![member(seat)],
+                    founded_at: founded,
+                    consensus_protocol: "quorum:2/3".to_owned(),
+                    consensus_protocol_entrenched: true,
+                    persist_row_hash: String::new(),
+                })
+                .await
+                .expect("seed the accord family");
+            // CC 4.2.1 — this node validly trusts BOTH roots, so leg 2 holds
+            // either way and cannot be what separates the two rows.
+            seed_delegates_to(
+                &backend,
+                local,
+                root,
+                &serde_json::json!(["infra:attest", "infra:serve"]),
+            )
+            .await;
+        }
+
+        // The same holder emits a drill about EACH accord. Only the root inside
+        // the signed bytes differs.
+        seed_accord_lifecycle(&backend, holder, accord_a).await;
+        seed_accord_lifecycle(&backend, holder, accord_b).await;
+
+        let own_accord_hash = locate_accord_hash(&bridge, accord_a, holder).await;
+        let other_accord_hash = locate_accord_hash(&bridge, accord_b, holder).await;
+        assert_ne!(
+            own_accord_hash, other_accord_hash,
+            "two distinct rows, differing only in the accord they name"
+        );
+
+        let bridge = bridge
+            .with_local_key_id(Some(local.to_string()))
+            .with_accord_relay_gate(Some(Arc::new(AccordRelayGate::new(
+                backend.clone(),
+                Some(local.to_string()),
+            ))));
+
+        let offer = bridge
+            .list_envelope_refs_for_peer(EnvelopeKind::Attestation, Some(peer))
+            .await;
+
+        // ── THE ALLOW HALF — without it a refuse-everything gate would pass ──
+        assert!(
+            offer.iter().any(|r| r.envelope_hash == own_accord_hash),
+            "the drill about the accord this holder IS seated on is ADVERTISED — the gate \
+             is not simply refusing everything"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &own_accord_hash,
+                    Some(peer)
+                )
+                .await
+                .is_some(),
+            "…and SERVED on the direct-fetch twin"
+        );
+
+        // ── THE DEFECT — the old gate carried this row ──────────────────────
+        assert!(
+            !offer.iter().any(|r| r.envelope_hash == other_accord_hash),
+            "a drill belonging to accord B is NOT advertised: the object names B, this \
+             holder holds no seat on B, and the fact that we trust B and that the holder \
+             is seated on A is not a licence to carry it (CIRISPersist#731)"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &other_accord_hash,
+                    Some(peer)
+                )
+                .await
+                .is_none(),
+            "…and cannot be obtained by fetching a hash learned out-of-band either"
+        );
+
+        // The refusal NAMES the right leg: the roster resolved (B is a real
+        // family here), so this is `signer_not_seated`, never `cannot judge`.
+        let snap = metrics.snapshot();
+        assert!(
+            snap.withholds_by_reason
+                .get(&WithholdReason::AccordRelaySignerNotSeated)
+                .copied()
+                .unwrap_or(0)
+                >= 1,
+            "booked `accord_relay_signer_not_seated`, got {:?}",
+            snap.withholds_by_reason
+        );
+        assert_eq!(
+            snap.withholds_by_reason
+                .get(&WithholdReason::AccordRelayRosterUnresolvable)
+                .copied()
+                .unwrap_or(0),
+            0,
+            "…and NOT `roster_unresolvable` — B's roster resolved; the signer is simply \
+             not on it"
+        );
+    }
+
+    /// CIRISPersist#731, the OTHER object-shaped leg: an `accord:*` row whose
+    /// signed bytes name no accord at all is REFUSED — loudly, with its own
+    /// ledger line — instead of being judged against a fallback root.
+    ///
+    /// `accord:human_dignity:v1` is the field shape: persist's own fixtures put
+    /// the SCORED AGENT in `attested_key_id` there, so nothing in the row names
+    /// an accord. Pre-#731 such a row was checked against the host's nominated
+    /// root and carried whenever that root happened to seat its signer.
+    ///
+    /// The allow half rides along: the SAME holder's drill still crosses, so
+    /// this proves a narrowing, not a dead gate.
+    #[tokio::test]
+    // One coherent scenario: seed + the rootless refusal + the allow half that
+    // proves the gate is not simply dead.
+    #[allow(clippy::too_many_lines)]
+    async fn an_accord_row_that_names_no_root_is_withheld_loudly() {
+        use crate::observability::WithholdReason;
+        use crate::replication::accord_relay_gate::AccordRelayGate;
+        use ciris_persist::federation::types::{Family, FamilyMember};
+
+        let local = "this-node";
+        let peer = "peer-consented";
+        let root = "humanity-accord-under-test";
+        let holder = "accord-holder-seated";
+        let scored = "some-scored-agent";
+        let (backend, bridge, metrics) = make_metered_bridge(&[
+            local.to_string(),
+            peer.to_string(),
+            root.to_string(),
+            scored.to_string(),
+        ]);
+        for (k, it) in [
+            (local, identity_type::NODE),
+            (peer, identity_type::AGENT),
+            (root, identity_type::NODE),
+            (scored, identity_type::AGENT),
+        ] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, it),
+                })
+                .await
+                .expect("seed key");
+        }
+        seed_accord_holder_key(&backend, holder).await;
+        seed_consent_membership(&backend, local, peer).await;
+
+        let founded: chrono::DateTime<chrono::Utc> = "2020-01-01T00:00:00Z"
+            .parse()
+            .expect("pinned founding instant");
+        backend
+            .put_family_local(Family {
+                family_key_id: root.to_owned(),
+                family_name: root.to_owned(),
+                members: vec![FamilyMember {
+                    key_id: holder.to_owned(),
+                    joined_at: founded,
+                    role: Some("founder".to_owned()),
+                }],
+                founded_at: founded,
+                consensus_protocol: "quorum:2/3".to_owned(),
+                consensus_protocol_entrenched: true,
+                persist_row_hash: String::new(),
+            })
+            .await
+            .expect("seed the accord family");
+        seed_delegates_to(
+            &backend,
+            local,
+            root,
+            &serde_json::json!(["infra:attest", "infra:serve"]),
+        )
+        .await;
+
+        // The drill (names its root) and a dignity score (names none).
+        seed_accord_lifecycle(&backend, holder, root).await;
+        let rootless_id = uuid::Uuid::new_v4().to_string();
+        seed_raw_attestation(
+            &backend,
+            &rootless_id,
+            holder,
+            scored,
+            "scores",
+            serde_json::json!({
+                "id": rootless_id,
+                "attesting_key_id": holder,
+                "attested_key_id": scored,
+                "attestation_type": "scores",
+                "dimension": "accord:human_dignity:v1",
+                "score": 1.0,
+                "confidence": 0.9,
+            }),
+        )
+        .await;
+
+        let drill_hash = locate_accord_hash(&bridge, root, holder).await;
+        let bridge = bridge
+            .with_local_key_id(Some(local.to_string()))
+            .with_accord_relay_gate(Some(Arc::new(AccordRelayGate::new(
+                backend.clone(),
+                Some(local.to_string()),
+            ))));
+
+        let offer = bridge
+            .list_envelope_refs_for_peer(EnvelopeKind::Attestation, Some(peer))
+            .await;
+
+        // The allow half — a seated holder's drill under a trusted root crosses.
+        assert!(
+            offer.iter().any(|r| r.envelope_hash == drill_hash),
+            "the root-naming drill by a seated holder is still carried"
+        );
+
+        // The rootless row is not in the offer, and the ledger says WHY with a
+        // reason of its own — not folded into `unresolved` (a timing fact) or
+        // `signer_not_seated` (a statement about the signer, which would be a
+        // confident lie: the signer is seated on the only accord we hold).
+        let snap = metrics.snapshot();
+        assert!(
+            snap.withholds_by_reason
+                .get(&WithholdReason::AccordRelayObjectRootUnnamed)
+                .copied()
+                .unwrap_or(0)
+                >= 1,
+            "booked `accord_relay_object_root_unnamed`, got {:?}",
+            snap.withholds_by_reason
+        );
+        assert_eq!(
+            snap.withholds_by_reason
+                .get(&WithholdReason::AccordRelaySignerNotSeated)
+                .copied()
+                .unwrap_or(0),
+            0,
+            "the signer IS seated — saying otherwise would send an operator to the roster \
+             for a problem that lives in the row's vocabulary"
+        );
+
+        // And every row that DID cross still fetches — advertise and serve
+        // agree, so nothing was advertised-then-refused (#429).
+        for r in &offer {
+            assert!(
+                bridge
+                    .fetch_envelope_bytes_for_peer(
+                        EnvelopeKind::Attestation,
+                        &r.envelope_hash,
+                        Some(peer)
+                    )
+                    .await
+                    .is_some(),
+                "advertise and serve AGREE"
+            );
+        }
+    }
+
     /// Workstream F — with NO gate installed, `accord:*` carriage is byte-for-
     /// byte what it was before this workstream (the `Global` projection row
     /// alone). Installing the gate is a deliberate fleet-floor wiring event
@@ -7786,7 +8132,7 @@ mod tests {
         // outright ("cannot judge"). Without one, nothing consults the
         // predicate.
         seed_accord_lifecycle(&backend, holder, root).await;
-        let hash = locate_accord_hash(&bridge, holder).await;
+        let hash = locate_accord_hash(&bridge, root, holder).await;
         let bridge = bridge.with_local_key_id(Some(local.to_string()));
 
         assert!(
@@ -7815,7 +8161,9 @@ mod tests {
     /// this is the event that must not wait for it.
     #[tokio::test]
     async fn an_admitted_family_apply_invalidates_the_cached_relay_verdict() {
-        use crate::replication::accord_relay_gate::{AccordRelayGate, RelayDecision, RelayRefusal};
+        use crate::replication::accord_relay_gate::{
+            AccordRelayGate, AccordRelaySubject, RelayDecision, RelayRefusal,
+        };
         use ciris_persist::federation::types::{Family, FamilyMember};
 
         let local = "this-node";
@@ -7835,21 +8183,23 @@ mod tests {
         let gate = Arc::new(AccordRelayGate::new(
             backend.clone(),
             Some(local.to_string()),
-            root,
         ));
         let bridge = bridge
             .with_local_key_id(Some(local.to_string()))
             .with_accord_relay_gate(Some(Arc::clone(&gate)));
 
+        // CIRISPersist#731 — the subject is the OBJECT's (root, signer) pair,
+        // not a root this test nominated at construction.
+        let subject = AccordRelaySubject {
+            root_ref: root.to_owned(),
+            signer_key_id: holder.to_owned(),
+        };
         // Prime a verdict: with no family seeded this is `cannot judge`, which
         // is a RESOLVED verdict — distinct from "we never ran".
         let t0 = std::time::Instant::now();
+        gate.prime(&subject, t0).await;
         assert_eq!(
-            gate.may_relay(holder, t0).await,
-            RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
-        );
-        assert_eq!(
-            gate.decide(holder, t0),
+            gate.decide(&subject, t0),
             RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
             "the sync predicate serves the cached verdict"
         );
@@ -7887,7 +8237,7 @@ mod tests {
             "an unsigned family declaration is refused at admission (persist E4)"
         );
         assert_eq!(
-            gate.decide(holder, t0),
+            gate.decide(&subject, t0),
             RelayDecision::Refused(RelayRefusal::RosterUnresolvable),
             "a REFUSED apply changed no state, so it must not drop the verdict"
         );
@@ -7900,7 +8250,7 @@ mod tests {
             .expect("seed the accord family");
         bridge.invalidate_accord_relay(&[root]);
         assert_eq!(
-            gate.decide(holder, t0),
+            gate.decide(&subject, t0),
             RelayDecision::Refused(RelayRefusal::Unresolved),
             "post-invalidation the gate reports `unresolved` — it no longer knows, and \
              says so rather than serving the dropped verdict"
@@ -7908,8 +8258,9 @@ mod tests {
         // …and re-resolving now sees the roster: the signer IS seated (only our
         // consent edge is still missing), which proves the drop was real and
         // not merely a stale repeat.
+        gate.prime(&subject, t0).await;
         assert_eq!(
-            gate.may_relay(holder, t0).await,
+            gate.decide(&subject, t0),
             RelayDecision::Refused(RelayRefusal::NoTrustEdge),
             "the re-resolve reads the NEW roster — `cannot judge` became `seated, \
              but this node never granted the root`"

--- a/src/replication/runtime.rs
+++ b/src/replication/runtime.rs
@@ -131,17 +131,16 @@ fn build_bridge(
         .with_local_key_id(config.local_key_id.clone())
         .with_metrics(config.metrics.clone())
         .with_mesh_config(mesh_config)
-        // Workstream F — installed iff the operator named an accord root. See
-        // `ReplicationRuntimeConfig::accord_relay_root`: the root is an
-        // instance parameter edge must be TOLD, so `None` keeps `accord:*`
-        // carriage on the projection row alone (pre-workstream behavior) and
-        // `Some` enforces the fail-closed relay predicate on both the advertise
-        // sweep and its direct-fetch twin.
-        .with_accord_relay_gate(config.accord_relay_root.as_ref().map(|root| {
+        // Workstream F — installed iff the operator turned enforcement ON. See
+        // `ReplicationRuntimeConfig::accord_relay_enforced`: `false` keeps
+        // `accord:*` carriage on the projection row alone (pre-workstream
+        // behavior) and `true` enforces the fail-closed relay predicate on both
+        // the advertise sweep and its direct-fetch twin. CIRISPersist#731 — no
+        // root is passed: each object names its own, in its signed bytes.
+        .with_accord_relay_gate(config.accord_relay_enforced.then(|| {
             Arc::new(crate::replication::accord_relay_gate::AccordRelayGate::new(
                 Arc::clone(directory),
                 config.local_key_id.clone(),
-                root.clone(),
             ))
         })),
     )
@@ -350,29 +349,35 @@ pub struct ReplicationRuntimeConfig {
     /// cannot evaluate its own trust. The server supplies the same
     /// `node_key_id` it already threads into consent-peer resolution.
     pub local_key_id: Option<String>,
-    /// Workstream F — the ACCORD ROOT this node relays `accord:*` objects
-    /// under. `Some` installs the
+    /// Workstream F — does this node ENFORCE the `accord:*` relay predicate?
+    /// `true` installs the
     /// [`AccordRelayGate`](crate::replication::accord_relay_gate::AccordRelayGate)
-    /// on the bridge (fail-closed carriage: persist v36.2.0's
-    /// `may_relay_accord_object` — seated signer AND a live
-    /// `delegates_to(self → root)`); `None` (the default) leaves `accord:*`
-    /// carriage exactly as the `Global` projection row alone decides it, i.e.
-    /// byte-identical pre-workstream behavior.
+    /// on the bridge (fail-closed carriage: persist's `may_relay_accord_object`
+    /// — seated signer AND a live `delegates_to(self → root)`); `false` (the
+    /// default) leaves `accord:*` carriage exactly as the `Global` projection
+    /// row alone decides it, i.e. byte-identical pre-workstream behavior.
     ///
-    /// It is an operator-supplied value on purpose. CC 4.2.3 makes the roster
-    /// an INSTANCE parameter (*"another instantiation of this form names its
-    /// own three"*), no `accord:*` row carries a field naming the root it acts
-    /// under, and persist exposes no `accord_root_of(row)` resolver — so edge
-    /// deriving it would be edge holding a rule that belongs upstream. A
-    /// single-instance fleet passes its genesis accord family id; turning this
-    /// on is a dated fleet-floor event (the AV-42 `RequireTransportBinding`
-    /// shape), never a silent default, because a fleet whose family records
-    /// have not converged would go dark on the accord plane the moment it
-    /// flipped — and "cannot judge" is a REFUSAL by design.
+    /// # A bool, because the root is NOT the operator's to name (CIRISPersist#731)
+    ///
+    /// This was an `Option<String>` — the accord root every `accord:*` object
+    /// was judged against. That is the defect #731 reports: a host that names
+    /// the wrong root gets a confidently wrong answer *in the permissive
+    /// direction*, because an object belonging to a different accord is checked
+    /// against a roster that may well seat its signer, and the predicate cannot
+    /// notice — it was never given the object. CC 4.2.3 does make the accord an
+    /// INSTANCE parameter (*"another instantiation of this form names its own
+    /// three"*), but the instance is named by each OBJECT, in its
+    /// signature-covered bytes, and reading it there is the fix.
+    ///
+    /// So the only thing left for an operator to decide is whether to enforce
+    /// at all. Turning it on remains a dated fleet-floor event (the AV-42
+    /// `RequireTransportBinding` shape), never a silent default: a fleet whose
+    /// family records have not converged goes dark on the accord plane the
+    /// moment it flips, and *"cannot judge"* is a REFUSAL by design.
     ///
     /// Requires [`Self::local_key_id`]: with no "I" there is no
     /// `delegates_to(self → root)` to evaluate, and the gate holds fully closed.
-    pub accord_relay_root: Option<String>,
+    pub accord_relay_enforced: bool,
 }
 
 /// Live replication runtime — bridge + registry + scheduler task +

--- a/src/scope_addressing.rs
+++ b/src/scope_addressing.rs
@@ -373,6 +373,20 @@ pub enum ScopeAddressError {
     /// Catching it here turns a key-reuse bug into a loud install-time
     /// error instead of a leviculum `register_destination` displacement
     /// warning and a half-deaf group.
+    ///
+    /// The two checks compose deliberately, and the ordering gives the
+    /// leviculum-side warning a sharper meaning than it would have alone.
+    /// Because the table refuses a colliding address BEFORE
+    /// [`ReticulumTransport::register_scoped_destination`] is ever
+    /// reached, leviculum's same-hash displacement warning (v0.19.0+)
+    /// should be **unreachable** for scope-derived destinations. If it
+    /// ever fires for one, it does not mean "a collision happened" — it
+    /// means a destination was registered by a path that bypassed this
+    /// table, which is a structurally more serious thing to learn. Worth
+    /// treating as a canary rather than as noise.
+    ///
+    /// [`ReticulumTransport::register_scoped_destination`]:
+    ///     crate::transport::reticulum::ReticulumTransport::register_scoped_destination
     #[error("scope_addressing: address collision on member '{member_key_id}' (epoch {epoch}) — reused exporter_secret?")]
     AddressCollision {
         /// The member whose derived address collided.

--- a/src/scope_addressing.rs
+++ b/src/scope_addressing.rs
@@ -80,24 +80,43 @@
 //! functions), so that module is the **only** place in the stack where a
 //! destination-derivation drift is caught.
 //!
-//! # Open: which MLS exporter label feeds `exporter_secret`
+//! # Which MLS exporter label feeds `exporter_secret` — RESOLVED
 //!
 //! `k_destination` takes "the group's `exporter_secret`", but RFC 9420
-//! §8.5's exporter is a *labelled* KDF — `export_secret(label, context,
-//! len)` — so that input is only well-defined once the label is fixed,
-//! and two members agree only if they export under the same one. That
-//! label is therefore as wire-affecting as the derivation itself and is
-//! **not** edge's to choose (raised on CIRISVerify#259 after v13.4.0
-//! closed it).
+//! §8.5's exporter is a *labelled* KDF, so that input is only
+//! well-defined once the label is fixed — and two members agree only if
+//! they export under the same one. That made the label as
+//! wire-affecting as the derivation itself, and therefore verify's to
+//! choose, not edge's.
 //!
-//! One thing is already settled in the negative: edge's existing
+//! **CIRISVerify v13.5.0 settled it.** The scope-privacy family now
+//! names all three parts of the exporter call:
+//!
+//! ```text
+//! S_record = MLS-Exporter(RECORD_EXPORTER_LABEL,      EXPORTER_CONTEXT, 32) → k_record_id, k_symbol
+//! S_dest   = MLS-Exporter(DESTINATION_EXPORTER_LABEL, EXPORTER_CONTEXT, 32) → k_destination
+//! ```
+//!
+//! with `EXPORTER_CONTEXT` **empty** — the exporter already binds
+//! `(group_id, epoch)`, so a context adds nothing and is one less thing
+//! to diverge on. Edge re-exports all four constants through
+//! [`crate::scope_privacy`] and calls them verbatim; the cohort-side
+//! producer is [`crate::mls::CohortGroup::destination_secret`].
+//!
+//! The destination plane gets its OWN label rather than sharing the
+//! record plane's, and the reason is load-bearing: the two secrets
+//! reach different subsystems, and sharing one PRK would mean any
+//! compromise yielding the record secret **retroactively deanonymizes
+//! all routing** — an adversary recomputes and links every address the
+//! node ever presented, collapsing exactly the unlinkability this
+//! module exists to buy.
+//!
+//! One candidate was refused on the record by both repos: edge's
 //! `ROOT_SECRET_LABEL` (`"ciris-realtime-av-epoch-dek-seed-v1"`,
-//! `transport::realtime_av_mls`) must NOT be that input. It is a DEK
-//! seed; feeding it here would derive a routing identifier that appears
-//! in the clear on the wire from the same material that seeds the
-//! content key, collapsing two secrets the exporter exists to keep
-//! independent. Until the label is specified, the table is simply never
-//! installed in production.
+//! `transport::realtime_av_mls`) must NOT be this input. It is a DEK
+//! seed; deriving a routing identifier that appears in the clear on the
+//! wire from the material that seeds the content key would collapse two
+//! secrets §8.5 exists to keep independent.
 //!
 //! # Locking
 //!

--- a/src/scope_lifecycle.rs
+++ b/src/scope_lifecycle.rs
@@ -1,0 +1,679 @@
+//! The scope-address lifecycle (CIRISEdge#499).
+//!
+//! Everything else in the scope-native stack is a mechanism: verify
+//! derives the bytes, [`ScopeAddressTable`] holds them, the MLS layer
+//! produces the epoch secret, and the transport registers destinations.
+//! This module is the thing that *drives* them, and it exists because
+//! those mechanisms only compose safely in one order.
+//!
+//! # The two halves must not drift
+//!
+//! A scoped address is real only if BOTH are true: edge's table admits
+//! it (so an arriving frame attributes to a group), and the leviculum
+//! node has it registered (so the frame arrives at all). Two separate
+//! call sites keeping those in step by convention is exactly the shape
+//! that fails silently — an RNS destination nobody registered is never
+//! delivered to, with no error anywhere, and a destination registered
+//! with nothing behind it accepts links it cannot attribute.
+//!
+//! So the lifecycle owns both, and every transition goes through it.
+//!
+//! # We register our OWN address, never a peer's
+//!
+//! Each `(scope, group, epoch, member)` has its own address. This node
+//! *listens* on exactly one of them per group-epoch — its own — and
+//! *dials* the rest. Registering a peer's derived address would put two
+//! endpoints under one RNS routing entry, which is unicast-ambiguous;
+//! leviculum v0.19 added a `register_destination` displacement warning
+//! for precisely that. The distinction is not a convention here: the
+//! lifecycle resolves the address to register through its own
+//! `own_key_id` and offers no way to name a different member.
+//!
+//! # Make-before-break
+//!
+//! MLS epochs advance per-member at slightly different wall-clock
+//! moments, so an epoch bump is never a cutover:
+//!
+//! ```text
+//! joined         install + register own address
+//! epoch advanced install_next + activate + register the NEW own address
+//!                (the superseded one stays registered and accepted)
+//! seal due       drop the superseded epoch + retire its destination
+//! ```
+//!
+//! Seal is time-driven rather than event-driven because there is no
+//! event that means "every peer has advanced" — the convergence window
+//! is a deliberate operator parameter, not something to infer.
+//!
+//! # Known gap: retirement is not yet enforceable at the RNS layer
+//!
+//! `leviculum-std`'s driver forwards `register_destination` but not its
+//! inverse (**leviculum#54**; `NodeCore::unregister_destination` exists
+//! and is simply not exposed on the `&self` driver an `Arc<ReticulumNode>`
+//! holder can reach). Until that lands, sealing removes an address from
+//! edge's table — so it stops being attributed — but the node keeps
+//! routing on it, meaning an observer who learned the old address can
+//! still confirm this node is there.
+//!
+//! That is a real residual disclosure and it is handled LOUDLY, never
+//! silently: [`ScopedDestinationSink::retire`] returns an error, the
+//! lifecycle counts and WARNs on it, and [`SealOutcome::unretired`]
+//! reports it to the caller. When the driver verb lands this becomes a
+//! one-line change in the sink, and the counter goes to zero.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::cohort_scope::CohortScope;
+use crate::scope_addressing::{MemberAddress, ScopeAddressError, ScopeAddressTable};
+
+/// How long a superseded epoch stays reachable after being superseded.
+///
+/// Not a tuning knob so much as a statement about the slowest peer a
+/// deployment is willing to keep: seal earlier and a straggler that has
+/// not re-keyed is cut off; seal later and a retired address stays live.
+pub const DEFAULT_CONVERGENCE_WINDOW: Duration = Duration::from_secs(300);
+
+/// Where the lifecycle installs and retires listening destinations.
+///
+/// Implemented by the transport. It is a trait rather than a direct
+/// dependency so the lifecycle can be tested without standing up a
+/// leviculum node, and so the sealed-but-unretired gap (leviculum#54)
+/// is visible at one seam instead of spread through the module.
+pub trait ScopedDestinationSink: Send + Sync {
+    /// Begin listening on `address` under `scope`, and record the scope
+    /// with the announce-suppression policy. Implementations MUST
+    /// refuse a `Public` scope for a derived address.
+    ///
+    /// # Errors
+    /// Implementation-defined; any error means the address is NOT live.
+    fn register(&self, address: &MemberAddress, scope: &CohortScope) -> Result<(), String>;
+
+    /// Stop listening on `address`. Idempotent.
+    ///
+    /// # Errors
+    /// Returns `Err` when the underlying transport cannot retire a
+    /// destination at all — the leviculum#54 gap. The lifecycle treats
+    /// that as loud-but-non-fatal, because there is no alternative
+    /// action available and pretending it succeeded would hide a
+    /// reachability disclosure.
+    fn retire(&self, address: &MemberAddress, scope: &CohortScope) -> Result<(), String>;
+}
+
+/// What a transition did, so the caller can log or assert on it rather
+/// than infer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TransitionOutcome {
+    /// Addresses derived and stored for this group-epoch (all members).
+    pub derived: usize,
+    /// The epoch now live for sending.
+    pub epoch: u64,
+    /// This node's own address at `epoch` — the one now registered.
+    pub own_address: MemberAddress,
+}
+
+/// The result of a seal pass.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SealOutcome {
+    /// Groups whose superseded epoch was dropped from the table.
+    pub sealed: usize,
+    /// Sealed epochs whose destination could NOT be retired from the
+    /// transport — the leviculum#54 residual. Non-zero means those
+    /// addresses remain routable despite being sealed.
+    pub unretired: usize,
+}
+
+/// Why a lifecycle transition failed.
+#[derive(Debug, thiserror::Error)]
+pub enum ScopeLifecycleError {
+    /// The address table refused the transition.
+    #[error("scope address table: {0}")]
+    Table(#[from] ScopeAddressError),
+    /// The table accepted the install but holds no address for THIS
+    /// node — meaning `own_key_id` was not in the roster handed in.
+    /// Refused rather than skipped: a node that installs a group it is
+    /// not a member of would dial peers on addresses it can never be
+    /// answered at.
+    #[error("this node ({own_key_id}) is not in the roster for group {group_id:?}")]
+    SelfNotInRoster {
+        /// This node's federation key id.
+        own_key_id: String,
+        /// The group whose roster omitted it.
+        group_id: String,
+    },
+    /// The transport refused to start listening. The table install is
+    /// rolled back, because a group whose own address is not registered
+    /// is worse than one that was never installed: it would look live.
+    #[error("registering the scoped destination failed: {0}")]
+    Register(String),
+}
+
+/// Drives scope-address transitions and keeps the table and the
+/// transport in step.
+pub struct ScopeLifecycle {
+    table: std::sync::Arc<ScopeAddressTable>,
+    sink: std::sync::Arc<dyn ScopedDestinationSink>,
+    own_key_id: String,
+    convergence: Duration,
+    /// `(scope, group_id) → the instant its superseded epoch may be
+    /// sealed`, plus the address to retire when it is.
+    pending: Mutex<HashMap<(CohortScope, String), PendingSeal>>,
+}
+
+#[derive(Debug, Clone)]
+struct PendingSeal {
+    due: Instant,
+    retiring: MemberAddress,
+}
+
+impl ScopeLifecycle {
+    /// Build a lifecycle over `table`, installing destinations through
+    /// `sink`, for the node identified by `own_key_id`.
+    #[must_use]
+    pub fn new(
+        table: std::sync::Arc<ScopeAddressTable>,
+        sink: std::sync::Arc<dyn ScopedDestinationSink>,
+        own_key_id: impl Into<String>,
+        convergence: Duration,
+    ) -> Self {
+        Self {
+            table,
+            sink,
+            own_key_id: own_key_id.into(),
+            convergence,
+            pending: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// This node's federation key id — the member whose address is the
+    /// one registered.
+    #[must_use]
+    pub fn own_key_id(&self) -> &str {
+        &self.own_key_id
+    }
+
+    /// A group became ours: derive every member's address for its
+    /// current epoch and start listening on our own.
+    ///
+    /// # Errors
+    /// See [`ScopeLifecycleError`]. On a registration failure the table
+    /// install is rolled back so the group is not left half-live.
+    pub fn joined(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+        epoch: u64,
+        exporter_secret: &[u8; 32],
+        members: &[impl AsRef<str>],
+    ) -> Result<TransitionOutcome, ScopeLifecycleError> {
+        let derived = self
+            .table
+            .install_group(scope, group_id, epoch, exporter_secret, members)?;
+        let own = self.own_address_or_rollback(scope, group_id, epoch)?;
+        if let Err(e) = self.sink.register(&own, scope) {
+            self.table.remove_group(scope, group_id);
+            return Err(ScopeLifecycleError::Register(e));
+        }
+        Ok(TransitionOutcome {
+            derived,
+            epoch,
+            own_address: own,
+        })
+    }
+
+    /// The group advanced to a new epoch: derive the new addresses,
+    /// make them the ones we send on, and start listening on our new
+    /// own address — while the superseded epoch stays live for receive
+    /// until [`Self::seal_due`] retires it.
+    ///
+    /// # Errors
+    /// See [`ScopeLifecycleError`].
+    pub fn epoch_advanced(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+        epoch: u64,
+        exporter_secret: &[u8; 32],
+        members: &[impl AsRef<str>],
+        now: Instant,
+    ) -> Result<TransitionOutcome, ScopeLifecycleError> {
+        // Capture the address we are about to supersede BEFORE the
+        // rotation moves it — after `activate_next` the table's notion
+        // of "current" has already changed, and the outgoing address is
+        // the one we will owe a retirement for.
+        let outgoing = self.table.live_epochs(scope, group_id).and_then(|live| {
+            self.table
+                .address_at(scope, group_id, live.current, &self.own_key_id)
+        });
+
+        let derived = self
+            .table
+            .install_next(scope, group_id, epoch, exporter_secret, members)?;
+        self.table.activate_next(scope, group_id)?;
+
+        let own = self.own_address_or_rollback(scope, group_id, epoch)?;
+        if let Err(e) = self.sink.register(&own, scope) {
+            // Do NOT roll the rotation back: the group is still live at
+            // the superseded epoch, and unwinding an activate would
+            // leave us sending on an epoch peers have already left.
+            // Surfacing the failure is the honest move.
+            return Err(ScopeLifecycleError::Register(e));
+        }
+
+        if let Some(retiring) = outgoing {
+            self.pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(
+                    (scope.clone(), group_id.to_owned()),
+                    PendingSeal {
+                        due: now + self.convergence,
+                        retiring,
+                    },
+                );
+        }
+
+        Ok(TransitionOutcome {
+            derived,
+            epoch,
+            own_address: own,
+        })
+    }
+
+    /// Seal every rotation whose convergence window has elapsed.
+    ///
+    /// Call on a timer. Idempotent, and cheap when nothing is due.
+    pub fn seal_due(&self, now: Instant) -> SealOutcome {
+        let ready: Vec<((CohortScope, String), PendingSeal)> = {
+            let mut pending = self
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let keys: Vec<_> = pending
+                .iter()
+                .filter(|(_, p)| now >= p.due)
+                .map(|(k, _)| k.clone())
+                .collect();
+            keys.into_iter()
+                .filter_map(|k| pending.remove(&k).map(|p| (k, p)))
+                .collect()
+        };
+
+        let mut out = SealOutcome::default();
+        for ((scope, group_id), seal) in ready {
+            match self.table.seal_rotation(&scope, &group_id) {
+                Ok(Some(_) | None) => out.sealed += 1,
+                Err(e) => {
+                    tracing::warn!(
+                        group = %group_id,
+                        error = %e,
+                        "scope address seal FAILED — the superseded epoch stays live \
+                         (CIRISEdge#499)"
+                    );
+                    continue;
+                }
+            }
+            if let Err(e) = self.sink.retire(&seal.retiring, &scope) {
+                out.unretired += 1;
+                tracing::warn!(
+                    group = %group_id,
+                    error = %e,
+                    "scope address SEALED but NOT retired from the transport — the node \
+                     keeps routing on a rotated-away address, so an observer that learned \
+                     it can still confirm this node is reachable (leviculum#54)"
+                );
+            }
+        }
+        out
+    }
+
+    /// Number of rotations awaiting their convergence window.
+    #[must_use]
+    pub fn pending_seals(&self) -> usize {
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
+    }
+
+    /// Resolve THIS node's address at `epoch`, rolling the install back
+    /// if the roster did not include us.
+    fn own_address_or_rollback(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+        epoch: u64,
+    ) -> Result<MemberAddress, ScopeLifecycleError> {
+        if let Some(a) = self
+            .table
+            .address_at(scope, group_id, epoch, &self.own_key_id)
+        {
+            return Ok(a);
+        }
+        self.table.remove_group(scope, group_id);
+        Err(ScopeLifecycleError::SelfNotInRoster {
+            own_key_id: self.own_key_id.clone(),
+            group_id: group_id.to_owned(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scope_addressing::StubDeriver;
+    use std::sync::Arc;
+
+    /// Records what was registered and retired, and can be made to fail.
+    #[derive(Default)]
+    struct RecordingSink {
+        registered: Mutex<Vec<([u8; 16], CohortScope)>>,
+        retired: Mutex<Vec<[u8; 16]>>,
+        register_fails: Mutex<bool>,
+        /// Models the leviculum#54 gap.
+        retire_unsupported: Mutex<bool>,
+    }
+
+    impl RecordingSink {
+        fn registered_hashes(&self) -> Vec<[u8; 16]> {
+            self.registered
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|(h, _)| *h)
+                .collect()
+        }
+    }
+
+    impl ScopedDestinationSink for RecordingSink {
+        fn register(&self, address: &MemberAddress, scope: &CohortScope) -> Result<(), String> {
+            if *self.register_fails.lock().unwrap() {
+                return Err("node refused".to_owned());
+            }
+            self.registered
+                .lock()
+                .unwrap()
+                .push((*address.as_bytes(), scope.clone()));
+            Ok(())
+        }
+        fn retire(&self, address: &MemberAddress, _scope: &CohortScope) -> Result<(), String> {
+            if *self.retire_unsupported.lock().unwrap() {
+                return Err("leviculum-std exposes no unregister_destination".to_owned());
+            }
+            self.retired.lock().unwrap().push(*address.as_bytes());
+            Ok(())
+        }
+    }
+
+    fn scope() -> CohortScope {
+        CohortScope::Family
+    }
+
+    fn fixture() -> (ScopeLifecycle, Arc<ScopeAddressTable>, Arc<RecordingSink>) {
+        let table = Arc::new(ScopeAddressTable::new(Arc::new(StubDeriver)));
+        let sink = Arc::new(RecordingSink::default());
+        let life = ScopeLifecycle::new(
+            Arc::clone(&table),
+            Arc::clone(&sink) as Arc<dyn ScopedDestinationSink>,
+            "node-self",
+            Duration::from_secs(300),
+        );
+        (life, table, sink)
+    }
+
+    #[test]
+    fn joining_registers_our_own_address_and_only_ours() {
+        // The property that keeps RNS unicast unambiguous: three members
+        // are derived, exactly ONE destination is registered, and it is
+        // this node's.
+        let (life, table, sink) = fixture();
+        let out = life
+            .joined(
+                &scope(),
+                "g",
+                1,
+                &[7u8; 32],
+                &["node-self", "peer-a", "peer-b"],
+            )
+            .expect("join");
+        assert_eq!(out.derived, 3, "all members are derived (we dial them)");
+
+        let registered = sink.registered_hashes();
+        assert_eq!(registered.len(), 1, "we listen on exactly one address");
+        assert_eq!(registered[0], *out.own_address.as_bytes());
+        assert_eq!(
+            registered[0],
+            *table
+                .send_address(&scope(), "g", "node-self")
+                .unwrap()
+                .as_bytes(),
+            "the registered address is OURS, not a peer's",
+        );
+        for peer in ["peer-a", "peer-b"] {
+            let peer_addr = *table.send_address(&scope(), "g", peer).unwrap().as_bytes();
+            assert!(
+                !registered.contains(&peer_addr),
+                "{peer}'s address must never be registered locally",
+            );
+        }
+    }
+
+    #[test]
+    fn a_group_we_are_not_in_is_refused_and_rolled_back() {
+        // Installing a group whose roster omits us would leave the node
+        // dialing peers on addresses it can never be answered at.
+        let (life, table, sink) = fixture();
+        let err = life
+            .joined(&scope(), "g", 1, &[7u8; 32], &["peer-a", "peer-b"])
+            .expect_err("a roster without us must be refused");
+        assert!(matches!(err, ScopeLifecycleError::SelfNotInRoster { .. }));
+        assert!(
+            table.send_address(&scope(), "g", "peer-a").is_none(),
+            "the install must be rolled back, not left half-present",
+        );
+        assert!(sink.registered_hashes().is_empty());
+    }
+
+    #[test]
+    fn a_failed_registration_rolls_the_join_back() {
+        // A group in the table whose own address is not registered is
+        // WORSE than one never installed: it looks live.
+        let (life, table, sink) = fixture();
+        *sink.register_fails.lock().unwrap() = true;
+        let err = life
+            .joined(&scope(), "g", 1, &[7u8; 32], &["node-self"])
+            .expect_err("registration failure must surface");
+        assert!(matches!(err, ScopeLifecycleError::Register(_)));
+        assert!(
+            table.send_address(&scope(), "g", "node-self").is_none(),
+            "a group we cannot listen for must not stay installed",
+        );
+    }
+
+    #[test]
+    fn an_advance_registers_the_new_address_before_the_old_is_retired() {
+        let (life, table, sink) = fixture();
+        let first = life
+            .joined(&scope(), "g", 1, &[7u8; 32], &["node-self", "peer-a"])
+            .unwrap();
+        let t0 = Instant::now();
+        let second = life
+            .epoch_advanced(&scope(), "g", 2, &[9u8; 32], &["node-self", "peer-a"], t0)
+            .unwrap();
+
+        assert_ne!(
+            first.own_address.as_bytes(),
+            second.own_address.as_bytes(),
+            "an epoch bump must move our address",
+        );
+        // Make-before-break: both registered, nothing retired yet.
+        let registered = sink.registered_hashes();
+        assert!(registered.contains(first.own_address.as_bytes()));
+        assert!(registered.contains(second.own_address.as_bytes()));
+        assert!(
+            sink.retired.lock().unwrap().is_empty(),
+            "nothing is retired before the convergence window elapses",
+        );
+        // ...and both still answer.
+        assert!(table
+            .accepts_inbound(first.own_address.as_bytes())
+            .is_some());
+        assert!(table
+            .accepts_inbound(second.own_address.as_bytes())
+            .is_some());
+        assert_eq!(life.pending_seals(), 1);
+    }
+
+    #[test]
+    fn seal_waits_for_the_window_then_retires_exactly_the_superseded_address() {
+        let (life, table, sink) = fixture();
+        let first = life
+            .joined(&scope(), "g", 1, &[7u8; 32], &["node-self"])
+            .unwrap();
+        let t0 = Instant::now();
+        let second = life
+            .epoch_advanced(&scope(), "g", 2, &[9u8; 32], &["node-self"], t0)
+            .unwrap();
+
+        // Too early: sealing now would cut off any peer that has not
+        // re-keyed yet.
+        let early = life.seal_due(t0 + Duration::from_secs(299));
+        assert_eq!(
+            early,
+            SealOutcome {
+                sealed: 0,
+                unretired: 0
+            }
+        );
+        assert!(table
+            .accepts_inbound(first.own_address.as_bytes())
+            .is_some());
+
+        let done = life.seal_due(t0 + Duration::from_secs(300));
+        assert_eq!(
+            done,
+            SealOutcome {
+                sealed: 1,
+                unretired: 0
+            }
+        );
+        assert_eq!(
+            *sink.retired.lock().unwrap(),
+            vec![*first.own_address.as_bytes()],
+            "exactly the superseded address is retired — never the live one",
+        );
+        assert!(
+            table
+                .accepts_inbound(first.own_address.as_bytes())
+                .is_none(),
+            "a sealed address is no longer ours",
+        );
+        assert!(
+            table
+                .accepts_inbound(second.own_address.as_bytes())
+                .is_some(),
+            "the live address must survive the seal",
+        );
+        assert_eq!(life.pending_seals(), 0);
+        // Idempotent.
+        assert_eq!(
+            life.seal_due(t0 + Duration::from_secs(600)),
+            SealOutcome::default(),
+        );
+    }
+
+    #[test]
+    fn an_unretirable_destination_is_counted_not_swallowed() {
+        // leviculum#54: until the driver forwards unregister_destination,
+        // a sealed address stays routable. That is a real disclosure, so
+        // it must reach the caller as a number rather than a log line
+        // nobody reads.
+        let (life, table, sink) = fixture();
+        *sink.retire_unsupported.lock().unwrap() = true;
+        let first = life
+            .joined(&scope(), "g", 1, &[7u8; 32], &["node-self"])
+            .unwrap();
+        let t0 = Instant::now();
+        life.epoch_advanced(&scope(), "g", 2, &[9u8; 32], &["node-self"], t0)
+            .unwrap();
+
+        let out = life.seal_due(t0 + Duration::from_secs(300));
+        assert_eq!(
+            out,
+            SealOutcome {
+                sealed: 1,
+                unretired: 1
+            },
+            "a seal whose retirement failed must report BOTH, so the residual \
+             reachability is visible rather than implied by silence",
+        );
+        // Edge's own admission is still closed even though RNS is not.
+        assert!(table
+            .accepts_inbound(first.own_address.as_bytes())
+            .is_none());
+    }
+
+    #[test]
+    fn scopes_are_tracked_independently() {
+        // The lifecycle must not confuse two groups that share a group
+        // id across different scopes — the table keys on (scope, group).
+        let (life, _table, _sink) = fixture();
+        let family = CohortScope::Family;
+        let cohort = CohortScope::Cohort {
+            cohort_id: "c-1".to_owned(),
+        };
+        // Real MLS groups never share an exporter secret, so the two
+        // secrets differ — that is what makes the addresses differ.
+        let a = life
+            .joined(&family, "shared", 1, &[7u8; 32], &["node-self"])
+            .unwrap();
+        let b = life
+            .joined(&cohort, "shared", 1, &[8u8; 32], &["node-self"])
+            .unwrap();
+        assert_ne!(
+            a.own_address.as_bytes(),
+            b.own_address.as_bytes(),
+            "same group id in two scopes must not collide",
+        );
+
+        let t0 = Instant::now();
+        life.epoch_advanced(&family, "shared", 2, &[9u8; 32], &["node-self"], t0)
+            .unwrap();
+        assert_eq!(life.pending_seals(), 1, "only the family group rotated");
+    }
+
+    #[test]
+    fn reusing_one_exporter_secret_across_groups_is_refused() {
+        // The derivation binds (secret, member) only — deliberately, since
+        // an MLS exporter ALREADY binds (group, epoch), so re-parameterising
+        // by group would be inventing a convention the KDF already provides.
+        //
+        // The consequence is that handing two groups the same secret is a
+        // key-reuse error, not merely an addressing one, and it surfaces
+        // here as a collision rather than as two groups silently sharing one
+        // RNS routing entry. Found by writing this test wrong: it originally
+        // passed `[7u8; 32]` to both groups and the table refused it.
+        let (life, _table, _sink) = fixture();
+        life.joined(&CohortScope::Family, "g-one", 1, &[7u8; 32], &["node-self"])
+            .expect("first install");
+        let err = life
+            .joined(
+                &CohortScope::Cohort {
+                    cohort_id: "c-1".to_owned(),
+                },
+                "g-two",
+                1,
+                &[7u8; 32],
+                &["node-self"],
+            )
+            .expect_err("reusing an exporter secret must be refused");
+        assert!(
+            matches!(
+                err,
+                ScopeLifecycleError::Table(ScopeAddressError::AddressCollision { .. })
+            ),
+            "expected an AddressCollision, got {err:?}",
+        );
+    }
+}

--- a/src/scope_lifecycle.rs
+++ b/src/scope_lifecycle.rs
@@ -45,21 +45,35 @@
 //! event that means "every peer has advanced" — the convergence window
 //! is a deliberate operator parameter, not something to infer.
 //!
-//! # Known gap: retirement is not yet enforceable at the RNS layer
+//! # Retirement, and what it does and does not cut
 //!
-//! `leviculum-std`'s driver forwards `register_destination` but not its
-//! inverse (**leviculum#54**; `NodeCore::unregister_destination` exists
-//! and is simply not exposed on the `&self` driver an `Arc<ReticulumNode>`
-//! holder can reach). Until that lands, sealing removes an address from
-//! edge's table — so it stops being attributed — but the node keeps
-//! routing on it, meaning an observer who learned the old address can
-//! still confirm this node is there.
+//! Sealing removes the superseded epoch from the table AND retires its
+//! destination from the node, so a peer that still holds a path and
+//! dials the old address finds nobody home. Both halves are needed: the
+//! table half stops attribution, the transport half stops the probe.
 //!
-//! That is a real residual disclosure and it is handled LOUDLY, never
-//! silently: [`ScopedDestinationSink::retire`] returns an error, the
-//! lifecycle counts and WARNs on it, and [`SealOutcome::unretired`]
-//! reports it to the caller. When the driver verb lands this becomes a
-//! one-line change in the sink, and the counter goes to zero.
+//! This was the one thing the lifecycle could not do at first —
+//! `leviculum-std`'s driver forwarded `register_destination` but not its
+//! inverse, so a sealed address stayed routable and an observer who
+//! learned it could keep re-confirming this node. Closed by
+//! **leviculum#54** in v0.20.0+ciris.1, whose contract edge relies on
+//! rather than infers: retirement is **idempotent** (so a timing-driven
+//! seal may fire twice) and **leaves established links running** (a link
+//! is keyed by `LinkId`, not by the destination it was dialled through).
+//!
+//! Edge deliberately does not follow retirement with a `close_link`
+//! sweep. A peer holding an established link dialled it while
+//! legitimately in the group; cutting it would drop a live stream, which
+//! is precisely what the make-before-break window exists to prevent. The
+//! unlinkability concern is about *new* probes, and retirement is what
+//! stops those. Cutting live links remains available and is a separate,
+//! deliberate act.
+//!
+//! [`SealOutcome::unretired`] therefore reports zero in a healthy
+//! deployment. It is kept — rather than removed now that the verb
+//! exists — because a non-zero value is the alarm for a transport that
+//! cannot retire, and silence is a worse way to learn that than a
+//! counter.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -94,10 +108,11 @@ pub trait ScopedDestinationSink: Send + Sync {
     ///
     /// # Errors
     /// Returns `Err` when the underlying transport cannot retire a
-    /// destination at all — the leviculum#54 gap. The lifecycle treats
-    /// that as loud-but-non-fatal, because there is no alternative
-    /// action available and pretending it succeeded would hide a
-    /// reachability disclosure.
+    /// destination. The lifecycle treats that as loud-but-non-fatal:
+    /// there is no alternative action available, and pretending it
+    /// succeeded would hide a reachability disclosure. The Reticulum
+    /// transport has been able to retire since leviculum#54, so this
+    /// arm is an alarm rather than an expected path.
     fn retire(&self, address: &MemberAddress, scope: &CohortScope) -> Result<(), String>;
 }
 
@@ -119,8 +134,10 @@ pub struct SealOutcome {
     /// Groups whose superseded epoch was dropped from the table.
     pub sealed: usize,
     /// Sealed epochs whose destination could NOT be retired from the
-    /// transport — the leviculum#54 residual. Non-zero means those
-    /// addresses remain routable despite being sealed.
+    /// transport. **Zero in a healthy deployment** since leviculum#54
+    /// (v0.20.0+ciris.1). Non-zero means those addresses remain routable
+    /// despite being sealed — a live reachability disclosure, and the
+    /// value to alert on.
     pub unretired: usize,
 }
 

--- a/src/scope_lifecycle.rs
+++ b/src/scope_lifecycle.rs
@@ -426,7 +426,12 @@ impl ScopeLifecycle {
             .install_group(scope, group_id, epoch, exporter_secret, members)?;
         let own = self.own_address_or_rollback(scope, group_id, epoch)?;
         if let Err(e) = self.sink.register(&own, scope) {
-            self.table.remove_group(scope, group_id);
+            // `leave`, not a bare `remove_group`: on the JOIN path nothing was
+            // registered yet so this retires nothing, but the ADVANCE path
+            // reaches the same rollback with prior epochs already registered,
+            // and a bare remove would strand them registered-but-unattributed.
+            // One teardown verb, so the two paths cannot diverge.
+            self.leave(scope, group_id);
             return Err(ScopeLifecycleError::Register(e));
         }
         Ok(TransitionOutcome {
@@ -533,6 +538,70 @@ impl ScopeLifecycle {
         })
     }
 
+    /// **Leave a group** — retire every address this node listens on for it,
+    /// then drop it from the table.
+    ///
+    /// The teardown direction, and it was missing. `ScopeAddressTable::remove_group`
+    /// retracts the reverse index — so the address stops being *attributed* —
+    /// but it never calls the sink, so the destination stays *registered* with
+    /// leviculum. That leaves an address registered-but-unattributed: it
+    /// accepts links this node cannot place, and it is confirmable by anyone
+    /// who learned it. Exactly the disclosure CIRISEdge#499 exists to remove,
+    /// and permanent for the process lifetime.
+    ///
+    /// Retires ALL live epochs, not just the current one: a group left
+    /// mid-rotation has a superseded and possibly an installed-next address
+    /// registered too, and leaving is the one moment none of them should
+    /// survive. Unlike a seal there is no convergence window — the group is
+    /// over, so there are no stragglers to keep answering for.
+    ///
+    /// Returns how many addresses were retired. Failures are counted in
+    /// [`SealOutcome::unretired`] and WARNed, never swallowed: a leave that
+    /// could not retire has left this node answering for a group it has left.
+    pub fn leave(&self, scope: &CohortScope, group_id: &str) -> SealOutcome {
+        let mut out = SealOutcome::default();
+        for address in self.own_live_addresses(scope, group_id) {
+            match self.sink.retire(&address, scope) {
+                Ok(()) => out.sealed += 1,
+                Err(e) => {
+                    out.unretired += 1;
+                    tracing::warn!(
+                        group = %group_id,
+                        error = %e,
+                        "LEAVING a group but its destination could NOT be retired — this \
+                         node keeps answering on an address for a group it has left \
+                         (CIRISEdge#499)"
+                    );
+                }
+            }
+        }
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&(scope.clone(), group_id.to_owned()));
+        self.table.remove_group(scope, group_id);
+        out
+    }
+
+    /// Every address THIS node listens on for `group_id`, across all live
+    /// epochs. Empty if the group is unknown.
+    ///
+    /// Only our own: the table holds every member's address (we dial those),
+    /// but this node ever registered exactly one per epoch.
+    fn own_live_addresses(&self, scope: &CohortScope, group_id: &str) -> Vec<MemberAddress> {
+        let Some(live) = self.table.live_epochs(scope, group_id) else {
+            return Vec::new();
+        };
+        [live.previous, Some(live.current), live.next]
+            .into_iter()
+            .flatten()
+            .filter_map(|epoch| {
+                self.table
+                    .address_at(scope, group_id, epoch, &self.own_key_id)
+            })
+            .collect()
+    }
+
     /// Seal every rotation whose convergence window has elapsed.
     ///
     /// Call on a timer. Idempotent, and cheap when nothing is due.
@@ -615,7 +684,12 @@ impl ScopeLifecycle {
         {
             return Ok(a);
         }
-        self.table.remove_group(scope, group_id);
+        // Retire before dropping. Reached from `epoch_advanced` when a roster
+        // no longer contains us (a member removed from its own group), and by
+        // then PRIOR epochs' addresses are registered. A bare `remove_group`
+        // here retracts attribution while leaving those destinations live —
+        // accepting links this node cannot place, permanently.
+        self.leave(scope, group_id);
         Err(ScopeLifecycleError::SelfNotInRoster {
             own_key_id: self.own_key_id.clone(),
             group_id: group_id.to_owned(),
@@ -951,6 +1025,78 @@ mod tests {
         assert!(table
             .accepts_inbound(third.own_address.as_bytes())
             .is_some());
+    }
+
+    #[test]
+    fn leaving_retires_every_live_epoch_not_just_the_current_one() {
+        // The teardown direction, which was missing: remove_group retracts
+        // ATTRIBUTION but never called the sink, so an address stayed
+        // REGISTERED — accepting links the node cannot place, permanently.
+        //
+        // Mid-rotation is the case that matters: a group left between an
+        // advance and its seal has a superseded address registered too, and
+        // leaving is the one moment none of them should survive.
+        let (life, table, sink) = fixture();
+        let first = life
+            .joined(&scope(), "g", 1, &[7u8; 32], &["node-self"])
+            .unwrap();
+        let t0 = Instant::now();
+        let second = life
+            .epoch_advanced(&scope(), "g", 2, &[9u8; 32], &["node-self"], t0)
+            .unwrap();
+
+        let out = life.leave(&scope(), "g");
+        assert_eq!(
+            out,
+            SealOutcome {
+                sealed: 2,
+                unretired: 0
+            },
+            "both live epochs must be retired, not only the current one",
+        );
+
+        let retired = sink.retired.lock().unwrap().clone();
+        assert!(retired.contains(first.own_address.as_bytes()));
+        assert!(retired.contains(second.own_address.as_bytes()));
+
+        // And the group is gone from the table, so nothing attributes either.
+        assert!(table
+            .accepts_inbound(first.own_address.as_bytes())
+            .is_none());
+        assert!(table
+            .accepts_inbound(second.own_address.as_bytes())
+            .is_none());
+        assert_eq!(life.pending_seals(), 0, "a left group owes no seal");
+    }
+
+    #[test]
+    fn a_roster_that_drops_us_mid_rotation_retires_what_was_registered() {
+        // The path the review flagged as latent: epoch_advanced with a roster
+        // that no longer contains us (a member removed from its own group).
+        // The rollback used to be a bare remove_group, which retracted
+        // attribution while leaving PRIOR epochs' destinations live.
+        let (life, table, sink) = fixture();
+        let first = life
+            .joined(&scope(), "g", 1, &[7u8; 32], &["node-self", "peer"])
+            .unwrap();
+
+        let err = life
+            .epoch_advanced(&scope(), "g", 2, &[9u8; 32], &["peer"], Instant::now())
+            .expect_err("a roster without us must be refused");
+        assert!(matches!(err, ScopeLifecycleError::SelfNotInRoster { .. }));
+
+        assert!(
+            sink.retired
+                .lock()
+                .unwrap()
+                .contains(first.own_address.as_bytes()),
+            "the address registered before the rollback must be RETIRED, not \
+             merely dropped from the table — otherwise it accepts links this \
+             node can no longer place",
+        );
+        assert!(table
+            .accepts_inbound(first.own_address.as_bytes())
+            .is_none());
     }
 
     #[test]

--- a/src/scope_lifecycle.rs
+++ b/src/scope_lifecycle.rs
@@ -166,6 +166,60 @@ pub enum ScopeLifecycleError {
     Register(String),
 }
 
+/// One group-epoch, ready to be addressed — the single shape every kind
+/// of MLS group edge holds is reduced to before it reaches the
+/// lifecycle.
+///
+/// This exists so downstream learns **one** verb pair. A community
+/// ([`CohortGroup`]) and a call ([`AvSession`]) are different types with
+/// different concurrency (the first is behind an async mutex, the second
+/// is not), so a common trait would have to be async and would not be
+/// `dyn`-safe. A common *value* costs one struct and gives every group
+/// kind the same call:
+///
+/// ```ignore
+/// let snap = cohort_addressing::snapshot(&community).await?;  // or av_addressing::snapshot(&call)?
+/// lifecycle.install(&scope, &snap)?;
+/// ```
+///
+/// The secret is borrowed for the lifetime of the snapshot and zeroized
+/// on drop; what outlives it is only the 16-byte public addresses
+/// derived from it.
+///
+/// [`CohortGroup`]: crate::mls::CohortGroup
+/// [`AvSession`]: crate::transport::realtime_av_session::AvSession
+pub struct ScopeGroupSnapshot {
+    /// The table's group id. Namespaced per kind by its producer, so a
+    /// community and a call inside it cannot collide.
+    pub group_id: String,
+    /// The MLS epoch these addresses belong to.
+    pub epoch: u64,
+    /// Every member's federation key id — we derive all of them (to
+    /// dial) and listen on exactly one (our own).
+    pub members: Vec<String>,
+    /// The DESTINATION-plane exporter secret for this epoch. Never the
+    /// record plane's, and never an A/V DEK seed.
+    pub destination_secret: [u8; 32],
+}
+
+impl std::fmt::Debug for ScopeGroupSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScopeGroupSnapshot")
+            .field("group_id", &self.group_id)
+            .field("epoch", &self.epoch)
+            .field("members", &self.members.len())
+            .field("destination_secret", &"<redacted>")
+            .finish()
+    }
+}
+
+impl Drop for ScopeGroupSnapshot {
+    fn drop(&mut self) {
+        use zeroize::Zeroize as _;
+        self.destination_secret.zeroize();
+    }
+}
+
 /// Drives scope-address transitions and keeps the table and the
 /// transport in step.
 pub struct ScopeLifecycle {
@@ -210,6 +264,52 @@ impl ScopeLifecycle {
         &self.own_key_id
     }
 
+    /// **The install verb.** A group became ours: derive every member's
+    /// address for its current epoch and start listening on our own.
+    ///
+    /// Takes the same [`ScopeGroupSnapshot`] for every kind of group, so
+    /// a community and a call are installed by the same call.
+    ///
+    /// # Errors
+    /// See [`ScopeLifecycleError`].
+    pub fn install(
+        &self,
+        scope: &CohortScope,
+        snapshot: &ScopeGroupSnapshot,
+    ) -> Result<TransitionOutcome, ScopeLifecycleError> {
+        self.joined(
+            scope,
+            &snapshot.group_id,
+            snapshot.epoch,
+            &snapshot.destination_secret,
+            &snapshot.members,
+        )
+    }
+
+    /// **The advance verb.** The group reached a new epoch: re-address
+    /// it make-before-break, and schedule the superseded epoch's seal.
+    ///
+    /// # Errors
+    /// See [`ScopeLifecycleError`].
+    pub fn advance(
+        &self,
+        scope: &CohortScope,
+        snapshot: &ScopeGroupSnapshot,
+        now: Instant,
+    ) -> Result<TransitionOutcome, ScopeLifecycleError> {
+        self.epoch_advanced(
+            scope,
+            &snapshot.group_id,
+            snapshot.epoch,
+            &snapshot.destination_secret,
+            &snapshot.members,
+            now,
+        )
+    }
+
+    /// The raw install, for callers that already hold the parts. Prefer
+    /// [`Self::install`], which is what the group-kind adapters use.
+    ///
     /// A group became ours: derive every member's address for its
     /// current epoch and start listening on our own.
     ///
@@ -239,6 +339,9 @@ impl ScopeLifecycle {
         })
     }
 
+    /// The raw advance, for callers that already hold the parts. Prefer
+    /// [`Self::advance`].
+    ///
     /// The group advanced to a new epoch: derive the new addresses,
     /// make them the ones we send on, and start listening on our new
     /// own address — while the superseded epoch stays live for receive

--- a/src/scope_lifecycle.rs
+++ b/src/scope_lifecycle.rs
@@ -264,6 +264,80 @@ impl ScopeLifecycle {
         &self.own_key_id
     }
 
+    /// The address table this lifecycle drives.
+    ///
+    /// Read-only in practice: the table's own transition verbs are what
+    /// the lifecycle sequences, and calling them behind its back is the
+    /// drift this module exists to prevent. Exposed for the lookups
+    /// (`address_at`, `send_address`, `accepts_inbound`) a caller needs
+    /// to dial a peer it has just installed.
+    #[must_use]
+    pub fn table(&self) -> &std::sync::Arc<ScopeAddressTable> {
+        &self.table
+    }
+
+    /// How long a superseded epoch stays reachable after being
+    /// superseded.
+    ///
+    /// Exposed so a caller that holds a SECOND make-before-break window
+    /// over the same rotation — the A/V relay's answerable address pair,
+    /// [`RelayNode`] — closes it on the same deadline rather than
+    /// inventing a parallel one. Two convergence windows over one
+    /// rotation is exactly the drift this module exists to prevent.
+    ///
+    /// [`RelayNode`]: crate::transport::realtime_av_relay::RelayNode
+    #[must_use]
+    pub fn convergence(&self) -> Duration {
+        self.convergence
+    }
+
+    /// When THIS group's pending rotation may be sealed, or `None` when
+    /// it has none.
+    ///
+    /// The deadline a cadence driver waits on. Returns
+    /// [`std::time::Instant`] deliberately: every timing decision on a
+    /// transport path is made against the monotonic clock, never a
+    /// runtime timer's notion of now (CIRISEdge#217).
+    #[must_use]
+    pub fn seal_deadline(&self, scope: &CohortScope, group_id: &str) -> Option<Instant> {
+        self.pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(&(scope.clone(), group_id.to_owned()))
+            .map(|p| p.due)
+    }
+
+    /// Seal exactly ONE group's rotation, if its convergence window has
+    /// elapsed. `None` when nothing was due for that group.
+    ///
+    /// [`Self::seal_due`] is the fleet-wide sweep; this is the targeted
+    /// verb, for a caller that must take a second action *iff* this
+    /// particular group sealed — the A/V spine drops the relay's
+    /// superseded address on exactly this signal, so the relay's
+    /// answerable set and the table's accept-set close together instead
+    /// of on two timers that can disagree.
+    ///
+    /// Idempotent, and cheap when nothing is due.
+    pub fn seal_group_due(
+        &self,
+        scope: &CohortScope,
+        group_id: &str,
+        now: Instant,
+    ) -> Option<SealOutcome> {
+        let key = (scope.clone(), group_id.to_owned());
+        let seal = {
+            let mut pending = self
+                .pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            match pending.get(&key) {
+                Some(p) if now >= p.due => pending.remove(&key)?,
+                _ => return None,
+            }
+        };
+        Some(self.seal_one(scope, group_id, &seal))
+    }
+
     /// **The install verb.** A group became ours: derive every member's
     /// address for its current epoch and start listening on our own.
     ///
@@ -382,7 +456,8 @@ impl ScopeLifecycle {
         }
 
         if let Some(retiring) = outgoing {
-            self.pending
+            let displaced = self
+                .pending
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
                 .insert(
@@ -392,6 +467,40 @@ impl ScopeLifecycle {
                         retiring,
                     },
                 );
+            // A SECOND rotation inside one convergence window — three
+            // people joining a call in five minutes produces it. There
+            // is one `previous` slot, so `activate_next` above already
+            // evicted the older epoch from the accept window: edge will
+            // not attribute an arrival on that address any more.
+            //
+            // Its destination is still REGISTERED, though, and the
+            // pending-seal entry that owed it a retirement has just been
+            // overwritten — so without this it would stay routable for
+            // the life of the process, accepting links nothing can
+            // attribute. Retire it now rather than schedule it: the
+            // convergence window it was serving ended the moment the
+            // table stopped accepting it.
+            if let Some(stale) = displaced {
+                match self.sink.retire(&stale.retiring, scope) {
+                    Ok(()) => tracing::info!(
+                        group = %group_id,
+                        epoch,
+                        "a second rotation inside one convergence window evicted an \
+                         older epoch early — its destination was retired immediately \
+                         rather than left registered with nothing behind it \
+                         (CIRISEdge#499)"
+                    ),
+                    Err(e) => tracing::warn!(
+                        group = %group_id,
+                        epoch,
+                        error = %e,
+                        "an early-evicted epoch's destination could NOT be retired — it \
+                         stays routable while the table no longer attributes it, so an \
+                         observer that learned it can still confirm this node \
+                         (leviculum#54)"
+                    ),
+                }
+            }
         }
 
         Ok(TransitionOutcome {
@@ -422,28 +531,40 @@ impl ScopeLifecycle {
 
         let mut out = SealOutcome::default();
         for ((scope, group_id), seal) in ready {
-            match self.table.seal_rotation(&scope, &group_id) {
-                Ok(Some(_) | None) => out.sealed += 1,
-                Err(e) => {
-                    tracing::warn!(
-                        group = %group_id,
-                        error = %e,
-                        "scope address seal FAILED — the superseded epoch stays live \
-                         (CIRISEdge#499)"
-                    );
-                    continue;
-                }
-            }
-            if let Err(e) = self.sink.retire(&seal.retiring, &scope) {
-                out.unretired += 1;
+            let one = self.seal_one(&scope, &group_id, &seal);
+            out.sealed += one.sealed;
+            out.unretired += one.unretired;
+        }
+        out
+    }
+
+    /// Seal one already-due rotation: drop the superseded epoch from the
+    /// table, then retire its destination from the transport. Shared by
+    /// the sweep ([`Self::seal_due`]) and the targeted verb
+    /// ([`Self::seal_group_due`]) so the two can never diverge.
+    fn seal_one(&self, scope: &CohortScope, group_id: &str, seal: &PendingSeal) -> SealOutcome {
+        let mut out = SealOutcome::default();
+        match self.table.seal_rotation(scope, group_id) {
+            Ok(Some(_) | None) => out.sealed += 1,
+            Err(e) => {
                 tracing::warn!(
                     group = %group_id,
                     error = %e,
-                    "scope address SEALED but NOT retired from the transport — the node \
-                     keeps routing on a rotated-away address, so an observer that learned \
-                     it can still confirm this node is reachable (leviculum#54)"
+                    "scope address seal FAILED — the superseded epoch stays live \
+                     (CIRISEdge#499)"
                 );
+                return out;
             }
+        }
+        if let Err(e) = self.sink.retire(&seal.retiring, scope) {
+            out.unretired += 1;
+            tracing::warn!(
+                group = %group_id,
+                error = %e,
+                "scope address SEALED but NOT retired from the transport — the node \
+                 keeps routing on a rotated-away address, so an observer that learned \
+                 it can still confirm this node is reachable (leviculum#54)"
+            );
         }
         out
     }
@@ -732,6 +853,81 @@ mod tests {
         assert!(table
             .accepts_inbound(first.own_address.as_bytes())
             .is_none());
+    }
+
+    #[test]
+    fn a_second_rotation_inside_one_window_retires_the_epoch_it_evicts_early() {
+        // Three people joining a call in five minutes: two rotations, one
+        // convergence window. There is ONE `previous` slot, so
+        // `activate_next` evicts the oldest epoch from the accept window
+        // — and there is ONE pending-seal entry per group, so the
+        // retirement that epoch was owed gets overwritten.
+        //
+        // Without the immediate retire, that destination stays registered
+        // with the transport for the life of the process while the table
+        // no longer attributes it: it accepts links it cannot place, and
+        // an observer that learned it can keep confirming this node. The
+        // regression is silent in every other way, which is why it is
+        // pinned here.
+        let (life, table, sink) = fixture();
+        let first = life
+            .joined(&scope(), "g", 1, &[7u8; 32], &["node-self"])
+            .unwrap();
+        let t0 = Instant::now();
+        let second = life
+            .epoch_advanced(&scope(), "g", 2, &[9u8; 32], &["node-self"], t0)
+            .unwrap();
+        assert!(sink.retired.lock().unwrap().is_empty());
+
+        let third = life
+            .epoch_advanced(
+                &scope(),
+                "g",
+                3,
+                &[11u8; 32],
+                &["node-self"],
+                t0 + Duration::from_secs(1),
+            )
+            .unwrap();
+
+        assert_eq!(
+            *sink.retired.lock().unwrap(),
+            vec![*first.own_address.as_bytes()],
+            "the early-evicted epoch's destination is retired IMMEDIATELY — its \
+             convergence window ended the moment the table stopped accepting it",
+        );
+        assert!(
+            table
+                .accepts_inbound(first.own_address.as_bytes())
+                .is_none(),
+            "and the table agrees: the evicted epoch is no longer ours",
+        );
+        // The two epochs still inside the window are untouched.
+        assert!(table
+            .accepts_inbound(second.own_address.as_bytes())
+            .is_some());
+        assert!(table
+            .accepts_inbound(third.own_address.as_bytes())
+            .is_some());
+        assert_eq!(
+            life.pending_seals(),
+            1,
+            "one pending seal per group — for the epoch that is actually superseded",
+        );
+
+        // The surviving pending seal retires the SUPERSEDED epoch, not
+        // the live one.
+        life.seal_due(t0 + Duration::from_secs(1) + DEFAULT_CONVERGENCE_WINDOW);
+        assert_eq!(
+            *sink.retired.lock().unwrap(),
+            vec![
+                *first.own_address.as_bytes(),
+                *second.own_address.as_bytes()
+            ],
+        );
+        assert!(table
+            .accepts_inbound(third.own_address.as_bytes())
+            .is_some());
     }
 
     #[test]

--- a/src/scope_lifecycle.rs
+++ b/src/scope_lifecycle.rs
@@ -45,6 +45,29 @@
 //! event that means "every peer has advanced" — the convergence window
 //! is a deliberate operator parameter, not something to infer.
 //!
+//! # The rotation TRIGGER is contingent on emitting nothing
+//!
+//! [`Self::advance`] fires on the MLS epoch, which advances on every
+//! Add/Remove — i.e. it is **group-event-driven**. That is correct
+//! today, and the reason is narrow enough to be worth writing down:
+//! **because a rotation emits nothing.** No announce, no probe, no
+//! packet an outsider can time. The trigger is unobservable, so binding
+//! it to membership costs nothing.
+//!
+//! CC 1.0-rc4's Position paragraph at 5.4.6 states that any future
+//! multi-hop relaxation carries a rotation rule — **clocks global,
+//! never group-event-driven** — because once a rotation *does* emit,
+//! an epoch-bound trigger turns every Add/Remove into a synchronized
+//! wave whose cardinality, timing and churn are themselves the leak.
+//!
+//! So the epoch binding here is not "right"; it is *right while nothing
+//! is emitted*. An implementer wiring a future amendment would land on
+//! this function, see a working rotation, and keep precisely the trigger
+//! the relaxation forbids. If emission is ever added, this trigger moves
+//! to a global clock in the same change — not afterwards.
+//! (CIRISVerify recorded the same contingency at `derive_destination`;
+//! CIRISVerify#264.)
+//!
 //! # Retirement, and what it does and does not cut
 //!
 //! Sealing removes the superseded epoch from the table AND retires its

--- a/src/scope_privacy.rs
+++ b/src/scope_privacy.rs
@@ -42,7 +42,8 @@
 
 pub use ciris_crypto::scope_privacy::{
     derive_destination, derive_record_id, derive_symbol_key, k_destination, k_record_id, k_symbol,
-    witness_cover_leaf, RecordType, LABEL_DESTINATION, LABEL_RECORD_ID, LABEL_SYMBOL,
+    witness_cover_leaf, RecordType, DESTINATION_EXPORTER_LABEL, EXPORTER_CONTEXT,
+    LABEL_DESTINATION, LABEL_RECORD_ID, LABEL_SYMBOL, RECORD_EXPORTER_LABEL,
 };
 
 // ─── §3.3 HPKE_SUITE_ID re-export (verify v6.3.0 pinned bytes) ──────

--- a/src/swarm/mod.rs
+++ b/src/swarm/mod.rs
@@ -80,6 +80,7 @@ pub use runtime::{
     FountainSwarmRuntime, ObservedClaim, SwarmEvent, SwarmRuntimeConfig, SwarmRuntimeEventSink,
     SwarmRuntimeOptions,
 };
-pub use scope::{
-    HoldingAnnounce, HoldingRefusal, HoldingsPublishGate, HoldingsScopeGate, HOLDING_AUTHORITY,
-};
+// `HOLDING_AUTHORITY` is GONE as of v37.1.0 (CIRISPersist#744): the
+// hard-coded `ProducerSteward` was the under-advertisement defect, and the
+// authority is now resolved per publisher by persist's `holdings_authority`.
+pub use scope::{HoldingAnnounce, HoldingRefusal, HoldingsPublishGate, HoldingsScopeGate};

--- a/src/swarm/mod.rs
+++ b/src/swarm/mod.rs
@@ -52,9 +52,21 @@
 //!
 //! See [`runtime`] for the live runtime + scheduler.
 
+//! ## v17.11.0 scope-native holdings (CIRISEdge#499)
+//!
+//! The publisher above used to broadcast every held `content_id` *and its
+//! `symbol_ids`* to every peer the cohort callback returned, with no
+//! entitlement filter at all. [`scope`] adds one: the host declares each
+//! content's scope, persist's `projection_for(Plane::FountainContent, …)`
+//! decides the audience KIND, and the node's scope-address table resolves
+//! whether a given peer is in that audience. Armed only where a
+//! `ScopeAddressTable` is installed — a deployment without one publishes
+//! byte-identically to before.
+
 pub mod diversity;
 pub mod persist_fountain_evict;
 pub mod runtime;
+pub mod scope;
 
 pub use diversity::{
     diversity_contribution, diversity_scores_for, NullRttObserver, PeerRttObserver,
@@ -67,4 +79,7 @@ pub use persist_fountain_evict::{
 pub use runtime::{
     FountainSwarmRuntime, ObservedClaim, SwarmEvent, SwarmRuntimeConfig, SwarmRuntimeEventSink,
     SwarmRuntimeOptions,
+};
+pub use scope::{
+    HoldingAnnounce, HoldingRefusal, HoldingsPublishGate, HoldingsScopeGate, HOLDING_AUTHORITY,
 };

--- a/src/swarm/persist_fountain_evict.rs
+++ b/src/swarm/persist_fountain_evict.rs
@@ -85,6 +85,34 @@ pub trait FountainHoldingsSource: Send + Sync {
     async fn list_held_fountain_content(
         &self,
     ) -> Result<Vec<HeldFountainContent>, FountainEvictError>;
+
+    /// CIRISEdge#499 — the SCOPE this held content lives in, so the
+    /// publisher can decide which peers may be told the holding exists.
+    ///
+    /// **Edge never infers a content's scope.** Content classification is
+    /// the persist-backed consumer's, exactly as it is on the blob plane
+    /// ([`BlobChunkSource::chunk_scope`](crate::blob_swarm::BlobChunkSource::chunk_scope),
+    /// whose shape this deliberately mirrors — one seam shape for the two
+    /// planes, not two). `None` means *undeterminable*, and is NEVER read
+    /// as `Public`: on a scope-native node it withholds the announcement
+    /// ([`HoldingRefusal::ScopeUndeterminable`](super::scope::HoldingRefusal::ScopeUndeterminable)).
+    ///
+    /// The default returns `None`, which keeps every existing
+    /// implementation compiling AND keeps its behaviour byte-identical:
+    /// the publish gate is armed only where a
+    /// [`ScopeAddressTable`](crate::scope_addressing::ScopeAddressTable)
+    /// is installed, and a deployment with no table announces every
+    /// holding regardless of what this returns. A consumer that installs
+    /// an address table MUST override this or its holdings plane fails
+    /// closed — which is the correct order of operations: publish a
+    /// scoped holding only once you can say what scope it is in.
+    ///
+    /// Synchronous on purpose: it is consulted once per held content on
+    /// the publish tick, between `.await` points, and an `async` seam here
+    /// would invite a lock guard to be held across one (CIRISEdge#217).
+    fn content_scope(&self, _content_id: &str) -> Option<crate::blob_swarm::ContentScope> {
+        None
+    }
 }
 
 /// A `FountainHoldingsSource` that returns an empty list. Used in

--- a/src/swarm/runtime.rs
+++ b/src/swarm/runtime.rs
@@ -67,6 +67,7 @@ use super::diversity::{diversity_contribution, NullRttObserver, PeerRttObserver}
 use super::persist_fountain_evict::{
     FountainEvictError, FountainHoldingsSource, HeldFountainContent,
 };
+use super::scope::{HoldingAnnounce, HoldingsPublishGate};
 use crate::holonomic::fountain_defaults::{recommended_policy, FountainPolicy};
 use crate::holonomic::swarm_rarity::{
     compute_rarity_score, should_eject_with_diversity, ConsentState, EjectionVerdict,
@@ -215,6 +216,15 @@ pub type SwarmRuntimeEventSink = Arc<dyn Fn(SwarmEvent) + Send + Sync>;
 /// - `rtt_observer`: latency source for the diversity-aware ejection
 ///   policy. `None` defaults to [`NullRttObserver`] — diversity
 ///   gating then degrades to rarity-only (the substrate verdict).
+/// - `scope_table` (CIRISEdge#499): the node's scope-address table. Its
+///   presence is the ARMING condition for the holdings scope gate — see
+///   [`super::scope`]. `None` (every deployment until the MLS exporter
+///   label is specified upstream) means the publisher broadcasts exactly
+///   as it did pre-#499.
+/// - `metrics` (CIRISEdge#433): the withhold-ledger handle. `None` means
+///   withholds are logged but not counted; production threads `Edge`'s
+///   handle, mirroring
+///   `FederationDirectoryReplicationBridge::with_metrics`.
 ///
 /// All optionals MAY be `None`; the runtime stays operational on every
 /// combination of present/absent fields. New optionals land here
@@ -227,6 +237,13 @@ pub struct SwarmRuntimeOptions {
     /// Per-peer RTT source for the diversity-aware ejection policy.
     /// `None` defaults to [`NullRttObserver`] (rarity-only fallback).
     pub rtt_observer: Option<Arc<dyn PeerRttObserver>>,
+    /// CIRISEdge#499 — the scope-address table. `Some` ARMS the holdings
+    /// scope gate: a held content's declared scope then decides which
+    /// peers are told the holding exists. `None` is pre-#499 behaviour.
+    pub scope_table: Option<Arc<crate::scope_addressing::ScopeAddressTable>>,
+    /// CIRISEdge#433 — withhold-ledger handle. Every holding withheld from
+    /// a peer is booked here with its named reason.
+    pub metrics: Option<crate::observability::EdgeMetrics>,
 }
 
 impl std::fmt::Debug for SwarmRuntimeOptions {
@@ -234,6 +251,8 @@ impl std::fmt::Debug for SwarmRuntimeOptions {
         f.debug_struct("SwarmRuntimeOptions")
             .field("signer_present", &self.signer.is_some())
             .field("rtt_observer_present", &self.rtt_observer.is_some())
+            .field("scope_native", &self.scope_table.is_some())
+            .field("metrics_present", &self.metrics.is_some())
             .finish()
     }
 }
@@ -401,6 +420,14 @@ impl FountainSwarmRuntime {
             .clone()
             .unwrap_or_else(|| Arc::new(NullRttObserver));
 
+        // CIRISEdge#499 — the publish-side scope gate. Built ONCE at start
+        // (it holds only an `Option<Arc<ScopeAddressTable>>` + the metrics
+        // handle, both cheap clones), but every DECISION it makes is
+        // resolved per record on the tick — the table is read live, never
+        // snapshotted, so a rotation seal takes effect on the next tick.
+        let publish_gate =
+            HoldingsPublishGate::new(options.scope_table.clone(), options.metrics.clone());
+
         let publisher_task = {
             let holdings = Arc::clone(&holdings);
             let transport = Arc::clone(&transport);
@@ -412,7 +439,15 @@ impl FountainSwarmRuntime {
             let signer = options.signer.clone();
             tokio::spawn(async move {
                 run_publisher(
-                    holdings, transport, cohort, local_peer, cadence, cancel_rx, sink, signer,
+                    holdings,
+                    transport,
+                    cohort,
+                    local_peer,
+                    cadence,
+                    cancel_rx,
+                    sink,
+                    signer,
+                    publish_gate,
                 )
                 .await;
             })
@@ -489,6 +524,7 @@ async fn run_publisher(
     mut cancel_rx: watch::Receiver<bool>,
     sink: Option<SwarmRuntimeEventSink>,
     signer: Option<Arc<LocalSigner>>,
+    publish_gate: HoldingsPublishGate,
 ) {
     let mut ticker = tokio::time::interval(cadence);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -508,6 +544,7 @@ async fn run_publisher(
                     &local_peer_id,
                     sink.as_ref(),
                     signer.as_ref(),
+                    &publish_gate,
                 )
                 .await
                 {
@@ -518,6 +555,7 @@ async fn run_publisher(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn publish_tick(
     holdings: &Arc<dyn FountainHoldingsSource>,
     transport: &Arc<dyn Transport>,
@@ -525,6 +563,7 @@ async fn publish_tick(
     local_peer_id: &str,
     sink: Option<&SwarmRuntimeEventSink>,
     signer: Option<&Arc<LocalSigner>>,
+    publish_gate: &HoldingsPublishGate,
 ) -> Result<usize, FountainEvictError> {
     let held = holdings.list_held_fountain_content().await?;
     let peers = cohort();
@@ -537,11 +576,29 @@ async fn publish_tick(
             content.symbol_ids.clone(),
             observed_at_unix_ms,
         );
+        // CIRISEdge#499 — the record's REAL scope, read per record on this
+        // tick from the host's declaration. Never cached across ticks and
+        // never inferred: a `None` here is *unknown*, and on a scope-native
+        // node unknown is withheld, not published (see `super::scope`).
+        // Synchronous, so no guard can outlive it into the `.await`s below
+        // (CIRISEdge#217).
+        let content_scope = holdings.content_scope(&content.content_id);
         for peer in &peers {
             // Skip self — the cohort callback typically already
             // excludes the local peer, but defense in depth.
             if peer == local_peer_id {
                 continue;
+            }
+            // CIRISEdge#499 — the entitlement filter this path never had.
+            // A holdings claim discloses `content_id` AND `symbol_ids`;
+            // announcing a family- or community-scoped holding to a peer
+            // outside its roster is a contextual-integrity violation even
+            // though no content bytes move. `admit_and_book` BOOKS the
+            // withhold (#433 ledger) and logs it before returning, so this
+            // is never a bare `continue`.
+            match publish_gate.admit_and_book(&content.content_id, content_scope.as_ref(), peer) {
+                HoldingAnnounce::Announce => {}
+                HoldingAnnounce::Withhold(_) => continue,
             }
             // v6.3.0 (CIRISEdge#184): when a signer is wired, ship a
             // signed `MessageType::FountainHoldingClaim` EdgeEnvelope.
@@ -1225,5 +1282,257 @@ mod tests {
         let all = claims.all_claims_for("c");
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].symbol_ids, vec![1, 2]);
+    }
+
+    // ─── CIRISEdge#499 — the publisher's entitlement filter ───────────
+    //
+    // These drive the REAL publisher loop (not the pure gate — that is
+    // pinned in `super::super::scope::tests`), because the defect was in
+    // the loop: it broadcast every held content_id AND its symbol_ids to
+    // every peer the cohort callback returned. A green gate with an
+    // unwired loop would be exactly the "test the convenient input, not
+    // the field's input" failure this repo has hit twice.
+
+    use crate::blob_swarm::ContentScope;
+    use crate::cohort_scope::CohortScope;
+    use crate::observability::{EdgeMetrics, WithholdReason};
+    use crate::scope_addressing::{ScopeAddressTable, StubDeriver};
+
+    const INSIDER: &str = "ed25519:bob";
+    const OUTSIDER: &str = "ed25519:mallory";
+
+    /// Holdings whose scope is declared by the HOST — the production
+    /// shape. Contents not named in `scopes` report `None`
+    /// (undeterminable), which is how an unwired consumer behaves.
+    struct ScopedHoldings {
+        held: Vec<HeldFountainContent>,
+        scopes: BTreeMap<String, ContentScope>,
+    }
+    #[async_trait]
+    impl FountainHoldingsSource for ScopedHoldings {
+        async fn list_held_fountain_content(
+            &self,
+        ) -> Result<Vec<HeldFountainContent>, FountainEvictError> {
+            Ok(self.held.clone())
+        }
+        fn content_scope(&self, content_id: &str) -> Option<ContentScope> {
+            self.scopes.get(content_id).cloned()
+        }
+    }
+
+    fn held(content_id: &str, symbol_ids: Vec<u32>) -> HeldFountainContent {
+        HeldFountainContent {
+            content_id: content_id.into(),
+            corpus_kind: "fountain-corpus".into(),
+            symbol_ids,
+        }
+    }
+
+    /// A table with ONE family group `fam-1` whose only member is
+    /// `INSIDER`. `OUTSIDER` is reachable on the federation address and
+    /// belongs to no scope group — the peer the leak used to reach.
+    fn family_table() -> Arc<ScopeAddressTable> {
+        let t = ScopeAddressTable::new(Arc::new(StubDeriver));
+        t.install_group(&CohortScope::Family, "fam-1", 1, &[0xA1; 32], &[INSIDER])
+            .expect("family install");
+        Arc::new(t)
+    }
+
+    /// Did `peer` receive an announcement naming `content_id`? The
+    /// holding claim's signing preimage carries the content_id verbatim
+    /// (`u64-lp(content_id)`), so a byte-window search over what the
+    /// transport actually shipped is the field's own evidence — no
+    /// re-derivation of what we THINK was sent.
+    fn announced(sends: &[(String, Vec<u8>)], peer: &str, content_id: &str) -> bool {
+        let needle = content_id.as_bytes();
+        sends
+            .iter()
+            .any(|(dest, bytes)| dest == peer && bytes.windows(needle.len()).any(|w| w == needle))
+    }
+
+    /// Run the publisher for a few ticks and return what the transport
+    /// was actually asked to send.
+    async fn drive_publisher(
+        holdings: Arc<dyn FountainHoldingsSource>,
+        peers: Vec<String>,
+        options: SwarmRuntimeOptions,
+    ) -> Vec<(String, Vec<u8>)> {
+        let recording_tx = Arc::new(RecordingTransport::default());
+        let tx: Arc<dyn Transport> = recording_tx.clone();
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(move || peers.clone());
+        let mut rt = FountainSwarmRuntime::start_with_options(
+            fast_config(),
+            holdings,
+            test_directory(),
+            tx,
+            cohort,
+            "alice".to_string(),
+            None,
+            options,
+        );
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        rt.shutdown().await;
+        let sends = recording_tx.sends.lock().unwrap().clone();
+        sends
+    }
+
+    /// **THE test.** A family-scoped holding is NOT announced to a peer
+    /// outside the family, and a federation-scoped holding IS announced
+    /// to that SAME peer on the SAME tick — so this cannot pass by
+    /// broadcasting nothing. The family member still gets both, so it
+    /// cannot pass by breaking the family plane either.
+    #[tokio::test]
+    async fn family_holding_is_not_announced_outside_the_cohort_but_federation_still_is() {
+        let holdings: Arc<dyn FountainHoldingsSource> = Arc::new(ScopedHoldings {
+            held: vec![held("c-family", vec![1, 2]), held("c-federation", vec![9])],
+            scopes: BTreeMap::from([
+                (
+                    "c-family".to_string(),
+                    ContentScope::Group {
+                        scope: CohortScope::Family,
+                        group_id: "fam-1".to_string(),
+                    },
+                ),
+                ("c-federation".to_string(), ContentScope::Federation),
+            ]),
+        });
+        let metrics = EdgeMetrics::default();
+        let sends = drive_publisher(
+            holdings,
+            vec![INSIDER.to_string(), OUTSIDER.to_string()],
+            SwarmRuntimeOptions {
+                scope_table: Some(family_table()),
+                metrics: Some(metrics.clone()),
+                ..SwarmRuntimeOptions::default()
+            },
+        )
+        .await;
+
+        assert!(
+            !announced(&sends, OUTSIDER, "c-family"),
+            "a family-scoped holding leaked to a peer outside the family",
+        );
+        assert!(
+            announced(&sends, OUTSIDER, "c-federation"),
+            "the federation-scoped holding must STILL reach that peer — a suite \
+             that passes by broadcasting nothing proves nothing",
+        );
+        assert!(
+            announced(&sends, INSIDER, "c-family"),
+            "the family MEMBER must still be told; withholding from everyone is \
+             not the fix",
+        );
+        assert!(announced(&sends, INSIDER, "c-federation"));
+        assert!(
+            metrics.withholds(WithholdReason::HoldingScopePeerNotInRoster) > 0,
+            "the withhold must be BOOKED, not a bare continue",
+        );
+    }
+
+    /// Unknown scope on a scope-native node is not announced to anyone,
+    /// and the refusal carries its own named reason — never folded into
+    /// the roster branch, and never read as "public".
+    #[tokio::test]
+    async fn unknown_scope_is_not_announced_and_books_its_own_reason() {
+        // No entry in `scopes` ⇒ `content_scope` returns None.
+        let holdings: Arc<dyn FountainHoldingsSource> = Arc::new(ScopedHoldings {
+            held: vec![held("c-unclassified", vec![4])],
+            scopes: BTreeMap::new(),
+        });
+        let metrics = EdgeMetrics::default();
+        let sends = drive_publisher(
+            holdings,
+            vec![INSIDER.to_string(), OUTSIDER.to_string()],
+            SwarmRuntimeOptions {
+                scope_table: Some(family_table()),
+                metrics: Some(metrics.clone()),
+                ..SwarmRuntimeOptions::default()
+            },
+        )
+        .await;
+
+        assert!(
+            sends.is_empty(),
+            "an undeterminable scope must not be announced to anyone, got {} sends",
+            sends.len(),
+        );
+        assert!(
+            metrics.withholds(WithholdReason::HoldingScopeUndeterminable) > 0,
+            "the undeterminable branch must book ITS OWN reason",
+        );
+        assert_eq!(
+            metrics.withholds(WithholdReason::HoldingScopePeerNotInRoster),
+            0,
+            "'I cannot tell what this is' must never be reported as \
+             'you are not on its roster' (CIRISEdge#433)",
+        );
+        let snap = metrics.snapshot();
+        assert!(snap
+            .recent_withholds
+            .iter()
+            .any(|w| w.detail.starts_with("fountain:c-unclassified")));
+    }
+
+    /// **The no-regression case.** A deployment with NO scope information
+    /// — no address table, no `content_scope` override — announces every
+    /// held content to every peer, exactly as it did pre-#499. This is
+    /// what makes the cut safe to ship inert.
+    #[tokio::test]
+    async fn a_deployment_with_no_scope_information_broadcasts_exactly_as_before() {
+        // `VecHoldings` does NOT override `content_scope`, so every
+        // content reports `None` — the pre-#499 consumer, verbatim.
+        let holdings: Arc<dyn FountainHoldingsSource> = Arc::new(VecHoldings(vec![
+            held("c-x", vec![1, 2, 3]),
+            held("c-y", vec![10, 20]),
+        ]));
+        let metrics = EdgeMetrics::default();
+        let sends = drive_publisher(
+            holdings,
+            vec![INSIDER.to_string(), OUTSIDER.to_string()],
+            SwarmRuntimeOptions {
+                // No table ⇒ the gate is not armed.
+                scope_table: None,
+                metrics: Some(metrics.clone()),
+                ..SwarmRuntimeOptions::default()
+            },
+        )
+        .await;
+
+        for peer in [INSIDER, OUTSIDER] {
+            for cid in ["c-x", "c-y"] {
+                assert!(
+                    announced(&sends, peer, cid),
+                    "unarmed deployment must announce {cid} to {peer} exactly as before",
+                );
+            }
+        }
+        assert!(
+            metrics.snapshot().withholds_by_reason.is_empty(),
+            "an unarmed deployment withholds nothing and books nothing",
+        );
+    }
+
+    /// The armed-but-unwired ordering fact, stated as a test so nobody
+    /// discovers it in production: installing an address table WITHOUT
+    /// overriding `content_scope` fails the holdings plane closed. That
+    /// is the correct order of operations (declare scopes, then derive
+    /// addresses), and it is loud — every refusal is booked.
+    #[tokio::test]
+    async fn arming_without_declaring_scopes_fails_closed_and_loud() {
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(VecHoldings(vec![held("c-x", vec![1])]));
+        let metrics = EdgeMetrics::default();
+        let sends = drive_publisher(
+            holdings,
+            vec![OUTSIDER.to_string()],
+            SwarmRuntimeOptions {
+                scope_table: Some(family_table()),
+                metrics: Some(metrics.clone()),
+                ..SwarmRuntimeOptions::default()
+            },
+        )
+        .await;
+        assert!(sends.is_empty());
+        assert!(metrics.withholds(WithholdReason::HoldingScopeUndeterminable) > 0);
     }
 }

--- a/src/swarm/runtime.rs
+++ b/src/swarm/runtime.rs
@@ -425,8 +425,17 @@ impl FountainSwarmRuntime {
         // handle, both cheap clones), but every DECISION it makes is
         // resolved per record on the tick — the table is read live, never
         // snapshotted, so a rotation seal takes effect on the next tick.
-        let publish_gate =
-            HoldingsPublishGate::new(options.scope_table.clone(), options.metrics.clone());
+        // CIRISPersist#744 — the gate asks its two persist verbs of the
+        // runtime's OWN directory, the one already required by this
+        // constructor. Deliberately NOT a new `SwarmRuntimeOptions`
+        // field: an armed node must never be one forgotten option away
+        // from a hard-coded authority class, and the directory it should
+        // ask is the same one the rest of the swarm reads.
+        let publish_gate = HoldingsPublishGate::new(
+            options.scope_table.clone(),
+            Some(Arc::clone(&directory)),
+            options.metrics.clone(),
+        );
 
         let publisher_task = {
             let holdings = Arc::clone(&holdings);
@@ -596,7 +605,22 @@ async fn publish_tick(
             // though no content bytes move. `admit_and_book` BOOKS the
             // withhold (#433 ledger) and logs it before returning, so this
             // is never a bare `continue`.
-            match publish_gate.admit_and_book(&content.content_id, content_scope.as_ref(), peer) {
+            // CIRISPersist#744 — `async` now: the gate resolves the
+            // PUBLISHER's authority class and the recipient set through
+            // persist. `local_peer_id` is the publisher — this node signs
+            // the holding claim — and it is passed rather than held on
+            // the gate so the authority is never cached across one.
+            // No guard is live across this await (CIRISEdge#217):
+            // `content_scope` above is a plain `Option<ContentScope>`.
+            match publish_gate
+                .admit_and_book(
+                    local_peer_id,
+                    &content.content_id,
+                    content_scope.as_ref(),
+                    peer,
+                )
+                .await
+            {
                 HoldingAnnounce::Announce => {}
                 HoldingAnnounce::Withhold(_) => continue,
             }
@@ -1357,16 +1381,30 @@ mod tests {
         peers: Vec<String>,
         options: SwarmRuntimeOptions,
     ) -> Vec<(String, Vec<u8>)> {
+        drive_publisher_as(holdings, peers, options, "alice", test_directory()).await
+    }
+
+    /// CIRISPersist#744 — drive the loop under a NAMED publisher against a
+    /// NAMED directory, because the publisher's authority class is now an
+    /// input to the gate. `drive_publisher` keeps the plain-producer
+    /// default; the federation-reach assertions need a real trust root.
+    async fn drive_publisher_as(
+        holdings: Arc<dyn FountainHoldingsSource>,
+        peers: Vec<String>,
+        options: SwarmRuntimeOptions,
+        publisher: &str,
+        directory: Arc<dyn FederationDirectory>,
+    ) -> Vec<(String, Vec<u8>)> {
         let recording_tx = Arc::new(RecordingTransport::default());
         let tx: Arc<dyn Transport> = recording_tx.clone();
         let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(move || peers.clone());
         let mut rt = FountainSwarmRuntime::start_with_options(
             fast_config(),
             holdings,
-            test_directory(),
+            directory,
             tx,
             cohort,
-            "alice".to_string(),
+            publisher.to_string(),
             None,
             options,
         );
@@ -1397,7 +1435,17 @@ mod tests {
             ]),
         });
         let metrics = EdgeMetrics::default();
-        let sends = drive_publisher(
+        // CIRISPersist#744 — the publisher is a REAL trust root
+        // (accord-co-scrubbed `infra:attest`, admitted through persist's
+        // own gate). That is what makes the federation-scoped holding
+        // reach an outsider at all: `holdings_authority` resolves
+        // `AccordCoScrub`, `projection_for` gives `Global`, and persist's
+        // recipient verb answers `Unbounded`. Under a plain producer the
+        // same content projects `Cohort` at a commons tier, which has no
+        // roster table, and persist withholds — see
+        // `a_plain_producers_federation_holding_is_withheld_by_the_verb`.
+        let (backend, _bundle) = crate::bundle_gate::test_support::field_fixture().await;
+        let sends = drive_publisher_as(
             holdings,
             vec![INSIDER.to_string(), OUTSIDER.to_string()],
             SwarmRuntimeOptions {
@@ -1405,6 +1453,8 @@ mod tests {
                 metrics: Some(metrics.clone()),
                 ..SwarmRuntimeOptions::default()
             },
+            crate::bundle_gate::test_support::PIPELINE,
+            Arc::new(backend),
         )
         .await;
 
@@ -1426,6 +1476,65 @@ mod tests {
         assert!(
             metrics.withholds(WithholdReason::HoldingScopePeerNotInRoster) > 0,
             "the withhold must be BOOKED, not a bare continue",
+        );
+    }
+
+    /// CIRISPersist#744, at the LOOP — the twin of
+    /// `family_holding_is_not_announced_outside_the_cohort_but_federation_still_is`.
+    ///
+    /// The same federation-scoped holding, the same armed table, the same
+    /// peers — only the PUBLISHER changes, from a trust root to a plain
+    /// producer. Persist projects `Cohort` at a commons tier, holds no
+    /// roster table for one, and answers "I cannot judge", so the holding
+    /// is withheld and BOOKED under its own reason.
+    ///
+    /// This is the half-landing guard driven through the real publisher
+    /// rather than the pure gate: revert the authority seam and the two
+    /// tests collapse onto one answer, which is precisely the collapse
+    /// that hid the defect.
+    #[tokio::test]
+    async fn a_plain_producers_federation_holding_is_withheld_by_the_verb() {
+        let holdings: Arc<dyn FountainHoldingsSource> = Arc::new(ScopedHoldings {
+            held: vec![held("c-federation", vec![9])],
+            scopes: BTreeMap::from([("c-federation".to_string(), ContentScope::Federation)]),
+        });
+        let metrics = EdgeMetrics::default();
+        let (backend, _bundle) = crate::bundle_gate::test_support::field_fixture().await;
+        let sends = drive_publisher_as(
+            holdings,
+            vec![INSIDER.to_string(), OUTSIDER.to_string()],
+            SwarmRuntimeOptions {
+                scope_table: Some(family_table()),
+                metrics: Some(metrics.clone()),
+                ..SwarmRuntimeOptions::default()
+            },
+            // A plain node row — NOT accord-co-scrubbed.
+            crate::bundle_gate::test_support::PRESENTER,
+            Arc::new(backend),
+        )
+        .await;
+
+        assert!(
+            !announced(&sends, OUTSIDER, "c-federation"),
+            "a PLAIN producer's federation holding must not be broadcast: \
+             persist projects Cohort at a commons tier, has no roster table \
+             for one, and says so",
+        );
+        assert!(
+            !announced(&sends, INSIDER, "c-federation"),
+            "'cannot judge' is about the SET, not about one peer — it \
+             withholds from everyone, including a family member",
+        );
+        assert!(
+            metrics.withholds(WithholdReason::HoldingScopeRecipientSetUnresolved) > 0,
+            "the withhold must be BOOKED under the 'cannot judge' reason, \
+             never as peer-not-in-roster",
+        );
+        assert_eq!(
+            metrics.withholds(WithholdReason::HoldingScopePeerNotInRoster),
+            0,
+            "an admission of ignorance must never be booked as an accusation \
+             about the peer",
         );
     }
 

--- a/src/swarm/scope.rs
+++ b/src/swarm/scope.rs
@@ -39,14 +39,41 @@
 //!   [`FountainHoldingsSource::content_scope`], exactly as
 //!   [`BlobChunkSource::chunk_scope`](crate::blob_swarm::BlobChunkSource::chunk_scope)
 //!   surfaces a blob's. `None` means **UNKNOWN**, never *public*.
-//! - **edge owns the per-recipient MECHANISM.** persist's [`Projection`]
-//!   names an audience *kind* (`Global` commons gossip / `Cohort`
-//!   hold-and-forward over the record's roster / `SelfOwn`
-//!   structurally-invisible publish-own); resolving "is THIS peer in that
-//!   audience" is the consumer tier's, and edge's existing resolver for a
-//!   scope roster is [`ScopeAddressTable::send_address`] — a peer holds a
-//!   derived address in a group iff it is a member at a live epoch. That
-//!   is the same membership fact
+//! - **persist owns the AUTHORITY, and it is asked of the SIGNER.**
+//!   v37.1.0 (CIRISPersist#744 item 2) — [`holdings_authority`] resolves
+//!   [`AuthorityClass::AccordCoScrub`] for a trust-root publisher and
+//!   [`AuthorityClass::ProducerSteward`] for everyone else, re-derived
+//!   from persist's own verified state on every call. Edge used to pass
+//!   a hard-coded `ProducerSteward`, which under-advertised a genuine
+//!   canonical corpus.
+//!
+//!   **Note the shape of the fix, because a cheaper one was refused.**
+//!   Authority could have ridden the fountain row's opaque signed
+//!   `envelope` — mechanically preimage-safe, since a new JSON key moves
+//!   no stored signature. It is substantively wrong: `AccordCoScrub` is
+//!   precisely the class a producer must never self-declare, or a corpus
+//!   confers trust-root reach on itself (CIRISPersist#543/#659 — a gate
+//!   that reads the subject rather than the signer). So the authority is
+//!   declared AT THE SEAM. `holdings_authority` takes only the publisher
+//!   key: `corpus_kind` is **not a parameter**, so the inference edge was
+//!   told not to make is not expressible, and this module must never add
+//!   a path that derives authority from the record.
+//!
+//! - **persist owns the RECIPIENT SET on the commons tiers.**
+//!   [`resolve_projection_recipients`] resolves the projection ITSELF
+//!   from `(plane, scope, authority, is_tombstone)` — never from a
+//!   caller-nominated [`Projection`] — and answers *"may this peer be
+//!   told we hold this?"* as a [`RecipientVerdict`]. Edge used to map
+//!   `Global | Cohort => announce` by hand, which is why the two halves
+//!   had to land together: see [`HoldingsScopeGate::admits`].
+//!
+//! - **edge owns the per-recipient MECHANISM on its OWN groups.**
+//!   For [`ContentScope::Group`] the audience is a roster edge holds in
+//!   its address table and persist does not have a key for — see
+//!   [`HoldingsScopeGate::admits`]'s "the seam edge cannot yet supply"
+//!   note. Edge's resolver is [`ScopeAddressTable::send_address`] — a
+//!   peer holds a derived address in a group iff it is a member at a
+//!   live epoch. That is the same membership fact
 //!   [`ScopeRouteRefusal::HolderNotInGroup`](crate::blob_swarm::ScopeRouteRefusal::HolderNotInGroup)
 //!   already rides, reused rather than re-derived.
 //!
@@ -78,32 +105,17 @@
 
 use std::sync::Arc;
 
-use ciris_persist::federation::namespace::{projection_for, AuthorityClass, Plane, Projection};
+use ciris_persist::federation::namespace::{
+    holdings_authority, projection_for, resolve_projection_recipients, AuthorityClass, Plane,
+    Projection, RecipientBasis, RecipientVerdict,
+};
 use ciris_persist::federation::types::cohort_scope;
+use ciris_persist::federation::FederationDirectory;
 
 use crate::blob_swarm::ContentScope;
 use crate::cohort_scope::CohortScope;
 use crate::observability::{EdgeMetrics, WithholdReason};
 use crate::scope_addressing::ScopeAddressTable;
-
-/// The [`AuthorityClass`] the holdings gate feeds `projection_for`.
-///
-/// **The negative default, deliberately.** `projection_for`'s authority
-/// axis is a property of the CONTENT's provenance (an accord-co-scrubbed
-/// canonical corpus vs. a plain producer's), and nothing on the holdings
-/// seam carries it: [`HeldFountainContent`](super::HeldFountainContent)
-/// has `content_id` / `corpus_kind` / `symbol_ids`, and mapping
-/// `corpus_kind` onto a trust-root class would be edge inventing an
-/// authority rule persist owns. So the gate asserts the class it can
-/// honestly assert — a plain producer/steward — which on
-/// [`Plane::FountainContent`] resolves `Cohort` where a trust root would
-/// resolve `Global`. Both admit the broadcast today, so the conservative
-/// choice costs nothing and stays correct if persist ever narrows
-/// `Cohort`.
-///
-/// Reported upstream as the one input this plane needs and no edge seam
-/// supplies.
-pub const HOLDING_AUTHORITY: AuthorityClass = AuthorityClass::ProducerSteward;
 
 /// Edge's [`CohortScope`] → persist's `cohort_scope` string token.
 ///
@@ -132,6 +144,32 @@ fn projection_tag(projection: Projection) -> &'static str {
         Projection::SelfOwn => "self_own",
         Projection::Capability(_) => "capability",
         Projection::Subject => "subject",
+    }
+}
+
+/// Stable low-cardinality tag for persist's [`RecipientBasis`] — WHY the
+/// recipient set could not be resolved.
+///
+/// Persist keeps three distinct *"I cannot judge"* causes because "each is
+/// a different thing for an operator to go fix". Edge books them under one
+/// [`WithholdReason`] (they are ONE branch here — the verdict said it could
+/// not judge) but carries the cause in the refusal's payload, its `Display`
+/// and its log line, so persist's distinction survives into the ledger
+/// instead of being flattened at edge's seam.
+///
+/// `RecipientBasis` is `#[non_exhaustive]`: persist adds a basis when a new
+/// audience axis lands. The wildcard is therefore REQUIRED by the type and
+/// is not a policy default — every arm below and the fallback alike are
+/// only ever reached on a verdict that already refused.
+fn basis_tag(basis: RecipientBasis) -> &'static str {
+    match basis {
+        RecipientBasis::OwnRoster => "own_roster",
+        RecipientBasis::CohortRoster => "cohort_roster",
+        RecipientBasis::Unbounded => "unbounded",
+        RecipientBasis::NoRosterForScope => "no_roster_for_scope",
+        RecipientBasis::GroupUnresolvable => "group_unresolvable",
+        RecipientBasis::NotRosterKeyed => "not_roster_keyed",
+        _ => "unknown_basis",
     }
 }
 
@@ -183,6 +221,52 @@ pub enum HoldingRefusal {
         /// resolve (`capability` / `subject`).
         projection: &'static str,
     },
+    /// The gate is ARMED (a [`ScopeAddressTable`] is installed) but no
+    /// [`FederationDirectory`] is wired, so neither
+    /// [`holdings_authority`] nor [`resolve_projection_recipients`] can
+    /// be asked. A wiring fault, not a policy decision — the same shape
+    /// as [`WithholdReason::LocalIdentityMissing`] on the replication
+    /// plane, and refused rather than silently falling back to the
+    /// pre-#744 hard-coded authority: falling back would resurrect
+    /// exactly the defect this cut removes, and would do it invisibly.
+    DirectoryMissing,
+    /// [`holdings_authority`] could not be resolved — the trust-root walk
+    /// over the PUBLISHER's key errored.
+    ///
+    /// Never folded into a `ProducerSteward` default. A read that failed
+    /// is not a statement that the publisher is a plain producer, and
+    /// quietly demoting it would be the #425 Exhibit C shape: an
+    /// infrastructure fault reported as a confident claim about the
+    /// signer.
+    AuthorityUnresolved,
+    /// [`resolve_projection_recipients`] answered *"I cannot judge"*
+    /// (`set_resolvable == false`).
+    ///
+    /// **Structurally distinct from [`PeerNotInRoster`](Self::PeerNotInRoster),
+    /// which is the whole point.** Persist keeps `set_resolvable` and
+    /// `peer_in_set` as two fields precisely so an admission of ignorance
+    /// is never reported as an accusation about the peer, and collapsing
+    /// them here would undo that one plane over (the CIRISPersist#731
+    /// lesson, restated for #744). An operator seeing this must go fix a
+    /// roster table or a group registration; an operator seeing
+    /// `PeerNotInRoster` must go fix a membership list. Different places.
+    RecipientSetUnresolved {
+        /// [`basis_tag`] of persist's [`RecipientBasis`] — WHICH of the
+        /// "cannot judge" causes fired (`no_roster_for_scope` /
+        /// `group_unresolvable`), so the ledger keeps the distinction
+        /// persist drew.
+        basis: &'static str,
+    },
+    /// [`resolve_projection_recipients`] itself returned `Err`.
+    ///
+    /// Persist documents every resolution path as returning `Ok` today
+    /// and retains the `Result` "because a future leg may need to
+    /// distinguish an infrastructure fault from a refusal". Edge honours
+    /// that split now rather than later: a transport/read fault is booked
+    /// as one, never as
+    /// [`RecipientSetUnresolved`](Self::RecipientSetUnresolved), which is
+    /// a VERDICT persist reached deliberately.
+    RecipientReadError,
 }
 
 impl HoldingRefusal {
@@ -197,6 +281,10 @@ impl HoldingRefusal {
             Self::PublicIsNotScoped => "holding_scope_public_group",
             Self::PeerNotInRoster { .. } => "holding_scope_peer_not_in_roster",
             Self::ProjectionUnsupported { .. } => "holding_scope_projection_unsupported",
+            Self::DirectoryMissing => "holding_scope_directory_missing",
+            Self::AuthorityUnresolved => "holding_scope_authority_unresolved",
+            Self::RecipientSetUnresolved { .. } => "holding_scope_recipient_set_unresolved",
+            Self::RecipientReadError => "holding_scope_recipient_read_error",
         }
     }
 
@@ -208,6 +296,12 @@ impl HoldingRefusal {
             Self::PublicIsNotScoped => WithholdReason::HoldingScopePublicGroup,
             Self::PeerNotInRoster { .. } => WithholdReason::HoldingScopePeerNotInRoster,
             Self::ProjectionUnsupported { .. } => WithholdReason::HoldingScopeProjectionUnsupported,
+            Self::DirectoryMissing => WithholdReason::HoldingScopeDirectoryMissing,
+            Self::AuthorityUnresolved => WithholdReason::HoldingScopeAuthorityUnresolved,
+            Self::RecipientSetUnresolved { .. } => {
+                WithholdReason::HoldingScopeRecipientSetUnresolved
+            }
+            Self::RecipientReadError => WithholdReason::HoldingScopeRecipientReadError,
         }
     }
 }
@@ -241,6 +335,30 @@ impl std::fmt::Display for HoldingRefusal {
                 "fountain holding projects '{projection}', an audience kind this gate has \
                  no peer-set mechanism for on Plane::FountainContent — refusing \
                  fail-closed rather than guessing the audience (CIRISEdge#499)"
+            ),
+            Self::DirectoryMissing => f.write_str(
+                "fountain holdings gate is ARMED (a scope-address table is installed) but no \
+                 FederationDirectory is wired, so neither the publisher's authority class nor \
+                 the recipient set can be resolved. Wire SwarmRuntimeOptions::directory; the \
+                 gate will NOT fall back to a hard-coded authority (CIRISPersist#744)",
+            ),
+            Self::AuthorityUnresolved => f.write_str(
+                "resolving the PUBLISHER's authority class (persist holdings_authority — the \
+                 accord-co-scrub trust-root walk) FAILED. Withholding: a read that failed is \
+                 not a statement that the publisher is a plain producer, and demoting it \
+                 silently is how a trust-root corpus loses its reach (CIRISPersist#744)",
+            ),
+            Self::RecipientSetUnresolved { basis } => write!(
+                f,
+                "persist's resolve_projection_recipients returned set_resolvable=false \
+                 (basis '{basis}') — it CANNOT JUDGE this record's recipient set, which is \
+                 NOT a statement that the peer is outside it. Withholding fail-closed; an \
+                 advertisement gate never fails open (CIRISPersist#744)"
+            ),
+            Self::RecipientReadError => f.write_str(
+                "persist's resolve_projection_recipients returned an ERROR — an \
+                 infrastructure fault, deliberately not booked as the 'cannot judge' verdict \
+                 it would otherwise be mistaken for. Withholding (CIRISPersist#744)",
             ),
         }
     }
@@ -285,15 +403,26 @@ impl HoldingAnnounce {
 #[derive(Clone, Default)]
 pub struct HoldingsScopeGate {
     table: Option<Arc<ScopeAddressTable>>,
+    directory: Option<Arc<dyn FederationDirectory>>,
 }
 
 impl HoldingsScopeGate {
-    /// A gate over an installed table. `None` — the production state
-    /// until the MLS exporter label is specified upstream — yields a gate
-    /// that announces everything, i.e. exactly pre-#499 behaviour.
+    /// A gate over an installed table and the federation directory the
+    /// two persist verbs are asked of.
+    ///
+    /// `table: None` — the production state until the MLS exporter label
+    /// is specified upstream — yields a gate that announces everything,
+    /// i.e. exactly pre-#499 behaviour, **without touching the
+    /// directory**. `table: Some` with `directory: None` is an armed but
+    /// unwired node, which fails closed
+    /// ([`HoldingRefusal::DirectoryMissing`]) rather than reverting to a
+    /// hard-coded authority class.
     #[must_use]
-    pub fn new(table: Option<Arc<ScopeAddressTable>>) -> Self {
-        Self { table }
+    pub fn new(
+        table: Option<Arc<ScopeAddressTable>>,
+        directory: Option<Arc<dyn FederationDirectory>>,
+    ) -> Self {
+        Self { table, directory }
     }
 
     /// `true` iff a [`ScopeAddressTable`] is installed, i.e. iff this node
@@ -307,16 +436,21 @@ impl HoldingsScopeGate {
         self.table.is_some()
     }
 
-    /// The projection persist resolves for `scope` on
+    /// The projection persist resolves for `scope` under `authority` on
     /// [`Plane::FountainContent`]. Exposed so the pin test reads the real
     /// table rather than a copy of it — the #636 lesson that a gate must
     /// see the table itself.
+    ///
+    /// `authority` is a PARAMETER as of v37.1.0 (CIRISPersist#744): it
+    /// used to be a hard-coded `ProducerSteward` const, and that const
+    /// was the under-advertisement bug. It is resolved per publisher by
+    /// [`holdings_authority`] and never inferred from the record.
     #[must_use]
-    pub fn projection_of(scope: &CohortScope) -> Projection {
+    pub fn projection_of(scope: &CohortScope, authority: AuthorityClass) -> Projection {
         projection_for(
             Plane::FountainContent,
             persist_scope_token(scope),
-            HOLDING_AUTHORITY,
+            authority,
             // A holdings claim is a live claim about what this node
             // currently retains. It is never a tombstone: there is no
             // "un-holding" record on this plane — a dropped holding is
@@ -337,9 +471,65 @@ impl HoldingsScopeGate {
     /// # Arming
     ///
     /// `is_scope_native() == false` ⇒ [`HoldingAnnounce::Announce`]
-    /// unconditionally, with no table probe and no log. See the module
-    /// docs: additive, not disruptive.
-    pub fn admits(&self, content: Option<&ContentScope>, peer_key_id: &str) -> HoldingAnnounce {
+    /// unconditionally, with no table probe, **no directory call** and no
+    /// log. See the module docs: additive, not disruptive. The early
+    /// return is byte-identical to pre-#499 and pre-#744 alike — an
+    /// unarmed node performs no `.await` on this path at all.
+    ///
+    /// # The two halves of CIRISPersist#744, and why they are one change
+    ///
+    /// `authority` is read by `projection_for` on
+    /// [`Plane::FountainContent`] at **exactly one scope** — `federation`
+    /// — where a trust root projects `Global` and everyone else projects
+    /// `Cohort`. Every other scope arm ignores it
+    /// (`authority_is_read_only_at_federation_scope` pins this). So the
+    /// authority seam and the recipient verb act on the SAME cell, and
+    /// landing either alone is a defect:
+    ///
+    /// - **verb alone** (authority still hard-coded `ProducerSteward`): a
+    ///   trust-root publisher's federation-scoped corpus resolves
+    ///   `Cohort`, `Cohort::from_token("federation")` has no roster table,
+    ///   and the verdict is `NoRosterForScope` — the canonical corpus
+    ///   goes DARK.
+    /// - **seam alone** (still hand-mapping `Global | Cohort => announce`):
+    ///   a trust-root publisher now resolves `AccordCoScrub` and so
+    ///   `Global`, which the hand-map admitted for free — because it
+    ///   admitted `Cohort` too. `Global` is *unbounded*; the hand-map made
+    ///   the widening invisible by treating "everyone" and "the cohort" as
+    ///   one answer.
+    ///
+    /// `neither_half_alone_is_safe` is the guard.
+    ///
+    /// # The seam edge cannot yet supply — [`ContentScope::Group`]
+    ///
+    /// The verb's roster leg reads `active_members(cohort, group_key_id)`,
+    /// a **federation group key id**. Edge's [`ContentScope::Group`]
+    /// carries the ADDRESS TABLE's group id, a different namespace —
+    /// `cohort_addressing::snapshot` mints it as `cohort:{community_id}`
+    /// and the A/V plane mints session ids alongside, both namespaced so
+    /// "a community and a call inside it cannot collide". The same field
+    /// is what [`ScopeAddressTable::send_address`] is keyed on, so one
+    /// string cannot be both.
+    ///
+    /// Passing it to persist anyway would not be fail-closed, it would be
+    /// a **wrong answer that happens to point the safe way**: persist
+    /// would resolve `GroupUnresolvable` for a group it was never asked
+    /// about, and every family/community holding would go dark under a
+    /// verdict that looks authoritative. That is the CIRISPersist#731
+    /// shape the verb's own signature exists to prevent (which is why it
+    /// takes `authority`/`is_tombstone` and resolves the projection
+    /// itself, rather than accepting a caller-nominated `Projection`).
+    ///
+    /// So this branch keeps edge's address-table membership — the only
+    /// registry edge holds a key for — and the group-key-id seam is
+    /// reported upstream rather than faked here.
+    pub async fn admits(
+        &self,
+        publisher_key_id: &str,
+        content: Option<&ContentScope>,
+        peer_key_id: &str,
+    ) -> HoldingAnnounce {
+        // ARMING — the byte-identical early return. No probe, no await.
         let Some(table) = self.table.as_ref() else {
             return HoldingAnnounce::Announce;
         };
@@ -348,45 +538,100 @@ impl HoldingsScopeGate {
             return HoldingAnnounce::Withhold(HoldingRefusal::ScopeUndeterminable);
         };
 
+        // A private roster at Public scope is a contradiction, not a
+        // configuration — refused before any lookup and before any
+        // directory call, exactly as the blob router refuses it on the
+        // send side. Hoisted above the awaits so a malformed declaration
+        // never reads as a wiring fault.
+        if let ContentScope::Group {
+            scope: CohortScope::Public,
+            ..
+        } = content
+        {
+            return HoldingAnnounce::Withhold(HoldingRefusal::PublicIsNotScoped);
+        }
+
+        let Some(directory) = self.directory.as_deref() else {
+            return HoldingAnnounce::Withhold(HoldingRefusal::DirectoryMissing);
+        };
+
+        // ── HALF 1: THE AUTHORITY SEAM ──────────────────────────────
+        // Asked of the SIGNER, re-derived from persist's verified state
+        // on every call. Never stored, never signed by the party it
+        // benefits, never inferred from `corpus_kind` — which is not even
+        // a parameter here, so the inference is not expressible.
+        //
+        // CIRISEdge#217: no guard is held here. `self.directory` is an
+        // `Arc` deref, and the only lock in this function
+        // (`send_address`'s, below) is taken AFTER every await and
+        // released within its own statement.
+        let authority = match holdings_authority(directory, publisher_key_id).await {
+            Ok(a) => a,
+            Err(e) => {
+                tracing::warn!(
+                    publisher = %publisher_key_id,
+                    error = %e,
+                    "holdings gate: holdings_authority FAILED — withholding",
+                );
+                return HoldingAnnounce::Withhold(HoldingRefusal::AuthorityUnresolved);
+            }
+        };
+
         // Resolve the projection PER RECORD from the record's real scope
         // — never from a cached assumption, the discipline `bridge.rs`
         // holds on the attestation plane.
         let content_scope = content.cohort_scope();
-        let projection = Self::projection_of(content_scope);
 
         match content {
-            // Federation/public content: the record names no roster, so
-            // its audience is the node's own cohort — which is precisely
-            // the peer set the publisher was handed. Byte-identical to
-            // pre-#499 for `Global` (trust-root commons gossip) and
-            // `Cohort` (hold-and-forward for non-root commons content)
-            // alike.
-            ContentScope::Federation => match projection {
-                Projection::Global | Projection::Cohort => HoldingAnnounce::Announce,
-                other => HoldingAnnounce::Withhold(HoldingRefusal::ProjectionUnsupported {
-                    projection: projection_tag(other),
-                }),
-            },
+            // ── HALF 2: THE RECIPIENT VERB ──────────────────────────
+            // Federation/commons content. Persist resolves the projection
+            // ITSELF and answers whether this peer may be told — replacing
+            // edge's hand-rolled `Global | Cohort => announce`.
+            //
+            // `group_key_id` is provably UNREAD on this branch: `Global`
+            // returns `Unbounded` and `Cohort` at a commons tier returns
+            // `NoRosterForScope`, both before any roster leg. It is passed
+            // empty rather than invented, and
+            // `federation_branch_never_reads_the_group_key_id` pins that.
+            ContentScope::Federation => {
+                let verdict = match resolve_projection_recipients(
+                    directory,
+                    Plane::FountainContent,
+                    persist_scope_token(content_scope),
+                    authority,
+                    // A holdings claim is a live claim about what this
+                    // node currently retains — never a tombstone. See
+                    // `projection_of`.
+                    false,
+                    "",
+                    peer_key_id,
+                )
+                .await
+                {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::warn!(
+                            peer = %peer_key_id,
+                            error = %e,
+                            "holdings gate: resolve_projection_recipients ERRORED — withholding",
+                        );
+                        return HoldingAnnounce::Withhold(HoldingRefusal::RecipientReadError);
+                    }
+                };
+                Self::read_verdict(verdict, content_scope, authority)
+            }
             ContentScope::Group { scope, group_id } => {
-                // A private roster at Public scope is a contradiction, not
-                // a configuration — refused before any lookup, exactly as
-                // the blob router refuses it on the send side.
-                if matches!(scope, CohortScope::Public) {
-                    return HoldingAnnounce::Withhold(HoldingRefusal::PublicIsNotScoped);
-                }
+                let projection = Self::projection_of(content_scope, authority);
                 match projection {
                     // Commons gossip — the record reaches the whole
-                    // federation regardless of roster. Unreachable under
-                    // `HOLDING_AUTHORITY`; kept exhaustive so a future
-                    // authority input is a one-line change, not a rewrite.
+                    // federation regardless of roster.
                     Projection::Global => HoldingAnnounce::Announce,
-                    // `Cohort` — persist: "the record relays to the members
-                    // of ITS community/affiliations roster". `SelfOwn` —
-                    // persist: publish-own, "the structurally-invisible
-                    // identity plane". Both bound the audience to the
-                    // record's OWN roster; edge's resolver for that roster
-                    // is the address table's membership, one hash-map probe
-                    // and no derivation.
+                    // `Cohort` / `SelfOwn` — both bound the audience to
+                    // the record's OWN roster. Edge's resolver for that
+                    // roster is the address table's membership, one
+                    // hash-map probe and no derivation. See the
+                    // "seam edge cannot yet supply" note above for why
+                    // persist's verb is NOT asked here.
                     Projection::Cohort | Projection::SelfOwn => {
                         if table.send_address(scope, group_id, peer_key_id).is_some() {
                             HoldingAnnounce::Announce
@@ -403,6 +648,59 @@ impl HoldingsScopeGate {
                 }
             }
         }
+    }
+
+    /// Read persist's [`RecipientVerdict`] into an announce decision.
+    ///
+    /// **The order of these two reads is load-bearing.** `set_resolvable`
+    /// is consulted FIRST and has its own refusal; only then is
+    /// `peer_in_set` meaningful. Reversing them — or reading
+    /// `peer_in_set` alone — reports *"I cannot judge"* as *"you are not
+    /// seated"*: an admission of ignorance dressed as an accusation, and
+    /// the exact collapse persist split the struct to prevent.
+    ///
+    /// `may_advertise()` is deliberately NOT used as the single test: it
+    /// is the right conjunction but it erases which half failed, and #433
+    /// requires the branch, not the disjunction.
+    fn read_verdict(
+        verdict: RecipientVerdict,
+        content_scope: &CohortScope,
+        authority: AuthorityClass,
+    ) -> HoldingAnnounce {
+        if !verdict.set_resolvable {
+            // "I cannot judge" — NOT "the peer is not in the set".
+            return match verdict.basis {
+                // Role-keyed / subject-keyed audiences are not a
+                // `(scope, group)` question at all. This is the exact
+                // condition `ProjectionUnsupported` was minted for, so it
+                // keeps that reason rather than minting a second name for
+                // one fact. Structurally unreachable against persist
+                // v37's FountainContent table (which yields only
+                // Global/Cohort/SelfOwn); booked fail-closed anyway so a
+                // future persist widening surfaces as a NAMED withhold
+                // instead of as an allow.
+                RecipientBasis::NotRosterKeyed => {
+                    HoldingAnnounce::Withhold(HoldingRefusal::ProjectionUnsupported {
+                        projection: projection_tag(Self::projection_of(content_scope, authority)),
+                    })
+                }
+                other => HoldingAnnounce::Withhold(HoldingRefusal::RecipientSetUnresolved {
+                    basis: basis_tag(other),
+                }),
+            };
+        }
+        if !verdict.peer_in_set {
+            // Resolved, and the peer is genuinely outside it.
+            return HoldingAnnounce::Withhold(HoldingRefusal::PeerNotInRoster {
+                content_kind: content_scope.kind_token(),
+                projection: projection_tag(Self::projection_of(content_scope, authority)),
+            });
+        }
+        debug_assert!(
+            verdict.may_advertise(),
+            "both verdict legs passed, so persist must also admit"
+        );
+        HoldingAnnounce::Announce
     }
 }
 
@@ -422,13 +720,18 @@ pub struct HoldingsPublishGate {
 }
 
 impl HoldingsPublishGate {
-    /// Construct from the runtime's optional address table and optional
-    /// metrics handle. Both `None` is the pre-#499 deployment: the gate
-    /// admits everything and books nothing.
+    /// Construct from the runtime's optional address table, the optional
+    /// federation directory the persist verbs are asked of, and the
+    /// optional metrics handle. All `None` is the pre-#499 deployment:
+    /// the gate admits everything and books nothing.
     #[must_use]
-    pub fn new(table: Option<Arc<ScopeAddressTable>>, metrics: Option<EdgeMetrics>) -> Self {
+    pub fn new(
+        table: Option<Arc<ScopeAddressTable>>,
+        directory: Option<Arc<dyn FederationDirectory>>,
+        metrics: Option<EdgeMetrics>,
+    ) -> Self {
         Self {
-            gate: HoldingsScopeGate::new(table),
+            gate: HoldingsScopeGate::new(table, directory),
             metrics,
         }
     }
@@ -442,17 +745,30 @@ impl HoldingsPublishGate {
     /// Decide whether `content_id` (scoped `content`) may be announced to
     /// `peer_key_id`, booking + logging any withhold before returning it.
     ///
-    /// Synchronous and lock-free across suspension points: the only guard
-    /// taken is inside [`ScopeAddressTable::send_address`], released
-    /// before this returns, so no guard can be held across the publisher's
-    /// subsequent `.await` on the transport (CIRISEdge#217).
-    pub fn admit_and_book(
+    /// `publisher_key_id` is the key the holding claim is published
+    /// under — the local node's. It is the ONLY input
+    /// [`holdings_authority`] takes, and it is a parameter rather than
+    /// gate state so the authority is resolved per publisher and never
+    /// cached across one.
+    ///
+    /// **CIRISEdge#217.** `async` as of v37.1.0 (the two persist verbs
+    /// are async), so the lock discipline is now load-bearing rather than
+    /// incidental: no guard is held across any `.await` here or in
+    /// [`HoldingsScopeGate::admits`]. The only lock taken is inside
+    /// [`ScopeAddressTable::send_address`], which runs after every await
+    /// and releases within its own statement; the metrics booking below
+    /// happens after the gate has fully returned.
+    pub async fn admit_and_book(
         &self,
+        publisher_key_id: &str,
         content_id: &str,
         content: Option<&ContentScope>,
         peer_key_id: &str,
     ) -> HoldingAnnounce {
-        let verdict = self.gate.admits(content, peer_key_id);
+        let verdict = self
+            .gate
+            .admits(publisher_key_id, content, peer_key_id)
+            .await;
         if let HoldingAnnounce::Withhold(refusal) = &verdict {
             if let Some(m) = self.metrics.as_ref() {
                 m.inc_withhold(
@@ -485,11 +801,25 @@ fn withhold_detail(content_id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::bundle_gate::test_support::{field_fixture, PIPELINE, PRESENTER};
     use crate::scope_addressing::StubDeriver;
 
     const ALICE: &str = "ed25519:alice";
     const BOB: &str = "ed25519:bob";
     const OUTSIDER: &str = "ed25519:mallory";
+
+    /// The REAL trust root: `field_fixture` seeds `PIPELINE` with an
+    /// accord-co-scrubbed `infra:attest` record admitted through persist's
+    /// own role gate — no fixture backdoor — so
+    /// `is_infra_attest_effective` (and therefore
+    /// `holdings_authority`) resolves `AccordCoScrub` for it.
+    /// `PRESENTER` is a plain node row and resolves `ProducerSteward`.
+    /// Using persist's real predicate both ways is what makes the seam
+    /// EXERCISED rather than asserted.
+    async fn directory() -> Arc<dyn FederationDirectory> {
+        let (backend, _bundle) = field_fixture().await;
+        Arc::new(backend)
+    }
 
     fn cohort(id: &str) -> CohortScope {
         CohortScope::Cohort {
@@ -514,8 +844,9 @@ mod tests {
         Arc::new(t)
     }
 
-    fn armed() -> HoldingsScopeGate {
-        HoldingsScopeGate::new(Some(table()))
+    /// Armed AND wired — a table plus the real directory.
+    async fn armed() -> HoldingsScopeGate {
+        HoldingsScopeGate::new(Some(table()), Some(directory().await))
     }
 
     fn family_content() -> ContentScope {
@@ -539,26 +870,64 @@ mod tests {
     /// this reds HERE rather than silently changing who learns what.
     #[test]
     fn persist_owns_the_fountain_content_projection() {
+        use AuthorityClass::{AccordCoScrub, ProducerSteward};
+        for authority in [ProducerSteward, AccordCoScrub] {
+            assert_eq!(
+                HoldingsScopeGate::projection_of(&CohortScope::SelfOnly, authority),
+                Projection::SelfOwn,
+                "self scope must be structurally invisible under {authority:?}",
+            );
+            assert_eq!(
+                HoldingsScopeGate::projection_of(&CohortScope::Family, authority),
+                Projection::SelfOwn,
+                "family scope must be structurally invisible under {authority:?}",
+            );
+            assert_eq!(
+                HoldingsScopeGate::projection_of(&cohort("neighbourhood"), authority),
+                Projection::Cohort,
+                "community scope relays over ITS OWN roster under {authority:?}",
+            );
+        }
         assert_eq!(
-            HoldingsScopeGate::projection_of(&CohortScope::SelfOnly),
-            Projection::SelfOwn,
-            "self scope must be structurally invisible",
-        );
-        assert_eq!(
-            HoldingsScopeGate::projection_of(&CohortScope::Family),
-            Projection::SelfOwn,
-            "family scope must be structurally invisible",
-        );
-        assert_eq!(
-            HoldingsScopeGate::projection_of(&cohort("neighbourhood")),
+            HoldingsScopeGate::projection_of(&CohortScope::Public, ProducerSteward),
             Projection::Cohort,
-            "community scope relays over ITS OWN roster, not the federation cohort",
+            "federation scope under a PLAIN producer is the cohort relay",
         );
         assert_eq!(
-            HoldingsScopeGate::projection_of(&CohortScope::Public),
-            Projection::Cohort,
-            "federation scope under a non-root authority is the cohort relay — \
-             the pre-#499 broadcast, unchanged",
+            HoldingsScopeGate::projection_of(&CohortScope::Public, AccordCoScrub),
+            Projection::Global,
+            "federation scope under a TRUST ROOT reaches the whole federation — \
+             the cell the #744 authority seam exists to reach",
+        );
+    }
+
+    /// **Why the two halves are ONE change, as a checked fact.**
+    ///
+    /// On `Plane::FountainContent` the authority axis is read at exactly
+    /// one scope — `federation`. Every other scope arm ignores it. That is
+    /// what makes the seam and the recipient verb act on the SAME cell,
+    /// and it is asserted here rather than claimed in a comment: if
+    /// persist ever makes another scope authority-sensitive, this reds and
+    /// the `admits` reasoning must be revisited.
+    #[test]
+    fn authority_is_read_only_at_federation_scope() {
+        use AuthorityClass::{AccordCoScrub, ProducerSteward};
+        for scope in [
+            CohortScope::SelfOnly,
+            CohortScope::Family,
+            cohort("neighbourhood"),
+        ] {
+            assert_eq!(
+                HoldingsScopeGate::projection_of(&scope, ProducerSteward),
+                HoldingsScopeGate::projection_of(&scope, AccordCoScrub),
+                "{scope:?} must be authority-INSENSITIVE on this plane",
+            );
+        }
+        assert_ne!(
+            HoldingsScopeGate::projection_of(&CohortScope::Public, ProducerSteward),
+            HoldingsScopeGate::projection_of(&CohortScope::Public, AccordCoScrub),
+            "federation scope is the ONE authority-sensitive cell — if this ever \
+             stops being true, the seam has moved and `admits` must follow",
         );
     }
 
@@ -586,18 +955,225 @@ mod tests {
     /// A node with NO address table announces everything, including
     /// content whose scope is unknown AND content that is family-scoped.
     /// This is the pre-#499 deployment and it must not change.
-    #[test]
-    fn unarmed_gate_announces_everything() {
-        let g = HoldingsScopeGate::new(None);
+    #[tokio::test]
+    async fn unarmed_gate_announces_everything() {
+        let g = HoldingsScopeGate::new(None, None);
         assert!(!g.is_scope_native());
-        assert!(g.admits(None, OUTSIDER).is_announced());
-        assert!(g
-            .admits(Some(&ContentScope::Federation), OUTSIDER)
-            .is_announced());
-        assert!(g.admits(Some(&family_content()), OUTSIDER).is_announced());
-        assert!(g
-            .admits(Some(&community_content()), OUTSIDER)
-            .is_announced());
+        for publisher in [PIPELINE, PRESENTER, "nobody-at-all"] {
+            assert!(g.admits(publisher, None, OUTSIDER).await.is_announced());
+            assert!(g
+                .admits(publisher, Some(&ContentScope::Federation), OUTSIDER)
+                .await
+                .is_announced());
+            assert!(g
+                .admits(publisher, Some(&family_content()), OUTSIDER)
+                .await
+                .is_announced());
+            assert!(g
+                .admits(publisher, Some(&community_content()), OUTSIDER)
+                .await
+                .is_announced());
+        }
+    }
+
+    /// The unarmed path must be byte-identical WITH a directory wired as
+    /// without one: arming is table installation, and #744 must not have
+    /// turned a directory into a second arming condition. If the early
+    /// return were dropped, a directory-wired unarmed node would start
+    /// consulting persist and a plain producer's federation content would
+    /// go dark on a deployment that never opted in.
+    #[tokio::test]
+    async fn unarmed_path_is_identical_with_and_without_a_directory() {
+        let dir = directory().await;
+        let no_dir = HoldingsScopeGate::new(None, None);
+        let with_dir = HoldingsScopeGate::new(None, Some(dir));
+        for publisher in [PIPELINE, PRESENTER] {
+            for content in [
+                None,
+                Some(ContentScope::Federation),
+                Some(family_content()),
+                Some(community_content()),
+            ] {
+                let a = no_dir.admits(publisher, content.as_ref(), OUTSIDER).await;
+                let b = with_dir.admits(publisher, content.as_ref(), OUTSIDER).await;
+                assert_eq!(a, HoldingAnnounce::Announce, "unarmed must announce");
+                assert_eq!(a, b, "a directory must not arm the gate");
+            }
+        }
+    }
+
+    // ─── CIRISPersist#744: the two halves ─────────────────────────────
+
+    /// **THE HALF-LANDING GUARD.** Both assertions live in ONE test on
+    /// purpose: each catches a different half, so the test reds if either
+    /// is reverted alone.
+    ///
+    /// - Revert the SEAM (hard-code `ProducerSteward` again) and the first
+    ///   assertion reds: the trust root's federation corpus resolves
+    ///   `Cohort`, which at a commons tier has no roster table, so the
+    ///   verb answers `NoRosterForScope` and the canonical corpus goes
+    ///   DARK.
+    /// - Revert the VERB (restore `Global | Cohort => announce`) and the
+    ///   second assertion reds: the plain producer's `Cohort` is admitted
+    ///   as if it were `Global`, which is the widening the hand-map hid by
+    ///   treating "everyone" and "the cohort" as one answer.
+    ///
+    /// A comment cannot catch either. This can.
+    #[tokio::test]
+    async fn neither_half_alone_is_safe() {
+        let g = armed().await;
+
+        // HALF 1 needs HALF 2 to be reached honestly.
+        assert_eq!(
+            g.admits(PIPELINE, Some(&ContentScope::Federation), OUTSIDER)
+                .await,
+            HoldingAnnounce::Announce,
+            "a TRUST-ROOT publisher's federation corpus projects Global, which \
+             persist resolves as Unbounded — every peer is in the set. If this \
+             reds, the authority seam is gone and the verb is dark-failing the \
+             canonical corpus it exists to carry",
+        );
+
+        // HALF 2 needs HALF 1 to be more than a widening.
+        assert_eq!(
+            g.admits(PRESENTER, Some(&ContentScope::Federation), OUTSIDER)
+                .await,
+            HoldingAnnounce::Withhold(HoldingRefusal::RecipientSetUnresolved {
+                basis: "no_roster_for_scope",
+            }),
+            "a PLAIN producer's federation corpus projects Cohort, and persist \
+             holds no roster table for a commons tier — 'I cannot judge', which \
+             withholds. If this reds, the hand-rolled `Global | Cohort => \
+             announce` is back and `Global`'s unboundedness is invisible again",
+        );
+    }
+
+    /// The seam itself, exercised BOTH ways against persist's real
+    /// predicate — a trust root and a non-trust root, resolved from rows
+    /// admitted through persist's own gate.
+    ///
+    /// Distinct from the guard above: this pins the AUTHORITY resolution,
+    /// so a mutation that resolves `AccordCoScrub` for everybody (the
+    /// dangerous direction — a corpus conferring trust-root reach on
+    /// itself) reds here even though it would leave the guard's first
+    /// assertion green.
+    #[tokio::test]
+    async fn the_seam_resolves_both_classes_from_persists_own_state() {
+        let dir = directory().await;
+        assert_eq!(
+            holdings_authority(dir.as_ref(), PIPELINE).await.unwrap(),
+            AuthorityClass::AccordCoScrub,
+            "an accord-co-scrubbed infra:attest pipeline IS a trust root",
+        );
+        assert_eq!(
+            holdings_authority(dir.as_ref(), PRESENTER).await.unwrap(),
+            AuthorityClass::ProducerSteward,
+            "a plain node row must NOT resolve the class it could never \
+             self-declare",
+        );
+        assert_eq!(
+            holdings_authority(dir.as_ref(), "never-registered")
+                .await
+                .unwrap(),
+            AuthorityClass::ProducerSteward,
+            "an unknown publisher takes the negative default, which never \
+             widens a cell",
+        );
+    }
+
+    /// `set_resolvable == false` is *"I cannot judge"* and MUST book its
+    /// own reason, never the peer-not-in-set one. Reading `peer_in_set`
+    /// alone would report an admission of ignorance as an accusation.
+    #[tokio::test]
+    async fn cannot_judge_is_not_the_same_refusal_as_peer_not_in_set() {
+        let g = armed().await;
+
+        // Cannot judge: a commons tier has no roster table at all.
+        let cannot_judge = g
+            .admits(PRESENTER, Some(&ContentScope::Federation), OUTSIDER)
+            .await;
+        // Judged, and the peer is genuinely outside the resolved set.
+        let not_seated = g.admits(PRESENTER, Some(&family_content()), OUTSIDER).await;
+
+        assert!(!cannot_judge.is_announced() && !not_seated.is_announced());
+        let (HoldingAnnounce::Withhold(a), HoldingAnnounce::Withhold(b)) =
+            (&cannot_judge, &not_seated)
+        else {
+            unreachable!("both must be withholds")
+        };
+        assert_ne!(
+            a.withhold_reason(),
+            b.withhold_reason(),
+            "collapsing set_resolvable into peer_in_set reports 'I cannot \
+             judge' as 'you are not seated' — persist splits the struct \
+             precisely to stop that",
+        );
+        assert_eq!(
+            a.withhold_reason(),
+            WithholdReason::HoldingScopeRecipientSetUnresolved
+        );
+        assert_eq!(
+            b.withhold_reason(),
+            WithholdReason::HoldingScopePeerNotInRoster
+        );
+    }
+
+    /// The federation branch passes an EMPTY `group_key_id` because
+    /// persist provably never reads it there — `Global` returns
+    /// `Unbounded` and `Cohort` at a commons tier returns
+    /// `NoRosterForScope`, both before any roster leg. Pinned against
+    /// persist directly: if a future persist starts reading it, this reds
+    /// rather than the gate silently asking about a group named "".
+    #[tokio::test]
+    async fn federation_branch_never_reads_the_group_key_id() {
+        let dir = directory().await;
+        for authority in [
+            AuthorityClass::AccordCoScrub,
+            AuthorityClass::ProducerSteward,
+        ] {
+            let mut seen = Vec::new();
+            for group in ["", "fam-1", "cohort:neighbourhood", "utter-nonsense"] {
+                seen.push(
+                    resolve_projection_recipients(
+                        dir.as_ref(),
+                        Plane::FountainContent,
+                        cohort_scope::FEDERATION,
+                        authority,
+                        false,
+                        group,
+                        OUTSIDER,
+                    )
+                    .await
+                    .unwrap(),
+                );
+            }
+            assert!(
+                seen.windows(2).all(|w| w[0] == w[1]),
+                "federation-scope verdicts must not vary with group_key_id \
+                 under {authority:?}, got {seen:?}",
+            );
+        }
+    }
+
+    /// An ARMED node with no directory cannot ask either verb, and must
+    /// say so — NOT fall back to the pre-#744 hard-coded authority, which
+    /// would restore the defect invisibly.
+    #[tokio::test]
+    async fn armed_without_a_directory_fails_closed_and_names_the_wiring() {
+        let g = HoldingsScopeGate::new(Some(table()), None);
+        assert!(g.is_scope_native());
+        assert_eq!(
+            g.admits(PIPELINE, Some(&ContentScope::Federation), BOB)
+                .await,
+            HoldingAnnounce::Withhold(HoldingRefusal::DirectoryMissing),
+            "a trust root's corpus must NOT be announced on an unwired node \
+             just because the old const would have admitted it",
+        );
+        // …and a family member is refused for the WIRING, not for the roster.
+        assert_eq!(
+            g.admits(PIPELINE, Some(&family_content()), BOB).await,
+            HoldingAnnounce::Withhold(HoldingRefusal::DirectoryMissing),
+        );
     }
 
     // ─── Armed: the leak closes, and only where it should ─────────────
@@ -605,25 +1181,31 @@ mod tests {
     /// THE test: a family-scoped holding is withheld from a peer outside
     /// the family, AND a federation-scoped one to the SAME peer still
     /// goes — so this cannot pass by announcing nothing.
-    #[test]
-    fn family_holding_withheld_from_outsider_while_federation_still_flows() {
-        let g = armed();
+    #[tokio::test]
+    async fn family_holding_withheld_from_outsider_while_federation_still_flows() {
+        let g = armed().await;
         assert_eq!(
-            g.admits(Some(&family_content()), OUTSIDER),
+            g.admits(PIPELINE, Some(&family_content()), OUTSIDER).await,
             HoldingAnnounce::Withhold(HoldingRefusal::PeerNotInRoster {
                 content_kind: "family",
                 projection: "self_own",
             }),
         );
         assert!(
-            g.admits(Some(&ContentScope::Federation), OUTSIDER)
+            g.admits(PIPELINE, Some(&ContentScope::Federation), OUTSIDER)
+                .await
                 .is_announced(),
             "a federation-scoped holding must still reach the same peer — \
-             otherwise this suite passes by broadcasting nothing",
+             otherwise this suite passes by broadcasting nothing. Note the \
+             publisher must now be a TRUST ROOT for this to hold: under a \
+             plain producer persist projects Cohort at a commons tier and \
+             withholds (CIRISPersist#744)",
         );
         // …and the family member still learns of it.
         assert!(
-            g.admits(Some(&family_content()), BOB).is_announced(),
+            g.admits(PIPELINE, Some(&family_content()), BOB)
+                .await
+                .is_announced(),
             "a family MEMBER must still be told; withholding from everyone \
              is not the fix",
         );
@@ -632,44 +1214,60 @@ mod tests {
     /// The community half of the same leak: persist projects `Cohort`,
     /// which persist defines as "the members of ITS roster" — not every
     /// peer the publisher happens to hold.
-    #[test]
-    fn community_holding_withheld_from_non_member() {
-        let g = armed();
+    #[tokio::test]
+    async fn community_holding_withheld_from_non_member() {
+        let g = armed().await;
         assert_eq!(
-            g.admits(Some(&community_content()), OUTSIDER),
+            g.admits(PIPELINE, Some(&community_content()), OUTSIDER)
+                .await,
             HoldingAnnounce::Withhold(HoldingRefusal::PeerNotInRoster {
                 content_kind: "cohort",
                 projection: "cohort",
             }),
         );
-        assert!(g.admits(Some(&community_content()), ALICE).is_announced());
+        assert!(g
+            .admits(PIPELINE, Some(&community_content()), ALICE)
+            .await
+            .is_announced());
     }
 
     /// Possession of the FAMILY roster says nothing about the COMMUNITY
     /// one and vice versa: membership is resolved per (scope, group), so a
     /// member of one group is not admitted to another group's holdings.
-    #[test]
-    fn membership_does_not_cross_groups() {
+    #[tokio::test]
+    async fn membership_does_not_cross_groups() {
         let t = ScopeAddressTable::new(Arc::new(StubDeriver));
         t.install_group(&CohortScope::Family, "fam-1", 1, &[0xA1; 32], &[ALICE])
             .expect("family install");
         t.install_group(&cohort("neighbourhood"), "com-1", 1, &[0xB2; 32], &[BOB])
             .expect("community install");
-        let g = HoldingsScopeGate::new(Some(Arc::new(t)));
+        let g = HoldingsScopeGate::new(Some(Arc::new(t)), Some(directory().await));
         // alice is family-only, bob is community-only.
-        assert!(g.admits(Some(&family_content()), ALICE).is_announced());
-        assert!(!g.admits(Some(&family_content()), BOB).is_announced());
-        assert!(g.admits(Some(&community_content()), BOB).is_announced());
-        assert!(!g.admits(Some(&community_content()), ALICE).is_announced());
+        assert!(g
+            .admits(PIPELINE, Some(&family_content()), ALICE)
+            .await
+            .is_announced());
+        assert!(!g
+            .admits(PIPELINE, Some(&family_content()), BOB)
+            .await
+            .is_announced());
+        assert!(g
+            .admits(PIPELINE, Some(&community_content()), BOB)
+            .await
+            .is_announced());
+        assert!(!g
+            .admits(PIPELINE, Some(&community_content()), ALICE)
+            .await
+            .is_announced());
     }
 
     /// Unknown scope on a scope-native node is refused, with the branch's
     /// own named reason — never read as public.
-    #[test]
-    fn unknown_scope_is_refused_not_defaulted_public() {
-        let g = armed();
+    #[tokio::test]
+    async fn unknown_scope_is_refused_not_defaulted_public() {
+        let g = armed().await;
         assert_eq!(
-            g.admits(None, BOB),
+            g.admits(PIPELINE, None, BOB).await,
             HoldingAnnounce::Withhold(HoldingRefusal::ScopeUndeterminable),
         );
         assert_eq!(
@@ -680,52 +1278,68 @@ mod tests {
 
     /// A group declared at Public scope is a contradiction, refused before
     /// any roster lookup — and NOT folded into `PeerNotInRoster`.
-    #[test]
-    fn group_at_public_scope_is_its_own_refusal() {
-        let g = armed();
+    #[tokio::test]
+    async fn group_at_public_scope_is_its_own_refusal() {
+        let g = armed().await;
         let bogus = ContentScope::Group {
             scope: CohortScope::Public,
             group_id: "fam-1".to_owned(),
         };
         assert_eq!(
-            g.admits(Some(&bogus), ALICE),
+            g.admits(PIPELINE, Some(&bogus), ALICE).await,
+            HoldingAnnounce::Withhold(HoldingRefusal::PublicIsNotScoped),
+        );
+        // A contradiction is a contradiction regardless of wiring: it is
+        // refused BEFORE the directory is consulted, so an unwired node
+        // still names the declaration rather than the missing directory.
+        let unwired = HoldingsScopeGate::new(Some(table()), None);
+        assert_eq!(
+            unwired.admits(PIPELINE, Some(&bogus), ALICE).await,
             HoldingAnnounce::Withhold(HoldingRefusal::PublicIsNotScoped),
         );
     }
 
     /// A member excluded at a rotation seal loses the holding announcement
     /// — the roster is read live, not cached.
-    #[test]
-    fn removed_member_stops_being_announced_to() {
+    #[tokio::test]
+    async fn removed_member_stops_being_announced_to() {
         let t = ScopeAddressTable::new(Arc::new(StubDeriver));
         t.install_group(&CohortScope::Family, "fam-1", 1, &[0xA1; 32], &[ALICE, BOB])
             .expect("family install");
         let t = Arc::new(t);
-        let g = HoldingsScopeGate::new(Some(Arc::clone(&t)));
-        assert!(g.admits(Some(&family_content()), BOB).is_announced());
+        let g = HoldingsScopeGate::new(Some(Arc::clone(&t)), Some(directory().await));
+        assert!(g
+            .admits(PIPELINE, Some(&family_content()), BOB)
+            .await
+            .is_announced());
         t.remove_member(&CohortScope::Family, "fam-1", BOB);
         assert!(
-            !g.admits(Some(&family_content()), BOB).is_announced(),
+            !g.admits(PIPELINE, Some(&family_content()), BOB)
+                .await
+                .is_announced(),
             "the roster must be read per-decision, never cached",
         );
     }
 
     /// Content naming a group the table has never heard of is withheld —
     /// fail-closed, not "no group means everyone".
-    #[test]
-    fn unknown_group_is_withheld() {
-        let g = armed();
+    #[tokio::test]
+    async fn unknown_group_is_withheld() {
+        let g = armed().await;
         let ghost = ContentScope::Group {
             scope: CohortScope::Family,
             group_id: "fam-does-not-exist".to_owned(),
         };
-        assert!(!g.admits(Some(&ghost), ALICE).is_announced());
+        assert!(!g.admits(PIPELINE, Some(&ghost), ALICE).await.is_announced());
     }
 
     // ─── The refusal taxonomy is a taxonomy ───────────────────────────
 
-    /// #433: one reason per branch. Four branches, four distinct
-    /// `WithholdReason`s, four distinct labels.
+    /// #433: one reason per branch. Every branch a distinct
+    /// `WithholdReason` and a distinct label — including the four
+    /// CIRISPersist#744 arms, and in particular `RecipientSetUnresolved`
+    /// ("I cannot judge") never colliding with `PeerNotInRoster`
+    /// ("judged, not seated").
     #[test]
     fn every_refusal_branch_has_its_own_named_reason() {
         let all = [
@@ -738,6 +1352,12 @@ mod tests {
             HoldingRefusal::ProjectionUnsupported {
                 projection: "subject",
             },
+            HoldingRefusal::DirectoryMissing,
+            HoldingRefusal::AuthorityUnresolved,
+            HoldingRefusal::RecipientSetUnresolved {
+                basis: "no_roster_for_scope",
+            },
+            HoldingRefusal::RecipientReadError,
         ];
         let tags: std::collections::BTreeSet<&str> =
             all.iter().map(HoldingRefusal::reason_tag).collect();
@@ -754,16 +1374,78 @@ mod tests {
         }
     }
 
+    /// Persist's three "cannot judge" causes stay distinguishable in the
+    /// booked record even though they share one `WithholdReason` — the
+    /// basis tag is the payload, so an operator is still sent to the right
+    /// place. Also pins that no basis tag collides.
+    #[test]
+    fn the_cannot_judge_bases_stay_distinguishable() {
+        let tags: std::collections::BTreeSet<&str> = [
+            RecipientBasis::OwnRoster,
+            RecipientBasis::CohortRoster,
+            RecipientBasis::Unbounded,
+            RecipientBasis::NoRosterForScope,
+            RecipientBasis::GroupUnresolvable,
+            RecipientBasis::NotRosterKeyed,
+        ]
+        .into_iter()
+        .map(basis_tag)
+        .collect();
+        assert_eq!(tags.len(), 6, "basis tags must not collide");
+        assert!(
+            HoldingRefusal::RecipientSetUnresolved {
+                basis: "group_unresolvable",
+            }
+            .to_string()
+            .contains("group_unresolvable"),
+            "the cause persist named must reach the operator",
+        );
+    }
+
+    /// Every `WithholdReason` this module can book is attributed to a CI
+    /// parameter, and the two publisher-side arms are attributed to
+    /// SENDER — not defaulted to Recipient. The gate cannot establish its
+    /// own publisher's standing in those branches, which is a sender
+    /// question even though it reads like infrastructure.
+    #[test]
+    fn holdings_refusals_are_attributed_to_the_right_ci_parameter() {
+        use crate::contextual_integrity::{parameter_of, CiParameter};
+        assert_eq!(
+            parameter_of(WithholdReason::HoldingScopeAuthorityUnresolved),
+            CiParameter::Sender,
+        );
+        assert_eq!(
+            parameter_of(WithholdReason::HoldingScopeDirectoryMissing),
+            CiParameter::Sender,
+        );
+        assert_eq!(
+            parameter_of(WithholdReason::HoldingScopeRecipientSetUnresolved),
+            CiParameter::Recipient,
+        );
+        assert_eq!(
+            parameter_of(WithholdReason::HoldingScopeRecipientReadError),
+            CiParameter::Recipient,
+        );
+    }
+
     // ─── Booking: a withhold is an event, not a non-event ─────────────
 
     /// `admit_and_book` books BEFORE returning, so an ignored return value
     /// still leaves a counted, attributed event.
-    #[test]
-    fn withholds_are_booked_on_the_ledger() {
+    #[tokio::test]
+    async fn withholds_are_booked_on_the_ledger() {
         let metrics = EdgeMetrics::default();
-        let pg = HoldingsPublishGate::new(Some(table()), Some(metrics.clone()));
-        let _ = pg.admit_and_book("c-secret", Some(&family_content()), OUTSIDER);
-        let _ = pg.admit_and_book("c-unknown", None, OUTSIDER);
+        let pg = HoldingsPublishGate::new(
+            Some(table()),
+            Some(directory().await),
+            Some(metrics.clone()),
+        );
+        let _ = pg
+            .admit_and_book(PIPELINE, "c-secret", Some(&family_content()), OUTSIDER)
+            .await;
+        let _ = pg
+            .admit_and_book(PIPELINE, "c-unknown", None, OUTSIDER)
+            .await;
         assert_eq!(
             metrics.withholds(WithholdReason::HoldingScopePeerNotInRoster),
             1
@@ -783,12 +1465,22 @@ mod tests {
 
     /// An ANNOUNCE books nothing — the ledger must distinguish a
     /// withholding node from a working one.
-    #[test]
-    fn announces_book_nothing() {
+    #[tokio::test]
+    async fn announces_book_nothing() {
         let metrics = EdgeMetrics::default();
-        let pg = HoldingsPublishGate::new(Some(table()), Some(metrics.clone()));
-        let _ = pg.admit_and_book("c-pub", Some(&ContentScope::Federation), OUTSIDER);
-        let _ = pg.admit_and_book("c-fam", Some(&family_content()), BOB);
+        let pg = HoldingsPublishGate::new(
+            Some(table()),
+            Some(directory().await),
+            Some(metrics.clone()),
+        );
+        // A TRUST-ROOT publisher: federation content reaches everyone,
+        // family content reaches the family member.
+        let _ = pg
+            .admit_and_book(PIPELINE, "c-pub", Some(&ContentScope::Federation), OUTSIDER)
+            .await;
+        let _ = pg
+            .admit_and_book(PIPELINE, "c-fam", Some(&family_content()), BOB)
+            .await;
         assert!(metrics.snapshot().withholds_by_reason.is_empty());
     }
 

--- a/src/swarm/scope.rs
+++ b/src/swarm/scope.rs
@@ -1,0 +1,802 @@
+//! Scope-aware fountain **holdings publication** (CIRISEdge#499).
+//!
+//! # The defect this closes
+//!
+//! Before this module the swarm publisher
+//! ([`run_publisher`](super::runtime::FountainSwarmRuntime)) walked every
+//! held `content_id` returned by
+//! [`FountainHoldingsSource::list_held_fountain_content`] and broadcast a
+//! signed [`FountainHoldingClaim`] — the `content_id` **and its
+//! `symbol_ids`** — to every peer a caller-supplied
+//! `Fn() -> Vec<String>` returned. There was no entitlement filter of any
+//! kind. A family-scoped or community-scoped holding was announced,
+//! unprompted, to peers with no business knowing it exists.
+//!
+//! That is a wider disclosure than the fetch path
+//! [`crate::blob_swarm::scope`] closes one plane over: a fetch discloses
+//! to one asker who at least had to ask, a holdings broadcast discloses to
+//! everyone on a timer. Per <https://ciris.ai/contextual-integrity/>,
+//! *"I hold this content"* is itself a flow — publishing it to the wrong
+//! cohort is a violation even though **no content bytes move**. The
+//! `symbol_ids` make it worse, not better: they are a per-content
+//! fingerprint that lets an observer correlate holdings across ticks.
+//!
+//! # Whose rule is whose
+//!
+//! This module invents **no** projection policy. It is a two-input join:
+//!
+//! - **persist owns the projection.** `Plane::FountainContent` is one of
+//!   persist's five planes and
+//!   [`projection_for`]`(Plane::FountainContent, cohort_scope, authority,
+//!   is_tombstone)` answers exactly the question "who may learn this?"
+//!   Edge's replication bridge already calls it on the advertise sweep
+//!   (`FederationDirectoryReplicationBridge::attestation_projection`); the
+//!   swarm publisher is performing an advertise by another name and was
+//!   the one advertise path skipping it.
+//! - **the host owns the content's scope.** Edge never infers what scope a
+//!   fountain content lives in — that is the persist-backed consumer's
+//!   classification, surfaced through
+//!   [`FountainHoldingsSource::content_scope`], exactly as
+//!   [`BlobChunkSource::chunk_scope`](crate::blob_swarm::BlobChunkSource::chunk_scope)
+//!   surfaces a blob's. `None` means **UNKNOWN**, never *public*.
+//! - **edge owns the per-recipient MECHANISM.** persist's [`Projection`]
+//!   names an audience *kind* (`Global` commons gossip / `Cohort`
+//!   hold-and-forward over the record's roster / `SelfOwn`
+//!   structurally-invisible publish-own); resolving "is THIS peer in that
+//!   audience" is the consumer tier's, and edge's existing resolver for a
+//!   scope roster is [`ScopeAddressTable::send_address`] — a peer holds a
+//!   derived address in a group iff it is a member at a live epoch. That
+//!   is the same membership fact
+//!   [`ScopeRouteRefusal::HolderNotInGroup`](crate::blob_swarm::ScopeRouteRefusal::HolderNotInGroup)
+//!   already rides, reused rather than re-derived.
+//!
+//! # Fail-closed, and the exact shape of "closed"
+//!
+//! [`HoldingAnnounce`] is `#[must_use]` and its refusal arm carries a
+//! named [`HoldingRefusal`] which maps to a
+//! [`WithholdReason`] — the #433 ledger, the #425 choke-point pattern.
+//! There is no arm that refuses silently and no arm a caller can drop on
+//! the floor: [`HoldingsPublishGate::admit_and_book`] books the withhold
+//! **before** it returns the refusal, so a caller that ignores the value
+//! still leaves a counted, attributed event behind.
+//!
+//! **But fail-closed is armed, not unconditional.** The whole gate is
+//! gated on whether a [`ScopeAddressTable`] is installed
+//! ([`HoldingsScopeGate::is_scope_native`]) — the identical arming
+//! condition [`BlobScopeRouter::is_scope_native`] uses, and for the
+//! identical reason. A deployment with no table has no scope roster to
+//! resolve anyone against, so a gate over it could only refuse
+//! everything; it therefore behaves **byte-identically to pre-#499**:
+//! every held content announced to every cohort peer. Refusing every
+//! holding on a node that cannot resolve a roster would not be
+//! fail-closed, it would be fail-broken.
+//!
+//! [`FountainHoldingsSource::list_held_fountain_content`]: super::FountainHoldingsSource::list_held_fountain_content
+//! [`FountainHoldingsSource::content_scope`]: super::FountainHoldingsSource::content_scope
+//! [`FountainHoldingClaim`]: crate::holonomic::swarm_rarity::FountainHoldingClaim
+//! [`BlobScopeRouter::is_scope_native`]: crate::blob_swarm::BlobScopeRouter::is_scope_native
+
+use std::sync::Arc;
+
+use ciris_persist::federation::namespace::{projection_for, AuthorityClass, Plane, Projection};
+use ciris_persist::federation::types::cohort_scope;
+
+use crate::blob_swarm::ContentScope;
+use crate::cohort_scope::CohortScope;
+use crate::observability::{EdgeMetrics, WithholdReason};
+use crate::scope_addressing::ScopeAddressTable;
+
+/// The [`AuthorityClass`] the holdings gate feeds `projection_for`.
+///
+/// **The negative default, deliberately.** `projection_for`'s authority
+/// axis is a property of the CONTENT's provenance (an accord-co-scrubbed
+/// canonical corpus vs. a plain producer's), and nothing on the holdings
+/// seam carries it: [`HeldFountainContent`](super::HeldFountainContent)
+/// has `content_id` / `corpus_kind` / `symbol_ids`, and mapping
+/// `corpus_kind` onto a trust-root class would be edge inventing an
+/// authority rule persist owns. So the gate asserts the class it can
+/// honestly assert — a plain producer/steward — which on
+/// [`Plane::FountainContent`] resolves `Cohort` where a trust root would
+/// resolve `Global`. Both admit the broadcast today, so the conservative
+/// choice costs nothing and stays correct if persist ever narrows
+/// `Cohort`.
+///
+/// Reported upstream as the one input this plane needs and no edge seam
+/// supplies.
+pub const HOLDING_AUTHORITY: AuthorityClass = AuthorityClass::ProducerSteward;
+
+/// Edge's [`CohortScope`] → persist's `cohort_scope` string token.
+///
+/// **Not a new mapping.** It is the exact mapping
+/// [`CohortScope::crypto_tier`] already performs against persist's
+/// 7-value lattice (`Public` → `federation`, `SelfOnly` → `self`,
+/// `Family` → `family`, `Cohort{..}` → `community`), lifted so the
+/// projection axis and the crypto-tier axis cannot drift to two answers
+/// for one scope. The tokens come from persist's own consts, never a
+/// string literal.
+fn persist_scope_token(scope: &CohortScope) -> &'static str {
+    match scope {
+        CohortScope::Public => cohort_scope::FEDERATION,
+        CohortScope::SelfOnly => cohort_scope::SELF,
+        CohortScope::Family => cohort_scope::FAMILY,
+        CohortScope::Cohort { .. } => cohort_scope::COMMUNITY,
+    }
+}
+
+/// Stable low-cardinality tag for a [`Projection`] — for logs and the
+/// bounded withhold record. Never carries a capability token's value.
+fn projection_tag(projection: Projection) -> &'static str {
+    match projection {
+        Projection::Global => "global",
+        Projection::Cohort => "cohort",
+        Projection::SelfOwn => "self_own",
+        Projection::Capability(_) => "capability",
+        Projection::Subject => "subject",
+    }
+}
+
+/// Why a holdings claim was NOT announced to a peer.
+///
+/// Each variant is ONE code branch, per the CIRISEdge#433 rule that a
+/// refusal reason is the BRANCH and never a disjunction — folding "I
+/// cannot tell what this content is" into "you are not on its roster"
+/// would send an operator to fix a membership list when the actual remedy
+/// is to wire [`FountainHoldingsSource::content_scope`](super::FountainHoldingsSource::content_scope).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HoldingRefusal {
+    /// The host could not determine the content's scope on a node that IS
+    /// scope-native. Refused rather than defaulted: "unclassified means
+    /// public" is the single most expensive default this stack could
+    /// adopt, and it is not edge's to choose — `content_scope`'s `None`
+    /// means *unknown*, not *public*.
+    ScopeUndeterminable,
+    /// The host declared [`ContentScope::Group`] at a `Public` cohort
+    /// scope. Refused for the same reason
+    /// [`ScopeRouteRefusal::PublicIsNotScoped`](crate::blob_swarm::ScopeRouteRefusal::PublicIsNotScoped)
+    /// is: a private roster paired with "public" is a contradiction, not
+    /// a configuration. Public content is [`ContentScope::Federation`].
+    PublicIsNotScoped,
+    /// The projection bounds this record to its OWN roster
+    /// ([`Projection::Cohort`] over a named group, or the
+    /// structurally-invisible [`Projection::SelfOwn`]) and this peer holds
+    /// no derived address in that group — not a member at any live epoch,
+    /// or excluded at a rotation seal. **This is the leak closing.**
+    PeerNotInRoster {
+        /// [`CohortScope::kind_token`] of the content's scope.
+        content_kind: &'static str,
+        /// Stable low-cardinality tag of the projection that bound the
+        /// audience (`cohort` / `self_own`).
+        projection: &'static str,
+    },
+    /// `projection_for` named an audience kind this gate has no mechanism
+    /// to resolve to a peer set on this plane — today
+    /// [`Projection::Capability`] / [`Projection::Subject`] (role-keyed
+    /// and subject-keyed audiences that `Plane::FountainContent` has no
+    /// cell for), or a `SelfOwn` record that names no roster to be
+    /// invisible within.
+    ///
+    /// Structurally unreachable against persist v37's table; booked
+    /// fail-closed anyway so a future persist widening surfaces as a NAMED
+    /// withhold instead of as an allow.
+    ProjectionUnsupported {
+        /// Stable low-cardinality tag of the projection edge cannot
+        /// resolve (`capability` / `subject`).
+        projection: &'static str,
+    },
+}
+
+impl HoldingRefusal {
+    /// Stable, low-cardinality tag for log throttling and metric detail.
+    /// Never contains a peer id, a content id or a group id — those ride
+    /// the bounded record, not the label (unbounded label cardinality
+    /// explodes downstream metric storage).
+    #[must_use]
+    pub const fn reason_tag(&self) -> &'static str {
+        match self {
+            Self::ScopeUndeterminable => "holding_scope_undeterminable",
+            Self::PublicIsNotScoped => "holding_scope_public_group",
+            Self::PeerNotInRoster { .. } => "holding_scope_peer_not_in_roster",
+            Self::ProjectionUnsupported { .. } => "holding_scope_projection_unsupported",
+        }
+    }
+
+    /// The withhold-ledger reason for this branch (CIRISEdge#433).
+    #[must_use]
+    pub const fn withhold_reason(&self) -> WithholdReason {
+        match self {
+            Self::ScopeUndeterminable => WithholdReason::HoldingScopeUndeterminable,
+            Self::PublicIsNotScoped => WithholdReason::HoldingScopePublicGroup,
+            Self::PeerNotInRoster { .. } => WithholdReason::HoldingScopePeerNotInRoster,
+            Self::ProjectionUnsupported { .. } => WithholdReason::HoldingScopeProjectionUnsupported,
+        }
+    }
+}
+
+impl std::fmt::Display for HoldingRefusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ScopeUndeterminable => f.write_str(
+                "fountain holding scope is UNDETERMINABLE and this node is scope-native \
+                 — refusing to announce the holding (and its symbol_ids) to anyone. Wire \
+                 FountainHoldingsSource::content_scope; a None answer is never read as \
+                 Public (CIRISEdge#499)",
+            ),
+            Self::PublicIsNotScoped => f.write_str(
+                "fountain holding declared a scope GROUP at Public scope — a private \
+                 roster is not a public audience; public content must be declared \
+                 ContentScope::Federation (CIRISEdge#499)",
+            ),
+            Self::PeerNotInRoster {
+                content_kind,
+                projection,
+            } => write!(
+                f,
+                "fountain holding is scoped '{content_kind}' and projects '{projection}' \
+                 (audience = the record's own roster); this peer holds no derived address \
+                 in that group at any live epoch, so it is not told the holding exists \
+                 (CIRISEdge#499)"
+            ),
+            Self::ProjectionUnsupported { projection } => write!(
+                f,
+                "fountain holding projects '{projection}', an audience kind this gate has \
+                 no peer-set mechanism for on Plane::FountainContent — refusing \
+                 fail-closed rather than guessing the audience (CIRISEdge#499)"
+            ),
+        }
+    }
+}
+
+/// Whether a holdings claim may be announced to one peer.
+///
+/// `#[must_use]` with a payload-carrying refusal arm, mirroring
+/// [`ServeAdmission`](crate::blob_swarm::ServeAdmission) and
+/// [`ApplyOutcome`](crate::replication::summary::ApplyOutcome)
+/// (CIRISEdge#425): the publisher cannot drop this on the floor, and a
+/// refusal always arrives with a named reason to book and log. A bare
+/// `bool` would have made "withheld" and "withheld for a reason nobody
+/// can see" the same value — the exact silent-refusal class #423–#429
+/// spent four cuts removing.
+#[must_use = "a holding admission carries a refusal reason the publisher must book and log — do not drop it"]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HoldingAnnounce {
+    /// Announce the holding to this peer.
+    Announce,
+    /// Do not announce; book and log this reason.
+    Withhold(HoldingRefusal),
+}
+
+impl HoldingAnnounce {
+    /// `true` iff the holding may be announced to this peer.
+    #[must_use]
+    pub fn is_announced(&self) -> bool {
+        matches!(self, Self::Announce)
+    }
+}
+
+/// Resolves whether a held content's scope admits announcing it to a
+/// given peer.
+///
+/// Holds only the address table (a pure lookup structure) — it cannot
+/// send, so it cannot be the place a publish decision leaks into the
+/// transport. Every method is synchronous and takes no lock across
+/// anything: the table's own methods are synchronous by design
+/// (CIRISEdge#217 — a guard held across an `.await` on a publish path is
+/// what produced the real hangs), and this type adds no state of its own.
+#[derive(Clone, Default)]
+pub struct HoldingsScopeGate {
+    table: Option<Arc<ScopeAddressTable>>,
+}
+
+impl HoldingsScopeGate {
+    /// A gate over an installed table. `None` — the production state
+    /// until the MLS exporter label is specified upstream — yields a gate
+    /// that announces everything, i.e. exactly pre-#499 behaviour.
+    #[must_use]
+    pub fn new(table: Option<Arc<ScopeAddressTable>>) -> Self {
+        Self { table }
+    }
+
+    /// `true` iff a [`ScopeAddressTable`] is installed, i.e. iff this node
+    /// can resolve a scope roster at all.
+    ///
+    /// THE arming condition. A deployment fact, not a policy knob: a node
+    /// with no table has no roster to resolve any peer against, so a gate
+    /// over it could only ever refuse everything.
+    #[must_use]
+    pub fn is_scope_native(&self) -> bool {
+        self.table.is_some()
+    }
+
+    /// The projection persist resolves for `scope` on
+    /// [`Plane::FountainContent`]. Exposed so the pin test reads the real
+    /// table rather than a copy of it — the #636 lesson that a gate must
+    /// see the table itself.
+    #[must_use]
+    pub fn projection_of(scope: &CohortScope) -> Projection {
+        projection_for(
+            Plane::FountainContent,
+            persist_scope_token(scope),
+            HOLDING_AUTHORITY,
+            // A holdings claim is a live claim about what this node
+            // currently retains. It is never a tombstone: there is no
+            // "un-holding" record on this plane — a dropped holding is
+            // expressed by the claim ceasing to be republished, which the
+            // runtime's TTL prune reads. Passing `true` here would raise
+            // every scoped holding to the anti-rollback ceiling.
+            false,
+        )
+    }
+
+    /// May a holdings claim for content scoped `content` be announced to
+    /// `peer_key_id`?
+    ///
+    /// `content` is the host's declaration
+    /// ([`FountainHoldingsSource::content_scope`](super::FountainHoldingsSource::content_scope)),
+    /// or `None` when it could not be determined.
+    ///
+    /// # Arming
+    ///
+    /// `is_scope_native() == false` ⇒ [`HoldingAnnounce::Announce`]
+    /// unconditionally, with no table probe and no log. See the module
+    /// docs: additive, not disruptive.
+    pub fn admits(&self, content: Option<&ContentScope>, peer_key_id: &str) -> HoldingAnnounce {
+        let Some(table) = self.table.as_ref() else {
+            return HoldingAnnounce::Announce;
+        };
+
+        let Some(content) = content else {
+            return HoldingAnnounce::Withhold(HoldingRefusal::ScopeUndeterminable);
+        };
+
+        // Resolve the projection PER RECORD from the record's real scope
+        // — never from a cached assumption, the discipline `bridge.rs`
+        // holds on the attestation plane.
+        let content_scope = content.cohort_scope();
+        let projection = Self::projection_of(content_scope);
+
+        match content {
+            // Federation/public content: the record names no roster, so
+            // its audience is the node's own cohort — which is precisely
+            // the peer set the publisher was handed. Byte-identical to
+            // pre-#499 for `Global` (trust-root commons gossip) and
+            // `Cohort` (hold-and-forward for non-root commons content)
+            // alike.
+            ContentScope::Federation => match projection {
+                Projection::Global | Projection::Cohort => HoldingAnnounce::Announce,
+                other => HoldingAnnounce::Withhold(HoldingRefusal::ProjectionUnsupported {
+                    projection: projection_tag(other),
+                }),
+            },
+            ContentScope::Group { scope, group_id } => {
+                // A private roster at Public scope is a contradiction, not
+                // a configuration — refused before any lookup, exactly as
+                // the blob router refuses it on the send side.
+                if matches!(scope, CohortScope::Public) {
+                    return HoldingAnnounce::Withhold(HoldingRefusal::PublicIsNotScoped);
+                }
+                match projection {
+                    // Commons gossip — the record reaches the whole
+                    // federation regardless of roster. Unreachable under
+                    // `HOLDING_AUTHORITY`; kept exhaustive so a future
+                    // authority input is a one-line change, not a rewrite.
+                    Projection::Global => HoldingAnnounce::Announce,
+                    // `Cohort` — persist: "the record relays to the members
+                    // of ITS community/affiliations roster". `SelfOwn` —
+                    // persist: publish-own, "the structurally-invisible
+                    // identity plane". Both bound the audience to the
+                    // record's OWN roster; edge's resolver for that roster
+                    // is the address table's membership, one hash-map probe
+                    // and no derivation.
+                    Projection::Cohort | Projection::SelfOwn => {
+                        if table.send_address(scope, group_id, peer_key_id).is_some() {
+                            HoldingAnnounce::Announce
+                        } else {
+                            HoldingAnnounce::Withhold(HoldingRefusal::PeerNotInRoster {
+                                content_kind: scope.kind_token(),
+                                projection: projection_tag(projection),
+                            })
+                        }
+                    }
+                    other => HoldingAnnounce::Withhold(HoldingRefusal::ProjectionUnsupported {
+                        projection: projection_tag(other),
+                    }),
+                }
+            }
+        }
+    }
+}
+
+/// The publisher-side choke point: decide **and book**.
+///
+/// Pairs the pure [`HoldingsScopeGate`] with the CIRISEdge#433 withhold
+/// ledger so the publisher has exactly one call to make and no way to
+/// refuse silently — [`Self::admit_and_book`] increments the counter and
+/// pushes the attribution record BEFORE it returns the refusal. A caller
+/// that ignores the returned value still leaves a counted, attributed,
+/// logged event behind, which is the property #433 exists to guarantee
+/// (a withholding node must not report what an idle node reports).
+#[derive(Clone, Default)]
+pub struct HoldingsPublishGate {
+    gate: HoldingsScopeGate,
+    metrics: Option<EdgeMetrics>,
+}
+
+impl HoldingsPublishGate {
+    /// Construct from the runtime's optional address table and optional
+    /// metrics handle. Both `None` is the pre-#499 deployment: the gate
+    /// admits everything and books nothing.
+    #[must_use]
+    pub fn new(table: Option<Arc<ScopeAddressTable>>, metrics: Option<EdgeMetrics>) -> Self {
+        Self {
+            gate: HoldingsScopeGate::new(table),
+            metrics,
+        }
+    }
+
+    /// `true` iff the gate is armed (a [`ScopeAddressTable`] is installed).
+    #[must_use]
+    pub fn is_scope_native(&self) -> bool {
+        self.gate.is_scope_native()
+    }
+
+    /// Decide whether `content_id` (scoped `content`) may be announced to
+    /// `peer_key_id`, booking + logging any withhold before returning it.
+    ///
+    /// Synchronous and lock-free across suspension points: the only guard
+    /// taken is inside [`ScopeAddressTable::send_address`], released
+    /// before this returns, so no guard can be held across the publisher's
+    /// subsequent `.await` on the transport (CIRISEdge#217).
+    pub fn admit_and_book(
+        &self,
+        content_id: &str,
+        content: Option<&ContentScope>,
+        peer_key_id: &str,
+    ) -> HoldingAnnounce {
+        let verdict = self.gate.admits(content, peer_key_id);
+        if let HoldingAnnounce::Withhold(refusal) = &verdict {
+            if let Some(m) = self.metrics.as_ref() {
+                m.inc_withhold(
+                    refusal.withhold_reason(),
+                    peer_key_id,
+                    &withhold_detail(content_id),
+                );
+            }
+            tracing::warn!(
+                peer = %peer_key_id,
+                content_id = %content_id,
+                reason = refusal.reason_tag(),
+                "swarm_runtime.publisher: holding WITHHELD — {refusal}",
+            );
+        }
+        verdict
+    }
+}
+
+/// The short, low-cardinality `detail` for a holdings withhold: the plane
+/// tag plus a bounded content-id prefix. Mirrors the bridge's
+/// `withhold_detail` (kind + 8-byte hash prefix) — the ring is an
+/// attribution window, not a log sink, so its entries stay bounded in size
+/// as well as in count.
+fn withhold_detail(content_id: &str) -> String {
+    let prefix: String = content_id.chars().take(16).collect();
+    format!("fountain:{prefix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scope_addressing::StubDeriver;
+
+    const ALICE: &str = "ed25519:alice";
+    const BOB: &str = "ed25519:bob";
+    const OUTSIDER: &str = "ed25519:mallory";
+
+    fn cohort(id: &str) -> CohortScope {
+        CohortScope::Cohort {
+            cohort_id: id.to_owned(),
+        }
+    }
+
+    /// One family group `fam-1` and one community group `com-1`, each
+    /// holding alice + bob. `mallory` is in NEITHER.
+    fn table() -> Arc<ScopeAddressTable> {
+        let t = ScopeAddressTable::new(Arc::new(StubDeriver));
+        t.install_group(&CohortScope::Family, "fam-1", 1, &[0xA1; 32], &[ALICE, BOB])
+            .expect("family install");
+        t.install_group(
+            &cohort("neighbourhood"),
+            "com-1",
+            1,
+            &[0xB2; 32],
+            &[ALICE, BOB],
+        )
+        .expect("community install");
+        Arc::new(t)
+    }
+
+    fn armed() -> HoldingsScopeGate {
+        HoldingsScopeGate::new(Some(table()))
+    }
+
+    fn family_content() -> ContentScope {
+        ContentScope::Group {
+            scope: CohortScope::Family,
+            group_id: "fam-1".to_owned(),
+        }
+    }
+
+    fn community_content() -> ContentScope {
+        ContentScope::Group {
+            scope: cohort("neighbourhood"),
+            group_id: "com-1".to_owned(),
+        }
+    }
+
+    // ─── The projection is persist's, and this reads the real table ───
+
+    /// The load-bearing pin: what `Plane::FountainContent` projects for
+    /// each scope token edge can produce. If persist re-decides a cell,
+    /// this reds HERE rather than silently changing who learns what.
+    #[test]
+    fn persist_owns_the_fountain_content_projection() {
+        assert_eq!(
+            HoldingsScopeGate::projection_of(&CohortScope::SelfOnly),
+            Projection::SelfOwn,
+            "self scope must be structurally invisible",
+        );
+        assert_eq!(
+            HoldingsScopeGate::projection_of(&CohortScope::Family),
+            Projection::SelfOwn,
+            "family scope must be structurally invisible",
+        );
+        assert_eq!(
+            HoldingsScopeGate::projection_of(&cohort("neighbourhood")),
+            Projection::Cohort,
+            "community scope relays over ITS OWN roster, not the federation cohort",
+        );
+        assert_eq!(
+            HoldingsScopeGate::projection_of(&CohortScope::Public),
+            Projection::Cohort,
+            "federation scope under a non-root authority is the cohort relay — \
+             the pre-#499 broadcast, unchanged",
+        );
+    }
+
+    /// The scope-token map is persist's lattice, not a literal table of
+    /// edge's own — pinned against persist's consts.
+    #[test]
+    fn scope_tokens_come_from_persists_lattice() {
+        assert_eq!(
+            persist_scope_token(&CohortScope::Public),
+            cohort_scope::FEDERATION
+        );
+        assert_eq!(
+            persist_scope_token(&CohortScope::SelfOnly),
+            cohort_scope::SELF
+        );
+        assert_eq!(
+            persist_scope_token(&CohortScope::Family),
+            cohort_scope::FAMILY
+        );
+        assert_eq!(persist_scope_token(&cohort("x")), cohort_scope::COMMUNITY);
+    }
+
+    // ─── Arming: the no-regression case ───────────────────────────────
+
+    /// A node with NO address table announces everything, including
+    /// content whose scope is unknown AND content that is family-scoped.
+    /// This is the pre-#499 deployment and it must not change.
+    #[test]
+    fn unarmed_gate_announces_everything() {
+        let g = HoldingsScopeGate::new(None);
+        assert!(!g.is_scope_native());
+        assert!(g.admits(None, OUTSIDER).is_announced());
+        assert!(g
+            .admits(Some(&ContentScope::Federation), OUTSIDER)
+            .is_announced());
+        assert!(g.admits(Some(&family_content()), OUTSIDER).is_announced());
+        assert!(g
+            .admits(Some(&community_content()), OUTSIDER)
+            .is_announced());
+    }
+
+    // ─── Armed: the leak closes, and only where it should ─────────────
+
+    /// THE test: a family-scoped holding is withheld from a peer outside
+    /// the family, AND a federation-scoped one to the SAME peer still
+    /// goes — so this cannot pass by announcing nothing.
+    #[test]
+    fn family_holding_withheld_from_outsider_while_federation_still_flows() {
+        let g = armed();
+        assert_eq!(
+            g.admits(Some(&family_content()), OUTSIDER),
+            HoldingAnnounce::Withhold(HoldingRefusal::PeerNotInRoster {
+                content_kind: "family",
+                projection: "self_own",
+            }),
+        );
+        assert!(
+            g.admits(Some(&ContentScope::Federation), OUTSIDER)
+                .is_announced(),
+            "a federation-scoped holding must still reach the same peer — \
+             otherwise this suite passes by broadcasting nothing",
+        );
+        // …and the family member still learns of it.
+        assert!(
+            g.admits(Some(&family_content()), BOB).is_announced(),
+            "a family MEMBER must still be told; withholding from everyone \
+             is not the fix",
+        );
+    }
+
+    /// The community half of the same leak: persist projects `Cohort`,
+    /// which persist defines as "the members of ITS roster" — not every
+    /// peer the publisher happens to hold.
+    #[test]
+    fn community_holding_withheld_from_non_member() {
+        let g = armed();
+        assert_eq!(
+            g.admits(Some(&community_content()), OUTSIDER),
+            HoldingAnnounce::Withhold(HoldingRefusal::PeerNotInRoster {
+                content_kind: "cohort",
+                projection: "cohort",
+            }),
+        );
+        assert!(g.admits(Some(&community_content()), ALICE).is_announced());
+    }
+
+    /// Possession of the FAMILY roster says nothing about the COMMUNITY
+    /// one and vice versa: membership is resolved per (scope, group), so a
+    /// member of one group is not admitted to another group's holdings.
+    #[test]
+    fn membership_does_not_cross_groups() {
+        let t = ScopeAddressTable::new(Arc::new(StubDeriver));
+        t.install_group(&CohortScope::Family, "fam-1", 1, &[0xA1; 32], &[ALICE])
+            .expect("family install");
+        t.install_group(&cohort("neighbourhood"), "com-1", 1, &[0xB2; 32], &[BOB])
+            .expect("community install");
+        let g = HoldingsScopeGate::new(Some(Arc::new(t)));
+        // alice is family-only, bob is community-only.
+        assert!(g.admits(Some(&family_content()), ALICE).is_announced());
+        assert!(!g.admits(Some(&family_content()), BOB).is_announced());
+        assert!(g.admits(Some(&community_content()), BOB).is_announced());
+        assert!(!g.admits(Some(&community_content()), ALICE).is_announced());
+    }
+
+    /// Unknown scope on a scope-native node is refused, with the branch's
+    /// own named reason — never read as public.
+    #[test]
+    fn unknown_scope_is_refused_not_defaulted_public() {
+        let g = armed();
+        assert_eq!(
+            g.admits(None, BOB),
+            HoldingAnnounce::Withhold(HoldingRefusal::ScopeUndeterminable),
+        );
+        assert_eq!(
+            HoldingRefusal::ScopeUndeterminable.withhold_reason(),
+            WithholdReason::HoldingScopeUndeterminable,
+        );
+    }
+
+    /// A group declared at Public scope is a contradiction, refused before
+    /// any roster lookup — and NOT folded into `PeerNotInRoster`.
+    #[test]
+    fn group_at_public_scope_is_its_own_refusal() {
+        let g = armed();
+        let bogus = ContentScope::Group {
+            scope: CohortScope::Public,
+            group_id: "fam-1".to_owned(),
+        };
+        assert_eq!(
+            g.admits(Some(&bogus), ALICE),
+            HoldingAnnounce::Withhold(HoldingRefusal::PublicIsNotScoped),
+        );
+    }
+
+    /// A member excluded at a rotation seal loses the holding announcement
+    /// — the roster is read live, not cached.
+    #[test]
+    fn removed_member_stops_being_announced_to() {
+        let t = ScopeAddressTable::new(Arc::new(StubDeriver));
+        t.install_group(&CohortScope::Family, "fam-1", 1, &[0xA1; 32], &[ALICE, BOB])
+            .expect("family install");
+        let t = Arc::new(t);
+        let g = HoldingsScopeGate::new(Some(Arc::clone(&t)));
+        assert!(g.admits(Some(&family_content()), BOB).is_announced());
+        t.remove_member(&CohortScope::Family, "fam-1", BOB);
+        assert!(
+            !g.admits(Some(&family_content()), BOB).is_announced(),
+            "the roster must be read per-decision, never cached",
+        );
+    }
+
+    /// Content naming a group the table has never heard of is withheld —
+    /// fail-closed, not "no group means everyone".
+    #[test]
+    fn unknown_group_is_withheld() {
+        let g = armed();
+        let ghost = ContentScope::Group {
+            scope: CohortScope::Family,
+            group_id: "fam-does-not-exist".to_owned(),
+        };
+        assert!(!g.admits(Some(&ghost), ALICE).is_announced());
+    }
+
+    // ─── The refusal taxonomy is a taxonomy ───────────────────────────
+
+    /// #433: one reason per branch. Four branches, four distinct
+    /// `WithholdReason`s, four distinct labels.
+    #[test]
+    fn every_refusal_branch_has_its_own_named_reason() {
+        let all = [
+            HoldingRefusal::ScopeUndeterminable,
+            HoldingRefusal::PublicIsNotScoped,
+            HoldingRefusal::PeerNotInRoster {
+                content_kind: "family",
+                projection: "self_own",
+            },
+            HoldingRefusal::ProjectionUnsupported {
+                projection: "subject",
+            },
+        ];
+        let tags: std::collections::BTreeSet<&str> =
+            all.iter().map(HoldingRefusal::reason_tag).collect();
+        assert_eq!(tags.len(), all.len(), "reason tags must not collide");
+        let reasons: std::collections::BTreeSet<WithholdReason> =
+            all.iter().map(HoldingRefusal::withhold_reason).collect();
+        assert_eq!(
+            reasons.len(),
+            all.len(),
+            "withhold reasons must not collide"
+        );
+        for r in &all {
+            assert!(!r.to_string().is_empty(), "every refusal must say why");
+        }
+    }
+
+    // ─── Booking: a withhold is an event, not a non-event ─────────────
+
+    /// `admit_and_book` books BEFORE returning, so an ignored return value
+    /// still leaves a counted, attributed event.
+    #[test]
+    fn withholds_are_booked_on_the_ledger() {
+        let metrics = EdgeMetrics::default();
+        let pg = HoldingsPublishGate::new(Some(table()), Some(metrics.clone()));
+        let _ = pg.admit_and_book("c-secret", Some(&family_content()), OUTSIDER);
+        let _ = pg.admit_and_book("c-unknown", None, OUTSIDER);
+        assert_eq!(
+            metrics.withholds(WithholdReason::HoldingScopePeerNotInRoster),
+            1
+        );
+        assert_eq!(
+            metrics.withholds(WithholdReason::HoldingScopeUndeterminable),
+            1
+        );
+        let snap = metrics.snapshot();
+        assert!(
+            snap.recent_withholds
+                .iter()
+                .any(|w| w.peer_key_id == OUTSIDER && w.detail.starts_with("fountain:")),
+            "the attribution ring must name the peer and the content",
+        );
+    }
+
+    /// An ANNOUNCE books nothing — the ledger must distinguish a
+    /// withholding node from a working one.
+    #[test]
+    fn announces_book_nothing() {
+        let metrics = EdgeMetrics::default();
+        let pg = HoldingsPublishGate::new(Some(table()), Some(metrics.clone()));
+        let _ = pg.admit_and_book("c-pub", Some(&ContentScope::Federation), OUTSIDER);
+        let _ = pg.admit_and_book("c-fam", Some(&family_content()), BOB);
+        assert!(metrics.snapshot().withholds_by_reason.is_empty());
+    }
+
+    /// The detail string stays bounded regardless of content-id length.
+    #[test]
+    fn withhold_detail_is_bounded() {
+        let long = "c".repeat(4096);
+        let d = withhold_detail(&long);
+        assert_eq!(d, format!("fountain:{}", "c".repeat(16)));
+    }
+}

--- a/src/transport/av_spine.rs
+++ b/src/transport/av_spine.rs
@@ -1,0 +1,1234 @@
+//! The A/V spine — the runtime that drives ONE call from join to media
+//! to heal (CIRISEdge#499 / the A/V-mesh flagship).
+//!
+//! # What was missing
+//!
+//! Every piece of a call already existed and was unit-tested: the MLS
+//! group ([`AvSession`]), the media roles ([`AvPublisher`], [`AvRelay`],
+//! [`AvSubscriber`]), the SFU roster + address-rotation window
+//! ([`RelayNode`]), the derived-address table
+//! ([`ScopeAddressTable`]), and the lifecycle that keeps the table and
+//! the transport in step ([`ScopeLifecycle`]). Nothing *sequenced* them,
+//! and the gap had a specific shape:
+//!
+//! **An epoch advance moved the keys and left the addresses behind.**
+//! Every roster change re-derives every member's scoped address, because
+//! the address is a function of the MLS epoch secret. [`AvPublisher`]'s
+//! `admit_joiner` / `advance_epoch` roll the epoch and rotate the DEK —
+//! and that is all they do. The lifecycle was never advanced, so this
+//! node kept listening on an address no peer derives any more; the
+//! relay's answerable window was never advanced, so it kept answering on
+//! an address the table would no longer attribute. Neither half errors.
+//! An RNS destination nobody registered is simply never delivered to,
+//! and the call goes quiet with a clean log.
+//!
+//! # The shape
+//!
+//! [`AvSpine`] owns the three objects that must move together — the
+//! publisher (which owns the session), the relay, and a handle to the
+//! lifecycle — and exposes the call's verbs. Because it owns them, the
+//! *only* way to advance a call's epoch is through a verb that
+//! re-addresses it:
+//!
+//! ```text
+//!   open      install the session's addresses; the relay is BORN at the
+//!             installed address (it is never constructible at another)
+//!   join      admit → MLS epoch → re-address → move the relay window
+//!   subscribe a roster member becomes a relay subscriber
+//!   publish   inner-seal ONCE → RelayNode::forward + the publisher's links
+//!   heal      a dropped subscriber is re-admitted, pruned, or evicted
+//!             (an eviction re-addresses, like any other epoch move)
+//!   seal      the convergence window closes BOTH make-before-break
+//!             windows on one deadline
+//! ```
+//!
+//! ## Where the epoch-advance hook lives, and why here
+//!
+//! Not inside [`AvPublisher::advance_epoch`]. That verb is the MLS +
+//! DEK move and is legitimately used with no addressing plane at all — a
+//! subscriber applying a Commit, a test, a caller whose transport is
+//! HTTP. Wiring the lifecycle into it would make every such caller carry
+//! a `ScopeLifecycle` it has no use for, and would still not move the
+//! relay window (not every node running a session relays it).
+//!
+//! So the hook is here, at the one place that holds all three, and the
+//! stranding is closed *structurally* rather than by discipline: the
+//! spine takes `AvPublisher` **by value** and hands back only `&`. Once
+//! a call is inside a spine, `advance_epoch` is unreachable, so an epoch
+//! cannot move without its addresses.
+//!
+//! ## Atomic from the caller's point of view
+//!
+//! An MLS commit cannot be un-committed, so "atomic" here means: the
+//! caller never observes a state where the two address planes disagree.
+//! The relay's window moves **only after, and only if,** the lifecycle
+//! advance succeeded. If the advance fails, the relay is left exactly
+//! where it was, so its answerable set still equals the table's
+//! accept-set — the call is *degraded* (it serves what is live and
+//! refuses to grow), never *half-live* (answering at an address nothing
+//! attributes). The degradation is a named, queryable state
+//! ([`StrandedEpoch`]), not a log line.
+//!
+//! ## Make-before-break, and what a rotation must never do
+//!
+//! A [`DestinationHash`] is used to *dial* and to *listen*, never per
+//! chunk, and an established link is keyed by `LinkId`. Live links
+//! therefore survive a rotation by construction, and the spine does not
+//! touch them: `publish` after a rotation fans to the same relay
+//! subscribers, on the same transit keys, with the same `link_seq`
+//! counters. Retirement stops NEW dials at the superseded address; it is
+//! deliberately not a link sweep.
+//!
+//! ## The relay never holds plaintext
+//!
+//! [`RelayNode`] has no [`EpochDek`] field and nothing reachable from it
+//! does. The spine preserves that: it hands the relay an
+//! [`InnerSealed`] — ciphertext under the epoch DEK — and the DEK itself
+//! stays inside [`AvPublisher`]. `seal_next` runs on the publisher;
+//! `forward` runs on the relay; the boundary between them is the one
+//! this module is careful never to blur.
+//!
+//! [`EpochDek`]: super::realtime_av::EpochDek
+//!
+//! ## Locks and time (CIRISEdge#217)
+//!
+//! The spine holds **no locks at all**. Every verb takes `&mut self`, so
+//! its state is reached by exclusive ownership and there is no guard in
+//! existence to hold across an `.await`. That is the structural form of
+//! the invariant, not an audited absence of one.
+//!
+//! Timing is likewise structural: no verb reads a clock. Every verb that
+//! can close a convergence window takes `now: std::time::Instant` from
+//! the caller, so the spine's deadline arithmetic is monotonic,
+//! deterministic under test, and cannot reach a runtime timer. The spine
+//! owns *what* seals and *when it is due*; the caller owns only what
+//! time it is.
+//!
+//! ## The seal cadence
+//!
+//! [`ScopeLifecycle::seal_due`] is timing-driven and, before this
+//! module, nothing called it — a superseded address stayed routable
+//! forever. The spine drives it two ways, and neither needs a timer for
+//! a call that is carrying media:
+//!
+//! 1. **Every verb seals first.** `join`, `subscribe`, `publish` and
+//!    `heal` open by closing any window that is due. A live call
+//!    publishes continuously, so the cadence rides the traffic that
+//!    makes it necessary.
+//! 2. **[`AvSpine::seal_deadline`]** is the single value an idle call's
+//!    host loop must wait on. It is `None` when nothing is pending.
+//!
+//! Both halves close on ONE deadline: [`AvSpine::seal_due`] drops the
+//! relay's superseded address on exactly the signal that dropped the
+//! table's superseded epoch ([`ScopeLifecycle::seal_group_due`]), so the
+//! two windows cannot end at different moments.
+//!
+//! [`AvSession`]: super::realtime_av_session::AvSession
+//! [`AvRelay`]: super::realtime_av_runtime::AvRelay
+//! [`AvSubscriber`]: super::realtime_av_runtime::AvSubscriber
+//! [`ScopeAddressTable`]: crate::scope_addressing::ScopeAddressTable
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use leviculum_core::DestinationHash;
+use leviculum_std::driver::ReticulumNode;
+
+use crate::av_addressing::{self, AvAddressError};
+use crate::cohort_scope::CohortScope;
+use crate::scope_addressing::MemberAddress;
+use crate::scope_lifecycle::{ScopeLifecycle, ScopeLifecycleError};
+
+use super::federation_session::PeerKexPubkeys;
+use super::realtime_av::{
+    ChunkLayer, ChunkSeq, Epoch, InnerSealed, ReceiverLayerPolicy, StreamId, CODEC_OPAQUE,
+};
+use super::realtime_av_dispatcher::AvSubscriberLink;
+use super::realtime_av_relay::{PeerKeyId, RelayError, RelayForwardOut, RelayNode};
+use super::realtime_av_runtime::{AvPublisher, AvRuntimeError};
+use super::realtime_av_session::RosterDelta;
+use ciris_crypto::MlDsa65Signer;
+
+// ─── errors ─────────────────────────────────────────────────────────
+
+/// An MLS epoch that moved without its scoped addresses.
+///
+/// The call is **degraded**: live links keep running (a link is keyed by
+/// `LinkId`, so a rotation never cut them), and both address planes
+/// still agree with each other — but this node is not listening at the
+/// live epoch's address, so nothing NEW can reach it. Verbs that would
+/// grow the call's reachability refuse while this is set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StrandedEpoch {
+    /// The MLS epoch the session reached.
+    pub epoch: u64,
+    /// Why its addresses did not follow.
+    pub reason: String,
+}
+
+/// Why a spine verb refused.
+#[derive(Debug, thiserror::Error)]
+pub enum AvSpineError {
+    /// The media / MLS tier refused (seal, dispatch, rekey, ALM).
+    #[error("A/V runtime: {0}")]
+    Runtime(#[from] AvRuntimeError),
+    /// The session's destination secret could not be derived.
+    #[error("session addressing: {0}")]
+    Addressing(#[from] AvAddressError),
+    /// The scope lifecycle refused the install or the advance.
+    #[error("scope lifecycle: {0}")]
+    Lifecycle(#[from] ScopeLifecycleError),
+    /// The relay refused a roster operation.
+    #[error("relay: {0}")]
+    Relay(#[from] RelayError),
+    /// The MLS epoch advanced and its addresses did not. The relay
+    /// window was deliberately NOT moved, so the two planes still agree;
+    /// see [`StrandedEpoch`].
+    #[error("epoch {} advanced without its scoped addresses ({}) — the call serves its live \
+             links but cannot be reached at the new epoch", .0.epoch, .0.reason)]
+    AddressStranded(StrandedEpoch),
+    /// A verb that would grow the call's reachability, refused because
+    /// the call is stranded. Growing a call nobody can dial into would
+    /// hand out addresses that answer nowhere.
+    #[error("{verb} refused: the call is stranded at epoch {} ({})", .stranded.epoch, .stranded.reason)]
+    Stranded {
+        /// The verb that refused.
+        verb: &'static str,
+        /// The state it refused in.
+        stranded: StrandedEpoch,
+    },
+    /// A peer that is not in the MLS roster cannot be a subscriber: it
+    /// holds no epoch DEK, so every chunk forwarded to it is a chunk it
+    /// cannot open, and the relay would be spending fan-out on a peer
+    /// the group never admitted.
+    #[error("{0} is not a member of this call — admit it via join before subscribing it")]
+    NotAMember(PeerKeyId),
+    /// A relay verb on a node that does not relay this stream.
+    #[error("this node does not relay stream {0:?} — open the spine with a relay node")]
+    NoRelay(StreamId),
+}
+
+// ─── outcomes ───────────────────────────────────────────────────────
+
+/// What an address move did. Returned inside every verb that advances an
+/// epoch, so a caller can assert on the move rather than infer it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub struct Readdressed {
+    /// The epoch now live for sending.
+    pub epoch: u64,
+    /// Addresses derived for this epoch (one per member).
+    pub derived: usize,
+    /// This node's address at `epoch` — registered, and the relay's new
+    /// send address when this node relays.
+    pub own_address: MemberAddress,
+    /// Whether the relay's answerable window moved with it. `false` only
+    /// when this node does not relay the stream.
+    pub relay_window_moved: bool,
+    /// An address pushed out of the relay's answerable window EARLY,
+    /// because a second rotation landed inside one convergence window
+    /// (three people joining a call in five minutes does it). The relay
+    /// holds one superseded address, so the oldest leaves; a peer still
+    /// dialling it re-dials at the live epoch. Reported rather than
+    /// asserted away — the table reports the same eviction as
+    /// `EpochTransition::evicted`.
+    pub relay_evicted_early: Option<[u8; 16]>,
+}
+
+/// Everything a joiner needs to enter the call, plus the proof its
+/// admission moved the addresses.
+#[derive(Debug)]
+#[must_use]
+pub struct JoinTicket {
+    /// The admitted member.
+    pub joiner: PeerKeyId,
+    /// The epoch its admission created.
+    pub epoch: Epoch,
+    /// MLS Commit — for the members already in the call.
+    pub commit_bytes: Vec<u8>,
+    /// MLS Welcome — for the joiner. Carries the inviter's ML-DSA-65
+    /// signature (CIRISEdge#331), so the joiner verifies who admitted it
+    /// directory-only, with no TOFU.
+    pub welcome_bytes: Vec<u8>,
+    /// Where the joiner dials to reach this node at the new epoch. When
+    /// this node relays the stream, this is also the relay's send
+    /// address — the two are the same value by construction, not by
+    /// convention.
+    pub dial_address: MemberAddress,
+    /// The address the joiner will present at this epoch, derived here
+    /// so this node can dial it. The joiner derives the same bytes from
+    /// its own session (RFC 9420 §8.5 makes the exporter epoch-
+    /// deterministic); nothing secret is disclosed by naming it.
+    pub joiner_address: Option<MemberAddress>,
+    /// The address move the admission performed.
+    pub readdressed: Readdressed,
+}
+
+/// A member registered on the relay's roster for this stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub struct Subscribed {
+    /// The subscriber.
+    pub subscriber: PeerKeyId,
+    /// The epoch it subscribed at.
+    pub epoch: Epoch,
+    /// The relay address it dials.
+    pub dial_address: MemberAddress,
+    /// Relay subscribers on this stream after the registration.
+    pub roster: usize,
+}
+
+/// One fan-out leg's result. A leg's failure is reported, never allowed
+/// to cancel the other leg's delivery (CIRISEdge#425 — no silent drop,
+/// and no silent *un*-drop either).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LegOutcome {
+    /// Nothing to do on this leg — no relay, or no links.
+    Idle,
+    /// Fanned to `reached` destinations.
+    Delivered {
+        /// Destinations the chunk reached.
+        reached: usize,
+    },
+    /// The leg failed. The chunk may have reached some destinations
+    /// before it did.
+    Failed {
+        /// Destinations reached before the failure, where the leg can
+        /// say. `RelayNode::forward` seals the whole roster or none of
+        /// it, so it is exact there; the publisher's dispatcher stops at
+        /// the first failing subscriber without reporting how many
+        /// preceded it, so it is `0` there and means "unknown, at least
+        /// one link did not get it" rather than "none did".
+        reached: usize,
+        /// The refusal, rendered.
+        error: String,
+    },
+}
+
+impl LegOutcome {
+    /// Destinations this leg reached.
+    #[must_use]
+    pub fn reached(&self) -> usize {
+        match self {
+            Self::Idle => 0,
+            Self::Delivered { reached } | Self::Failed { reached, .. } => *reached,
+        }
+    }
+
+    /// Whether this leg failed.
+    #[must_use]
+    pub fn failed(&self) -> bool {
+        matches!(self, Self::Failed { .. })
+    }
+}
+
+/// The result of publishing one chunk through the spine.
+///
+/// Both legs are reported because a chunk is inner-sealed ONCE and
+/// handed to both: returning `Err` on one leg's failure would silently
+/// discard the other leg's already-sealed wire bytes.
+#[derive(Debug)]
+#[must_use]
+pub struct Fanout {
+    /// The sequence the chunk was stamped with.
+    pub chunk_seq: ChunkSeq,
+    /// The epoch it was sealed under.
+    pub epoch: Epoch,
+    /// Wire-ready sealed bytes, one per ADMITTED relay subscriber, for
+    /// the caller's Layer-2 dispatch. Empty when this node does not
+    /// relay the stream.
+    pub relayed: Vec<RelayForwardOut>,
+    /// Relay subscribers whose layer policy withheld this chunk. The
+    /// relay skips them silently inside `forward`; the spine counts the
+    /// difference so a withheld chunk is a number rather than a
+    /// non-event (CIRISEdge#425).
+    pub relay_withheld: usize,
+    /// The relay leg.
+    pub relay: LegOutcome,
+    /// The publisher's own downstream links (the hop to a REMOTE relay,
+    /// when this node is not the relay).
+    pub direct: LegOutcome,
+    /// Set when the call is serving live links at a superseded epoch.
+    pub stranded: Option<StrandedEpoch>,
+    /// Any convergence window this publish closed on its way in.
+    pub sealed: SpineSeal,
+}
+
+/// Why a dropped subscriber was pruned rather than re-admitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PruneReason {
+    /// It is no longer in the MLS roster, so there is nothing to
+    /// re-admit it to — it holds no epoch DEK.
+    NotAMember,
+    /// The caller classified the drop as recoverable but offered no
+    /// re-dial material, so the relay cannot re-key the hop.
+    NoRedialOffered,
+}
+
+/// How the caller classified a subscriber's disappearance.
+///
+/// The spine does **not** infer this. Whether a dropped link is a
+/// transient fault or a departure is a policy question — how many
+/// consecutive failures, over what window, count as gone — and neither
+/// CIRISPersist nor CIRISVerify supplies that rule, so edge must not
+/// invent one. The caller classifies; the spine executes, and each
+/// classification has exactly one correct convergence.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DropCause {
+    /// The hop failed but the peer is still on the call. Re-key the hop;
+    /// do NOT move the epoch (a rekey per flaky link would churn every
+    /// member's address for one peer's Wi-Fi).
+    LinkFailure,
+    /// The peer left. Forward secrecy requires it out of the MLS group,
+    /// which moves the epoch and therefore the addresses.
+    Departed,
+}
+
+/// Re-dial material for a [`DropCause::LinkFailure`] heal.
+pub struct Redial {
+    /// The freshly-KEX'd per-(subscriber, stream) transit key. A re-dial
+    /// is a new link, so it is a new transit key; re-using the old one
+    /// across a re-dial would restart a keystream under a used key.
+    pub transit_key: [u8; 32],
+    /// The subscriber's layer-admission cap on the new hop.
+    pub layer_policy: ReceiverLayerPolicy,
+}
+
+impl std::fmt::Debug for Redial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Redial")
+            .field("transit_key", &"<redacted>")
+            .field("layer_policy", &self.layer_policy)
+            .finish()
+    }
+}
+
+/// A subscriber that stopped receiving, and how the caller classified
+/// it.
+#[derive(Debug)]
+pub struct SubscriberDrop {
+    /// The subscriber that dropped.
+    pub subscriber: PeerKeyId,
+    /// The caller's classification.
+    pub cause: DropCause,
+    /// Re-dial material. Required to re-admit a
+    /// [`DropCause::LinkFailure`]; ignored for a departure.
+    pub redial: Option<Redial>,
+}
+
+/// How a drop converged. Every branch is named — a heal never ends in a
+/// bare `continue` (CIRISEdge#425).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub enum HealOutcome {
+    /// Re-keyed onto a fresh hop. The roster and the addresses did not
+    /// move: the peer never left, so nothing about the group changed.
+    Readmitted {
+        /// The re-admitted subscriber.
+        subscriber: PeerKeyId,
+        /// The epoch it rejoined at (unchanged).
+        epoch: Epoch,
+    },
+    /// Removed from the relay roster only. The MLS group is untouched
+    /// because the peer was already out of it (or never in it).
+    RosterPruned {
+        /// The pruned subscriber.
+        subscriber: PeerKeyId,
+        /// Why pruning was the right convergence.
+        reason: PruneReason,
+    },
+    /// Removed from the MLS group: the epoch advanced, every member's
+    /// address moved with it, and the seal is scheduled.
+    Evicted {
+        /// The evicted member.
+        subscriber: PeerKeyId,
+        /// Whether it was also on the relay roster.
+        was_subscribed: bool,
+        /// The address move the eviction performed.
+        readdressed: Readdressed,
+    },
+}
+
+/// What a seal pass closed. `Default` is "nothing was due".
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[must_use]
+pub struct SpineSeal {
+    /// The table dropped this group's superseded epoch.
+    pub sealed: bool,
+    /// The superseded destination could NOT be retired from the
+    /// transport — it stays routable despite being sealed. Zero in a
+    /// healthy deployment since leviculum#54; a `true` here is the
+    /// reachability-disclosure alarm.
+    pub unretired: bool,
+    /// The relay's superseded answerable address, dropped by this seal.
+    pub relay_retired: Option<[u8; 16]>,
+    /// The table refused the seal, so the relay's window was deliberately
+    /// left open too — closing one plane without the other is the drift
+    /// this whole module exists to prevent.
+    pub table_refused: bool,
+}
+
+/// A call's live state, for a health endpoint or a test.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+pub struct SpineHealth {
+    /// The stream.
+    pub stream_id: StreamId,
+    /// The live MLS epoch.
+    pub epoch: Epoch,
+    /// MLS roster size.
+    pub members: usize,
+    /// Relay subscribers on this stream.
+    pub relay_subscribers: usize,
+    /// This node's registered address at the live epoch.
+    pub own_address: [u8; 16],
+    /// Every address the relay currently answers on — one outside a
+    /// rotation window, two inside one. Empty when this node does not
+    /// relay.
+    pub relay_answers: Vec<[u8; 16]>,
+    /// Set when the call is serving live links at a superseded epoch.
+    pub stranded: Option<StrandedEpoch>,
+    /// When the pending convergence window closes, if one is open.
+    pub seal_deadline: Option<Instant>,
+}
+
+/// A joiner's admission material.
+pub struct Joiner<'a> {
+    /// The joiner's federation key id.
+    pub key_id: &'a str,
+    /// The KeyPackage it published to the federation directory.
+    pub key_package: openmls::prelude::KeyPackage,
+    /// Its advertised hybrid KEX pubkeys — the Welcome is wrapped to
+    /// these.
+    pub kex: &'a PeerKexPubkeys,
+    /// This node's long-term ML-DSA-65 federation signer. The Welcome
+    /// carries its signature so the joiner can prove who invited it
+    /// (CIRISEdge#331 / CC 5.4.4).
+    pub inviter_signer: &'a MlDsa65Signer,
+    /// This node's directory pk_id, so the joiner can resolve the key
+    /// that signature verifies against.
+    pub inviter_pk_id: &'a str,
+}
+
+// ─── the spine ──────────────────────────────────────────────────────
+
+/// One call's lifecycle: the publisher, the relay, and the addresses,
+/// driven together.
+///
+/// See the module head for the shape and the invariants. The type holds
+/// no locks and reads no clock.
+pub struct AvSpine {
+    scope: CohortScope,
+    group_id: String,
+    lifecycle: Arc<ScopeLifecycle>,
+    /// Owned by value: this is what makes `advance_epoch` unreachable
+    /// from outside, and therefore what makes an un-addressed epoch move
+    /// unrepresentable.
+    publisher: AvPublisher,
+    /// `None` when this node is on the call but does not relay it.
+    relay: Option<RelayNode>,
+    own_address: MemberAddress,
+    stranded: Option<StrandedEpoch>,
+}
+
+impl AvSpine {
+    /// Stand a call up: install the session's scoped addresses, and — if
+    /// this node relays the stream — mint the relay AT the installed
+    /// address.
+    ///
+    /// `relay_node` is the leviculum node the relay rides. The spine
+    /// constructs the [`RelayNode`] itself rather than taking one,
+    /// because a relay's address must be a derived, scope-native one
+    /// from its first instant: a relay built at some other address would
+    /// answer on a hash the table never installed, which is exactly the
+    /// disagreement this module exists to make impossible. Pass `None`
+    /// for a node that publishes or subscribes without relaying.
+    ///
+    /// # Errors
+    ///
+    /// [`AvSpineError::Addressing`] if the session's destination secret
+    /// cannot be derived; [`AvSpineError::Lifecycle`] if the table
+    /// refuses the install or the transport refuses to listen (in which
+    /// case the install is rolled back — the call is not created
+    /// half-live).
+    pub fn open(
+        scope: CohortScope,
+        lifecycle: Arc<ScopeLifecycle>,
+        publisher: AvPublisher,
+        relay_node: Option<Arc<ReticulumNode>>,
+    ) -> Result<Self, AvSpineError> {
+        let group_id = av_addressing::session_group_id(publisher.session());
+        let installed = {
+            let snapshot = av_addressing::snapshot(publisher.session())?;
+            lifecycle.install(&scope, &snapshot)?
+        };
+        let relay = relay_node.map(|node| {
+            RelayNode::new(
+                node,
+                DestinationHash::new(*installed.own_address.as_bytes()),
+            )
+        });
+        tracing::info!(
+            stream = ?publisher.stream_id(),
+            group = %group_id,
+            epoch = installed.epoch,
+            derived = installed.derived,
+            relays = relay.is_some(),
+            "AV spine: call opened — scoped addresses installed"
+        );
+        Ok(Self {
+            scope,
+            group_id,
+            lifecycle,
+            publisher,
+            relay,
+            own_address: installed.own_address,
+            stranded: None,
+        })
+    }
+
+    // ── reads ───────────────────────────────────────────────────────
+
+    /// The stream this spine drives.
+    #[must_use]
+    pub fn stream_id(&self) -> StreamId {
+        self.publisher.stream_id()
+    }
+
+    /// The live MLS epoch.
+    #[must_use]
+    pub fn epoch(&self) -> Epoch {
+        self.publisher.epoch()
+    }
+
+    /// This node's registered address at the live epoch.
+    #[must_use]
+    pub fn own_address(&self) -> &MemberAddress {
+        &self.own_address
+    }
+
+    /// The publisher, read-only. Deliberately no `&mut`: handing one out
+    /// would re-open `advance_epoch` and with it the un-addressed epoch
+    /// move this module closes.
+    #[must_use]
+    pub fn publisher(&self) -> &AvPublisher {
+        &self.publisher
+    }
+
+    /// The relay, read-only, when this node relays the stream.
+    #[must_use]
+    pub fn relay(&self) -> Option<&RelayNode> {
+        self.relay.as_ref()
+    }
+
+    /// The call's degraded state, if it has one.
+    #[must_use]
+    pub fn stranded(&self) -> Option<&StrandedEpoch> {
+        self.stranded.as_ref()
+    }
+
+    /// Whether `key_id` is in the call's MLS roster.
+    #[must_use]
+    pub fn is_member(&self, key_id: &str) -> bool {
+        self.publisher
+            .session()
+            .member_key_ids()
+            .iter()
+            .any(|m| m == key_id)
+    }
+
+    /// A snapshot of the call, for a health endpoint or an assertion.
+    pub fn health(&self) -> SpineHealth {
+        let stream_id = self.publisher.stream_id();
+        let relay_answers = self.relay.as_ref().map_or_else(Vec::new, |r| {
+            let mut answers = vec![*r.address().as_bytes()];
+            if let Some(sup) = r.superseded_address() {
+                answers.push(*sup.as_bytes());
+            }
+            answers
+        });
+        SpineHealth {
+            stream_id,
+            epoch: self.publisher.epoch(),
+            members: self.publisher.session().member_key_ids().len(),
+            relay_subscribers: self
+                .relay
+                .as_ref()
+                .map_or(0, |r| r.subscriber_count(stream_id)),
+            own_address: *self.own_address.as_bytes(),
+            relay_answers,
+            stranded: self.stranded.clone(),
+            seal_deadline: self.seal_deadline(),
+        }
+    }
+
+    // ── the seal cadence ────────────────────────────────────────────
+
+    /// When this call's pending convergence window closes, or `None`
+    /// when no rotation is pending.
+    ///
+    /// The one value an idle call's host loop needs to wait on. A call
+    /// that is carrying media never needs it: every verb seals first.
+    #[must_use]
+    pub fn seal_deadline(&self) -> Option<Instant> {
+        self.lifecycle.seal_deadline(&self.scope, &self.group_id)
+    }
+
+    /// Close this call's convergence window if it is due.
+    ///
+    /// Retires **exactly** the superseded address, on both planes, on one
+    /// deadline: the table's superseded epoch and the relay's superseded
+    /// answerable address are dropped together, because the relay's drop
+    /// is conditioned on the table's. The live address is never touched
+    /// — the relay's send address and the table's current epoch are not
+    /// part of what a seal removes.
+    ///
+    /// Idempotent, and cheap when nothing is due. Called at the head of
+    /// every other verb, so a caller normally never calls it directly.
+    pub fn seal_due(&mut self, now: Instant) -> SpineSeal {
+        let Some(table) = self
+            .lifecycle
+            .seal_group_due(&self.scope, &self.group_id, now)
+        else {
+            return SpineSeal::default();
+        };
+        if table.sealed == 0 {
+            // The table refused. Dropping the relay's superseded address
+            // now would leave the relay deaf at an epoch the table still
+            // attributes — the exact drift the lifecycle exists to
+            // prevent — so both windows stay open and say so.
+            tracing::warn!(
+                group = %self.group_id,
+                "AV spine seal: the table refused this group's seal, so the relay's \
+                 answerable window is deliberately left OPEN too — both planes stay at \
+                 the superseded epoch rather than disagreeing (CIRISEdge#499)"
+            );
+            return SpineSeal {
+                sealed: false,
+                unretired: table.unretired > 0,
+                relay_retired: None,
+                table_refused: true,
+            };
+        }
+        let relay_retired = self
+            .relay
+            .as_mut()
+            .and_then(RelayNode::seal_address_rotation)
+            .map(|d| *d.as_bytes());
+        tracing::info!(
+            group = %self.group_id,
+            unretired = table.unretired,
+            relay_retired = relay_retired.is_some(),
+            "AV spine seal: convergence window closed on both planes"
+        );
+        SpineSeal {
+            sealed: true,
+            unretired: table.unretired > 0,
+            relay_retired,
+            table_refused: false,
+        }
+    }
+
+    // ── join ────────────────────────────────────────────────────────
+
+    /// Admit a joiner, advance the epoch, re-address the call, and hand
+    /// back everything the joiner needs to dial in.
+    ///
+    /// The MLS add, the address move and the relay-window move are one
+    /// step from the caller's point of view: either the ticket names a
+    /// converged epoch, or the error names the degradation and the two
+    /// address planes still agree with each other.
+    ///
+    /// # Errors
+    ///
+    /// [`AvSpineError::Stranded`] when the call cannot currently be
+    /// reached at its live epoch — admitting a joiner would hand it an
+    /// address that answers nowhere. [`AvSpineError::Runtime`] if the
+    /// MLS add fails (it is refused before the epoch moves, e.g. a
+    /// joiner without ML-KEM-768). [`AvSpineError::AddressStranded`] if
+    /// the epoch moved but its addresses could not.
+    pub fn join(&mut self, joiner: Joiner<'_>, now: Instant) -> Result<JoinTicket, AvSpineError> {
+        let sealed = self.seal_due(now);
+        self.refuse_if_stranded("join")?;
+
+        let mut artifacts = self.publisher.admit_joiner(
+            joiner.key_id,
+            joiner.key_package,
+            joiner.kex,
+            joiner.inviter_signer,
+            joiner.inviter_pk_id,
+        )?;
+        // From here the MLS epoch HAS moved. `readdress` either moves both
+        // address planes with it or leaves both where they were.
+        let readdressed = self.readdress(now)?;
+
+        let welcome_bytes = if artifacts.welcome_bytes.is_empty() {
+            // An Add always emits exactly one Welcome; an empty vec would
+            // mean the joiner can never bootstrap, which is a refusal, not
+            // a quiet zero.
+            return Err(AvSpineError::AddressStranded(StrandedEpoch {
+                epoch: readdressed.epoch,
+                reason: format!("MLS emitted no Welcome for joiner {}", joiner.key_id),
+            }));
+        } else {
+            std::mem::take(&mut artifacts.welcome_bytes[0])
+        };
+
+        tracing::info!(
+            stream = ?self.publisher.stream_id(),
+            peer = %joiner.key_id,
+            epoch = readdressed.epoch,
+            derived = readdressed.derived,
+            relay_window_moved = readdressed.relay_window_moved,
+            sealed = sealed.sealed,
+            "AV spine JOIN: joiner admitted, epoch + addresses moved together"
+        );
+        Ok(JoinTicket {
+            joiner: joiner.key_id.to_owned(),
+            epoch: artifacts.new_epoch,
+            commit_bytes: std::mem::take(&mut artifacts.commit_bytes),
+            welcome_bytes,
+            dial_address: readdressed.own_address,
+            joiner_address: self.address_of(joiner.key_id, readdressed.epoch),
+            readdressed,
+        })
+    }
+
+    // ── subscribe ───────────────────────────────────────────────────
+
+    /// Register a call member as a downstream subscriber on this node's
+    /// relay.
+    ///
+    /// Narrowed to the MLS roster on purpose: a non-member holds no
+    /// epoch DEK, so every chunk the relay would seal for it is a chunk
+    /// it cannot open. Refusing here keeps fan-out spent only on peers
+    /// the group admitted.
+    ///
+    /// Idempotent on `subscriber` — re-subscribing replaces the transit
+    /// key and the layer policy, zeroizing the old key.
+    ///
+    /// # Errors
+    ///
+    /// [`AvSpineError::NoRelay`] if this node does not relay the stream;
+    /// [`AvSpineError::NotAMember`] if the peer is not on the call;
+    /// [`AvSpineError::Stranded`] if the call cannot be dialled at its
+    /// live epoch.
+    pub fn subscribe(
+        &mut self,
+        subscriber: &PeerKeyId,
+        transit_key: [u8; 32],
+        layer_policy: ReceiverLayerPolicy,
+        now: Instant,
+    ) -> Result<Subscribed, AvSpineError> {
+        let _sealed = self.seal_due(now);
+        self.refuse_if_stranded("subscribe")?;
+        if !self.is_member(subscriber) {
+            tracing::warn!(
+                stream = ?self.publisher.stream_id(),
+                peer = %subscriber,
+                "AV spine SUBSCRIBE refused: not in the call's MLS roster — it holds no \
+                 epoch DEK, so every forwarded chunk would be unopenable (CIRISEdge#425)"
+            );
+            return Err(AvSpineError::NotAMember(subscriber.clone()));
+        }
+        let stream_id = self.publisher.stream_id();
+        let epoch = self.publisher.epoch();
+        let dial_address = self.own_address;
+        let relay = self
+            .relay
+            .as_mut()
+            .ok_or(AvSpineError::NoRelay(stream_id))?;
+        relay.subscribe(stream_id, subscriber.clone(), transit_key, layer_policy)?;
+        let roster = relay.subscriber_count(stream_id);
+        tracing::info!(
+            stream = ?stream_id,
+            peer = %subscriber,
+            epoch = epoch.0,
+            roster,
+            "AV spine SUBSCRIBE: member registered on the relay roster"
+        );
+        Ok(Subscribed {
+            subscriber: subscriber.clone(),
+            epoch,
+            dial_address,
+            roster,
+        })
+    }
+
+    /// Attach a downstream link to the PUBLISHER's own dispatcher — the
+    /// hop toward a remote relay, for a node that publishes without
+    /// relaying.
+    ///
+    /// # Errors
+    ///
+    /// [`AvSpineError::Runtime`] if the dispatcher refuses the link.
+    pub fn attach_downstream(&mut self, link: AvSubscriberLink) -> Result<(), AvSpineError> {
+        self.publisher.add_subscriber(link)?;
+        Ok(())
+    }
+
+    /// Detach a downstream publisher link.
+    pub fn detach_downstream(&mut self, subscriber: &PeerKeyId) {
+        self.publisher.remove_subscriber(subscriber);
+    }
+
+    // ── relay / publish ─────────────────────────────────────────────
+
+    /// Inner-seal one opaque chunk and fan it through both legs.
+    ///
+    /// # Errors
+    ///
+    /// [`AvSpineError::Runtime`] if the inner seal fails — the only
+    /// failure that means nothing was emitted anywhere. A leg's failure
+    /// is reported in [`Fanout`], not raised, so one leg's refusal never
+    /// discards the other leg's already-sealed bytes.
+    pub async fn publish(
+        &mut self,
+        plaintext: &[u8],
+        now: Instant,
+    ) -> Result<Fanout, AvSpineError> {
+        self.publish_chunk(plaintext, CODEC_OPAQUE, ChunkLayer::BASE, now)
+            .await
+    }
+
+    /// Inner-seal one chunk under the live epoch DEK and fan the SAME
+    /// ciphertext through the relay roster ([`RelayNode::forward`]) and
+    /// the publisher's own links.
+    ///
+    /// One inner seal, two fan-outs — the CIRISEdge#122 shape. The relay
+    /// leg receives an [`InnerSealed`]: ciphertext under a DEK the relay
+    /// does not have and cannot reach.
+    ///
+    /// A rotation does not interrupt this. Subscribers keep their
+    /// transit keys and their `link_seq` counters across an epoch move,
+    /// because a live link is keyed by `LinkId` and was never dialled
+    /// again.
+    ///
+    /// # Errors
+    ///
+    /// [`AvSpineError::Runtime`] on inner-seal failure.
+    pub async fn publish_chunk(
+        &mut self,
+        plaintext: &[u8],
+        codec_id: u8,
+        layer: ChunkLayer,
+        now: Instant,
+    ) -> Result<Fanout, AvSpineError> {
+        let sealed = self.seal_due(now);
+        let (chunk_seq, inner) = self.publisher.seal_next(plaintext, codec_id, layer)?;
+        let stream_id = self.publisher.stream_id();
+
+        let (relayed, relay_withheld, relay) =
+            Self::forward_leg(self.relay.as_mut(), stream_id, &inner);
+
+        // `inner` moves into the dispatcher here. Nothing borrowed from
+        // `self.relay` is alive across this await — the relay leg is
+        // fully resolved into owned values above (CIRISEdge#217).
+        let direct = match self.publisher.dispatch_inner(inner).await {
+            Ok(0) => LegOutcome::Idle,
+            Ok(reached) => LegOutcome::Delivered { reached },
+            Err(e) => {
+                tracing::warn!(
+                    stream = ?stream_id,
+                    chunk_seq = chunk_seq.0,
+                    error = %e,
+                    "AV spine publish: the publisher's own links FAILED — the relay leg's \
+                     result stands (CIRISEdge#425)"
+                );
+                LegOutcome::Failed {
+                    reached: 0,
+                    error: e.to_string(),
+                }
+            }
+        };
+
+        Ok(Fanout {
+            chunk_seq,
+            epoch: self.publisher.epoch(),
+            relayed,
+            relay_withheld,
+            relay,
+            direct,
+            stranded: self.stranded.clone(),
+            sealed,
+        })
+    }
+
+    /// The relay fan-out leg, resolved to owned values so no borrow of
+    /// the relay can outlive it into an `.await`.
+    fn forward_leg(
+        relay: Option<&mut RelayNode>,
+        stream_id: StreamId,
+        inner: &InnerSealed,
+    ) -> (Vec<RelayForwardOut>, usize, LegOutcome) {
+        let Some(relay) = relay else {
+            return (Vec::new(), 0, LegOutcome::Idle);
+        };
+        let roster = relay.subscriber_count(stream_id);
+        if roster == 0 {
+            return (Vec::new(), 0, LegOutcome::Idle);
+        }
+        match relay.forward(stream_id, inner) {
+            Ok(out) => {
+                // `forward` skips a policy-refused subscriber with a bare
+                // `continue`; the shortfall is the only evidence it
+                // happened, so the spine counts it rather than let a
+                // withheld chunk read as absence-of-work.
+                let withheld = roster.saturating_sub(out.len());
+                if withheld > 0 {
+                    tracing::info!(
+                        stream = ?stream_id,
+                        chunk_seq = inner.chunk_seq().0,
+                        withheld,
+                        roster,
+                        "AV spine relay: chunk WITHHELD from subscribers by their layer \
+                         policy (not a loss — CIRISEdge#128 admission)"
+                    );
+                }
+                let reached = out.len();
+                (out, withheld, LegOutcome::Delivered { reached })
+            }
+            Err(e) => {
+                tracing::warn!(
+                    stream = ?stream_id,
+                    chunk_seq = inner.chunk_seq().0,
+                    error = %e,
+                    "AV spine relay: fan-out FAILED — no downstream subscriber received this \
+                     chunk (CIRISEdge#425)"
+                );
+                (
+                    Vec::new(),
+                    0,
+                    LegOutcome::Failed {
+                        reached: 0,
+                        error: e.to_string(),
+                    },
+                )
+            }
+        }
+    }
+
+    // ── heal ────────────────────────────────────────────────────────
+
+    /// Converge the call around a subscriber that stopped receiving.
+    ///
+    /// Three convergences, one per classification, all named:
+    ///
+    /// - a recoverable drop of a still-current member → **re-admitted**
+    ///   on a fresh transit key, with the epoch untouched;
+    /// - a drop of a peer that is no longer in the MLS roster, or a
+    ///   recoverable drop with no re-dial material → **pruned** from the
+    ///   relay roster;
+    /// - a departure → **evicted** from MLS, which advances the epoch
+    ///   and re-addresses the call exactly as a join does.
+    ///
+    /// A departure is executed even when the call is stranded: leaving a
+    /// departed member keyed is a forward-secrecy failure, and the
+    /// eviction's own re-address either lifts the degradation or leaves
+    /// it named.
+    ///
+    /// # Errors
+    ///
+    /// [`AvSpineError::NoRelay`] for a heal on a non-relaying node;
+    /// [`AvSpineError::Runtime`] if the MLS remove fails;
+    /// [`AvSpineError::AddressStranded`] if an eviction's epoch moved but
+    /// its addresses could not.
+    pub fn heal(
+        &mut self,
+        drop: SubscriberDrop,
+        now: Instant,
+    ) -> Result<HealOutcome, AvSpineError> {
+        let _sealed = self.seal_due(now);
+        let stream_id = self.publisher.stream_id();
+        if self.relay.is_none() {
+            return Err(AvSpineError::NoRelay(stream_id));
+        }
+        let still_a_member = self.is_member(&drop.subscriber);
+
+        match drop.cause {
+            DropCause::LinkFailure => {
+                let reason = if still_a_member {
+                    match drop.redial {
+                        Some(redial) => {
+                            let relay = self
+                                .relay
+                                .as_mut()
+                                .ok_or(AvSpineError::NoRelay(stream_id))?;
+                            relay.subscribe(
+                                stream_id,
+                                drop.subscriber.clone(),
+                                redial.transit_key,
+                                redial.layer_policy,
+                            )?;
+                            tracing::info!(
+                                stream = ?stream_id,
+                                peer = %drop.subscriber,
+                                epoch = self.publisher.epoch().0,
+                                "AV spine HEAL: subscriber re-admitted on a fresh hop — the \
+                                 epoch did NOT move (a rekey per flaky link would churn every \
+                                 member's address for one peer's radio)"
+                            );
+                            return Ok(HealOutcome::Readmitted {
+                                subscriber: drop.subscriber,
+                                epoch: self.publisher.epoch(),
+                            });
+                        }
+                        None => PruneReason::NoRedialOffered,
+                    }
+                } else {
+                    PruneReason::NotAMember
+                };
+                self.prune_from_relay(&drop.subscriber, stream_id);
+                tracing::warn!(
+                    stream = ?stream_id,
+                    peer = %drop.subscriber,
+                    ?reason,
+                    "AV spine HEAL: subscriber PRUNED from the relay roster (CIRISEdge#425)"
+                );
+                Ok(HealOutcome::RosterPruned {
+                    subscriber: drop.subscriber,
+                    reason,
+                })
+            }
+            DropCause::Departed => {
+                let was_subscribed = self.prune_from_relay(&drop.subscriber, stream_id);
+                if !still_a_member {
+                    tracing::warn!(
+                        stream = ?stream_id,
+                        peer = %drop.subscriber,
+                        "AV spine HEAL: departure of a peer already out of the MLS roster — \
+                         relay roster pruned, no epoch move (CIRISEdge#425)"
+                    );
+                    return Ok(HealOutcome::RosterPruned {
+                        subscriber: drop.subscriber,
+                        reason: PruneReason::NotAMember,
+                    });
+                }
+                // Forward secrecy: the departed member must not hold the
+                // DEK that seals the next chunk. This moves the epoch,
+                // so it re-addresses exactly like a join.
+                self.publisher
+                    .advance_epoch(RosterDelta::Leave(drop.subscriber.clone()))?;
+                let readdressed = self.readdress(now)?;
+                tracing::info!(
+                    stream = ?stream_id,
+                    peer = %drop.subscriber,
+                    epoch = readdressed.epoch,
+                    was_subscribed,
+                    relay_window_moved = readdressed.relay_window_moved,
+                    "AV spine HEAL: member EVICTED — epoch + addresses moved together"
+                );
+                Ok(HealOutcome::Evicted {
+                    subscriber: drop.subscriber,
+                    was_subscribed,
+                    readdressed,
+                })
+            }
+        }
+    }
+
+    // ── internals ───────────────────────────────────────────────────
+
+    /// **The hook.** Move both address planes onto the epoch the session
+    /// just reached.
+    ///
+    /// Order is the whole point. The lifecycle goes first, because it is
+    /// the one that can fail: it derives the new addresses, activates
+    /// them for sending, registers this node's own with the transport,
+    /// and schedules the seal. Only once it has succeeded does the
+    /// relay's answerable window move — so the relay can never be
+    /// answering on an address the table never installed, and a failure
+    /// leaves the two planes agreeing with each other at the superseded
+    /// epoch rather than disagreeing across it.
+    fn readdress(&mut self, now: Instant) -> Result<Readdressed, AvSpineError> {
+        let advanced = {
+            let snapshot = av_addressing::snapshot(self.publisher.session())?;
+            let epoch = snapshot.epoch;
+            match self.lifecycle.advance(&self.scope, &snapshot, now) {
+                Ok(outcome) => outcome,
+                Err(e) => {
+                    let stranded = StrandedEpoch {
+                        epoch,
+                        reason: e.to_string(),
+                    };
+                    tracing::error!(
+                        stream = ?self.publisher.stream_id(),
+                        group = %self.group_id,
+                        epoch,
+                        error = %e,
+                        "AV spine: the MLS epoch advanced and its scoped addresses did NOT. \
+                         The relay's answerable window is deliberately left where it is, so \
+                         both planes still agree; live links keep running and the call \
+                         refuses to grow until this is resolved (CIRISEdge#499/#425)"
+                    );
+                    self.stranded = Some(stranded.clone());
+                    return Err(AvSpineError::AddressStranded(stranded));
+                }
+            }
+        };
+
+        let mut relay_evicted_early = None;
+        let relay_window_moved = if let Some(relay) = self.relay.as_mut() {
+            relay_evicted_early =
+                av_addressing::advance_relay_window(relay, &advanced).map(|d| *d.as_bytes());
+            true
+        } else {
+            false
+        };
+        if relay_evicted_early.is_some() {
+            tracing::info!(
+                stream = ?self.publisher.stream_id(),
+                group = %self.group_id,
+                epoch = advanced.epoch,
+                "AV spine: a second rotation inside one convergence window pushed the                  oldest address out of the relay's answerable window early — a peer                  still dialling it re-dials at the live epoch (CIRISEdge#499)"
+            );
+        }
+
+        self.own_address = advanced.own_address;
+        self.stranded = None;
+        Ok(Readdressed {
+            epoch: advanced.epoch,
+            derived: advanced.derived,
+            own_address: advanced.own_address,
+            relay_window_moved,
+            relay_evicted_early,
+        })
+    }
+
+    /// Refuse a verb that would grow the call's reachability while the
+    /// call cannot be reached at its live epoch.
+    fn refuse_if_stranded(&self, verb: &'static str) -> Result<(), AvSpineError> {
+        if let Some(stranded) = self.stranded.clone() {
+            tracing::warn!(
+                stream = ?self.publisher.stream_id(),
+                verb,
+                epoch = stranded.epoch,
+                "AV spine: verb REFUSED — the call is stranded at a superseded epoch, so \
+                 anything it handed out would name an address that answers nowhere"
+            );
+            return Err(AvSpineError::Stranded { verb, stranded });
+        }
+        Ok(())
+    }
+
+    /// Drop a subscriber from the relay roster. Returns whether it was
+    /// there. A `SubscriberNotFound` is the expected answer for a peer
+    /// that never subscribed, so it is reported as `false` rather than
+    /// raised.
+    fn prune_from_relay(&mut self, subscriber: &PeerKeyId, stream_id: StreamId) -> bool {
+        let Some(relay) = self.relay.as_mut() else {
+            return false;
+        };
+        relay.unsubscribe(stream_id, subscriber).is_ok()
+    }
+
+    /// A member's derived address at `epoch`, if the table holds one.
+    fn address_of(&self, key_id: &str, epoch: u64) -> Option<MemberAddress> {
+        self.lifecycle
+            .table()
+            .address_at(&self.scope, &self.group_id, epoch, key_id)
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/transport/av_spine/tests.rs
+++ b/src/transport/av_spine/tests.rs
@@ -1,0 +1,1014 @@
+//! Spine acceptance — driven through REAL sessions, not mocks.
+//!
+//! Every call here runs a live openmls (X-Wing 0x004D) group, the real
+//! `ScopePrivacyDeriver` address derivation, a real `RelayNode` over a
+//! real leviculum node handle, and the real two-layer AEAD. The only
+//! stub is the destination sink, and only so a registration can be made
+//! to fail on demand — the one failure the transport will not produce to
+//! order.
+
+use super::*;
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use ciris_crypto::{ml_kem, x25519, PqcSigner};
+
+use crate::mls::welcome_wrap::FederationDirectoryEntry;
+use crate::scope_addressing::{ScopeAddressTable, ScopePrivacyDeriver};
+use crate::scope_lifecycle::ScopedDestinationSink;
+use crate::transport::federation_session::OwnKexKeys;
+use crate::transport::realtime_av::{open_av_chunk, EpochDek, SealedAvChunk};
+use crate::transport::realtime_av_mls::mint_joiner_key_material;
+use crate::transport::realtime_av_session::AvSession;
+
+const CONVERGENCE: Duration = Duration::from_secs(300);
+
+// ─── fixtures ───────────────────────────────────────────────────────
+
+/// Records what the lifecycle registered and retired, and can be told to
+/// refuse the next registration.
+#[derive(Default)]
+struct RecordingSink {
+    registered: Mutex<Vec<[u8; 16]>>,
+    retired: Mutex<Vec<[u8; 16]>>,
+    refuse: Mutex<bool>,
+}
+
+impl RecordingSink {
+    fn refuse_next(&self, refuse: bool) {
+        *self.refuse.lock().unwrap() = refuse;
+    }
+    fn retired(&self) -> Vec<[u8; 16]> {
+        self.retired.lock().unwrap().clone()
+    }
+    fn registered(&self) -> Vec<[u8; 16]> {
+        self.registered.lock().unwrap().clone()
+    }
+}
+
+impl ScopedDestinationSink for RecordingSink {
+    fn register(&self, address: &MemberAddress, _scope: &CohortScope) -> Result<(), String> {
+        if *self.refuse.lock().unwrap() {
+            return Err("node refused to listen".to_owned());
+        }
+        self.registered.lock().unwrap().push(*address.as_bytes());
+        Ok(())
+    }
+    fn retire(&self, address: &MemberAddress, _scope: &CohortScope) -> Result<(), String> {
+        self.retired.lock().unwrap().push(*address.as_bytes());
+        Ok(())
+    }
+}
+
+/// A throwaway leviculum node. The spine's relay never drives it for
+/// I/O — `forward` is pure compute — so a synthetic identity suffices.
+/// Each call gets its own storage path so builders do not collide.
+fn test_node() -> Arc<ReticulumNode> {
+    use leviculum_core::Identity;
+    use leviculum_std::driver::ReticulumNodeBuilder;
+    let mut priv_bytes = [0u8; 64];
+    for (i, b) in priv_bytes.iter_mut().enumerate() {
+        *b = u8::try_from(i)
+            .expect("index < 64")
+            .wrapping_mul(31)
+            .wrapping_add(7);
+    }
+    let identity =
+        Identity::from_private_key_bytes(&priv_bytes).expect("identity from synthetic key");
+    let storage =
+        std::env::temp_dir().join(format!("ciris-edge-spine-test-{}", uuid::Uuid::new_v4()));
+    Arc::new(
+        ReticulumNodeBuilder::new()
+            .identity(identity)
+            .storage_path(storage)
+            .build_sync()
+            .expect("build spine test node"),
+    )
+}
+
+/// A fresh joiner X-Wing kex pair.
+#[allow(clippy::similar_names)]
+fn fresh_joiner_xwing() -> (PeerKexPubkeys, OwnKexKeys) {
+    let (x_sk, x_pk) = x25519::generate_ephemeral_keypair().expect("x25519 keypair");
+    let (mlkem_sk, mlkem_pk) = ml_kem::generate_keypair().expect("ml-kem keypair");
+    (
+        PeerKexPubkeys {
+            x25519_pub: x_pk,
+            mlkem768_pub: Some(mlkem_pk.clone()),
+        },
+        OwnKexKeys {
+            x25519_priv: x_sk,
+            mlkem768_priv: Some(mlkem_sk),
+            mlkem768_pub: Some(mlkem_pk),
+        },
+    )
+}
+
+fn directory_resolving(
+    pk_id: &str,
+    ml_dsa_pk: Vec<u8>,
+) -> impl FnMut(&str) -> Option<FederationDirectoryEntry> {
+    let want = pk_id.to_owned();
+    move |id: &str| {
+        (id == want).then(|| FederationDirectoryEntry {
+            pk_id: id.to_owned(),
+            ml_dsa_pk: ml_dsa_pk.clone(),
+            x_wing_pk: None,
+        })
+    }
+}
+
+fn scope() -> CohortScope {
+    CohortScope::Cohort {
+        cohort_id: "the-call".to_owned(),
+    }
+}
+
+/// One node's whole A/V stack, plus the peer sessions it admitted, so a
+/// test can assert on the real byte path from both ends.
+struct TestCall {
+    spine: AvSpine,
+    sink: Arc<RecordingSink>,
+    table: Arc<ScopeAddressTable>,
+    inviter: MlDsa65Signer,
+    inviter_pk: Vec<u8>,
+    t0: Instant,
+}
+
+/// A peer this node admitted: its own MLS session (so it derives the
+/// same DEKs), its transit key, and its live epoch DEK.
+struct Peer {
+    key_id: PeerKeyId,
+    session: AvSession,
+    transit_key: [u8; 32],
+    dek: EpochDek,
+    /// The relay's per-subscriber `link_seq` from this peer's point of
+    /// view. Counts ADMITTED chunks and is NOT reset by an epoch move —
+    /// which is exactly the make-before-break property under test.
+    link_seq: u64,
+}
+
+impl Peer {
+    /// Open a chunk the relay sealed for this peer, advancing its
+    /// `link_seq` exactly as its receive loop would.
+    fn open(&mut self, sealed: &SealedAvChunk) -> Vec<u8> {
+        let out = open_av_chunk(
+            sealed,
+            &self.transit_key,
+            self.key_id.as_bytes(),
+            self.link_seq,
+            &self.dek,
+        )
+        .expect("subscriber opens both AEAD layers");
+        self.link_seq += 1;
+        out
+    }
+}
+
+impl TestCall {
+    /// A call with exactly this node in it, relaying its own stream.
+    fn open(stream_seed: u8) -> Self {
+        Self::open_with(stream_seed, true)
+    }
+
+    fn open_with(stream_seed: u8, relays: bool) -> Self {
+        let sink = Arc::new(RecordingSink::default());
+        let table = Arc::new(ScopeAddressTable::new(Arc::new(ScopePrivacyDeriver)));
+        let lifecycle = Arc::new(ScopeLifecycle::new(
+            Arc::clone(&table),
+            Arc::clone(&sink) as Arc<dyn ScopedDestinationSink>,
+            "node-self",
+            CONVERGENCE,
+        ));
+        let stream_id = StreamId([stream_seed; 32]);
+        // No initial members: every other member arrives through the
+        // spine's own `join`, so each one has a REAL session built from
+        // a REAL Welcome and derives the DEKs independently.
+        let (session, dek) =
+            AvSession::create(stream_id, "node-self", Vec::new()).expect("create session");
+        let publisher =
+            AvPublisher::from_session(stream_id, session, dek, Vec::new()).expect("publisher");
+        let inviter = MlDsa65Signer::new().expect("inviter signer");
+        let inviter_pk = inviter.public_key().expect("inviter pk");
+        let spine = AvSpine::open(scope(), lifecycle, publisher, relays.then(test_node))
+            .expect("spine opens");
+        Self {
+            spine,
+            sink,
+            table,
+            inviter,
+            inviter_pk,
+            t0: Instant::now(),
+        }
+    }
+
+    /// Admit a peer through the spine and stand its own session up from
+    /// the Welcome, so it derives the same epoch DEK independently.
+    fn join(&mut self, key_id: &str, transit_key: [u8; 32], at: Instant) -> (Peer, JoinTicket) {
+        let (material, key_package) = mint_joiner_key_material(key_id).expect("mint key package");
+        let (kex_pub, kex_secret) = fresh_joiner_xwing();
+        let ticket = self
+            .spine
+            .join(
+                Joiner {
+                    key_id,
+                    key_package,
+                    kex: &kex_pub,
+                    inviter_signer: &self.inviter,
+                    inviter_pk_id: "node-self-fed",
+                },
+                at,
+            )
+            .expect("join succeeds");
+        let mut session = AvSession::new_joiner(self.spine.stream_id(), material);
+        let dek = session
+            .process_welcome(
+                &ticket.welcome_bytes,
+                &kex_secret,
+                directory_resolving("node-self-fed", self.inviter_pk.clone()),
+            )
+            .expect("joiner bootstraps from the Welcome");
+        (
+            Peer {
+                key_id: key_id.to_owned(),
+                session,
+                transit_key,
+                dek,
+                link_seq: 0,
+            },
+            ticket,
+        )
+    }
+
+    /// Try to admit a peer, surfacing the refusal.
+    fn try_join(&mut self, key_id: &str, at: Instant) -> Result<JoinTicket, AvSpineError> {
+        let (_material, key_package) = mint_joiner_key_material(key_id).expect("mint key package");
+        let (kex_pub, _secret) = fresh_joiner_xwing();
+        self.spine.join(
+            Joiner {
+                key_id,
+                key_package,
+                kex: &kex_pub,
+                inviter_signer: &self.inviter,
+                inviter_pk_id: "node-self-fed",
+            },
+            at,
+        )
+    }
+
+    fn relay_address(&self) -> [u8; 16] {
+        *self
+            .spine
+            .relay()
+            .expect("this call relays")
+            .address()
+            .as_bytes()
+    }
+
+    fn relay_answers(&self, addr: &[u8; 16]) -> bool {
+        self.spine
+            .relay()
+            .expect("this call relays")
+            .accepts(&DestinationHash::new(*addr))
+    }
+}
+
+/// Pull the sealed chunk the relay produced for `peer` out of a fan-out.
+fn chunk_for<'a>(fanout: &'a Fanout, peer: &str) -> &'a SealedAvChunk {
+    &fanout
+        .relayed
+        .iter()
+        .find(|o| o.subscriber == peer)
+        .unwrap_or_else(|| panic!("no relayed chunk for {peer}"))
+        .sealed
+}
+
+// ─── 1. a third joins mid-stream ────────────────────────────────────
+
+/// **The load-bearing acceptance.** A two-member call is carrying media
+/// when a third joins. The epoch advances, every address moves with it,
+/// and the subscriber that was already receiving KEEPS receiving across
+/// the rotation — same transit key, same continuing `link_seq`, no
+/// re-dial.
+///
+/// This is the whole point of make-before-break, asserted on the real
+/// byte path rather than on a flag: the second chunk is opened by a
+/// session that derived its DEK from the Commit, at a `link_seq` that
+/// continued from the first chunk. A rotation that tore the link down
+/// would fail the open.
+// A single acceptance narrative, deliberately not split: each assertion
+// only means anything in sequence after the ones above it.
+#[allow(clippy::too_many_lines)]
+#[tokio::test]
+async fn a_third_member_joins_mid_stream_and_the_existing_subscriber_keeps_receiving() {
+    let mut call = TestCall::open(0xA1);
+    let t0 = call.t0;
+    // The address the call was opened at, before anyone joined.
+    let addr_at_open = *call.spine.own_address().as_bytes();
+
+    // ── two members, one carrying media ──────────────────────────────
+    let (mut alice, _) = call.join("peer-alice", [0x11u8; 32], t0);
+    let _subscribed = call
+        .spine
+        .subscribe(
+            &alice.key_id,
+            alice.transit_key,
+            ReceiverLayerPolicy::UNCAPPED,
+            t0,
+        )
+        .expect("alice subscribes");
+
+    let addr_before = *call.spine.own_address().as_bytes();
+    let relay_before = call.relay_address();
+    assert_eq!(
+        relay_before, addr_before,
+        "the relay SENDS from this node's scoped address — one value, not two \
+         conventions that can drift",
+    );
+
+    let first = call
+        .spine
+        .publish(b"frame-before-the-join", t0)
+        .await
+        .expect("publish");
+    assert_eq!(first.relayed.len(), 1, "one sealed chunk for alice");
+    assert_eq!(
+        alice.open(chunk_for(&first, "peer-alice")),
+        b"frame-before-the-join",
+        "alice receives the pre-rotation chunk byte-intact",
+    );
+
+    // ── a third member joins mid-stream ──────────────────────────────
+    let epoch_before = call.spine.epoch();
+    let (_bob, ticket) = call.join("peer-bob", [0x22u8; 32], t0);
+
+    assert!(
+        ticket.readdressed.epoch > epoch_before.0,
+        "the join must advance the MLS epoch",
+    );
+    assert_eq!(
+        ticket.readdressed.derived, 3,
+        "all three members' addresses are derived at the new epoch",
+    );
+    assert!(
+        ticket.readdressed.relay_window_moved,
+        "a relaying node's answerable window must move with the epoch",
+    );
+    assert_eq!(
+        ticket.readdressed.relay_evicted_early,
+        Some(addr_at_open),
+        "two joins inside one convergence window is ordinary; the relay holds ONE \
+         superseded address, so the oldest leaves the window and the outcome SAYS \
+         so rather than asserting it away",
+    );
+
+    // ── the addresses MOVED ──────────────────────────────────────────
+    let addr_after = *call.spine.own_address().as_bytes();
+    assert_ne!(
+        addr_after, addr_before,
+        "an epoch bump re-derives every member's address, including ours",
+    );
+    assert_eq!(
+        call.relay_address(),
+        addr_after,
+        "the relay's send address moved onto the new epoch",
+    );
+    assert!(
+        call.sink.registered().contains(&addr_after),
+        "the new address is REGISTERED with the transport — an unregistered \
+         destination is never delivered to, with no error anywhere",
+    );
+    assert_eq!(
+        ticket.dial_address.as_bytes(),
+        &addr_after,
+        "the ticket hands the joiner the address it must actually dial",
+    );
+    assert!(
+        ticket.joiner_address.is_some(),
+        "the joiner's own address is derived here too — we dial it",
+    );
+
+    // ── ...and nothing was broken to move them ───────────────────────
+    assert!(
+        call.relay_answers(&addr_before),
+        "make-before-break: the relay still ANSWERS on the superseded address, so a \
+         peer mid-dial is not stranded",
+    );
+    assert!(call.relay_answers(&addr_after));
+    assert!(
+        call.table.accepts_inbound(&addr_before).is_some(),
+        "the table also still attributes the superseded address",
+    );
+    assert!(call.table.accepts_inbound(&addr_after).is_some());
+    let retired = call.sink.retired();
+    assert!(
+        !retired.contains(&addr_before) && !retired.contains(&addr_after),
+        "neither the superseded address nor the live one is retired before the \
+         convergence window elapses: {retired:?}",
+    );
+    assert_eq!(
+        retired,
+        vec![addr_at_open],
+        "the ONE address retired is the one the second rotation pushed out of the \
+         window early — leaving it registered would keep a destination routable that \
+         the table no longer attributes",
+    );
+
+    // ── the existing subscriber KEEPS receiving ──────────────────────
+    // Alice applies the Commit and derives the new epoch's DEK — the
+    // same 32 bytes the publisher rotated to (RFC 9420 §8.5).
+    alice.dek = alice
+        .session
+        .process_commit(&ticket.commit_bytes)
+        .expect("alice applies the Commit");
+
+    let second = call
+        .spine
+        .publish(b"frame-after-the-join", t0)
+        .await
+        .expect("publish across the rotation");
+    assert_eq!(
+        second.relayed.len(),
+        1,
+        "alice is STILL on the relay roster after the rotation — a rotation that \
+         dropped her would be a dropped live stream",
+    );
+    assert_eq!(
+        alice.link_seq, 1,
+        "alice's link_seq continued rather than resetting — the link was never \
+         re-dialled, which is what 'a link is keyed by LinkId' buys",
+    );
+    assert_eq!(
+        alice.open(chunk_for(&second, "peer-alice")),
+        b"frame-after-the-join",
+        "the post-rotation chunk opens on the SAME link at the CONTINUED link_seq",
+    );
+    assert_eq!(second.epoch.0, ticket.readdressed.epoch);
+}
+
+// ─── 2. heal ────────────────────────────────────────────────────────
+
+/// A dropped subscriber is healed and the roster converges — each of the
+/// three convergences named, never inferred.
+// A single acceptance narrative, deliberately not split: each assertion
+// only means anything in sequence after the ones above it.
+#[allow(clippy::too_many_lines)]
+#[tokio::test]
+async fn a_dropped_subscriber_is_healed_and_the_roster_converges() {
+    let mut call = TestCall::open(0xB2);
+    let t0 = call.t0;
+    let (mut alice, _) = call.join("peer-alice", [0x11u8; 32], t0);
+    let (bob, bob_ticket) = call.join("peer-bob", [0x22u8; 32], t0);
+    alice.dek = alice
+        .session
+        .process_commit(&bob_ticket.commit_bytes)
+        .expect("alice applies bob's Commit");
+    for peer in [&alice, &bob] {
+        let _subscribed = call
+            .spine
+            .subscribe(
+                &peer.key_id,
+                peer.transit_key,
+                ReceiverLayerPolicy::UNCAPPED,
+                t0,
+            )
+            .expect("subscribe");
+    }
+    assert_eq!(call.spine.health().relay_subscribers, 2);
+
+    // ── a recoverable drop: re-key the hop, do NOT move the epoch ────
+    let epoch_before = call.spine.epoch();
+    let addr_before = *call.spine.own_address().as_bytes();
+    let healed = call
+        .spine
+        .heal(
+            SubscriberDrop {
+                subscriber: alice.key_id.clone(),
+                cause: DropCause::LinkFailure,
+                redial: Some(Redial {
+                    transit_key: [0xAAu8; 32],
+                    layer_policy: ReceiverLayerPolicy::UNCAPPED,
+                }),
+            },
+            t0,
+        )
+        .expect("heal a link failure");
+    assert_eq!(
+        healed,
+        HealOutcome::Readmitted {
+            subscriber: "peer-alice".to_owned(),
+            epoch: epoch_before,
+        },
+    );
+    assert_eq!(
+        call.spine.epoch(),
+        epoch_before,
+        "a flaky link must NOT churn every member's address",
+    );
+    assert_eq!(*call.spine.own_address().as_bytes(), addr_before);
+    assert_eq!(call.spine.health().relay_subscribers, 2, "roster converged");
+
+    // The re-dial actually took: the hop is on the NEW transit key, from
+    // link_seq 0 (a re-dial is a new link).
+    alice.transit_key = [0xAAu8; 32];
+    alice.link_seq = 0;
+    let fanout = call.spine.publish(b"post-heal", t0).await.expect("publish");
+    assert_eq!(
+        alice.open(chunk_for(&fanout, "peer-alice")),
+        b"post-heal",
+        "the re-admitted hop carries media on its fresh transit key",
+    );
+
+    // ── a departure: forward secrecy, so the epoch AND the addresses move
+    let evicted = call
+        .spine
+        .heal(
+            SubscriberDrop {
+                subscriber: bob.key_id.clone(),
+                cause: DropCause::Departed,
+                redial: None,
+            },
+            t0,
+        )
+        .expect("heal a departure");
+    let HealOutcome::Evicted {
+        was_subscribed,
+        readdressed,
+        ..
+    } = &evicted
+    else {
+        panic!("a departure must evict, got {evicted:?}");
+    };
+    assert!(was_subscribed, "bob was on the relay roster");
+    assert!(
+        readdressed.epoch > epoch_before.0,
+        "an eviction moves the epoch",
+    );
+    assert!(readdressed.relay_window_moved);
+    assert_ne!(
+        *call.spine.own_address().as_bytes(),
+        addr_before,
+        "an eviction re-addresses the call exactly as a join does",
+    );
+    assert!(
+        !call.spine.is_member("peer-bob"),
+        "the departed member is out of the MLS group — it must not hold the DEK \
+         that seals the next chunk",
+    );
+    assert_eq!(
+        call.spine.health().relay_subscribers,
+        1,
+        "the relay roster converged with the MLS roster",
+    );
+    assert_eq!(readdressed.derived, 2, "two members remain to address");
+
+    // ── a second drop of the already-departed peer: pruned, not evicted
+    let again = call
+        .spine
+        .heal(
+            SubscriberDrop {
+                subscriber: bob.key_id.clone(),
+                cause: DropCause::LinkFailure,
+                redial: Some(Redial {
+                    transit_key: [0xBBu8; 32],
+                    layer_policy: ReceiverLayerPolicy::UNCAPPED,
+                }),
+            },
+            t0,
+        )
+        .expect("heal a non-member");
+    assert_eq!(
+        again,
+        HealOutcome::RosterPruned {
+            subscriber: "peer-bob".to_owned(),
+            reason: PruneReason::NotAMember,
+        },
+        "a peer with no epoch DEK must never be re-admitted to the relay roster",
+    );
+}
+
+/// A recoverable drop the caller cannot re-key is pruned with its own
+/// reason — never left in the roster to be silently fanned to.
+#[tokio::test]
+async fn a_link_failure_with_no_redial_material_is_pruned_loudly() {
+    let mut call = TestCall::open(0xB3);
+    let t0 = call.t0;
+    let (alice, _) = call.join("peer-alice", [0x11u8; 32], t0);
+    let _subscribed = call
+        .spine
+        .subscribe(
+            &alice.key_id,
+            alice.transit_key,
+            ReceiverLayerPolicy::UNCAPPED,
+            t0,
+        )
+        .expect("subscribe");
+
+    let out = call
+        .spine
+        .heal(
+            SubscriberDrop {
+                subscriber: alice.key_id.clone(),
+                cause: DropCause::LinkFailure,
+                redial: None,
+            },
+            t0,
+        )
+        .expect("heal");
+    assert_eq!(
+        out,
+        HealOutcome::RosterPruned {
+            subscriber: "peer-alice".to_owned(),
+            reason: PruneReason::NoRedialOffered,
+        },
+    );
+    assert_eq!(call.spine.health().relay_subscribers, 0);
+    assert!(
+        call.spine.is_member("peer-alice"),
+        "pruning a hop must not evict the member — it can re-subscribe when it \
+         re-dials",
+    );
+}
+
+// ─── 3. the seal cadence ────────────────────────────────────────────
+
+/// Seal runs on cadence and retires **exactly** the superseded address —
+/// on both planes, on one deadline — and never the live one.
+#[tokio::test]
+async fn seal_runs_on_cadence_and_retires_exactly_the_superseded_address() {
+    let mut call = TestCall::open(0xC3);
+    let t0 = call.t0;
+    let before = *call.spine.own_address().as_bytes();
+    assert_eq!(
+        call.spine.seal_deadline(),
+        None,
+        "a call with no rotation has no deadline to wait on",
+    );
+
+    let (_alice, _) = call.join("peer-alice", [0x11u8; 32], t0);
+    let after = *call.spine.own_address().as_bytes();
+    assert_ne!(before, after);
+    assert_eq!(
+        call.spine.seal_deadline(),
+        Some(t0 + CONVERGENCE),
+        "the rotation armed exactly one deadline, on the monotonic clock",
+    );
+
+    // ── too early: sealing now cuts off any peer that has not re-keyed
+    let early = call.spine.seal_due(
+        t0 + CONVERGENCE
+            .checked_sub(Duration::from_secs(1))
+            .expect("window > 1s"),
+    );
+    assert_eq!(early, SpineSeal::default(), "nothing is due yet");
+    assert!(call.relay_answers(&before), "the relay still answers");
+    assert!(call.table.accepts_inbound(&before).is_some());
+    assert!(call.sink.retired().is_empty());
+
+    // ── the window closes ────────────────────────────────────────────
+    let sealed = call.spine.seal_due(t0 + CONVERGENCE);
+    assert_eq!(
+        sealed,
+        SpineSeal {
+            sealed: true,
+            unretired: false,
+            relay_retired: Some(before),
+            table_refused: false,
+        },
+        "the seal names the ONE address it dropped",
+    );
+    assert_eq!(
+        call.sink.retired(),
+        vec![before],
+        "exactly the superseded destination is retired from the transport",
+    );
+
+    // ── the live address survives, on both planes ────────────────────
+    assert!(
+        !call.relay_answers(&before),
+        "a sealed address is no longer answered — that is what stops new probes",
+    );
+    assert!(
+        call.relay_answers(&after),
+        "the LIVE address must survive the seal",
+    );
+    assert_eq!(
+        call.relay_address(),
+        after,
+        "a seal must never move the send address",
+    );
+    assert!(call.table.accepts_inbound(&before).is_none());
+    assert!(
+        call.table.accepts_inbound(&after).is_some(),
+        "the table's live epoch must survive the seal",
+    );
+
+    // ── idempotent, and the deadline is disarmed ─────────────────────
+    assert_eq!(call.spine.seal_deadline(), None);
+    assert_eq!(
+        call.spine.seal_due(t0 + CONVERGENCE * 2),
+        SpineSeal::default(),
+        "sealing twice must not strand the live address",
+    );
+    assert!(call.relay_answers(&after));
+}
+
+/// The cadence is owned by the spine, not by the caller: an ordinary
+/// verb closes a window that has come due, with no timer anywhere.
+#[tokio::test]
+async fn an_ordinary_verb_closes_a_window_that_has_come_due() {
+    let mut call = TestCall::open(0xC4);
+    let t0 = call.t0;
+    let before = *call.spine.own_address().as_bytes();
+    let (_alice, _) = call.join("peer-alice", [0x11u8; 32], t0);
+    assert!(call.spine.seal_deadline().is_some());
+
+    // No explicit seal call anywhere — just media, at a later instant.
+    let fanout = call
+        .spine
+        .publish(b"traffic", t0 + CONVERGENCE)
+        .await
+        .expect("publish");
+    assert!(
+        fanout.sealed.sealed,
+        "publishing past the deadline closed the window: a call carrying media \
+         needs no timer to converge",
+    );
+    assert_eq!(fanout.sealed.relay_retired, Some(before));
+    assert_eq!(call.spine.seal_deadline(), None);
+    assert!(!call.relay_answers(&before));
+}
+
+// ─── 4. a failed address install ────────────────────────────────────
+
+/// An epoch advance whose address install fails must not leave the call
+/// half-live.
+///
+/// The MLS commit cannot be undone, so the test asserts the property
+/// that IS achievable: the two address planes still agree with each
+/// other, the relay never starts answering (or sending) on an address
+/// the table never registered, the degradation is named, and the live
+/// stream is not dropped to achieve any of it.
+// A single acceptance narrative, deliberately not split: each assertion
+// only means anything in sequence after the ones above it.
+#[allow(clippy::too_many_lines)]
+#[tokio::test]
+async fn an_epoch_advance_whose_address_install_fails_does_not_leave_the_call_half_live() {
+    let mut call = TestCall::open(0xD4);
+    let t0 = call.t0;
+    let (alice, _) = call.join("peer-alice", [0x11u8; 32], t0);
+    let _subscribed = call
+        .spine
+        .subscribe(
+            &alice.key_id,
+            alice.transit_key,
+            ReceiverLayerPolicy::UNCAPPED,
+            t0,
+        )
+        .expect("alice subscribes");
+
+    let own_before = *call.spine.own_address().as_bytes();
+    let relay_before = call.relay_address();
+    let superseded_before = call
+        .spine
+        .relay()
+        .expect("relays")
+        .superseded_address()
+        .map(|d| *d.as_bytes());
+    let registered_before = call.sink.registered().len();
+
+    // The transport refuses to listen on the next epoch's address.
+    call.sink.refuse_next(true);
+    let err = call
+        .try_join("peer-bob", t0)
+        .expect_err("a join whose address install fails must surface");
+    let AvSpineError::AddressStranded(stranded) = &err else {
+        panic!("expected AddressStranded, got {err:?}");
+    };
+    assert!(stranded.reason.contains("registering"), "{stranded:?}");
+
+    // ── the relay window did NOT move ────────────────────────────────
+    assert_eq!(
+        call.relay_address(),
+        relay_before,
+        "the relay must not SEND from an address the transport never registered",
+    );
+    assert_eq!(
+        call.spine
+            .relay()
+            .expect("relays")
+            .superseded_address()
+            .map(|d| *d.as_bytes()),
+        superseded_before,
+        "the relay's rotation window must be UNCHANGED — an install with no activate \
+         is the state that silently loses an epoch, and an install+activate would \
+         make it send from an address the transport never registered",
+    );
+    assert!(
+        call.relay_answers(&relay_before),
+        "the relay still answers where it always did",
+    );
+    assert_eq!(
+        *call.spine.own_address().as_bytes(),
+        own_before,
+        "the spine's notion of its own address must not advance past what is \
+         actually registered",
+    );
+    assert_eq!(
+        call.sink.registered().len(),
+        registered_before,
+        "nothing new was registered",
+    );
+
+    // ── the degradation is a named state, not a log line ─────────────
+    let health = call.spine.health();
+    assert_eq!(health.stranded.as_ref(), Some(stranded));
+    let mut expected_answers = vec![relay_before];
+    expected_answers.extend(superseded_before);
+    assert_eq!(
+        health.relay_answers, expected_answers,
+        "the relay's answerable set is exactly what it was before the failed \
+         advance — the planes agree",
+    );
+
+    // ── the call refuses to GROW ─────────────────────────────────────
+    let refused = call
+        .spine
+        .subscribe(
+            &"peer-alice".to_owned(),
+            [0x99u8; 32],
+            ReceiverLayerPolicy::UNCAPPED,
+            t0,
+        )
+        .expect_err("a stranded call must not hand out addresses that answer nowhere");
+    assert!(
+        matches!(
+            refused,
+            AvSpineError::Stranded {
+                verb: "subscribe",
+                ..
+            }
+        ),
+        "{refused:?}",
+    );
+    assert!(
+        matches!(
+            call.try_join("peer-carol", t0),
+            Err(AvSpineError::Stranded { verb: "join", .. })
+        ),
+        "a stranded call must not admit a joiner it cannot be dialled by",
+    );
+
+    // ── ...but it does NOT drop the live stream ──────────────────────
+    // Alice's link was dialled while she was legitimately in the group
+    // and is keyed by LinkId; cutting it to signal an addressing fault
+    // would be the one thing make-before-break exists to prevent.
+    let fanout = call
+        .spine
+        .publish(b"still-serving", t0)
+        .await
+        .expect("a stranded call still serves its live links");
+    assert_eq!(
+        fanout.relayed.len(),
+        1,
+        "alice is still fanned to across the degradation",
+    );
+    assert_eq!(
+        fanout.stranded.as_ref(),
+        Some(stranded),
+        "every publish carries the degradation forward — it never goes quiet",
+    );
+}
+
+// ─── structural properties ──────────────────────────────────────────
+
+/// The relay is born AT the installed scoped address. There is no window
+/// in which it answers on a bootstrap address the table never installed,
+/// because there is no constructor that can put it there.
+#[tokio::test]
+async fn a_relay_is_born_at_the_installed_scoped_address() {
+    let call = TestCall::open(0xE5);
+    let own = *call.spine.own_address().as_bytes();
+    assert_eq!(call.relay_address(), own);
+    assert!(
+        call.table.accepts_inbound(&own).is_some(),
+        "the address the relay answers on is one the table attributes",
+    );
+    assert_eq!(
+        call.sink.registered(),
+        vec![own],
+        "and one the transport is listening on — exactly one, ours",
+    );
+    assert_eq!(
+        call.spine.health().relay_answers,
+        vec![own],
+        "one answerable address outside a rotation window",
+    );
+}
+
+/// A peer that is not in the MLS roster cannot become a relay
+/// subscriber: it holds no epoch DEK, so every chunk sealed for it is
+/// fan-out spent on ciphertext it can never open.
+#[tokio::test]
+async fn a_non_member_cannot_be_subscribed() {
+    let mut call = TestCall::open(0xE6);
+    let t0 = call.t0;
+    let err = call
+        .spine
+        .subscribe(
+            &"stranger".to_owned(),
+            [0x11u8; 32],
+            ReceiverLayerPolicy::UNCAPPED,
+            t0,
+        )
+        .expect_err("a stranger is not on the call");
+    assert!(
+        matches!(err, AvSpineError::NotAMember(ref p) if p == "stranger"),
+        "{err:?}"
+    );
+    assert_eq!(call.spine.health().relay_subscribers, 0);
+}
+
+/// A node that publishes without relaying is a first-class shape: the
+/// epoch still re-addresses, and the outcome says the relay window did
+/// not move because there is no relay — not because the move was
+/// forgotten.
+#[tokio::test]
+async fn a_non_relaying_node_still_re_addresses_and_says_so() {
+    let mut call = TestCall::open_with(0xE7, false);
+    let t0 = call.t0;
+    assert!(call.spine.relay().is_none());
+    let before = *call.spine.own_address().as_bytes();
+
+    let (_alice, ticket) = call.join("peer-alice", [0x11u8; 32], t0);
+    assert!(
+        !ticket.readdressed.relay_window_moved,
+        "no relay to move — reported, not silently true",
+    );
+    assert_ne!(*call.spine.own_address().as_bytes(), before);
+    assert!(call.table.accepts_inbound(&before).is_some());
+
+    // A relay verb on a non-relaying node is a named refusal.
+    let err = call
+        .spine
+        .subscribe(
+            &"peer-alice".to_owned(),
+            [0x11u8; 32],
+            ReceiverLayerPolicy::UNCAPPED,
+            t0,
+        )
+        .expect_err("no relay");
+    assert!(matches!(err, AvSpineError::NoRelay(_)), "{err:?}");
+
+    // The seal still runs, on the plane that exists.
+    let sealed = call.spine.seal_due(t0 + CONVERGENCE);
+    assert_eq!(
+        sealed,
+        SpineSeal {
+            sealed: true,
+            unretired: false,
+            relay_retired: None,
+            table_refused: false,
+        },
+    );
+    assert!(call.table.accepts_inbound(&before).is_none());
+}
+
+/// One inner seal feeds both fan-out legs. Sealing twice would re-derive
+/// the same `(stream, epoch, chunk_seq)` inner nonce for a second
+/// ciphertext, so the sequence must advance once per chunk no matter how
+/// many legs it rides.
+#[tokio::test]
+async fn one_chunk_is_inner_sealed_once_for_both_legs() {
+    let mut call = TestCall::open(0xE8);
+    let t0 = call.t0;
+    let (alice, _) = call.join("peer-alice", [0x11u8; 32], t0);
+    let _subscribed = call
+        .spine
+        .subscribe(
+            &alice.key_id,
+            alice.transit_key,
+            ReceiverLayerPolicy::UNCAPPED,
+            t0,
+        )
+        .expect("subscribe");
+
+    let a = call.spine.publish(b"one", t0).await.expect("publish");
+    let b = call.spine.publish(b"two", t0).await.expect("publish");
+    assert_eq!(a.chunk_seq.0, 0);
+    assert_eq!(b.chunk_seq.0, 1, "one seq per chunk, not one per leg");
+    assert_eq!(a.relay.reached(), 1);
+    assert_eq!(
+        a.direct,
+        LegOutcome::Idle,
+        "this node relays rather than dialling a remote relay",
+    );
+    assert_eq!(a.relay_withheld, 0);
+    // The relay's own sealed output is ciphertext under a DEK it does
+    // not hold: the same inner ciphertext rides both legs.
+    assert_ne!(
+        chunk_for(&a, "peer-alice").double_sealed_ciphertext,
+        chunk_for(&b, "peer-alice").double_sealed_ciphertext,
+    );
+}

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -621,6 +621,9 @@ async fn inbound_handler(
         // CIRISEdge#402 — HTTP attributes via mTLS/bearer (`source_key_id`); it
         // carries no advisory-link identity, so no bootstrap carve-out here.
         link_key_id: None,
+        // CIRISEdge#499 — HTTP has no scope-derived destination plane; every
+        // request arrives at the federation endpoint.
+        arrival_scope: None,
     };
     match state.sink.send(frame).await {
         Ok(()) => StatusCode::ACCEPTED.into_response(),

--- a/src/transport/lxmf_serve.rs
+++ b/src/transport/lxmf_serve.rs
@@ -214,6 +214,52 @@ impl Default for LxmfServeLimits {
 /// policy is persist's or the constitution's to state. Edge offers the
 /// mechanism and fails closed.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
+/// # Why this is NOT `resolve_transit_eligibility` (CIRISPersist#561 / CIRISEdge#430)
+///
+/// The obvious move is to reuse the RNS transit rule — *directory-present,
+/// `identity_type` contains `node`, self-offers `infra:transport`, shares a
+/// trust root I trust* — since both planes carry only ciphertext. **That rule
+/// is too wide here**, and persist's own rationale for why it is wide is what
+/// rules it out:
+///
+/// > A relay carries only ciphertext — no `EpochDek` is reachable from a hop
+/// > … and it is what keeps relaying DECENTRALIZED: any trust-anchored node
+/// > offering transport can serve as a hop.
+///
+/// Three legs hold that up, and LXMF propagation satisfies only the first:
+///
+/// | | RNS transit | LXMF propagation |
+/// |---|---|---|
+/// | ciphertext-only | yes | **yes** |
+/// | transient | the frame passes, the node forgets | **retains for days** |
+/// | breadth is the point | yes, every hop matters | no, a mailbox needs no strangers |
+///
+/// The decisive difference is what the node **learns and holds over time**. A
+/// transit hop sees `(prev, next, size, time)` and forgets. A propagation node
+/// holds a mailbox **keyed by recipient**, and durably learns which
+/// destinations have mail waiting, how much and from whom, and *when the
+/// recipient came online to collect it* — a presence oracle. It can also
+/// withhold or delete, which is an availability lever aimed at one named
+/// person.
+///
+/// So the confidentiality property is identical and the metadata and
+/// availability properties are categorically different. `infra:transport`'s
+/// bar is proportionate to *"carries ciphertext and forgets"*. It is not
+/// proportionate to *"holds your mailbox and knows when you check it"*.
+///
+/// # The rule that does apply
+///
+/// **Self, family, and the communities this node is a member of** — the
+/// cohort-scope vocabulary CC already defines, resolved through machinery
+/// CIRISEdge#499 already built (`CohortGroup`'s roster, `ScopeAddressTable`'s
+/// membership). Edge POPULATES this roster from cohort membership; it does not
+/// author a predicate, which is what kept this from being edge writing policy.
+///
+/// Both legs read the same set, and they are different questions:
+/// - **upload** — someone hands this node mail *for* `R`: `R` must be served.
+/// - **download** — a requester wants `R`'s mail: the requester must *be* `R`
+///   (already structural, since the mailbox indexes by destination) *and* `R`
+///   must be served.
 pub enum PropagationAudience {
     /// This node does not carry third-party mail. The default posture.
     #[default]
@@ -223,6 +269,50 @@ pub enum PropagationAudience {
 }
 
 impl PropagationAudience {
+    /// Build the roster from **cohort membership** — self, family, and the
+    /// communities this node belongs to.
+    ///
+    /// This is the rule that applies to propagation (see the type docs for
+    /// why it is not `resolve_transit_eligibility`), expressed as code so the
+    /// next implementer inherits it rather than re-deriving it.
+    ///
+    /// `groups` is the set of `(scope, group_id)` pairs this node is a member
+    /// of — exactly what a host already holds after driving
+    /// [`ScopeLifecycle::install`] for each. For each, every member's derived
+    /// address is added, because a propagation node holds mail *for the
+    /// cohort*, not only for itself.
+    ///
+    /// Edge is POPULATING a set here, not authoring a predicate: membership is
+    /// answered by [`ScopeAddressTable`], and the scope vocabulary is CC's.
+    ///
+    /// Returns [`Self::Disabled`] when the table admits nothing — an empty
+    /// roster and "carry no third-party mail" are the same posture, and
+    /// collapsing them means there is no way to be armed-but-empty and believe
+    /// otherwise.
+    ///
+    /// [`ScopeLifecycle::install`]: crate::scope_lifecycle::ScopeLifecycle::install
+    /// [`ScopeAddressTable`]: crate::scope_addressing::ScopeAddressTable
+    #[must_use]
+    pub fn from_cohort_membership(
+        table: &crate::scope_addressing::ScopeAddressTable,
+        groups: &[(crate::cohort_scope::CohortScope, String)],
+        members_of: &dyn Fn(&crate::cohort_scope::CohortScope, &str) -> Vec<String>,
+    ) -> Self {
+        let mut roster = BTreeSet::new();
+        for (scope, group_id) in groups {
+            for member in members_of(scope, group_id) {
+                if let Some(addr) = table.send_address(scope, group_id, &member) {
+                    roster.insert(*addr.as_bytes());
+                }
+            }
+        }
+        if roster.is_empty() {
+            Self::Disabled
+        } else {
+            Self::Roster(roster)
+        }
+    }
+
     /// Whether `destination` is one this node carries for.
     #[must_use]
     pub fn serves(&self, destination: &DestinationHash16) -> bool {

--- a/src/transport/lxmf_serve.rs
+++ b/src/transport/lxmf_serve.rs
@@ -1,0 +1,901 @@
+//! LXMF propagation **host serve path** — this node acting as a
+//! propagation node for others (CIRISEdge#169).
+//!
+//! [`crate::transport::lxmf_propagation`] is the CLIENT half plus an
+//! unscoped admission core. This module is the other half: the state
+//! machine that answers a stranger's `/get` and admits a stranger's
+//! upload. It is what "#169 host serve path" means, and it is the piece
+//! that was blocked until **leviculum#38 landed** — at edge's pinned
+//! `v0.20.0+ciris.1` the host-direction codecs are public
+//! (`PropagationUpload::decode`, `MessageGetRequest::decode`,
+//! `MessageListResponse::encode`, `MessageGetResponse::encode`,
+//! `PropagationSignal::encode`) and, decisively,
+//! [`PropagatedMessage::from_unstamped_bytes`] +
+//! [`PropagatedMessage::destination_hash`] are public, which is what makes
+//! **per-recipient mailbox scoping** possible at all.
+//!
+//! We INTEGRATE `leviculum-lxmf`; every wire byte, hash and proof-of-work
+//! comes from it. This module contributes exactly three things the crate
+//! deliberately leaves to a host: **who we serve**, **what we retain**,
+//! and **for how long**.
+//!
+//! # Sans-I/O, and therefore CIRISEdge#217-safe by construction
+//!
+//! Nothing here is `async` and nothing here `.await`s, so a lock guard
+//! *cannot* be held across an await on the transport path — the invariant
+//! is structural rather than reviewed. Timing is
+//! [`std::time::Instant`] (monotonic), never `tokio::time` and never the
+//! wall clock: a retention window must not be shortened or extended by an
+//! NTP step. `now` is a parameter, so every bound is testable at its exact
+//! ceiling.
+//!
+//! # Retention posture — bounded, explicit, and refusing rather than evicting
+//!
+//! Edge's recorded position on LXMF propagation is that a propagation node
+//! holds LXMF **end-to-end ciphertext** and has no key and no decrypt path,
+//! so it is a *metadata observer* and an *availability lever*, not a
+//! confidentiality break — and that third-party propagation is therefore a
+//! deliberate operator choice for genuinely asleep peers, never the default
+//! reply path (which is why store-and-forward stays OFF the #353/#373
+//! live-link reply path). This module holds that line in four ways:
+//!
+//! 1. **Default OFF.** [`PropagationAudience::Disabled`] is
+//!    [`Default`]. A node that has not been explicitly told whose mail to
+//!    hold answers every propagation request with a named refusal. There
+//!    is deliberately **no "open node" variant**: serving all comers is a
+//!    policy choice about who may propagate what, and that rule is
+//!    persist's or the constitution's, not edge's (see *Upstream*, below).
+//! 2. **Explicit roster.** [`PropagationAudience::Roster`] is an operator-
+//!    supplied set of destination hashes. Both legs check it: an upload is
+//!    admitted only for a rostered *recipient*, and a `/get` is answered
+//!    only for a rostered *requester*.
+//! 3. **Bounded retention.** [`LxmfServeLimits::retention`] evicts
+//!    uncollected mail, and every eviction is reported as a
+//!    [`WithholdReason::LxmfRetentionExpired`] notice. A propagation node
+//!    that dropped third-party mail silently would be indistinguishable
+//!    from one that never received it.
+//! 4. **Full means refuse, not evict.** Every other bounded store in edge
+//!    (notably [`crate::transport::store_and_forward`]) evicts oldest-first
+//!    to admit. This one **refuses**, and that difference is the security
+//!    property: store-and-forward queues *this node's own* outbound
+//!    envelopes, where there is no third party to harm, whereas evicting
+//!    here would let an attacker flush a victim's pending mail with junk
+//!    uploads — turning a capacity bound into a censorship lever.
+//!
+//! # Recipient scoping is structural
+//!
+//! The mailbox is `destination -> transient_id -> ciphertext`. "You may
+//! read only your own mail" is therefore the shape of the data, not a
+//! filter that a future edit can forget to apply: serving another
+//! destination's message would require indexing a map this code never
+//! indexes. A requester that names a transient ID parked for someone
+//! *else* is reported as [`WithholdReason::LxmfMailboxScopeMismatch`] —
+//! including on the acknowledge leg, where it would otherwise be a way to
+//! **purge a stranger's mailbox**.
+//!
+//! # What this module refuses to decide (upstream)
+//!
+//! *Who may use this node as a propagation node* is not edge's rule to
+//! write. Edge supplies the mechanism (a roster) and fails closed; the
+//! roster's **source** — whether propagation carriage follows
+//! `infra:transport` conferral, the accord roster, or something else — is
+//! an upstream question. It is deliberately NOT wired to
+//! `resolve_transit_eligibility` here, because choosing that would be edge
+//! inventing the policy. See the module's report notes and CIRISEdge#169.
+//!
+//! Likewise the node-to-node `/offer` peer-sync direction is not
+//! implemented, because `leviculum-lxmf` does not implement it
+//! (leviculum#209); a well-formed multi-message upload is reported as
+//! [`WithholdReason::LxmfPeerSyncUnsupported`] rather than mis-parsed.
+//!
+//! # Where this hooks into the event loop
+//!
+//! Edge has exactly one Reticulum event loop and this module does not add
+//! a second. It is a pure decision function driven from
+//! [`crate::transport::reticulum`]'s existing `handle_event`:
+//!
+//! * `NodeEvent::RequestReceived` with `path == `[`MESSAGE_GET_PATH`] →
+//!   [`LxmfServeNode::serve_get`], whose `requester` argument is
+//!   `Node::get_remote_identity(link_id)` reduced to that identity's
+//!   destination hash. [`ServeOutcome::Respond`] carries the bytes for
+//!   `send_response(request_id, ..)`.
+//! * the inbound upload link-data / resource path →
+//!   [`LxmfServeNode::serve_upload`].
+//! * any existing periodic tick → [`LxmfServeNode::sweep`], so retention
+//!   is enforced on an idle node too.
+//!
+//! In every case the caller must drain [`ServeResult::notices`] into
+//! [`crate::observability::EdgeMetrics::inc_withhold`]; `ServeResult` is
+//! `#[must_use]` so a refusal cannot be dropped on the floor
+//! (CIRISEdge#425/#433).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use leviculum_lxmf::constants::{
+    DESTINATION_LENGTH, PROPAGATION_LIMIT_KB, WORKBLOCK_EXPAND_ROUNDS_PN,
+};
+use leviculum_lxmf::stamp::{self, CooperativeStamper, ReadyYield};
+use leviculum_lxmf::{
+    MessageGetRequest, MessageGetResponse, MessageListResponse, PeerError, PropagatedMessage,
+    PropagationError, PropagationSignal, PropagationUpload, TransientId,
+};
+
+use crate::contextual_integrity::{parameter_of, CiParameter, Delivery};
+use crate::observability::WithholdReason;
+
+/// Re-exported so the event loop's `register_request_handler` and this
+/// module's dispatch agree by construction.
+pub use leviculum_lxmf::MESSAGE_GET_PATH;
+
+/// A Reticulum destination hash — the mailbox key, and the identity a
+/// requester is scoped to.
+pub type DestinationHash16 = [u8; DESTINATION_LENGTH];
+
+/// Bytes each parked entry costs in addition to its ciphertext: the
+/// destination hash plus the transient ID that key it.
+///
+/// Counted deliberately. `leviculum-lxmf`'s own `MemoryLxmfStorage` learned
+/// this upstream — "counting values alone lets an attacker exhaust a
+/// constrained target with many large keys carrying empty values" — and the
+/// lesson is applied here rather than re-derived: a peer must not be able to
+/// size an allocation we did not account for.
+const ENTRY_OVERHEAD_BYTES: usize = DESTINATION_LENGTH + 32;
+
+/// Every ceiling this node enforces while serving strangers.
+///
+/// A propagation node serves parties it has no relationship with, so every
+/// buffer, queue and retention window has an explicit bound. Boundary
+/// semantics follow `leviculum-lxmf`'s own convention (`DELIVERY_LIMIT_BYTES`:
+/// "exactly at the limit is accepted; the comparison is `size > limit`"):
+/// a value **equal to** a size ceiling is admitted, one **above** it is
+/// refused; a count ceiling is full when reached; retention expires when
+/// the window is reached.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LxmfServeLimits {
+    /// Largest `/get` request body accepted, before any decode.
+    pub max_request_bytes: usize,
+    /// Largest upload envelope accepted, before any decode.
+    pub max_upload_bytes: usize,
+    /// Most transient IDs one request may name across `wants` + `haves`.
+    /// Bounds the work a single request can buy.
+    pub max_ids_per_request: usize,
+    /// Total mailbox bytes retained, keys included.
+    pub max_store_bytes: usize,
+    /// Most messages parked for any one destination.
+    pub max_messages_per_destination: usize,
+    /// Most distinct destinations with a live mailbox. Without this an
+    /// attacker mints unbounded mailbox keys under the byte cap.
+    pub max_destinations: usize,
+    /// Most messages returned in one `/get` download response.
+    pub max_messages_per_response: usize,
+    /// Most bytes returned in one `/get` download response.
+    pub max_response_bytes: usize,
+    /// How long an uncollected message is retained before it is evicted
+    /// and reported. The retention posture, in one field.
+    pub retention: Duration,
+    /// Admission proof-of-work cost (leading-zero bits) this node
+    /// advertises and enforces. `0` disables the spam bound, so the
+    /// default is non-zero.
+    pub stamp_cost: u8,
+}
+
+impl Default for LxmfServeLimits {
+    /// Defaults chosen from upstream and from edge's existing #169 Scope-B
+    /// budget rather than invented: the per-transfer sizes are
+    /// `leviculum-lxmf`'s own [`PROPAGATION_LIMIT_KB`] (Python
+    /// `LXMRouter.PROPAGATION_LIMIT`), and the store budget, per-destination
+    /// depth and retention window match
+    /// [`crate::transport::store_and_forward`]'s defaults so an operator
+    /// running both planes reasons about one set of numbers.
+    fn default() -> Self {
+        let propagation_limit_bytes =
+            usize::try_from(PROPAGATION_LIMIT_KB * 1000).unwrap_or(256 * 1000);
+        Self {
+            max_request_bytes: 64 * 1024,
+            max_upload_bytes: propagation_limit_bytes,
+            max_ids_per_request: 1024,
+            max_store_bytes: 64 * 1024 * 1024,
+            max_messages_per_destination: 256,
+            max_destinations: 1024,
+            max_messages_per_response: 64,
+            max_response_bytes: propagation_limit_bytes,
+            retention: Duration::from_secs(7 * 24 * 60 * 60),
+            stamp_cost: 8,
+        }
+    }
+}
+
+/// Whose mail this node is willing to hold and serve.
+///
+/// There is no "serve everyone" variant, and that absence is the point:
+/// *who may use this node as a propagation node* is a policy question, and
+/// policy is persist's or the constitution's to state. Edge offers the
+/// mechanism and fails closed.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum PropagationAudience {
+    /// This node does not carry third-party mail. The default posture.
+    #[default]
+    Disabled,
+    /// The operator-supplied set of destinations this node holds mail for.
+    Roster(BTreeSet<DestinationHash16>),
+}
+
+impl PropagationAudience {
+    /// Whether `destination` is one this node carries for.
+    #[must_use]
+    pub fn serves(&self, destination: &DestinationHash16) -> bool {
+        match self {
+            Self::Disabled => false,
+            Self::Roster(set) => set.contains(destination),
+        }
+    }
+
+    /// Whether the node is operating as a propagation node at all.
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        matches!(self, Self::Roster(_))
+    }
+}
+
+/// One thing this node declined to do, or undid, in commitment terms.
+///
+/// Emitted for refusals AND for retention evictions, so nothing leaves the
+/// mailbox silently (CIRISEdge#425/#433). The caller pushes each into the
+/// withhold ledger.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Notice {
+    /// The gate that refused, or the clock that evicted.
+    pub reason: WithholdReason,
+    /// Short, static, low-cardinality leg descriptor — never peer-supplied
+    /// bytes, matching `inc_withhold`'s contract that the ring stays
+    /// bounded in entry size as well as in count.
+    pub detail: &'static str,
+    /// The destination this concerned, when one is known.
+    pub destination: Option<DestinationHash16>,
+}
+
+impl Notice {
+    fn new(
+        reason: WithholdReason,
+        detail: &'static str,
+        destination: Option<DestinationHash16>,
+    ) -> Self {
+        Self {
+            reason,
+            detail,
+            destination,
+        }
+    }
+
+    /// The commitment this notice defends — the single source of truth is
+    /// [`parameter_of`], never a second table here.
+    #[must_use]
+    pub fn parameter(&self) -> CiParameter {
+        parameter_of(self.reason)
+    }
+
+    /// The decision in commitment vocabulary, for an operator log.
+    #[must_use]
+    pub fn delivery(&self) -> Delivery {
+        Delivery::withheld(self.reason)
+    }
+}
+
+/// What the event loop must do with this request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ServeOutcome {
+    /// Send these bytes back via `send_response(request_id, ..)`.
+    Respond(Vec<u8>),
+    /// An upload was admitted and is now parked. LXMF sends no
+    /// acknowledgement for a successful upload, so there is nothing to
+    /// write back.
+    Admitted {
+        /// The re-derived transient ID it was parked under — never the
+        /// wire-supplied one.
+        transient_id: TransientId,
+        /// The recipient whose mailbox now holds it.
+        destination: DestinationHash16,
+    },
+    /// Refused. `response`, when present, is the wire refusal the protocol
+    /// defines for this leg (a `PeerError` code on `/get`, a
+    /// [`PropagationSignal`] on upload); `None` means the protocol defines
+    /// no reply and the caller should simply not answer.
+    Refused {
+        /// The gate that refused.
+        reason: WithholdReason,
+        /// Short static leg descriptor.
+        detail: &'static str,
+        /// Bytes to send back, if the protocol defines a refusal reply.
+        response: Option<Vec<u8>>,
+    },
+}
+
+/// The outcome plus every notice the call produced.
+///
+/// `#[must_use]`: a caller that dropped this would drop refusals and
+/// retention evictions on the floor, which is exactly the silent-drop class
+/// CIRISEdge#425/#433 exists to make impossible.
+#[must_use]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ServeResult {
+    /// What to do next.
+    pub outcome: ServeOutcome,
+    /// Refusals and evictions to push into the withhold ledger. Bounded by
+    /// construction: never more than the number of messages the mailbox
+    /// ceilings allow it to hold.
+    pub notices: Vec<Notice>,
+}
+
+impl ServeResult {
+    fn refused(
+        notices: Vec<Notice>,
+        reason: WithholdReason,
+        detail: &'static str,
+        response: Option<Vec<u8>>,
+    ) -> Self {
+        let mut notices = notices;
+        notices.push(Notice::new(reason, detail, None));
+        Self {
+            outcome: ServeOutcome::Refused {
+                reason,
+                detail,
+                response,
+            },
+            notices,
+        }
+    }
+
+    /// Whether the outcome was a refusal.
+    #[must_use]
+    pub fn refused_reason(&self) -> Option<WithholdReason> {
+        match self.outcome {
+            ServeOutcome::Refused { reason, .. } => Some(reason),
+            _ => None,
+        }
+    }
+}
+
+/// One message parked on behalf of a third party.
+#[derive(Clone, Debug)]
+struct Parked {
+    /// LXMF end-to-end ciphertext, verbatim. This node holds no key for it
+    /// and there is no decrypt path on this type.
+    ciphertext: Vec<u8>,
+    /// Monotonic admission instant — the retention clock.
+    stored_at: Instant,
+}
+
+/// `destination -> transient_id -> parked`. The nesting IS the scoping.
+#[derive(Debug, Default)]
+struct MailboxState {
+    boxes: BTreeMap<DestinationHash16, BTreeMap<TransientId, Parked>>,
+    /// Running total of `ENTRY_OVERHEAD_BYTES + ciphertext.len()`.
+    bytes: usize,
+}
+
+impl MailboxState {
+    /// Evict everything past the retention window, reporting each.
+    fn sweep(&mut self, now: Instant, retention: Duration) -> Vec<Notice> {
+        let mut notices = Vec::new();
+        let mut emptied: Vec<DestinationHash16> = Vec::new();
+        for (dest, entries) in &mut self.boxes {
+            let expired: Vec<TransientId> = entries
+                .iter()
+                .filter(|(_, p)| now.duration_since(p.stored_at) >= retention)
+                .map(|(id, _)| *id)
+                .collect();
+            for id in expired {
+                if let Some(p) = entries.remove(&id) {
+                    self.bytes = self
+                        .bytes
+                        .saturating_sub(ENTRY_OVERHEAD_BYTES + p.ciphertext.len());
+                    notices.push(Notice::new(
+                        WithholdReason::LxmfRetentionExpired,
+                        "retention_window",
+                        Some(*dest),
+                    ));
+                }
+            }
+            if entries.is_empty() {
+                emptied.push(*dest);
+            }
+        }
+        // An emptied mailbox is removed so it stops counting against
+        // `max_destinations`; leaving it would let expired traffic
+        // permanently consume the destination budget.
+        for dest in emptied {
+            self.boxes.remove(&dest);
+        }
+        notices
+    }
+
+    /// Whether any destination OTHER than `owner` holds `id`. The
+    /// cross-recipient probe detector.
+    fn held_by_other(&self, owner: &DestinationHash16, id: &TransientId) -> bool {
+        self.boxes
+            .iter()
+            .any(|(dest, entries)| dest != owner && entries.contains_key(id))
+    }
+}
+
+/// The propagation-node host: bounded, rostered, recipient-scoped.
+#[derive(Debug)]
+pub struct LxmfServeNode {
+    limits: LxmfServeLimits,
+    audience: PropagationAudience,
+    state: Mutex<MailboxState>,
+}
+
+impl LxmfServeNode {
+    /// A node with an explicit audience and explicit ceilings.
+    #[must_use]
+    pub fn new(audience: PropagationAudience, limits: LxmfServeLimits) -> Self {
+        Self {
+            limits,
+            audience,
+            state: Mutex::new(MailboxState::default()),
+        }
+    }
+
+    /// A node that serves `roster` under [`LxmfServeLimits::default`].
+    #[must_use]
+    pub fn serving(roster: BTreeSet<DestinationHash16>) -> Self {
+        Self::new(
+            PropagationAudience::Roster(roster),
+            LxmfServeLimits::default(),
+        )
+    }
+
+    /// A node in the default posture: carries nobody's mail.
+    #[must_use]
+    pub fn disabled() -> Self {
+        Self::new(PropagationAudience::Disabled, LxmfServeLimits::default())
+    }
+
+    /// The ceilings in force.
+    #[must_use]
+    pub fn limits(&self) -> LxmfServeLimits {
+        self.limits
+    }
+
+    /// The audience in force.
+    #[must_use]
+    pub fn audience(&self) -> &PropagationAudience {
+        &self.audience
+    }
+
+    /// Run the mailbox state under the lock.
+    ///
+    /// A poisoned lock is recovered rather than propagated: a propagation
+    /// node must not become permanently unserviceable because one request
+    /// panicked, which would make a panic a remote availability kill.
+    /// There is no `.await` inside any caller of this, so no guard can
+    /// cross a suspension point (CIRISEdge#217).
+    fn with_state<T>(&self, f: impl FnOnce(&mut MailboxState) -> T) -> T {
+        let mut guard = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        f(&mut guard)
+    }
+
+    /// Evict everything past the retention window. Drive this from the
+    /// event loop's existing periodic tick so retention is enforced on an
+    /// idle node, not only when traffic happens to arrive.
+    pub fn sweep(&self, now: Instant) -> Vec<Notice> {
+        let retention = self.limits.retention;
+        self.with_state(|st| st.sweep(now, retention))
+    }
+
+    /// Total retained ciphertext + key bytes.
+    #[must_use]
+    pub fn stored_bytes(&self) -> usize {
+        self.with_state(|st| st.bytes)
+    }
+
+    /// Number of destinations with a live mailbox.
+    #[must_use]
+    pub fn destination_count(&self) -> usize {
+        self.with_state(|st| st.boxes.len())
+    }
+
+    /// Messages parked for one destination.
+    #[must_use]
+    pub fn pending_for(&self, destination: &DestinationHash16) -> usize {
+        self.with_state(|st| st.boxes.get(destination).map_or(0, BTreeMap::len))
+    }
+
+    /// The announce parameters this node's advertised terms imply, for the
+    /// caller to encode into a [`leviculum_lxmf::PropagationNodeAnnounce`].
+    /// Advertising a `stamp_cost` other than the one enforced would be a
+    /// node lying about its price of carriage, so both come from here.
+    #[must_use]
+    pub fn advertised_stamp_cost(&self) -> u64 {
+        u64::from(self.limits.stamp_cost)
+    }
+
+    // ── The `/get` mailbox exchange ─────────────────────────────────────
+
+    /// Answer a client's `/get`.
+    ///
+    /// `requester` is the destination hash the link's remote identity
+    /// resolves to — the caller reads it from
+    /// `Node::get_remote_identity(link_id)`. `None` means the link is
+    /// unidentified, which is refused: there is no answer to "whose
+    /// mailbox is this".
+    pub fn serve_get(
+        &self,
+        requester: Option<DestinationHash16>,
+        body: &[u8],
+        now: Instant,
+    ) -> ServeResult {
+        let notices = self.sweep(now);
+
+        if !self.audience.enabled() {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfPropagationDisabled,
+                "get",
+                Some(peer_error_list(PeerError::NoAccess)),
+            );
+        }
+        if body.len() > self.limits.max_request_bytes {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfFrameOversized,
+                "get_request_bytes",
+                Some(peer_error_list(PeerError::InvalidData)),
+            );
+        }
+        let Some(requester) = requester else {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfRequesterUnidentified,
+                "get_link_unidentified",
+                Some(peer_error_list(PeerError::NoIdentity)),
+            );
+        };
+        if !self.audience.serves(&requester) {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfDestinationNotServed,
+                "get_requester_off_roster",
+                Some(peer_error_list(PeerError::NoAccess)),
+            );
+        }
+        let Ok(request) = MessageGetRequest::decode(body) else {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfWireUnparseable,
+                "get_request",
+                Some(peer_error_list(PeerError::InvalidData)),
+            );
+        };
+        let named =
+            request.wants.as_ref().map_or(0, Vec::len) + request.haves.as_ref().map_or(0, Vec::len);
+        if named > self.limits.max_ids_per_request {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfFrameOversized,
+                "get_request_id_count",
+                Some(peer_error_list(PeerError::InvalidData)),
+            );
+        }
+
+        match (request.wants, request.haves) {
+            (Some(wants), _) => self.download(requester, &wants, notices),
+            (None, Some(haves)) => self.acknowledge(requester, &haves, notices),
+            (None, None) => self.list(requester, notices),
+        }
+    }
+
+    /// `wants: None, haves: None` — list this requester's own transient IDs.
+    fn list(&self, requester: DestinationHash16, notices: Vec<Notice>) -> ServeResult {
+        let ids = self.with_state(|st| {
+            st.boxes
+                .get(&requester)
+                .map_or_else(Vec::new, |entries| entries.keys().copied().collect())
+        });
+        respond(MessageListResponse::TransientIds(ids).encode(), notices)
+    }
+
+    /// `wants: Some(..)` — serve only what is parked for this requester.
+    fn download(
+        &self,
+        requester: DestinationHash16,
+        wants: &[TransientId],
+        notices: Vec<Notice>,
+    ) -> ServeResult {
+        let limits = self.limits;
+        let (messages, mut extra) = self.with_state(|st| {
+            let mut messages: Vec<Vec<u8>> = Vec::new();
+            let mut extra: Vec<Notice> = Vec::new();
+            let mut bytes = 0usize;
+            for id in wants {
+                let Some(parked) = st.boxes.get(&requester).and_then(|e| e.get(id)) else {
+                    // Not ours to serve. Two very different misses:
+                    if st.held_by_other(&requester, id) {
+                        // Parked for SOMEONE ELSE — a cross-recipient probe.
+                        // Reported, because this miss is evidence of an
+                        // attack rather than of a race.
+                        extra.push(Notice::new(
+                            WithholdReason::LxmfMailboxScopeMismatch,
+                            "download_foreign_transient_id",
+                            Some(requester),
+                        ));
+                    }
+                    // Held by nobody: an ordinary absence (already collected,
+                    // expired, or never existed). NOT a withhold — we are not
+                    // declining to serve something we hold — and ledgering it
+                    // would drown the real signal above in routine misses.
+                    continue;
+                };
+                if messages.len() >= limits.max_messages_per_response
+                    || bytes + parked.ciphertext.len() > limits.max_response_bytes
+                {
+                    // We DO hold it and are declining to send it in this
+                    // response: a withhold, not a miss.
+                    extra.push(Notice::new(
+                        WithholdReason::LxmfFrameOversized,
+                        "download_response_cap",
+                        Some(requester),
+                    ));
+                    continue;
+                }
+                bytes += parked.ciphertext.len();
+                messages.push(parked.ciphertext.clone());
+            }
+            (messages, extra)
+        });
+        let mut notices = notices;
+        notices.append(&mut extra);
+        respond(MessageGetResponse::Messages(messages).encode(), notices)
+    }
+
+    /// `wants: None, haves: Some(..)` — purge, from this requester's box only.
+    fn acknowledge(
+        &self,
+        requester: DestinationHash16,
+        haves: &[TransientId],
+        notices: Vec<Notice>,
+    ) -> ServeResult {
+        let mut extra = self.with_state(|st| {
+            let mut extra: Vec<Notice> = Vec::new();
+            for id in haves {
+                let removed = st
+                    .boxes
+                    .get_mut(&requester)
+                    .and_then(|entries| entries.remove(id));
+                if let Some(p) = removed {
+                    st.bytes = st
+                        .bytes
+                        .saturating_sub(ENTRY_OVERHEAD_BYTES + p.ciphertext.len());
+                } else if st.held_by_other(&requester, id) {
+                    // Acknowledging someone else's message would DELETE it.
+                    // The scoping makes that impossible; this says so.
+                    extra.push(Notice::new(
+                        WithholdReason::LxmfMailboxScopeMismatch,
+                        "acknowledge_foreign_transient_id",
+                        Some(requester),
+                    ));
+                }
+            }
+            if st.boxes.get(&requester).is_some_and(BTreeMap::is_empty) {
+                st.boxes.remove(&requester);
+            }
+            extra
+        });
+        let mut notices = notices;
+        notices.append(&mut extra);
+        // Python answers the purge exchange with the (now shorter) list.
+        let ids = self.with_state(|st| {
+            st.boxes
+                .get(&requester)
+                .map_or_else(Vec::new, |entries| entries.keys().copied().collect())
+        });
+        respond(MessageListResponse::TransientIds(ids).encode(), notices)
+    }
+
+    // ── Upload admission ────────────────────────────────────────────────
+
+    /// Admit (or refuse) an inbound upload envelope from raw link data or a
+    /// resource body.
+    ///
+    /// Ordering is deliberate: every cheap check runs *before* the
+    /// proof-of-work validation, so junk never buys us a workblock hash;
+    /// and the proof-of-work runs *outside* the mailbox lock, so the
+    /// expensive step never blocks another request (CIRISEdge#217 in
+    /// spirit as well as letter — there is no `.await` here at all).
+    pub fn serve_upload(&self, body: &[u8], now: Instant) -> ServeResult {
+        let notices = self.sweep(now);
+
+        if !self.audience.enabled() {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfPropagationDisabled,
+                "upload",
+                None,
+            );
+        }
+        if body.len() > self.limits.max_upload_bytes {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfFrameOversized,
+                "upload_bytes",
+                None,
+            );
+        }
+        let upload = match PropagationUpload::decode(body) {
+            Ok(u) => u,
+            Err(PropagationError::MultipleMessages) => {
+                return ServeResult::refused(
+                    notices,
+                    WithholdReason::LxmfPeerSyncUnsupported,
+                    "upload_offer_form",
+                    None,
+                );
+            }
+            Err(_) => {
+                return ServeResult::refused(
+                    notices,
+                    WithholdReason::LxmfWireUnparseable,
+                    "upload_envelope",
+                    None,
+                );
+            }
+        };
+
+        // The recipient is read from the ciphertext's own framing, never
+        // from anything the uploader asserts separately. Structurally
+        // infallible after a successful `decode` — which guarantees
+        // `unstamped.len() > LXMF_OVERHEAD`, exactly this call's
+        // precondition — and pinned as such by
+        // `decode_success_implies_readable_destination`.
+        let Ok(propagated) = PropagatedMessage::from_unstamped_bytes(upload.unstamped_lxmf())
+        else {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfWireUnparseable,
+                "upload_destination",
+                None,
+            );
+        };
+        let destination = *propagated.destination_hash();
+
+        if !self.audience.serves(&destination) {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfDestinationNotServed,
+                "upload_recipient_off_roster",
+                None,
+            );
+        }
+
+        // Spam bound. Outside the lock, on the re-derived transient ID.
+        if !self.stamp_clears_cost(upload.transient_id(), upload.propagation_stamp()) {
+            return ServeResult::refused(
+                notices,
+                WithholdReason::LxmfStampBelowCost,
+                "upload_stamp",
+                Some(PropagationSignal::InvalidStamp.encode()),
+            );
+        }
+
+        self.park(destination, &upload, now, notices)
+    }
+
+    /// Validate the outer propagation-node proof-of-work stamp against the
+    /// cost this node advertises. `leviculum-lxmf` does the work; a stamp
+    /// that does not clear the cost yields `Ok(None)`, and an engine error
+    /// is treated as "did not clear" (fail-closed).
+    fn stamp_clears_cost(&self, transient_id: &TransientId, stamp_bytes: &[u8; 32]) -> bool {
+        let mut engine = CooperativeStamper::new(rand::rngs::OsRng, ReadyYield);
+        futures::executor::block_on(stamp::validate(
+            &mut engine,
+            transient_id,
+            stamp_bytes,
+            self.limits.stamp_cost,
+            WORKBLOCK_EXPAND_ROUNDS_PN,
+            &[],
+        ))
+        .ok()
+        .flatten()
+        .is_some()
+    }
+
+    /// Capacity check and insert, atomically under the lock.
+    ///
+    /// Full means **refuse**, never evict — see the module docs.
+    fn park(
+        &self,
+        destination: DestinationHash16,
+        upload: &PropagationUpload,
+        now: Instant,
+        notices: Vec<Notice>,
+    ) -> ServeResult {
+        let limits = self.limits;
+        let transient_id = *upload.transient_id();
+        let ciphertext = upload.unstamped_lxmf().to_vec();
+        let cost = ENTRY_OVERHEAD_BYTES + ciphertext.len();
+
+        // Every ceiling is evaluated BEFORE any mutation, so a refused
+        // upload leaves the mailbox byte-identical — in particular it
+        // cannot leave an empty mailbox behind that would occupy the
+        // destination budget.
+        let full = self.with_state(|st| {
+            let existing = st.boxes.get(&destination);
+            if existing.is_none() && st.boxes.len() >= limits.max_destinations {
+                return Some("upload_destination_cap");
+            }
+            // A repeat upload of a message already parked is idempotent, so
+            // it is not charged against the depth cap and its old bytes are
+            // credited back against the byte cap.
+            let replacing = existing
+                .and_then(|entries| entries.get(&transient_id))
+                .map(|p| p.ciphertext.len());
+            let depth = existing.map_or(0, BTreeMap::len);
+            if replacing.is_none() && depth >= limits.max_messages_per_destination {
+                return Some("upload_destination_depth");
+            }
+            let projected = st
+                .bytes
+                .saturating_sub(replacing.map_or(0, |n| ENTRY_OVERHEAD_BYTES + n))
+                + cost;
+            if projected > limits.max_store_bytes {
+                return Some("upload_store_bytes");
+            }
+            st.boxes.entry(destination).or_default().insert(
+                transient_id,
+                Parked {
+                    ciphertext,
+                    stored_at: now,
+                },
+            );
+            st.bytes = projected;
+            None
+        });
+
+        match full {
+            Some(detail) => {
+                ServeResult::refused(notices, WithholdReason::LxmfMailboxFull, detail, None)
+            }
+            None => ServeResult {
+                outcome: ServeOutcome::Admitted {
+                    transient_id,
+                    destination,
+                },
+                notices,
+            },
+        }
+    }
+}
+
+/// The node's `/get` refusal reply: a bare `PeerError` code, which both
+/// [`MessageListResponse`] and [`MessageGetResponse`] decode identically.
+fn peer_error_list(error: PeerError) -> Vec<u8> {
+    MessageListResponse::Error(error)
+        .encode()
+        .unwrap_or_default()
+}
+
+/// Wrap an encoder result into a response, degrading an encode failure into
+/// a named refusal rather than a panic or an empty answer.
+fn respond(encoded: Result<Vec<u8>, PropagationError>, notices: Vec<Notice>) -> ServeResult {
+    match encoded {
+        Ok(bytes) => ServeResult {
+            outcome: ServeOutcome::Respond(bytes),
+            notices,
+        },
+        Err(_) => ServeResult::refused(
+            notices,
+            WithholdReason::LxmfWireUnparseable,
+            "response_encode",
+            None,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/transport/lxmf_serve/tests.rs
+++ b/src/transport/lxmf_serve/tests.rs
@@ -890,3 +890,61 @@ fn every_refusal_emits_a_matching_notice() {
         );
     }
 }
+
+// ── The roster rule: cohort membership, not RNS transit eligibility ──
+
+/// The propagation roster is COHORT MEMBERSHIP — self, family, and the
+/// communities this node is in — and deliberately NOT the RNS transit rule.
+///
+/// Reusing `resolve_transit_eligibility` here would admit any trust-anchored
+/// node self-offering `infra:transport`. That bar is proportionate to "carries
+/// ciphertext and forgets"; it is not proportionate to "holds your mailbox and
+/// knows when you check it". See `PropagationAudience`'s docs for the full
+/// reasoning.
+#[test]
+fn the_roster_is_cohort_membership_and_admits_only_members() {
+    use crate::cohort_scope::CohortScope;
+    use crate::scope_addressing::{ScopeAddressTable, StubDeriver};
+    use std::sync::Arc;
+
+    let family = CohortScope::Family;
+    let table = ScopeAddressTable::new(Arc::new(StubDeriver));
+    table
+        .install_group(&family, "kin", 1, &[7u8; 32], &["me", "sibling"])
+        .expect("install");
+
+    let audience = PropagationAudience::from_cohort_membership(
+        &table,
+        &[(family.clone(), "kin".to_owned())],
+        &|_, _| vec!["me".to_owned(), "sibling".to_owned()],
+    );
+
+    for member in ["me", "sibling"] {
+        let addr = table.send_address(&family, "kin", member).expect("addr");
+        assert!(
+            audience.serves(addr.as_bytes()),
+            "{member} is in the cohort, so this node holds mail for them",
+        );
+    }
+
+    // The half the transit rule would get wrong: a stranger sharing a trust
+    // root passes `infra:transport` and must still fail here.
+    assert!(
+        !audience.serves(&[0x5a; DESTINATION_LENGTH]),
+        "a non-member destination must not be served",
+    );
+}
+
+/// An empty membership collapses to `Disabled` rather than an armed-but-empty
+/// roster: there must be no state in which a node believes it is carrying mail
+/// and is not.
+#[test]
+fn an_empty_membership_collapses_to_disabled() {
+    use crate::scope_addressing::{ScopeAddressTable, StubDeriver};
+    use std::sync::Arc;
+
+    let table = ScopeAddressTable::new(Arc::new(StubDeriver));
+    let audience = PropagationAudience::from_cohort_membership(&table, &[], &|_, _| Vec::new());
+    assert_eq!(audience, PropagationAudience::Disabled);
+    assert!(!audience.serves(&[0u8; DESTINATION_LENGTH]));
+}

--- a/src/transport/lxmf_serve/tests.rs
+++ b/src/transport/lxmf_serve/tests.rs
@@ -1,0 +1,892 @@
+//! CIRISEdge#169 — host serve-path tests.
+//!
+//! Two disciplines this repo learned the hard way and applies here:
+//!
+//! * **Both sides asserted.** Every refusal test is paired with an
+//!   admission on the same node, so a serve path that refused
+//!   *everything* could not pass.
+//! * **One bound per fixture.** Every ceiling test starts from
+//!   [`generous`] — limits set high enough that nothing else can fire —
+//!   and lowers exactly the field under test. A test that passed because
+//!   a neighbouring default was already safe would prove nothing, which
+//!   is the trap that has bitten this repo repeatedly.
+
+use super::*;
+use leviculum_lxmf::constants::{LXMF_OVERHEAD, STAMP_SIZE};
+use leviculum_lxmf::msgpack;
+
+const A: DestinationHash16 = [0xAA; DESTINATION_LENGTH];
+const B: DestinationHash16 = [0xBB; DESTINATION_LENGTH];
+const C: DestinationHash16 = [0xCC; DESTINATION_LENGTH];
+
+/// Ciphertext length that clears `LXMF_OVERHEAD` with room to spare.
+const CIPHER_LEN: usize = 200;
+
+/// What one parked fixture message costs the byte budget.
+///
+/// Spelled out rather than inlined because it is easy to get wrong in a
+/// way that makes a ceiling test pass for the wrong reason: the stored
+/// value is the VERBATIM unstamped LXMF payload, which already begins with
+/// its own 16-byte destination hash, and on top of that the mailbox is
+/// keyed by (destination, transient ID).
+const fn entry_cost() -> usize {
+    ENTRY_OVERHEAD_BYTES + DESTINATION_LENGTH + CIPHER_LEN
+}
+
+/// Limits under which NO bound can fire. Each ceiling test lowers exactly
+/// one field, so the assertion can only be explained by that field.
+fn generous() -> LxmfServeLimits {
+    LxmfServeLimits {
+        max_request_bytes: 1 << 20,
+        max_upload_bytes: 1 << 20,
+        max_ids_per_request: 4096,
+        max_store_bytes: 1 << 20,
+        max_messages_per_destination: 4096,
+        max_destinations: 4096,
+        max_messages_per_response: 4096,
+        max_response_bytes: 1 << 20,
+        retention: Duration::from_secs(3600),
+        // 0 keeps the fixtures fast; the stamp bound has its own test that
+        // runs at a real non-zero cost.
+        stamp_cost: 0,
+    }
+}
+
+fn roster(dests: &[DestinationHash16]) -> BTreeSet<DestinationHash16> {
+    dests.iter().copied().collect()
+}
+
+fn node(dests: &[DestinationHash16], limits: LxmfServeLimits) -> LxmfServeNode {
+    LxmfServeNode::new(PropagationAudience::Roster(roster(dests)), limits)
+}
+
+/// `destination_hash || ciphertext` — the unstamped LXMF shape a
+/// propagation node indexes. `tag` varies the ciphertext so distinct
+/// messages get distinct transient IDs.
+fn unstamped(dest: DestinationHash16, tag: u8, cipher_len: usize) -> Vec<u8> {
+    let mut v = dest.to_vec();
+    v.extend(std::iter::repeat_n(tag, cipher_len));
+    v
+}
+
+/// A real upload envelope, stamped at `cost` by the SAME generator a field
+/// client uses — field provenance, not a convenient hand-built stamp.
+fn upload_at_cost(dest: DestinationHash16, tag: u8, cipher_len: usize, cost: u8) -> Vec<u8> {
+    let payload = unstamped(dest, tag, cipher_len);
+    let stamp = crate::transport::lxmf_propagation::LxmfPropagationClient::new()
+        .generate_propagation_stamp(&payload, cost)
+        .expect("stamp generation");
+    PropagationUpload::single(1.0, payload, stamp).encode()
+}
+
+/// An upload envelope stamped at cost 0 (the `generous` fixture).
+fn upload(dest: DestinationHash16, tag: u8) -> Vec<u8> {
+    upload_at_cost(dest, tag, CIPHER_LEN, 0)
+}
+
+fn transient_of(dest: DestinationHash16, tag: u8, cipher_len: usize) -> TransientId {
+    leviculum_core::crypto::full_hash(&unstamped(dest, tag, cipher_len))
+}
+
+fn admitted(result: &ServeResult) -> (TransientId, DestinationHash16) {
+    match result.outcome {
+        ServeOutcome::Admitted {
+            transient_id,
+            destination,
+        } => (transient_id, destination),
+        ref other => panic!("expected Admitted, got {other:?}"),
+    }
+}
+
+fn responded(result: &ServeResult) -> &[u8] {
+    match result.outcome {
+        ServeOutcome::Respond(ref bytes) => bytes,
+        ref other => panic!("expected Respond, got {other:?}"),
+    }
+}
+
+fn listed(result: &ServeResult) -> Vec<TransientId> {
+    match MessageListResponse::decode(responded(result)).expect("list response decodes") {
+        MessageListResponse::TransientIds(ids) => ids,
+        MessageListResponse::Error(e) => panic!("expected ids, got peer error {e:?}"),
+    }
+}
+
+fn downloaded(result: &ServeResult) -> Vec<Vec<u8>> {
+    match MessageGetResponse::decode(responded(result)).expect("get response decodes") {
+        MessageGetResponse::Messages(m) => m,
+        MessageGetResponse::Error(e) => panic!("expected messages, got peer error {e:?}"),
+    }
+}
+
+fn has_notice(result: &ServeResult, reason: WithholdReason) -> bool {
+    result.notices.iter().any(|n| n.reason == reason)
+}
+
+fn count_notice(result: &ServeResult, reason: WithholdReason) -> usize {
+    result.notices.iter().filter(|n| n.reason == reason).count()
+}
+
+fn list_request() -> Vec<u8> {
+    MessageGetRequest::list().encode().expect("list encodes")
+}
+
+fn get_request(wants: Vec<TransientId>) -> Vec<u8> {
+    MessageGetRequest {
+        wants: Some(wants),
+        haves: None,
+        transfer_limit_kb: None,
+    }
+    .encode()
+    .expect("get encodes")
+}
+
+fn ack_request(haves: Vec<TransientId>) -> Vec<u8> {
+    MessageGetRequest::acknowledge(haves)
+        .encode()
+        .expect("ack encodes")
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// The headline pair: admits well-formed, refuses malformed
+// ─────────────────────────────────────────────────────────────────────
+
+/// The serve path admits a well-formed upload AND refuses a malformed one
+/// **on the same node**, so it cannot pass by refusing everything.
+#[test]
+fn admits_well_formed_upload_and_refuses_malformed_one() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+
+    let good = n.serve_upload(&upload(A, 0x01), t0);
+    let (id, dest) = admitted(&good);
+    assert_eq!(dest, A);
+    assert_eq!(id, transient_of(A, 0x01, CIPHER_LEN));
+    assert!(good.notices.is_empty(), "a clean admit emits no notices");
+    assert_eq!(n.pending_for(&A), 1);
+
+    // Malformed: not a msgpack upload envelope at all.
+    let bad = n.serve_upload(&[0x00, 0x01, 0x02], t0);
+    assert_eq!(
+        bad.refused_reason(),
+        Some(WithholdReason::LxmfWireUnparseable)
+    );
+    // The refusal did not disturb the admitted message.
+    assert_eq!(n.pending_for(&A), 1, "a refusal must not evict good mail");
+}
+
+/// The full happy path over the real leviculum-lxmf wire: upload → list →
+/// download → acknowledge, with the served ciphertext byte-identical to
+/// what was uploaded (the node never rewraps, and holds no key to decrypt).
+#[test]
+fn round_trip_upload_list_download_acknowledge() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+    let payload = unstamped(A, 0x07, CIPHER_LEN);
+
+    let (id, _) = admitted(&n.serve_upload(&upload(A, 0x07), t0));
+
+    let list = n.serve_get(Some(A), &list_request(), t0);
+    assert_eq!(listed(&list), vec![id]);
+
+    let got = n.serve_get(Some(A), &get_request(vec![id]), t0);
+    assert_eq!(
+        downloaded(&got),
+        vec![payload],
+        "served bytes must be the uploaded ciphertext, verbatim"
+    );
+
+    let ack = n.serve_get(Some(A), &ack_request(vec![id]), t0);
+    assert!(listed(&ack).is_empty(), "acknowledge purges");
+    assert_eq!(n.pending_for(&A), 0);
+    assert_eq!(n.destination_count(), 0, "an emptied mailbox is reclaimed");
+    assert_eq!(n.stored_bytes(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Recipient scoping — the contextual-integrity core
+// ─────────────────────────────────────────────────────────────────────
+
+/// B cannot download A's mail, and the probe is REPORTED rather than
+/// silently omitted. A's message survives.
+#[test]
+fn a_requester_cannot_download_another_destinations_mail() {
+    let n = node(&[A, B], generous());
+    let t0 = Instant::now();
+    let (a_id, _) = admitted(&n.serve_upload(&upload(A, 0x11), t0));
+
+    // Sanity: A really can fetch it — so the refusal below is scoping, not
+    // a node that serves nobody.
+    assert_eq!(
+        downloaded(&n.serve_get(Some(A), &get_request(vec![a_id]), t0)).len(),
+        1
+    );
+
+    let probe = n.serve_get(Some(B), &get_request(vec![a_id]), t0);
+    assert!(
+        downloaded(&probe).is_empty(),
+        "B must receive none of A's messages"
+    );
+    assert!(
+        has_notice(&probe, WithholdReason::LxmfMailboxScopeMismatch),
+        "a cross-recipient probe must be reported, not silently omitted"
+    );
+    assert_eq!(n.pending_for(&A), 1, "A's mail is untouched");
+}
+
+/// B cannot PURGE A's mail by acknowledging its transient ID — the
+/// censorship lever the per-destination index closes.
+#[test]
+fn a_requester_cannot_acknowledge_away_another_destinations_mail() {
+    let n = node(&[A, B], generous());
+    let t0 = Instant::now();
+    let (a_id, _) = admitted(&n.serve_upload(&upload(A, 0x22), t0));
+
+    let attack = n.serve_get(Some(B), &ack_request(vec![a_id]), t0);
+    assert!(
+        has_notice(&attack, WithholdReason::LxmfMailboxScopeMismatch),
+        "a foreign acknowledge must be reported"
+    );
+    assert_eq!(
+        n.pending_for(&A),
+        1,
+        "A's mail must survive B's acknowledge"
+    );
+
+    // And A can still collect it — the message was never damaged.
+    assert_eq!(
+        downloaded(&n.serve_get(Some(A), &get_request(vec![a_id]), t0)).len(),
+        1
+    );
+}
+
+/// A list response contains only the requester's own mail.
+#[test]
+fn list_is_scoped_to_the_requesters_own_mailbox() {
+    let n = node(&[A, B], generous());
+    let t0 = Instant::now();
+    let (a_id, _) = admitted(&n.serve_upload(&upload(A, 0x31), t0));
+    let (b_id, _) = admitted(&n.serve_upload(&upload(B, 0x32), t0));
+    assert_ne!(a_id, b_id);
+
+    assert_eq!(
+        listed(&n.serve_get(Some(A), &list_request(), t0)),
+        vec![a_id]
+    );
+    assert_eq!(
+        listed(&n.serve_get(Some(B), &list_request(), t0)),
+        vec![b_id]
+    );
+}
+
+/// An ordinary miss (nobody holds the ID) is NOT reported as a scope
+/// mismatch — otherwise routine races would drown the attack signal.
+#[test]
+fn an_unheld_transient_id_is_a_miss_not_a_scope_mismatch() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+    admitted(&n.serve_upload(&upload(A, 0x41), t0));
+
+    let miss = n.serve_get(Some(A), &get_request(vec![[0x99; 32]]), t0);
+    assert!(downloaded(&miss).is_empty());
+    assert!(
+        !has_notice(&miss, WithholdReason::LxmfMailboxScopeMismatch),
+        "an ID nobody holds is an absence, not a cross-recipient probe"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Audience — default OFF, explicit roster, both legs
+// ─────────────────────────────────────────────────────────────────────
+
+/// The default posture carries nobody's mail, on both legs, and says so.
+#[test]
+fn the_default_posture_serves_nobody_and_names_the_refusal() {
+    assert_eq!(
+        PropagationAudience::default(),
+        PropagationAudience::Disabled
+    );
+    let n = LxmfServeNode::disabled();
+    let t0 = Instant::now();
+
+    let up = n.serve_upload(&upload(A, 0x51), t0);
+    assert_eq!(
+        up.refused_reason(),
+        Some(WithholdReason::LxmfPropagationDisabled)
+    );
+    let get = n.serve_get(Some(A), &list_request(), t0);
+    assert_eq!(
+        get.refused_reason(),
+        Some(WithholdReason::LxmfPropagationDisabled)
+    );
+    assert_eq!(n.stored_bytes(), 0);
+}
+
+/// Roster is checked on BOTH legs: an off-roster recipient's upload is
+/// refused, and an off-roster requester's `/get` is refused — while the
+/// rostered destination works, so the roster is a filter, not a wall.
+#[test]
+fn the_roster_gates_both_the_upload_recipient_and_the_get_requester() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+
+    admitted(&n.serve_upload(&upload(A, 0x61), t0));
+
+    let off_roster_upload = n.serve_upload(&upload(C, 0x62), t0);
+    assert_eq!(
+        off_roster_upload.refused_reason(),
+        Some(WithholdReason::LxmfDestinationNotServed)
+    );
+    assert_eq!(n.destination_count(), 1, "no mailbox minted for C");
+
+    let off_roster_get = n.serve_get(Some(C), &list_request(), t0);
+    assert_eq!(
+        off_roster_get.refused_reason(),
+        Some(WithholdReason::LxmfDestinationNotServed)
+    );
+}
+
+/// An unidentified link gets no mail — there is no answer to "whose
+/// mailbox is this".
+#[test]
+fn an_unidentified_requester_is_refused() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+    admitted(&n.serve_upload(&upload(A, 0x71), t0));
+
+    let anon = n.serve_get(None, &list_request(), t0);
+    assert_eq!(
+        anon.refused_reason(),
+        Some(WithholdReason::LxmfRequesterUnidentified)
+    );
+    // Identified, the same request succeeds.
+    assert_eq!(listed(&n.serve_get(Some(A), &list_request(), t0)).len(), 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Bounds, each exercised AT its ceiling and one step past it
+// ─────────────────────────────────────────────────────────────────────
+
+/// `max_request_bytes`: a body exactly at the ceiling passes the size gate
+/// (and is then judged on its content); one byte over is refused by the
+/// size gate itself. The two different reasons prove the boundary is where
+/// it is claimed to be.
+#[test]
+fn max_request_bytes_admits_at_the_ceiling_and_refuses_one_over() {
+    let mut limits = generous();
+    limits.max_request_bytes = 64;
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+
+    let at = n.serve_get(Some(A), &[0xFFu8; 64], t0);
+    assert_eq!(
+        at.refused_reason(),
+        Some(WithholdReason::LxmfWireUnparseable),
+        "exactly at the ceiling must reach the decoder, not the size gate"
+    );
+
+    let over = n.serve_get(Some(A), &[0xFFu8; 65], t0);
+    assert_eq!(
+        over.refused_reason(),
+        Some(WithholdReason::LxmfFrameOversized)
+    );
+
+    // And a real request under the ceiling still works.
+    assert!(listed(&n.serve_get(Some(A), &list_request(), t0)).is_empty());
+}
+
+/// `max_upload_bytes`: same boundary discipline on the upload leg.
+#[test]
+fn max_upload_bytes_admits_at_the_ceiling_and_refuses_one_over() {
+    let body = upload(A, 0x81);
+    let mut limits = generous();
+    limits.max_upload_bytes = body.len();
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+
+    // Exactly at the ceiling: admitted.
+    admitted(&n.serve_upload(&body, t0));
+
+    // One byte over the ceiling: refused by the size gate.
+    let over = n.serve_upload(&vec![0x00u8; body.len() + 1], t0);
+    assert_eq!(
+        over.refused_reason(),
+        Some(WithholdReason::LxmfFrameOversized)
+    );
+}
+
+/// `max_ids_per_request`: `wants` + `haves` are counted together, so the
+/// ceiling cannot be doubled by splitting a request across both fields.
+#[test]
+fn max_ids_per_request_counts_wants_and_haves_together() {
+    let mut limits = generous();
+    limits.max_ids_per_request = 2;
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+
+    let at = n.serve_get(Some(A), &get_request(vec![[1u8; 32], [2u8; 32]]), t0);
+    assert!(
+        at.refused_reason().is_none(),
+        "two IDs is exactly the ceiling"
+    );
+
+    let over = n.serve_get(
+        Some(A),
+        &get_request(vec![[1u8; 32], [2u8; 32], [3u8; 32]]),
+        t0,
+    );
+    assert_eq!(
+        over.refused_reason(),
+        Some(WithholdReason::LxmfFrameOversized)
+    );
+
+    // Split across both fields: 2 wants + 1 have is still 3.
+    let split = MessageGetRequest {
+        wants: Some(vec![[1u8; 32], [2u8; 32]]),
+        haves: Some(vec![[3u8; 32]]),
+        transfer_limit_kb: None,
+    }
+    .encode()
+    .expect("encodes");
+    assert_eq!(
+        n.serve_get(Some(A), &split, t0).refused_reason(),
+        Some(WithholdReason::LxmfFrameOversized),
+        "the ceiling must not be doubled by splitting across wants and haves"
+    );
+}
+
+/// `max_store_bytes`: the byte budget counts KEY bytes as well as
+/// ciphertext (the upstream `MemoryLxmfStorage` lesson), and a submission
+/// landing exactly on the budget is admitted while the next is refused.
+#[test]
+fn max_store_bytes_admits_exactly_at_the_budget_and_refuses_past_it() {
+    let entry = entry_cost();
+    let mut limits = generous();
+    limits.max_store_bytes = entry * 2;
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+
+    admitted(&n.serve_upload(&upload(A, 0x91), t0));
+    admitted(&n.serve_upload(&upload(A, 0x92), t0));
+    assert_eq!(
+        n.stored_bytes(),
+        entry * 2,
+        "accounting must include the destination hash and transient ID"
+    );
+
+    let over = n.serve_upload(&upload(A, 0x93), t0);
+    assert_eq!(over.refused_reason(), Some(WithholdReason::LxmfMailboxFull));
+    assert_eq!(n.pending_for(&A), 2, "refuse, never evict to admit");
+}
+
+/// `max_messages_per_destination`: full means refused, and — the security
+/// property — the messages already parked are NOT evicted to make room.
+#[test]
+fn max_messages_per_destination_refuses_rather_than_evicting() {
+    let mut limits = generous();
+    limits.max_messages_per_destination = 2;
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+
+    let (first, _) = admitted(&n.serve_upload(&upload(A, 0xA1), t0));
+    admitted(&n.serve_upload(&upload(A, 0xA2), t0));
+
+    let over = n.serve_upload(&upload(A, 0xA3), t0);
+    assert_eq!(over.refused_reason(), Some(WithholdReason::LxmfMailboxFull));
+    assert_eq!(n.pending_for(&A), 2);
+    assert!(
+        listed(&n.serve_get(Some(A), &list_request(), t0)).contains(&first),
+        "the OLDEST message must survive: evicting it would let an attacker \
+         flush a victim's mailbox with junk uploads"
+    );
+}
+
+/// A repeat upload of an already-parked message is idempotent: it is not
+/// charged against the depth cap, so a full mailbox still accepts a retry.
+#[test]
+fn a_repeat_upload_is_idempotent_at_the_depth_ceiling() {
+    let mut limits = generous();
+    limits.max_messages_per_destination = 2;
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+
+    admitted(&n.serve_upload(&upload(A, 0xB1), t0));
+    admitted(&n.serve_upload(&upload(A, 0xB2), t0));
+    // At the ceiling — but this is a re-send of one already held.
+    admitted(&n.serve_upload(&upload(A, 0xB1), t0));
+    assert_eq!(n.pending_for(&A), 2);
+    assert_eq!(n.stored_bytes(), entry_cost() * 2);
+}
+
+/// `max_destinations`: the ceiling bounds NEW mailboxes; an existing
+/// destination keeps working once the ceiling is reached.
+#[test]
+fn max_destinations_bounds_new_mailboxes_only() {
+    let mut limits = generous();
+    limits.max_destinations = 2;
+    let n = node(&[A, B, C], limits);
+    let t0 = Instant::now();
+
+    admitted(&n.serve_upload(&upload(A, 0xC1), t0));
+    admitted(&n.serve_upload(&upload(B, 0xC2), t0));
+    assert_eq!(n.destination_count(), 2);
+
+    let third = n.serve_upload(&upload(C, 0xC3), t0);
+    assert_eq!(
+        third.refused_reason(),
+        Some(WithholdReason::LxmfMailboxFull)
+    );
+    assert_eq!(
+        n.destination_count(),
+        2,
+        "a refused upload mints no mailbox"
+    );
+
+    // An already-known destination is unaffected by the destination cap.
+    admitted(&n.serve_upload(&upload(A, 0xC4), t0));
+    assert_eq!(n.pending_for(&A), 2);
+}
+
+/// `max_messages_per_response`: the response is truncated at the ceiling
+/// and the held-back messages are REPORTED (they are withheld, not missing).
+#[test]
+fn max_messages_per_response_truncates_at_the_ceiling_and_reports() {
+    let mut limits = generous();
+    limits.max_messages_per_response = 1;
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+    let (id1, _) = admitted(&n.serve_upload(&upload(A, 0xD1), t0));
+    let (id2, _) = admitted(&n.serve_upload(&upload(A, 0xD2), t0));
+
+    let got = n.serve_get(Some(A), &get_request(vec![id1, id2]), t0);
+    assert_eq!(downloaded(&got).len(), 1, "truncated at the ceiling");
+    assert_eq!(
+        count_notice(&got, WithholdReason::LxmfFrameOversized),
+        1,
+        "the held-back message must be reported, not silently dropped"
+    );
+    // Nothing was consumed: both are still parked for a follow-up request.
+    assert_eq!(n.pending_for(&A), 2);
+}
+
+/// `max_response_bytes`: one message exactly fills the budget; the second
+/// is withheld and reported.
+#[test]
+fn max_response_bytes_admits_exactly_one_full_budget_and_reports_the_rest() {
+    let msg_len = DESTINATION_LENGTH + CIPHER_LEN;
+    let mut limits = generous();
+    limits.max_response_bytes = msg_len;
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+    let (id1, _) = admitted(&n.serve_upload(&upload(A, 0xE1), t0));
+    let (id2, _) = admitted(&n.serve_upload(&upload(A, 0xE2), t0));
+
+    let got = n.serve_get(Some(A), &get_request(vec![id1, id2]), t0);
+    assert_eq!(
+        downloaded(&got).len(),
+        1,
+        "a message landing exactly on the byte budget is served"
+    );
+    assert_eq!(count_notice(&got, WithholdReason::LxmfFrameOversized), 1);
+
+    // Raising the budget by one message admits both — proving the previous
+    // truncation was the byte budget and not some other ceiling.
+    let mut wider = generous();
+    wider.max_response_bytes = msg_len * 2;
+    let n2 = node(&[A], wider);
+    admitted(&n2.serve_upload(&upload(A, 0xE1), t0));
+    admitted(&n2.serve_upload(&upload(A, 0xE2), t0));
+    assert_eq!(
+        downloaded(&n2.serve_get(Some(A), &get_request(vec![id1, id2]), t0)).len(),
+        2
+    );
+}
+
+/// `retention`: a message is retained one instant short of the window and
+/// evicted exactly at it — and the eviction is reported.
+#[test]
+fn retention_evicts_exactly_at_the_window_and_reports_it() {
+    let mut limits = generous();
+    limits.retention = Duration::from_secs(60);
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+    admitted(&n.serve_upload(&upload(A, 0xF1), t0));
+
+    // One nanosecond short of the window: still held, nothing reported.
+    let just_under = n.sweep(
+        (t0 + Duration::from_secs(60))
+            .checked_sub(Duration::from_nanos(1))
+            .expect("one nanosecond before the window"),
+    );
+    assert!(just_under.is_empty());
+    assert_eq!(n.pending_for(&A), 1);
+
+    // Exactly at the window: evicted, and loudly.
+    let at = n.sweep(t0 + Duration::from_secs(60));
+    assert_eq!(at.len(), 1);
+    assert_eq!(at[0].reason, WithholdReason::LxmfRetentionExpired);
+    assert_eq!(at[0].destination, Some(A));
+    assert_eq!(n.pending_for(&A), 0);
+    assert_eq!(n.stored_bytes(), 0, "eviction must reclaim the byte budget");
+    assert_eq!(n.destination_count(), 0, "and the destination budget");
+}
+
+/// Retention is enforced on the request paths too, not only on an explicit
+/// sweep — so an expired message is never served.
+#[test]
+fn an_expired_message_is_never_served() {
+    let mut limits = generous();
+    limits.retention = Duration::from_secs(60);
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+    let (id, _) = admitted(&n.serve_upload(&upload(A, 0xF2), t0));
+
+    // Before expiry it is served.
+    assert_eq!(
+        downloaded(&n.serve_get(Some(A), &get_request(vec![id]), t0)).len(),
+        1
+    );
+
+    let later = t0 + Duration::from_secs(60);
+    let got = n.serve_get(Some(A), &get_request(vec![id]), later);
+    assert!(downloaded(&got).is_empty(), "expired mail is not served");
+    assert!(
+        has_notice(&got, WithholdReason::LxmfRetentionExpired),
+        "the request path must report the eviction it performed"
+    );
+}
+
+/// `stamp_cost`: a stamp below the advertised cost is refused with the
+/// protocol's own signalling packet, and a REAL stamp at that cost is
+/// admitted — so the gate is a price, not a wall.
+#[test]
+fn stamp_below_advertised_cost_is_refused_and_a_real_stamp_is_admitted() {
+    let cost = 8u8;
+    let mut limits = generous();
+    limits.stamp_cost = cost;
+    let n = node(&[A], limits);
+    let t0 = Instant::now();
+
+    // A stamp must be PROVEN under cost, not assumed to be. A stamp
+    // generated at cost 0 clears cost 8 by chance about one time in 256,
+    // which made an earlier version of this test flaky — so the fixture is
+    // searched with the node's OWN validator and verified before use.
+    let payload = unstamped(A, 0x01, CIPHER_LEN);
+    let transient = leviculum_core::crypto::full_hash(&payload);
+    let dud = (0u8..=255)
+        .map(|seed| [seed; STAMP_SIZE])
+        .find(|candidate| !n.stamp_clears_cost(&transient, candidate))
+        .expect("some 32-byte stamp fails to clear cost 8");
+    let understamped = PropagationUpload::single(1.0, payload.clone(), dud).encode();
+
+    let refused = n.serve_upload(&understamped, t0);
+    assert_eq!(
+        refused.refused_reason(),
+        Some(WithholdReason::LxmfStampBelowCost)
+    );
+    assert_eq!(n.pending_for(&A), 0, "spam must not reach storage");
+    match refused.outcome {
+        ServeOutcome::Refused {
+            response: Some(ref bytes),
+            ..
+        } => assert_eq!(
+            PropagationSignal::decode(bytes).expect("signal decodes"),
+            PropagationSignal::InvalidStamp,
+            "the refusal must be the protocol's own signalling packet"
+        ),
+        ref other => panic!("expected a signalled refusal, got {other:?}"),
+    }
+
+    // The same payload, stamped at the advertised cost, is admitted.
+    let paid = upload_at_cost(A, 0x01, CIPHER_LEN, cost);
+    admitted(&n.serve_upload(&paid, t0));
+    assert_eq!(n.pending_for(&A), 1);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Wire-shape refusals
+// ─────────────────────────────────────────────────────────────────────
+
+/// A well-formed MULTI-message upload is the node-to-node `/offer` sync
+/// form, which edge does not serve. It is reported as its own reason, NOT
+/// folded into "malformed" — the operator's remedy is different.
+#[test]
+fn a_multi_message_upload_is_reported_as_the_unsupported_offer_form() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+
+    // `[timestamp, [stamped_a, stamped_b]]` — the peer-sync wire shape.
+    let stamped = |tag: u8| {
+        let mut v = unstamped(A, tag, CIPHER_LEN);
+        v.extend_from_slice(&[0u8; STAMP_SIZE]);
+        v
+    };
+    let (m1, m2) = (stamped(0x01), stamped(0x02));
+    let mut body = Vec::new();
+    msgpack::array(&mut body, 2);
+    msgpack::f64(&mut body, 1.0);
+    msgpack::array(&mut body, 2);
+    msgpack::bin(&mut body, &m1);
+    msgpack::bin(&mut body, &m2);
+
+    let refused = n.serve_upload(&body, t0);
+    assert_eq!(
+        refused.refused_reason(),
+        Some(WithholdReason::LxmfPeerSyncUnsupported),
+        "a peer /offer upload is a message for an endpoint we do not serve, \
+         not a malformed one"
+    );
+
+    // The singleton form on the same node IS admitted.
+    admitted(&n.serve_upload(&upload(A, 0x03), t0));
+}
+
+/// Structural pin: a payload short enough to make the destination hash
+/// unreadable can never reach that code path, because
+/// `PropagationUpload::decode` already guarantees
+/// `unstamped.len() > LXMF_OVERHEAD` — exactly
+/// `PropagatedMessage::from_unstamped_bytes`'s precondition. If leviculum
+/// ever relaxes one guard without the other, this fails rather than edge
+/// silently gaining an unreachable-turned-reachable branch.
+#[test]
+fn decode_success_implies_readable_destination() {
+    for cipher_len in [0usize, 1, 95, 96, 97, LXMF_OVERHEAD, LXMF_OVERHEAD + 1, 200] {
+        let payload = unstamped(A, 0x01, cipher_len);
+        let body = PropagationUpload::single(1.0, payload.clone(), [0u8; STAMP_SIZE]).encode();
+        if let Ok(decoded) = PropagationUpload::decode(&body) {
+            assert!(
+                PropagatedMessage::from_unstamped_bytes(decoded.unstamped_lxmf()).is_ok(),
+                "decode accepted a {cipher_len}-byte ciphertext whose destination \
+                 hash is unreadable — the two guards have drifted apart",
+            );
+        }
+    }
+}
+
+/// A too-short upload is refused as malformed rather than parked.
+#[test]
+fn a_too_short_upload_is_refused() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+    let short = PropagationUpload::single(1.0, vec![0x01; 8], [0u8; STAMP_SIZE]).encode();
+    assert_eq!(
+        n.serve_upload(&short, t0).refused_reason(),
+        Some(WithholdReason::LxmfWireUnparseable)
+    );
+    assert_eq!(n.stored_bytes(), 0);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Contextual integrity + refusal-reply shape
+// ─────────────────────────────────────────────────────────────────────
+
+/// Every serve-path refusal names the commitment it defends, and the
+/// attribution comes from `parameter_of` alone — never a second table.
+#[test]
+fn every_serve_path_reason_is_attributed_to_its_commitment() {
+    let expected = [
+        (
+            WithholdReason::LxmfPropagationDisabled,
+            CiParameter::TransmissionPrinciple,
+        ),
+        (
+            WithholdReason::LxmfDestinationNotServed,
+            CiParameter::Recipient,
+        ),
+        (
+            WithholdReason::LxmfRequesterUnidentified,
+            CiParameter::Sender,
+        ),
+        (
+            WithholdReason::LxmfMailboxScopeMismatch,
+            CiParameter::Recipient,
+        ),
+        (
+            WithholdReason::LxmfStampBelowCost,
+            CiParameter::TransmissionPrinciple,
+        ),
+        (
+            WithholdReason::LxmfWireUnparseable,
+            CiParameter::InformationType,
+        ),
+        (
+            WithholdReason::LxmfPeerSyncUnsupported,
+            CiParameter::InformationType,
+        ),
+        (
+            WithholdReason::LxmfFrameOversized,
+            CiParameter::TransmissionPrinciple,
+        ),
+        (
+            WithholdReason::LxmfMailboxFull,
+            CiParameter::TransmissionPrinciple,
+        ),
+        (
+            WithholdReason::LxmfRetentionExpired,
+            CiParameter::TransmissionPrinciple,
+        ),
+    ];
+    for (reason, parameter) in expected {
+        let notice = Notice::new(reason, "test", None);
+        assert_eq!(notice.parameter(), parameter, "{}", reason.as_str());
+        assert_eq!(
+            notice.delivery(),
+            Delivery::withheld(reason),
+            "the notice's delivery must come from parameter_of, not a copy",
+        );
+    }
+}
+
+/// Every `/get` refusal carries a decodable `PeerError` reply, so a client
+/// learns why rather than timing out; upload refusals carry a reply only
+/// where the protocol defines one.
+#[test]
+fn get_refusals_carry_a_decodable_peer_error() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+    let cases = [
+        n.serve_get(None, &list_request(), t0),
+        n.serve_get(Some(C), &list_request(), t0),
+        n.serve_get(Some(A), &[0xFF, 0xFE], t0),
+        LxmfServeNode::disabled().serve_get(Some(A), &list_request(), t0),
+    ];
+    for case in &cases {
+        let ServeOutcome::Refused {
+            response: Some(ref bytes),
+            reason,
+            ..
+        } = case.outcome
+        else {
+            panic!("expected a refusal with a reply, got {:?}", case.outcome);
+        };
+        assert!(
+            matches!(
+                MessageListResponse::decode(bytes),
+                Ok(MessageListResponse::Error(_))
+            ),
+            "{} must answer with a decodable PeerError",
+            reason.as_str(),
+        );
+    }
+}
+
+/// Every refusal also pushes its own notice, so the ledger sees the
+/// refusal even when the caller only forwards the wire reply.
+#[test]
+fn every_refusal_emits_a_matching_notice() {
+    let n = node(&[A], generous());
+    let t0 = Instant::now();
+    for case in [
+        n.serve_get(None, &list_request(), t0),
+        n.serve_get(Some(C), &list_request(), t0),
+        n.serve_upload(&upload(C, 0x01), t0),
+        n.serve_upload(&[0x00], t0),
+    ] {
+        let reason = case.refused_reason().expect("refusal");
+        assert!(
+            has_notice(&case, reason),
+            "{} must appear in notices, not only in the outcome",
+            reason.as_str(),
+        );
+    }
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -85,6 +85,18 @@ pub mod realtime_av_dispatcher;
 /// behind `_reticulum-module` (their only leviculum dependency).
 pub mod realtime_av_runtime;
 
+/// The A/V spine (CIRISEdge#499) — the integrating runtime that drives
+/// ONE call from join to media to heal. Owns the publisher, the relay
+/// and the scope-address lifecycle *together*, so an MLS epoch can never
+/// move without the scoped addresses that epoch derives: the gap that
+/// silently stranded peers (an RNS destination nobody registered is
+/// never delivered to, with no error anywhere). Also the only thing that
+/// drives [`crate::scope_lifecycle::ScopeLifecycle::seal_due`] on a
+/// cadence. Gated alongside the rest of the Reticulum surface because it
+/// owns a [`realtime_av_relay::RelayNode`].
+#[cfg(feature = "_reticulum-module")]
+pub mod av_spine;
+
 /// Application-Layer Multicast (ALM) — mesh-tree video built on the
 /// per-peer [`realtime_av_relay::RelayNode`] primitive (CIRISEdge#131 +
 /// CIRISEdge#128 MDC). Pure-Rust, signed [`realtime_av_alm::RelayCapacity`]

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -169,6 +169,17 @@ pub mod store_and_forward;
 #[cfg(feature = "lxmf")]
 pub mod lxmf_propagation;
 
+/// CIRISEdge#169 — the LXMF propagation **host serve path**: this node
+/// acting as a propagation node for others, with a rostered audience, a
+/// recipient-scoped mailbox and a bounded retention window.
+///
+/// Gated on `all(_reticulum-module, lxmf)` because it exists to be driven
+/// from edge's one Reticulum event loop; a build with `lxmf` alone gets the
+/// transport-agnostic codecs in [`lxmf_propagation`] and no serve path.
+/// With either feature off, edge behaves byte-identically to today.
+#[cfg(all(feature = "_reticulum-module", feature = "lxmf"))]
+pub mod lxmf_serve;
+
 // Remaining implementations land in subsequent commits; trait shape
 // sealed Phase 1.
 //

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -419,6 +419,30 @@ pub struct InboundFrame {
     /// for transports that don't carry an advisory-link identity (HTTP, packet
     /// radio, FFI — those attribute via `source_key_id` or not at all).
     pub link_key_id: Option<String>,
+    /// CIRISEdge#499 — the SCOPE-DERIVED address this frame arrived on, resolved
+    /// by the transport against its installed
+    /// [`ScopeAddressTable`](crate::scope_addressing::ScopeAddressTable).
+    ///
+    /// A `Some` here is a **cryptographic admission fact, not a hint**: the only
+    /// way this field is populated is that the frame's destination hash matched
+    /// the table's reverse index, and those hashes are derived from the group's
+    /// MLS `exporter_secret`, which binds `(group_id, epoch)` per RFC 9420 §8.5.
+    /// So arrival on one proves the sender possessed that group secret. There is
+    /// no public constructor for
+    /// [`InboundAddress`](crate::scope_addressing::InboundAddress), so this field
+    /// cannot carry a forged claim — unlike [`Self::link_key_id`], which is
+    /// deliberately a bare `String` routing hint.
+    ///
+    /// `None` means the frame arrived on the node's FEDERATION address (or on a
+    /// transport with no scope table, or with none installed — the production
+    /// state until the MLS exporter label is specified upstream). `None` is
+    /// therefore read as `CohortScope::Public` by the serve gates: reaching a
+    /// public discovery address proves reachability and nothing more.
+    ///
+    /// Resolved ONCE, at the transport, ahead of any envelope parse — which is
+    /// what lets [`admit_blob_serve`](crate::blob_swarm::admit_blob_serve) gate a
+    /// chunk request before its body is deserialized rather than after.
+    pub arrival_scope: Option<crate::scope_addressing::InboundAddress>,
 }
 
 /// The trait every transport implements. Edge holds a

--- a/src/transport/packet_radio/mod.rs
+++ b/src/transport/packet_radio/mod.rs
@@ -249,6 +249,9 @@ impl Transport for PacketRadioTransport {
                         received_at: Utc::now(),
                         source_key_id: None,
                         link_key_id: None, // CIRISEdge#402 — no advisory-link identity
+                        // CIRISEdge#499 — packet radio has no scope-derived destination
+                        // plane; every frame arrives at the federation address.
+                        arrival_scope: None,
                     };
                     if sink.send(frame).await.is_err() {
                         // Sink closed — listener should exit cleanly.

--- a/src/transport/realtime_av_mls.rs
+++ b/src/transport/realtime_av_mls.rs
@@ -846,6 +846,16 @@ impl MlsSession {
     /// to compute `RosterDelta::Replace` diffs. Returns owned
     /// `String`s because the underlying openmls `members()`
     /// iterator borrows ephemeral storage.
+    /// CIRISEdge#499 — this epoch's destination secret, the input to
+    /// `k_destination`. Independent of the DEK seed by construction;
+    /// see [`export_destination_secret`].
+    ///
+    /// # Errors
+    /// [`MlsError::ExportFailed`] on corrupted group state.
+    pub fn destination_secret(&self) -> Result<[u8; 32], MlsError> {
+        export_destination_secret(&self.group, &self.provider)
+    }
+
     pub fn member_key_ids(&self) -> Vec<String> {
         self.group
             .members()
@@ -1475,6 +1485,37 @@ fn decode_wrapped_welcome(buf: &[u8]) -> Result<WrappedWelcome, MlsError> {
         inviter_pk_id,
         inviter_pk_bytes,
     })
+}
+
+/// CIRISEdge#499 — derive this A/V epoch's **destination** secret,
+/// under CIRISVerify's `DESTINATION_EXPORTER_LABEL` (v13.5.0).
+///
+/// The twin of [`export_root_secret`], and deliberately NOT the same
+/// bytes. `export_root_secret` produces the DEK seed under
+/// [`ROOT_SECRET_LABEL`]; this produces the addressing secret. Verify
+/// refused the DEK-seed label for scope-privacy inputs explicitly and
+/// on the record: deriving a routing identifier that appears in the
+/// clear on the wire from the material that seeds the content key would
+/// collapse two secrets RFC 9420 §8.5 exists to keep independent.
+///
+/// One extra `export_secret` per epoch boundary — a cold path, since
+/// epochs advance on membership change, never per chunk.
+fn export_destination_secret(
+    group: &MlsGroup,
+    provider: &LibcruxProvider,
+) -> Result<[u8; 32], MlsError> {
+    let bytes = group
+        .export_secret(
+            provider.crypto(),
+            crate::scope_privacy::DESTINATION_EXPORTER_LABEL,
+            crate::scope_privacy::EXPORTER_CONTEXT,
+            32,
+        )
+        .map_err(|e| MlsError::ExportFailed(format!("{e:?}")))?;
+    let out: [u8; 32] = bytes.try_into().map_err(|v: Vec<u8>| {
+        MlsError::ExportFailed(format!("expected 32 bytes, got {}", v.len()))
+    })?;
+    Ok(out)
 }
 
 /// Derive the current epoch's [`RootSecret`] from the group's

--- a/src/transport/realtime_av_runtime.rs
+++ b/src/transport/realtime_av_runtime.rs
@@ -83,8 +83,8 @@
 use tokio::sync::mpsc;
 
 use super::realtime_av::{
-    seal_av_inner, ChunkLayer, ChunkSeq, Epoch, EpochDek, RealtimeAvError, SealedAvChunk, StreamId,
-    CODEC_OPAQUE,
+    seal_av_inner, ChunkLayer, ChunkSeq, Epoch, EpochDek, InnerSealed, RealtimeAvError,
+    SealedAvChunk, StreamId, CODEC_OPAQUE,
 };
 use super::realtime_av_alm::{
     AlmJoinError, AlmJoinPlanner, JoinPlan, ParentCandidate, TransitGate,
@@ -234,6 +234,19 @@ impl AvPublisher {
         self.epoch
     }
 
+    /// Borrow the MLS session backing this publisher.
+    ///
+    /// CIRISEdge#499 — the session is the addressing plane's input:
+    /// [`crate::av_addressing::snapshot`] reduces it to the one shape
+    /// [`crate::scope_lifecycle::ScopeLifecycle`] takes. Read-only by
+    /// design; every mutation of the session still runs through
+    /// [`Self::admit_joiner`] / [`Self::advance_epoch`], so an epoch can
+    /// never move without this struct's DEK moving with it.
+    #[must_use]
+    pub fn session(&self) -> &AvSession {
+        &self.session
+    }
+
     /// Downstream subscriber count.
     #[must_use]
     pub fn subscriber_count(&self) -> usize {
@@ -260,6 +273,36 @@ impl AvPublisher {
         codec_id: u8,
         layer: ChunkLayer,
     ) -> Result<ChunkSeq, AvRuntimeError> {
+        let (seq, inner) = self.seal_next(plaintext, codec_id, layer)?;
+        self.dispatch_inner(inner).await?;
+        Ok(seq)
+    }
+
+    /// Inner-seal one chunk under the current epoch DEK and stamp it
+    /// with the next [`ChunkSeq`], WITHOUT dispatching it.
+    ///
+    /// The split exists for the CIRISEdge#122 fan-out shape: a node that
+    /// both publishes and relays a stream must inner-seal **once** and
+    /// hand the same [`super::realtime_av::InnerSealed`] to every
+    /// fan-out point (its own dispatcher links AND its
+    /// [`super::realtime_av_relay::RelayNode`] roster). Sealing twice
+    /// would re-derive the same `(stream, epoch, chunk_seq)` inner nonce
+    /// for a second ciphertext — wasteful at best, and a nonce-reuse
+    /// hazard the moment the two plaintexts differ.
+    ///
+    /// The sequence counter advances HERE rather than after a successful
+    /// dispatch: once a nonce has been used to seal bytes, re-issuing it
+    /// is unsafe whether or not those bytes reached the wire.
+    ///
+    /// # Errors
+    ///
+    /// [`AvRuntimeError::Seal`] on inner-seal failure.
+    pub fn seal_next(
+        &mut self,
+        plaintext: &[u8],
+        codec_id: u8,
+        layer: ChunkLayer,
+    ) -> Result<(ChunkSeq, InnerSealed), AvRuntimeError> {
         let seq = ChunkSeq(self.next_chunk_seq);
         let inner = seal_av_inner(
             plaintext,
@@ -270,17 +313,30 @@ impl AvPublisher {
             codec_id,
             layer,
         )?;
+        self.next_chunk_seq = self.next_chunk_seq.wrapping_add(1);
         tracing::info!(
             stream = %stream_tag(self.stream_id),
             epoch = self.epoch.0,
             chunk_seq = seq.0,
             bytes = plaintext.len(),
             subscribers = self.dispatcher.subscriber_count(),
-            "AV publish: inner-sealed, fanning out"
+            "AV publish: inner-sealed"
         );
+        Ok((seq, inner))
+    }
+
+    /// Outer-seal an already-inner-sealed chunk per downstream
+    /// subscriber and enqueue it onto each subscriber's link. Returns
+    /// the number of links fanned to.
+    ///
+    /// # Errors
+    ///
+    /// [`AvRuntimeError::Dispatcher`] on outer-seal / transport-send
+    /// failure (fan-out stops at the first failing subscriber).
+    pub async fn dispatch_inner(&mut self, inner: InnerSealed) -> Result<usize, AvRuntimeError> {
+        let reached = self.dispatcher.subscriber_count();
         self.dispatcher.publish_inner(inner).await?;
-        self.next_chunk_seq = self.next_chunk_seq.wrapping_add(1);
-        Ok(seq)
+        Ok(reached)
     }
 
     /// Publish an opaque chunk with the substrate default codec + layer.

--- a/src/transport/realtime_av_session.rs
+++ b/src/transport/realtime_av_session.rs
@@ -359,6 +359,28 @@ impl AvSession {
     }
 
     /// Current epoch counter — tracks the underlying MLS group epoch.
+    /// CIRISEdge#499 — this epoch's DESTINATION secret, the input to
+    /// `k_destination` and therefore to every scoped address this node
+    /// presents in the session.
+    ///
+    /// Distinct from the epoch DEK's seed by construction: verify gives
+    /// the record and destination planes separate exporter labels
+    /// precisely so a compromise of one cannot recompute the other. See
+    /// `realtime_av_mls::export_destination_secret`.
+    ///
+    /// # Errors
+    /// [`AvSessionError`] on corrupted group state.
+    pub fn destination_secret(&self) -> Result<[u8; 32], AvSessionError> {
+        self.mls().destination_secret().map_err(map_mls_err)
+    }
+
+    /// CIRISEdge#499 — the session roster, for deriving every member's
+    /// scoped address at the current epoch.
+    #[must_use]
+    pub fn member_key_ids(&self) -> Vec<String> {
+        self.mls().member_key_ids()
+    }
+
     pub fn epoch(&self) -> Epoch {
         self.epoch
     }

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -2797,6 +2797,44 @@ impl ReticulumTransport {
         Ok(())
     }
 
+    /// CIRISEdge#499 — retire a scope-derived destination.
+    ///
+    /// The inverse of [`Self::register_scoped_destination`], and the one
+    /// half of the lifecycle edge cannot currently honour:
+    /// `leviculum-std`'s driver forwards `register_destination` but not
+    /// `unregister_destination` (**leviculum#54**). `NodeCore` has the
+    /// verb and it does the right thing — it drops the routing entry and
+    /// the destination — it is simply not exposed on the `&self` driver
+    /// an `Arc<ReticulumNode>` holder can reach, and there is no
+    /// `destination_mut` or node escape hatch to route around it.
+    ///
+    /// So this returns `Err` rather than silently succeeding. A sealed
+    /// address that stays registered is a real residual disclosure: an
+    /// observer who learned it can keep probing and keep confirming this
+    /// node is reachable, which is the reachability publication
+    /// CIRISEdge#311 exists to prevent. Reporting that honestly is worth
+    /// more than a no-op that reads as success.
+    ///
+    /// When the driver verb lands, the body becomes
+    /// `self.node.unregister_destination(&DestinationHash::new(hash))`
+    /// plus the announce-policy `forget`, and
+    /// [`crate::scope_lifecycle::SealOutcome::unretired`] goes to zero.
+    ///
+    /// # Errors
+    /// Always, until leviculum#54 lands.
+    pub fn retire_scoped_destination(
+        &self,
+        address: &MemberAddress,
+        _scope: &crate::cohort_scope::CohortScope,
+    ) -> Result<(), TransportError> {
+        let _ = address;
+        Err(TransportError::Config(
+            "leviculum-std exposes no unregister_destination on the node driver \
+             (leviculum#54); the sealed scope address stays routable"
+                .to_owned(),
+        ))
+    }
+
     /// CIRISEdge#499 — resolve an inbound destination hash to the scope
     /// group, member and epoch it was derived for, or `None` if it is not one
     /// of ours.
@@ -9532,5 +9570,30 @@ mod scope_native_addressing_tests {
             transport.inbound_scope(&[0u8; 16]).is_none(),
             "an unrelated hash must not resolve",
         );
+    }
+}
+
+/// CIRISEdge#499 — the transport as the lifecycle's destination sink.
+///
+/// Keeps the two halves that must not drift — edge's address table and
+/// the leviculum node's routing table — behind one object, so a
+/// transition cannot update one and forget the other.
+impl crate::scope_lifecycle::ScopedDestinationSink for ReticulumTransport {
+    fn register(
+        &self,
+        address: &MemberAddress,
+        scope: &crate::cohort_scope::CohortScope,
+    ) -> Result<(), String> {
+        self.register_scoped_destination(address, scope)
+            .map_err(|e| e.to_string())
+    }
+
+    fn retire(
+        &self,
+        address: &MemberAddress,
+        scope: &crate::cohort_scope::CohortScope,
+    ) -> Result<(), String> {
+        self.retire_scoped_destination(address, scope)
+            .map_err(|e| e.to_string())
     }
 }

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -1123,6 +1123,29 @@ pub struct ReticulumTransportConfig {
     /// TCP address the node listens on for inbound Reticulum links.
     /// Legacy v0.11.x field — consulted only when [`Self::interfaces`]
     /// is empty.
+    /// **"Allow me to be visible to the federation so I can use the mesh."**
+    ///
+    /// The wizard question, and the ONE opt-in that decides this node's
+    /// reachability posture. When `true` the node's named discovery
+    /// destination announces, transport nodes learn a path to it, and it
+    /// participates in the mesh. When `false` it announces nothing and is
+    /// reachable **point-to-point only** — a peer must already hold its
+    /// address to reach it.
+    ///
+    /// Getting the direction right matters, because it is easy to read
+    /// scope-native addressing (CIRISEdge#499) as a privacy feature you trade
+    /// reach for. It is not. A node that has not opted into federation
+    /// visibility is point-to-point **anyway**; scoped destinations being
+    /// one-hop (CC 5.4.6, ruled at CIRISConstitution#91) costs such a node
+    /// nothing it had. The trade only exists for a node that IS
+    /// federation-visible and is choosing to move some flows off that plane.
+    ///
+    /// Defaults to `true` — NOT because visibility is the right default, but
+    /// because flipping a deployed node to invisible on upgrade would silently
+    /// remove it from the mesh, and a silent reachability change is the one
+    /// failure mode worse than an over-visible default. A wizard MUST ask
+    /// rather than inherit this.
+    pub federation_visible: bool,
     pub listen_addr: SocketAddr,
     /// Bootstrap peer TCP addresses dialled as Reticulum TCP clients
     /// on startup. Empty is valid (listen-only / announce-discovered).
@@ -1198,6 +1221,7 @@ impl ReticulumTransportConfig {
     pub fn new(identity_path: PathBuf, local_key_id: impl Into<String>) -> Self {
         Self {
             listen_addr: "0.0.0.0:4242".parse().expect("static addr parses"),
+            federation_visible: true,
             bootstrap_peers: Vec::new(),
             identity_path,
             announce_interval: Duration::from_secs(300),
@@ -2440,10 +2464,31 @@ impl ReticulumTransport {
         // adds suppression for scoped destinations (register future ones via
         // the retained `announce_policy` handle).
         let announce_policy = crate::announce_suppression::ScopePrivacyAnnouncePolicy::new();
-        announce_policy.register_destination_scope(
-            local_named_dest_hash.into_bytes(),
-            crate::cohort_scope::CohortScope::Public,
-        );
+        // The federation-visibility opt-in, and the only thing that decides
+        // whether this node is on the mesh at all.
+        //
+        // `Public` is the one scope the policy lets announce, so registering
+        // the named discovery destination as `Public` is what puts this node
+        // in the mesh. Leaving it UNregistered is not an oversight — the
+        // policy default-SUPPRESSES anything it does not know, so an invisible
+        // node falls out of the same rule that keeps scoped destinations
+        // silent, rather than needing a second mechanism to be quiet.
+        //
+        // A point-to-point node is still fully reachable by anyone who already
+        // holds its address; what it does not do is advertise so strangers can
+        // learn one.
+        if config.federation_visible {
+            announce_policy.register_destination_scope(
+                local_named_dest_hash.into_bytes(),
+                crate::cohort_scope::CohortScope::Public,
+            );
+        } else {
+            tracing::info!(
+                "federation visibility OFF — this node announces nothing and is reachable \
+                 point-to-point only. Scoped destinations were already one-hop (CC 5.4.6), \
+                 so scope-native addressing costs this posture nothing."
+            );
+        }
         node.set_announce_control(Some(Box::new(announce_policy.clone())));
 
         // Take the single event receiver before starting, then start
@@ -2919,6 +2964,25 @@ impl ReticulumTransport {
     /// What the ruling DID keep is that in-group MLS distribution of addressing
     /// material was never prohibited — the cached-directory discipline — so a
     /// roster learning its own members' addresses over MLS stays open.
+    ///
+    /// # Why one hop is not fatal to a mesh call
+    ///
+    /// CC 1.0-rc4's Position paragraph at 5.4.6 names the reason, and it holds
+    /// in this implementation: **derivation replaces discovery, and determinism
+    /// replaces coordination.** Every member can derive every other member's
+    /// address from the group secret without asking anyone, so the candidate
+    /// set is complete without a discovery round — which is what recovers the
+    /// ⌈log_k N⌉ ALM fan-out (CC 6.1.6) that a one-hop-only reading looks like
+    /// it should destroy.
+    ///
+    /// Concretely: [`AlmJoinPlanner::plan`] takes a caller-supplied candidate
+    /// set under staleness and reachability filters. It plans over advertised
+    /// candidates and established links, never over an assumption that every
+    /// member is dialable. So the one-hop property constrains FIRST CONTACT —
+    /// which happens on the federation plane, where announces are permitted —
+    /// and not the shape of the tree built afterwards.
+    ///
+    /// [`AlmJoinPlanner::plan`]: crate::transport::realtime_av_alm::AlmJoinPlanner::plan
     ///
     /// # Errors
     /// [`TransportError::BodyTooLarge`] above the AV-13 ceiling;
@@ -9572,9 +9636,9 @@ mod scope_native_addressing_tests {
     use crate::scope_addressing::StubDeriver;
     use leviculum_core::AnnounceControl as _;
 
-    async fn bare_transport(dir: &std::path::Path, key_id: &str) -> ReticulumTransport {
-        // A hybrid signer, because CIRISEdge#333 refuses to build a transport
-        // that cannot self-attest its announces.
+    /// A hybrid signer — CIRISEdge#333 refuses a transport that cannot
+    /// self-attest its announces.
+    fn test_signer(key_id: &str) -> Arc<LocalSigner> {
         let mut ed_seed = [0u8; 32];
         let mut pqc_seed = [0u8; 32];
         let salt = u8::try_from(key_id.len() % 251).expect("in range");
@@ -9593,7 +9657,24 @@ mod scope_native_addressing_tests {
             )
             .expect("ml_dsa_65"),
         );
-        let signer = Arc::new(LocalSigner::new(key_id, classical, Some(pqc)));
+        Arc::new(LocalSigner::new(key_id, classical, Some(pqc)))
+    }
+
+    async fn transport_with(config: ReticulumTransportConfig, key_id: &str) -> ReticulumTransport {
+        let signer = test_signer(key_id);
+        ReticulumTransport::new(
+            config,
+            ReticulumAuth {
+                signer: Some(signer),
+                ..ReticulumAuth::default()
+            },
+        )
+        .await
+        .expect("transport")
+    }
+
+    async fn bare_transport(dir: &std::path::Path, key_id: &str) -> ReticulumTransport {
+        let signer = test_signer(key_id);
 
         // No typed interfaces, and the default `0.0.0.0:4242` server replaced
         // with an ephemeral port so these four tests can run concurrently. The
@@ -9622,6 +9703,48 @@ mod scope_native_addressing_tests {
             .install_group(scope, group_id, 1, &[9u8; 32], members)
             .expect("install group");
         table
+    }
+
+    #[tokio::test]
+    async fn federation_visibility_off_makes_the_node_announce_nothing() {
+        // The wizard's "allow me to be visible to the federation so I can use
+        // the mesh" opt-in. OFF means point-to-point only: the node announces
+        // nothing, so no stranger can learn an address for it.
+        //
+        // Asserted on the POLICY rather than on the flag, because the flag
+        // being read is not the property — the property is that the named
+        // discovery destination stops being announceable.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let mut config = ReticulumTransportConfig::new(dir.path().join("t.id"), "edge-invisible");
+        config.listen_addr = "127.0.0.1:0".parse().expect("addr");
+        config.federation_visible = false;
+
+        let transport = transport_with(config, "edge-invisible").await;
+        assert!(
+            transport
+                .announce_policy
+                .should_suppress_announce(&DestinationHash::new(transport.local_named_dest_hash())),
+            "an invisible node must not announce its discovery destination",
+        );
+        assert_eq!(
+            transport.announce_policy.len(),
+            0,
+            "invisibility is the policy's DEFAULT-suppress, not a second \
+             mechanism — nothing should be registered at all",
+        );
+    }
+
+    #[tokio::test]
+    async fn federation_visibility_on_keeps_the_node_discoverable() {
+        // The other half, so the pair cannot pass by suppressing everything.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transport = bare_transport(dir.path(), "edge-visible").await;
+        assert!(
+            !transport
+                .announce_policy
+                .should_suppress_announce(&DestinationHash::new(transport.local_named_dest_hash())),
+            "a federation-visible node must still announce discovery",
+        );
     }
 
     #[tokio::test]

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -2883,11 +2883,42 @@ impl ReticulumTransport {
     /// BROADCAST-ONLY: it reaches a directly-attached neighbour and no further,
     /// exactly like a v7 explicit-hash peer before `prime_peer`.
     ///
-    /// How a scoped address becomes relay-routable without re-publishing the
-    /// reachability fact is **not edge's rule to choose** and is raised rather
-    /// than guessed. Until it is specified, a multi-hop scoped fetch fails at
-    /// the establish timeout with [`TransportError::NoRouteToPeer`] — loudly,
-    /// and without ever having put the scoped bytes on the federation address.
+    /// **This is a RULED posture, not a gap to fix.** CIRISConstitution#91
+    /// asked whether CC 5.4.6's announce prohibition binds the *packet* or the
+    /// *leak*, and CC 1.0-rc4 ruled: **the packet, stated as the emission**. A
+    /// directed announce iterated over the roster inherits the prohibition
+    /// rather than escaping it — the clause binds the emission, not the
+    /// addressing mode. Three legs, now in-clause at 5.4.6:
+    ///
+    /// - No directed announce on RNS transport can satisfy the purposive
+    ///   gloss, because multi-hop path learning IS outsider observation, and
+    ///   the path state intermediates retain is exactly the class the subpoena
+    ///   framing promises does not exist.
+    /// - The flat `MUST NOT` was never broadcast-era shorthand: the same
+    ///   section bans the targeted, non-broadcast per-destination query in the
+    ///   same breath, so the emission class was always the object.
+    /// - A directed announce would trade *no emission exists* — structural and
+    ///   honestly claimable — for *emissions exist but resist analysis*, which
+    ///   is traffic-analysis privacy, precisely the claim CEG/RET declines to
+    ///   make outside the Anonymous Tier (CC 1.13.3.1). **A reading must not
+    ///   spend a claimable guarantee to purchase an unclaimable one.**
+    ///
+    /// The ruling also names a bind edge's own filing missed: the derivation
+    /// is EPOCH-BOUND, so an announcing scheme must either re-announce
+    /// roster-wide on every Add/Remove — a synchronized wave whose cardinality,
+    /// timing and churn are themselves the leak — or never rotate, which leaves
+    /// a removed member holding every peer's addressing forever.
+    ///
+    /// So a multi-hop scoped fetch fails at the establish timeout with
+    /// [`TransportError::NoRouteToPeer`] — loudly, and without ever having put
+    /// the scoped bytes on the federation address. **Do not "fix" this by
+    /// announcing.** Multi-hop scoped reach remains open on the amendment
+    /// plane with its bar stated: no outsider-observable emission, no
+    /// outsider-retained path state, no epoch-correlated wave.
+    ///
+    /// What the ruling DID keep is that in-group MLS distribution of addressing
+    /// material was never prohibited — the cached-directory discipline — so a
+    /// roster learning its own members' addresses over MLS stays open.
     ///
     /// # Errors
     /// [`TransportError::BodyTooLarge`] above the AV-13 ceiling;

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -2799,40 +2799,54 @@ impl ReticulumTransport {
 
     /// CIRISEdge#499 — retire a scope-derived destination.
     ///
-    /// The inverse of [`Self::register_scoped_destination`], and the one
-    /// half of the lifecycle edge cannot currently honour:
-    /// `leviculum-std`'s driver forwards `register_destination` but not
-    /// `unregister_destination` (**leviculum#54**). `NodeCore` has the
-    /// verb and it does the right thing — it drops the routing entry and
-    /// the destination — it is simply not exposed on the `&self` driver
-    /// an `Arc<ReticulumNode>` holder can reach, and there is no
-    /// `destination_mut` or node escape hatch to route around it.
+    /// The inverse of [`Self::register_scoped_destination`], and the
+    /// second half of the rotation: after this returns the hash is no
+    /// longer one of ours, so a peer that still holds a path and dials
+    /// it finds nobody home. Without it a superseded address keeps
+    /// answering forever, which re-confirms this node to anyone still
+    /// probing it — the reachability disclosure CIRISEdge#311 exists to
+    /// prevent, and the reason a rotation that cannot retire only ever
+    /// *adds* addresses.
     ///
-    /// So this returns `Err` rather than silently succeeding. A sealed
-    /// address that stays registered is a real residual disclosure: an
-    /// observer who learned it can keep probing and keep confirming this
-    /// node is reachable, which is the reachability publication
-    /// CIRISEdge#311 exists to prevent. Reporting that honestly is worth
-    /// more than a no-op that reads as success.
+    /// Landed in leviculum v0.20.0+ciris.1 (leviculum#54). Two contract
+    /// points edge relies on, both pinned by leviculum's own
+    /// `destination_lifecycle.rs` rather than inferred here:
     ///
-    /// When the driver verb lands, the body becomes
-    /// `self.node.unregister_destination(&DestinationHash::new(hash))`
-    /// plus the announce-policy `forget`, and
-    /// [`crate::scope_lifecycle::SealOutcome::unretired`] goes to zero.
+    /// - **Idempotent** — retiring an already-gone or never-registered
+    ///   hash is a no-op. That is what lets the seal be timing-driven
+    ///   ([`crate::scope_lifecycle::ScopeLifecycle::seal_due`] may fire
+    ///   twice for one rotation).
+    /// - **Established links keep running** — a link is keyed by its
+    ///   `LinkId`, not by the destination it was dialled through, so
+    ///   only NEW link requests are refused.
+    ///
+    /// That second point is the behaviour edge wants, and edge
+    /// deliberately does NOT follow it with a `close_link` sweep.
+    /// A peer holding an established link dialled it while legitimately
+    /// in the group; tearing it down would drop a live stream, which is
+    /// exactly what the make-before-break rotation window exists to
+    /// prevent (a `DestinationHash` is used to dial and listen, never
+    /// per chunk). The unlinkability concern is about *new* probes, and
+    /// those are what retirement stops. Cutting live links is available
+    /// (`close_link` by `LinkId`) and is a separate, deliberate act.
     ///
     /// # Errors
-    /// Always, until leviculum#54 lands.
+    /// [`TransportError::Config`] never, currently — retained in the
+    /// signature because the sink contract
+    /// ([`crate::scope_lifecycle::ScopedDestinationSink::retire`]) is
+    /// fallible and a future transport may not be able to retire.
     pub fn retire_scoped_destination(
         &self,
         address: &MemberAddress,
         _scope: &crate::cohort_scope::CohortScope,
     ) -> Result<(), TransportError> {
-        let _ = address;
-        Err(TransportError::Config(
-            "leviculum-std exposes no unregister_destination on the node driver \
-             (leviculum#54); the sealed scope address stays routable"
-                .to_owned(),
-        ))
+        let hash = *address.as_bytes();
+        self.node
+            .unregister_destination(&DestinationHash::new(hash));
+        // Drop the scope record too, so the policy map does not grow one
+        // entry per epoch per group for addresses that are no longer ours.
+        self.announce_policy.forget(&hash);
+        Ok(())
     }
 
     /// CIRISEdge#499 — resolve an inbound destination hash to the scope
@@ -9525,6 +9539,61 @@ mod scope_native_addressing_tests {
                     &DestinationHash::new(transport.local_named_dest_hash()),
                 ),
             "the named Commons discovery destination still announces",
+        );
+    }
+
+    #[tokio::test]
+    async fn a_scoped_destination_round_trips_register_then_retire() {
+        // leviculum#54 (v0.20.0+ciris.1) — the seal half of the rotation.
+        // Without retirement a superseded address keeps answering forever
+        // and an observer who learned it can re-confirm this node, which
+        // is the reachability disclosure the whole feature removes.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let transport = bare_transport(dir.path(), "edge-retire").await;
+
+        let scope = CohortScope::Family;
+        let table = table_with_group(&scope, "grp-r", &["member-r"]);
+        let address = table
+            .send_address(&scope, "grp-r", "member-r")
+            .expect("derived address");
+        let hash = *address.as_bytes();
+
+        let before = transport.announce_policy.len();
+        transport
+            .register_scoped_destination(&address, &scope)
+            .expect("register");
+        assert_eq!(transport.announce_policy.len(), before + 1);
+
+        transport
+            .retire_scoped_destination(&address, &scope)
+            .expect("retire");
+        // The scope record goes too, or the policy map grows one entry per
+        // epoch per group for addresses that are no longer ours.
+        assert_eq!(
+            transport.announce_policy.len(),
+            before,
+            "retiring must drop the scope record, not just the destination",
+        );
+
+        // Idempotent — leviculum pins this, and the seal is timing-driven
+        // so it may genuinely fire twice for one rotation.
+        transport
+            .retire_scoped_destination(&address, &scope)
+            .expect("retiring twice is a no-op");
+        assert_eq!(transport.announce_policy.len(), before);
+
+        // And re-registering the same address afterwards still works: a
+        // member re-admitted at a later epoch must not be poisoned by the
+        // earlier retirement.
+        transport
+            .register_scoped_destination(&address, &scope)
+            .expect("re-register after retire");
+        assert_eq!(transport.announce_policy.len(), before + 1);
+        assert!(
+            transport
+                .announce_policy
+                .should_suppress_announce(&DestinationHash::new(hash)),
+            "a re-registered scoped destination is still never announced",
         );
     }
 

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -98,6 +98,8 @@ use super::{InboundFrame, Transport, TransportError, TransportId, TransportSendO
 use crate::identity::LocalSigner;
 use crate::reachability::{AttemptOutcome, ReachabilityTracker};
 use crate::scope_addressing::{InboundAddress, MemberAddress, ScopeAddressTable};
+#[cfg(feature = "lxmf")]
+use crate::transport::lxmf_serve::ServeOutcome;
 use crate::verify::{
     HybridPolicy, ProvenanceChain, RootingDirectory, RootingRejection, RootingVerdict,
 };
@@ -1697,6 +1699,11 @@ pub struct ReticulumTransport {
     /// `None` until installed: every scope-native lookup then declines and
     /// the federation-scope paths are unaffected.
     scope_addresses: OnceLock<Arc<ScopeAddressTable>>,
+    /// CIRISEdge#169 — the LXMF propagation serve node, when this node has
+    /// been configured to carry third-party mail. `None` (the default) means
+    /// the `RequestReceived` arm declines every propagation request.
+    #[cfg(feature = "lxmf")]
+    lxmf_serve: OnceLock<Arc<crate::transport::lxmf_serve::LxmfServeNode>>,
     /// Edge's own announce attestation app-data — built once in
     /// `new` (sign with the federation `LocalSigner`) and emitted
     /// verbatim on every announce. `None` when no signer was
@@ -2539,6 +2546,8 @@ impl ReticulumTransport {
             local_transport_pubkey,
             local_identity: identity.clone(),
             scope_addresses: OnceLock::new(),
+            #[cfg(feature = "lxmf")]
+            lxmf_serve: OnceLock::new(),
             local_attestation,
             local_signer,
             self_route,
@@ -2761,6 +2770,50 @@ impl ReticulumTransport {
         self.scope_addresses
             .set(table)
             .map_err(|_| TransportError::Config("scope address table already installed".to_owned()))
+    }
+
+    /// CIRISEdge#169 — install the LXMF propagation serve node and register
+    /// its request handler, so this node begins carrying third-party mail.
+    ///
+    /// Called ONCE. Two things happen together on purpose: without the
+    /// registration no `RequestReceived` ever arrives, and without the node
+    /// the arm declines every one — so installing one without the other is a
+    /// node that either cannot hear or cannot answer, and both look like
+    /// silence from outside.
+    ///
+    /// The roster inside the node decides WHO is served
+    /// ([`PropagationAudience::from_cohort_membership`] — self, family, and
+    /// the communities this node is in; deliberately NOT the RNS transit
+    /// rule). This verb decides only THAT the node serves.
+    ///
+    /// # Errors
+    /// [`TransportError::Config`] if a serve node is already installed.
+    ///
+    /// [`PropagationAudience::from_cohort_membership`]:
+    ///     crate::transport::lxmf_serve::PropagationAudience::from_cohort_membership
+    #[cfg(feature = "lxmf")]
+    pub fn install_lxmf_serve(
+        &self,
+        serve: Arc<crate::transport::lxmf_serve::LxmfServeNode>,
+    ) -> Result<(), TransportError> {
+        self.lxmf_serve
+            .set(serve)
+            .map_err(|_| TransportError::Config("LXMF serve node already installed".to_owned()))?;
+        // Register on the node's NAMED discovery destination — the one a
+        // client can actually reach. An explicit-hash destination cannot be
+        // path-resolved (CC 5.4.6 / CIRISConstitution#91), so a propagation
+        // node has to be reachable on the plane that announces.
+        self.node.register_request_handler(
+            DestinationHash::new(self.local_named_dest_hash()),
+            crate::transport::lxmf_serve::MESSAGE_GET_PATH,
+            leviculum_core::RequestPolicy::AllowAll,
+        );
+        tracing::info!(
+            path = crate::transport::lxmf_serve::MESSAGE_GET_PATH,
+            "CIRISEdge#169 — LXMF propagation serve path REGISTERED. This node now \
+             carries mail for the destinations in its roster."
+        );
+        Ok(())
     }
 
     /// CIRISEdge#499 — the installed scope-address table, if any.
@@ -5121,6 +5174,8 @@ impl Transport for ReticulumTransport {
                         inbound_reasm: &self.inbound_reasm,
                         dialed_link_dest: &self.dialed_link_dest,
                         scope_addresses: &self.scope_addresses,
+                        #[cfg(feature = "lxmf")]
+                        lxmf_serve: &self.lxmf_serve,
                     };
                     handle_event(event, &ctx).await;
 
@@ -5247,6 +5302,10 @@ struct EventCtx<'a> {
     /// label is specified) ⇒ every frame is stamped `None`, i.e. federation
     /// arrival, i.e. exactly pre-#499 behaviour.
     scope_addresses: &'a OnceLock<Arc<ScopeAddressTable>>,
+    /// CIRISEdge#169 — the LXMF serve node, borrowed like every other
+    /// sub-protocol's state (the `EventCtx` field pattern).
+    #[cfg(feature = "lxmf")]
+    lxmf_serve: &'a OnceLock<Arc<crate::transport::lxmf_serve::LxmfServeNode>>,
 }
 
 /// CIRISEdge#424 — the classified result of attributing an inbound frame's link to
@@ -6103,6 +6162,86 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
                 ));
             }
         }
+        // CIRISEdge#169 — the LXMF propagation HOST serve path.
+        //
+        // The decision is made by `LxmfServeNode`, which is sans-I/O: no async,
+        // no `.await`, no clock of its own. This arm does the I/O and nothing
+        // else — which is why the serve logic can be exhaustively tested
+        // without a node, and why no lock can cross a suspension point here.
+        #[cfg(feature = "lxmf")]
+        NodeEvent::RequestReceived {
+            link_id,
+            request_id,
+            ref path,
+            ref data,
+            ..
+        } if path == crate::transport::lxmf_serve::MESSAGE_GET_PATH => {
+            let Some(serve) = ctx.lxmf_serve.get() else {
+                // Not configured to carry third-party mail. Declining is the
+                // DEFAULT posture (`PropagationAudience::Disabled`), not a
+                // fault, so this is a trace rather than a withhold: nothing
+                // was refused, because nothing was ever offered.
+                tracing::trace!(
+                    %path,
+                    "LXMF propagation request on a node that carries no third-party mail"
+                );
+                return;
+            };
+
+            // The requester is the LINK's own remote identity — never a
+            // wire-supplied field. A propagation node that took the requester
+            // from the request body would serve any mailbox on demand, which
+            // is the whole attack the per-recipient scoping exists to stop.
+            let requester = ctx.node.get_remote_identity(&link_id).map(|id| {
+                let mut out = [0u8; leviculum_lxmf::constants::DESTINATION_LENGTH];
+                out.copy_from_slice(&id.hash()[..leviculum_lxmf::constants::DESTINATION_LENGTH]);
+                out
+            });
+
+            let result = serve.serve_get(requester, data, std::time::Instant::now());
+
+            // The notices carry typed `WithholdReason`s and BELONG in the
+            // counted ledger — but the transport holds no `EdgeMetrics`
+            // handle (`inc_withhold` is never called from this file). That is
+            // the serve/inbound attribution asymmetry recorded in
+            // `crate::contextual_integrity`, meeting a serve path that happens
+            // to live in the event loop. Until the transport carries a metrics
+            // handle these are LOUD but uncounted, which is stated rather than
+            // silently accepted.
+            for notice in &result.notices {
+                drop_inbound(Some(link_id), notice.reason.as_str(), notice.detail);
+            }
+
+            if let ServeOutcome::Respond(ref bytes) = result.outcome {
+                match ctx.node.send_response(&link_id, &request_id, bytes).await {
+                    Ok(()) => {
+                        // MEASURED CONTRACT (leviculum#55): `Ok` means HANDED
+                        // TO THE LINK, not delivered. If the peer vanished
+                        // before the link's death was processed, this returns
+                        // `Ok(())` and the bytes go nowhere — and for a
+                        // propagation node serving churning mobiles that is
+                        // the normal case, not the edge case.
+                        //
+                        // So the mailbox entry is NOT dropped here. Delivery
+                        // evidence has to come from the application layer —
+                        // the peer's next request implying receipt — and
+                        // `serve_get` is deliberately non-destructive for
+                        // exactly this reason.
+                        tracing::debug!(?link_id, "LXMF propagation response handed to link");
+                    }
+                    Err(e) => {
+                        // A link known to be dead answers `LinkNotFound` — the
+                        // typed signal, and the honest one.
+                        drop_inbound(
+                            Some(link_id),
+                            "lxmf-response-undeliverable",
+                            &format!("{e}"),
+                        );
+                    }
+                }
+            }
+        }
+
         // CIRISEdge#484 — `ResponseReceived` / `RequestTimedOut` are now resolved by
         // the leviculum v0.16 completion registry (fed at the dispatch layer), so
         // `link_request` no longer mirrors them here — the events fall through to the

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -2797,6 +2797,146 @@ impl ReticulumTransport {
         Ok(())
     }
 
+    /// CIRISEdge#499 — send a byte-exact signed envelope to a peer at its
+    /// SCOPE-DERIVED address rather than its federation address.
+    ///
+    /// This is the send half of scope-native addressing, and its whole design
+    /// is in the signature. `Transport::send` deliberately grows no scope
+    /// parameter — it has 10 implementors, including HTTP and packet radio,
+    /// neither of which has a scope-derived destination plane — and this method
+    /// deliberately parses no scope. It takes a [`MemberAddress`], which has no
+    /// public byte constructor: the ONLY way a caller holds one is to have
+    /// obtained it from a [`ScopeAddressTable`] lookup keyed by a
+    /// `member_key_id`. So "this address is the right one for this content's
+    /// scope" is a property the caller already proved, above the transport,
+    /// and hands down as a value that cannot be wrong — the `ResolvedRecipient`
+    /// pattern (CIRISEdge#396/#402), applied to addressing.
+    ///
+    /// `destination_key_id` is still required, and is NOT the routing input: it
+    /// is the peer's federation key id, used only to resolve the transport-tier
+    /// Ed25519 the link proof is verified against. The dial target is the
+    /// derived address, exclusively — there is no arm of this method that falls
+    /// back to a federation candidate, because a silent fallback is precisely
+    /// the context collapse the derivation exists to remove.
+    ///
+    /// # Routability (the open upstream question)
+    ///
+    /// A scope-derived destination is registered with
+    /// [`Self::register_scoped_destination`], which builds an EXPLICIT-HASH
+    /// destination and suppresses its announce (CC 5.4 — group-scoped
+    /// destinations MUST NOT announce; announcing one would publish the very
+    /// reachability fact the derivation withholds). Reference RNS therefore
+    /// holds no learned path to it, and leviculum v0.19 answers path requests
+    /// for explicit-hash destinations with silence. So this dial is
+    /// BROADCAST-ONLY: it reaches a directly-attached neighbour and no further,
+    /// exactly like a v7 explicit-hash peer before `prime_peer`.
+    ///
+    /// How a scoped address becomes relay-routable without re-publishing the
+    /// reachability fact is **not edge's rule to choose** and is raised rather
+    /// than guessed. Until it is specified, a multi-hop scoped fetch fails at
+    /// the establish timeout with [`TransportError::NoRouteToPeer`] — loudly,
+    /// and without ever having put the scoped bytes on the federation address.
+    ///
+    /// # Errors
+    /// [`TransportError::BodyTooLarge`] above the AV-13 ceiling;
+    /// [`TransportError::Unreachable`] when the peer's transport identity
+    /// cannot be resolved (no signing key ⇒ no link proof);
+    /// [`TransportError::NoRouteToPeer`] / [`TransportError::Timeout`] when the
+    /// derived destination does not establish; [`TransportError::Io`] on a
+    /// leviculum fault.
+    pub async fn send_to_scoped_destination(
+        &self,
+        destination_key_id: &str,
+        address: &MemberAddress,
+        envelope_bytes: &[u8],
+    ) -> Result<TransportSendOutcome, TransportError> {
+        if envelope_bytes.len() > MAX_BODY_BYTES {
+            return Err(TransportError::BodyTooLarge {
+                actual: envelope_bytes.len(),
+                limit: MAX_BODY_BYTES,
+            });
+        }
+
+        let dest_hash = DestinationHash::new(*address.as_bytes());
+        // Operator deny-list first, on the DERIVED hash — a ban must not be
+        // bypassable by addressing the peer in one of its scopes.
+        self.check_blackhole(&dest_hash.into_bytes()).await?;
+
+        // The peer's transport-tier Ed25519, for the link proof. Any candidate
+        // carries it (they differ in ROUTING hash, not in signing key), so take
+        // the first. The candidate's own dest_hash is deliberately discarded:
+        // routing here is the derived address, never a federation one.
+        let Some(signing_key) = self
+            .resolve_dial_candidates(destination_key_id)
+            .await
+            .first()
+            .map(|c| c.signing_key)
+        else {
+            return Err(TransportError::Unreachable(format!(
+                "scope-native send: no transport identity resolved for \
+                 destination_key_id={destination_key_id} — cannot prove a link to its \
+                 derived address (CIRISEdge#499)"
+            )));
+        };
+
+        let (link, established) = self
+            .node
+            .connect_awaited(&dest_hash, &signing_key)
+            .await
+            .map_err(|e| TransportError::Io(format!("reticulum connect (scoped): {e}")))?;
+        let link_id = *link.link_id();
+        // CIRISEdge#424 — record the dest we dialed so a reply arriving on this
+        // link attributes to this peer (leviculum's `link_destination` is `None`
+        // for our own dialed links).
+        self.dialed_link_dest
+            .lock()
+            .await
+            .insert(link_id, dest_hash);
+
+        // Explicit-hash destinations are never pathed (see the routability note
+        // above), so this is always the bootstrap-broadcast budget.
+        if !matches!(
+            with_timeout(NO_PATH_ESTABLISH_TIMEOUT, established).await,
+            Some(Ok(()))
+        ) {
+            tracing::error!(
+                key_id = %destination_key_id,
+                target_dest = %hex::encode(dest_hash.into_bytes()),
+                "scope-native send: derived destination did not establish. A derived \
+                 address is announce-suppressed by design (CC 5.4), so it is \
+                 broadcast-only — only a directly-attached neighbour answers. Making a \
+                 scoped address relay-routable without re-publishing the reachability \
+                 fact is unspecified upstream (CIRISEdge#499). NOT retried on the \
+                 federation address: that would collapse the very context this \
+                 address exists to separate."
+            );
+            return Err(TransportError::NoRouteToPeer {
+                key_id: destination_key_id.to_string(),
+                target_dest: hex::encode(dest_hash.into_bytes()),
+                has_path: false,
+                paths: self.path_table_snapshot(),
+            });
+        }
+
+        // CIRISEdge#340 — IDENTIFY before shipping, so the responder can
+        // attribute the frame. Same ordering as the federation send path.
+        self.node
+            .identify_link(&link_id, &self.local_identity)
+            .await
+            .map_err(|e| TransportError::Io(format!("reticulum identify_link (scoped): {e}")))?;
+
+        self.ship_resource_on_link(
+            &link_id,
+            envelope_bytes,
+            DIAL_NO_PROGRESS_WINDOW,
+            RESOURCE_TRANSFER_TIMEOUT,
+        )
+        .await
+        .map_err(ShipError::into_transport)?;
+
+        Ok(TransportSendOutcome::Delivered)
+    }
+
     /// CIRISEdge#499 — resolve an inbound destination hash to the scope
     /// group, member and epoch it was derived for, or `None` if it is not one
     /// of ours.
@@ -4833,6 +4973,7 @@ impl Transport for ReticulumTransport {
                         link_last_inbound_at: &self.link_last_inbound_at,
                         inbound_reasm: &self.inbound_reasm,
                         dialed_link_dest: &self.dialed_link_dest,
+                        scope_addresses: &self.scope_addresses,
                     };
                     handle_event(event, &ctx).await;
 
@@ -4951,6 +5092,14 @@ struct EventCtx<'a> {
     /// same name on [`ReticulumTransport`]). Consulted in `attribute_and_deliver`
     /// when leviculum's `link_destination` is `None` for an own-dialed link.
     dialed_link_dest: &'a Mutex<HashMap<LinkId, DestinationHash>>,
+    /// CIRISEdge#499 — the scope-native address table (see the field of the same
+    /// name on [`ReticulumTransport`]). `attribute_and_deliver` probes its
+    /// reverse index once per frame to stamp `InboundFrame::arrival_scope`,
+    /// which is the receive-side admission fact the blob serve gate consumes.
+    /// Empty `OnceLock` (the production state until CIRISVerify#259's exporter
+    /// label is specified) ⇒ every frame is stamped `None`, i.e. federation
+    /// arrival, i.e. exactly pre-#499 behaviour.
+    scope_addresses: &'a OnceLock<Arc<ScopeAddressTable>>,
 }
 
 /// CIRISEdge#424 — the classified result of attributing an inbound frame's link to
@@ -5310,12 +5459,34 @@ async fn attribute_and_deliver(ctx: &EventCtx<'_>, link_id: LinkId, data: Vec<u8
         // exact condition already stated upstream).
         None => None,
     };
+    // CIRISEdge#499 — resolve the SCOPE-DERIVED address this frame arrived on,
+    // here, once, BEFORE the envelope is parsed. `dest` is the link's
+    // destination, already in hand for the attribution above; the resolution is
+    // a single hash-map probe against the reverse index (the table exists
+    // precisely so the packet path never derives — see
+    // `scope_addressing::lookup_never_calls_the_deriver`).
+    //
+    // `None` — no table installed, or a hash that is not one of ours — means the
+    // frame arrived on the FEDERATION address, which downstream reads as
+    // `CohortScope::Public`. That is not a downgrade: it is the literal truth
+    // about what reaching a public discovery address demonstrates.
+    //
+    // This is a receive-side ADMISSION FACT, orthogonal to `source_key_id`: it
+    // says which group secret the sender possessed, not who the sender is. A
+    // frame can carry one without the other, and the blob serve gate needs
+    // exactly this one.
+    let arrival_scope = dest.and_then(|d| {
+        ctx.scope_addresses
+            .get()
+            .and_then(|t| t.accepts_inbound(&d.into_bytes()))
+    });
     let frame = InboundFrame {
         envelope_bytes: data,
         transport: TransportId::RETICULUM_RS,
         received_at: Utc::now(),
         source_key_id,
         link_key_id,
+        arrival_scope,
     };
     if let Err(e) = ctx.sink.send(frame).await {
         tracing::error!(error = %e, "inbound channel send failed");

--- a/tests/accord_carrier_verify.rs
+++ b/tests/accord_carrier_verify.rs
@@ -456,6 +456,8 @@ async fn accord_carrier_2_of_3_valid_propagates() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 
@@ -514,6 +516,8 @@ async fn accord_carrier_1_of_3_refuses_and_emits_refusal() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 
@@ -579,6 +583,8 @@ async fn accord_carrier_3_of_3_propagates() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 
@@ -642,6 +648,8 @@ async fn accord_carrier_2_valid_1_invalid_propagates() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 
@@ -699,6 +707,8 @@ async fn accord_carrier_0_accord_holders_in_directory_refuses_with_no_accord_hol
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 
@@ -768,6 +778,8 @@ async fn accord_carrier_duplicate_signatures_from_same_holder_count_once() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 
@@ -826,6 +838,8 @@ async fn accord_carrier_non_accord_class_announcements_skip_threshold_check() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 
@@ -899,6 +913,8 @@ async fn accord_carrier_classical_only_signatures_refused_require_hybrid() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 
@@ -966,6 +982,8 @@ async fn accord_carrier_spare_holder_not_seated_does_not_count() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 

--- a/tests/ceg_content_discipline.rs
+++ b/tests/ceg_content_discipline.rs
@@ -189,6 +189,8 @@ impl Transport for InjectTransport {
                 received_at: chrono::Utc::now(),
                 source_key_id: None,
                 link_key_id: None,
+                // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+                arrival_scope: None,
             };
             if sink.send(frame).await.is_err() {
                 break;

--- a/tests/cohort_scope_persist_backed.rs
+++ b/tests/cohort_scope_persist_backed.rs
@@ -225,6 +225,8 @@ async fn dispatch(
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
     Ok(())

--- a/tests/cohort_scope_refusal.rs
+++ b/tests/cohort_scope_refusal.rs
@@ -557,6 +557,8 @@ async fn dispatch_with_cohort_scope(
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
     Ok(())

--- a/tests/content_fetch.rs
+++ b/tests/content_fetch.rs
@@ -193,6 +193,8 @@ impl Transport for InjectTransport {
                 received_at: chrono::Utc::now(),
                 source_key_id: None,
                 link_key_id: None,
+                // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+                arrival_scope: None,
             };
             if sink.send(frame).await.is_err() {
                 break;

--- a/tests/federation_announcement.rs
+++ b/tests/federation_announcement.rs
@@ -70,6 +70,20 @@ impl FedKey {
         B64.encode(self.signer().public_key().expect("pubkey"))
     }
 
+    /// The PQC half. Derived from the same seed so the fixture stays
+    /// deterministic; the byte flip keeps it distinct from the Ed25519 seed.
+    fn pqc_signer(&self) -> ciris_keyring::MlDsa65SoftwareSigner {
+        let mut seed = self.seed;
+        seed[0] ^= 0x55;
+        ciris_keyring::MlDsa65SoftwareSigner::from_seed_bytes(&seed, format!("{}-pqc", self.key_id))
+            .expect("ml_dsa_65 from seed")
+    }
+
+    fn pqc_pubkey_b64(&self) -> String {
+        use ciris_keyring::PqcSigner as _;
+        B64.encode(futures::executor::block_on(self.pqc_signer().public_key()).expect("pqc pubkey"))
+    }
+
     fn write_seed_dir(&self, base: &std::path::Path) -> PathBuf {
         let dir = base.join(format!("seed-{}", self.key_id));
         std::fs::create_dir_all(&dir).expect("create seed dir");
@@ -87,7 +101,11 @@ impl FedKey {
         })
         .await
         .expect("load_local_seed");
-        Arc::new(LocalSigner::new(self.key_id.clone(), classical, None))
+        // HYBRID. A classical-only signer here would make every fixture a
+        // producer of hybrid-pending rows, which persist's Strict policy
+        // rejects at admission — the shape that reddened this file.
+        let pqc: Arc<dyn ciris_keyring::PqcSigner> = Arc::new(self.pqc_signer());
+        Arc::new(LocalSigner::new(self.key_id.clone(), classical, Some(pqc)))
     }
 }
 
@@ -104,7 +122,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
     KeyRecord {
         key_id: subject.key_id.clone(),
         pubkey_ed25519_base64: subject.pubkey_b64(),
-        pubkey_ml_dsa_65_base64: None,
+        pubkey_ml_dsa_65_base64: Some(subject.pqc_pubkey_b64()),
         algorithm: "hybrid".to_string(),
         identity_type: identity_type.to_string(),
         identity_ref: subject.key_id.clone(),
@@ -553,7 +571,21 @@ async fn av_replayed_attestation_is_idempotent() {
     };
     let canonical = att.canonical_bytes().expect("canonical");
     let sig = peer.signer().sign(&canonical).expect("sign");
-    att.signature_classical_base64 = B64.encode(sig);
+    att.signature_classical_base64 = B64.encode(&sig);
+    // HYBRID, per AV-33: ML-DSA-65 over `canonical || classical_sig`. A
+    // classical-only row is hybrid-pending and Strict rejects it at admission.
+    att.signature_pqc_base64 = Some(
+        B64.encode(
+            futures::executor::block_on({
+                use ciris_keyring::PqcSigner as _;
+                let mut bound = canonical.clone();
+                bound.extend_from_slice(&sig);
+                let p = peer.pqc_signer();
+                async move { p.sign(&bound).await }
+            })
+            .expect("pqc sign"),
+        ),
+    );
 
     nc.put_delivery_attestation(att.clone())
         .await
@@ -621,6 +653,16 @@ async fn edge_emitted_attestation_passes_persist_admission() {
     let canonical = edge_att.canonical_bytes().expect("canonical");
     let sig = peer_signer.classical.sign(&canonical).await.expect("sign");
     edge_att.signature_classical_base64 = B64.encode(&sig);
+    // HYBRID, matching what edge's own producer now REQUIRES rather than
+    // treats as optional — this test asserts edge-emitted rows pass persist
+    // admission, so signing it any other way would test a shape edge can no
+    // longer emit.
+    {
+        let mut bound = canonical.clone();
+        bound.extend_from_slice(&sig);
+        let pqc = peer_signer.pqc.as_ref().expect("hybrid signer");
+        edge_att.signature_pqc_base64 = Some(B64.encode(pqc.sign(&bound).await.expect("pqc sign")));
+    }
 
     let json = serde_json::to_string(&edge_att).expect("ser");
     let persist_att: ciris_persist::cirisnode::DeliveryAttestation =

--- a/tests/multimedia_tier.rs
+++ b/tests/multimedia_tier.rs
@@ -238,6 +238,8 @@ async fn dispatch_contribution(
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 }

--- a/tests/observability_metrics.rs
+++ b/tests/observability_metrics.rs
@@ -296,6 +296,8 @@ async fn metrics_counter_increments_on_receive() {
         received_at: chrono::Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 
@@ -420,6 +422,8 @@ async fn metrics_transport_bytes_io_counted() {
         received_at: chrono::Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 
@@ -477,6 +481,8 @@ async fn metrics_verify_failure_classified_by_error() {
         received_at: chrono::Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 

--- a/tests/observability_tracing.rs
+++ b/tests/observability_tracing.rs
@@ -285,6 +285,8 @@ async fn dispatch_inbound_emits_structured_span_with_fields() {
         received_at: chrono::Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 
@@ -368,6 +370,8 @@ async fn verify_failure_emits_structured_error_event() {
         received_at: chrono::Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
 

--- a/tests/probe_pattern_observer_integration.rs
+++ b/tests/probe_pattern_observer_integration.rs
@@ -291,6 +291,8 @@ async fn unconsented_external_traffic_drives_observations() {
             received_at: Utc::now(),
             source_key_id: None,
             link_key_id: None,
+            // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+            arrival_scope: None,
         })
         .await;
     }
@@ -338,6 +340,8 @@ async fn peer_role_traffic_produces_no_observations() {
             received_at: Utc::now(),
             source_key_id: None,
             link_key_id: None,
+            // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+            arrival_scope: None,
         })
         .await;
     }
@@ -382,6 +386,8 @@ async fn detector_disabled_is_a_full_noop() {
             received_at: Utc::now(),
             source_key_id: None,
             link_key_id: None,
+            // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+            arrival_scope: None,
         })
         .await;
     }

--- a/tests/steward_topology.rs
+++ b/tests/steward_topology.rs
@@ -63,11 +63,40 @@ impl FedKey {
         B64.encode(self.signer().public_key().expect("pubkey"))
     }
 
+    /// The PQC half. Same seed with a byte flipped, so the fixture stays
+    /// deterministic while the two keys stay distinct.
+    fn pqc_signer(&self) -> ciris_keyring::MlDsa65SoftwareSigner {
+        let mut seed = self.seed;
+        seed[0] ^= 0x55;
+        ciris_keyring::MlDsa65SoftwareSigner::from_seed_bytes(&seed, format!("{}-pqc", self.key_id))
+            .expect("ml_dsa_65 from seed")
+    }
+
+    fn pqc_pubkey_b64(&self) -> String {
+        use ciris_keyring::PqcSigner as _;
+        B64.encode(futures::executor::block_on(self.pqc_signer().public_key()).expect("pqc pubkey"))
+    }
+
     fn write_seed_dir(&self, base: &std::path::Path) -> PathBuf {
         let dir = base.join(format!("seed-{}", self.key_id));
         std::fs::create_dir_all(&dir).expect("create seed dir");
         std::fs::write(dir.join("ed25519.seed"), self.seed).expect("write seed");
         dir
+    }
+
+    /// A signer with NO PQC half — the shape edge's attestation producer
+    /// refuses (CIRISEdge#458: no classical-only paths, gone not superseded).
+    async fn classical_only_signer(&self, base: &std::path::Path) -> Arc<LocalSigner> {
+        let seed_dir = self.write_seed_dir(base);
+        let (classical, _pqc) = ciris_keyring::load_local_seed(ciris_keyring::LocalSeedConfig {
+            key_id: self.key_id.clone(),
+            key_path: seed_dir.join("ed25519.seed"),
+            pqc_key_id: None,
+            pqc_key_path: None,
+        })
+        .await
+        .expect("load_local_seed");
+        Arc::new(LocalSigner::new(self.key_id.clone(), classical, None))
     }
 
     async fn local_signer(&self, base: &std::path::Path) -> Arc<LocalSigner> {
@@ -80,7 +109,11 @@ impl FedKey {
         })
         .await
         .expect("load_local_seed");
-        Arc::new(LocalSigner::new(self.key_id.clone(), classical, None))
+        // HYBRID. Edge's attestation producer REQUIRES a PQC signer — a
+        // classical-only one emits nothing at all, because a hybrid-pending
+        // row is rejected by persist's Strict policy at admission.
+        let pqc: Arc<dyn ciris_keyring::PqcSigner> = Arc::new(self.pqc_signer());
+        Arc::new(LocalSigner::new(self.key_id.clone(), classical, Some(pqc)))
     }
 }
 
@@ -95,7 +128,7 @@ fn signed_record(subject: &FedKey, signer: &FedKey, identity_type: &str) -> KeyR
     KeyRecord {
         key_id: subject.key_id.clone(),
         pubkey_ed25519_base64: subject.pubkey_b64(),
-        pubkey_ml_dsa_65_base64: None,
+        pubkey_ml_dsa_65_base64: Some(subject.pqc_pubkey_b64()),
         algorithm: "hybrid".to_string(),
         identity_type: identity_type.to_string(),
         identity_ref: subject.key_id.clone(),
@@ -187,6 +220,28 @@ async fn build_edge(
     subscription_filter: Option<Arc<dyn PeerSubscriptionFilter>>,
 ) -> Edge {
     let signer = me.local_signer(tmp.path()).await;
+    build_edge_with_signer(
+        tmp,
+        me,
+        directory,
+        queue,
+        steward_dir,
+        subscription_filter,
+        signer,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn build_edge_with_signer(
+    _tmp: &tempfile::TempDir,
+    _me: &FedKey,
+    directory: Arc<SqliteBackend>,
+    queue: Arc<SqliteBackend>,
+    steward_dir: Arc<dyn StewardDirectory>,
+    subscription_filter: Option<Arc<dyn PeerSubscriptionFilter>>,
+    signer: Arc<LocalSigner>,
+) -> Edge {
     // Tests seed Ed25519-only rows (no PQC); accept those via the
     // sovereign-mode policy so the verify pipeline can clear them.
     // Strict (the default) would reject every test row as
@@ -411,6 +466,96 @@ async fn send_federation_with_zero_stewards_returns_typed_error() {
 /// Ask #3 — Federation-class envelopes auto-emit a `DeliveryAttestation`
 /// on verified receipt at every steward, same wire shape v0.6.0
 /// introduced for the Mandatory class. Pinned at the wire-type allow-
+/// CIRISEdge#458 — a node that cannot sign HYBRID emits no attestation at all.
+///
+/// Edge's producer signed PQC under `if let Some(pqc)`, so a classical-only
+/// signer emitted a hybrid-pending row that persist's Strict policy rejects at
+/// admission — a failure that surfaced at the FAR END of an emit, with nothing
+/// local naming the cause. It is refused at the producer now.
+///
+/// Refused rather than degraded: FSD §3.2's
+/// "missing-attestation-as-delivery-gap" is observable at the steward end
+/// either way, so the gap may as well be loud and local.
+///
+/// Drives the REAL dispatch path with a real queue. An earlier attempt
+/// asserted against a reimplementation of the guard and stayed GREEN when the
+/// real guard was deleted — verified by mutation — which is exactly the
+/// wrong-input-path trap this repo keeps paying for. The setup is duplicated
+/// from the test above rather than extracted, deliberately: refactoring a
+/// passing end-to-end test to add a sibling risks the coverage that already
+/// works.
+#[tokio::test]
+async fn a_classical_only_receiver_emits_no_attestation() {
+    let _ = tracing_subscriber::fmt::try_init();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bootstrap = FedKey::new("bootstrap-steward", 0x01);
+    let sender = FedKey::new("sender-steward", 0xC0);
+    let receiver = FedKey::new("receiver-steward", 0xD0);
+
+    let directory = directory_with(vec![
+        signed_record(&bootstrap, &bootstrap, "steward"),
+        signed_record(&sender, &bootstrap, "steward"),
+        signed_record(&receiver, &bootstrap, "steward"),
+    ])
+    .await;
+    let queue = directory.clone();
+    let steward_dir: Arc<dyn StewardDirectory> = directory.clone();
+    let sender_signer = sender.local_signer(tmp.path()).await;
+
+    // The ONE difference from the hybrid test: a receiver that cannot sign PQC.
+    let receiver_edge = build_edge_with_signer(
+        &tmp,
+        &receiver,
+        directory.clone(),
+        queue.clone(),
+        steward_dir,
+        None,
+        receiver.classical_only_signer(tmp.path()).await,
+    )
+    .await;
+
+    let directive = sample_directive();
+    let mut env = build_envelope(
+        StewardDirective::TYPE,
+        &sender.key_id,
+        &receiver.key_id,
+        &directive,
+        None,
+    )
+    .expect("build_envelope");
+    sign_envelope(&sender_signer, &mut env)
+        .await
+        .expect("sign_envelope");
+
+    let frame = InboundFrame {
+        envelope_bytes: serde_json::to_vec(&env).expect("serialize env"),
+        received_at: chrono::Utc::now(),
+        transport: TransportId::HTTP,
+        source_key_id: None,
+        link_key_id: None,
+        arrival_scope: None,
+    };
+    receiver_edge.dispatch_inbound_for_test(frame).await;
+
+    let rows = OutboundHandle::list_outbound(
+        &*queue,
+        OutboundFilter {
+            message_type: Some("DeliveryAttestation".into()),
+            ..Default::default()
+        },
+        100,
+    )
+    .await
+    .expect("list_outbound");
+    assert_eq!(
+        rows.len(),
+        0,
+        "a classical-only signer must emit NOTHING — a hybrid-pending row would be \
+         rejected at persist admission, so emitting one is a delivery gap dressed \
+         as an emission"
+    );
+}
+
 /// list helper so the dispatch-side emission keys on the correct types.
 #[tokio::test]
 async fn federation_delivery_emits_attestation_per_recipient() {

--- a/tests/steward_topology.rs
+++ b/tests/steward_topology.rs
@@ -497,6 +497,8 @@ async fn federation_delivery_emits_attestation_per_recipient() {
         transport: TransportId::HTTP,
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     receiver_edge.dispatch_inbound_for_test(frame).await;
 

--- a/tests/tier3_fetch_content_and_feed.rs
+++ b/tests/tier3_fetch_content_and_feed.rs
@@ -431,6 +431,8 @@ async fn tier3_dispatch_inbound_signals_fetch_content() {
         received_at: chrono::Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     })
     .await;
 

--- a/tests/trust_recursion_depth_wired.rs
+++ b/tests/trust_recursion_depth_wired.rs
@@ -242,6 +242,8 @@ async fn dispatch(
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
     Ok(())

--- a/tests/trust_short_circuit.rs
+++ b/tests/trust_short_circuit.rs
@@ -251,6 +251,8 @@ async fn dispatch(
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_for_test(frame).await;
     Ok(())
@@ -625,6 +627,8 @@ async fn build_signed_envelope_from_software_signer_drives_trust_gate() {
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     let outcome = edge.dispatch_inbound_observed_outcome_for_test(frame).await;
 
@@ -665,6 +669,8 @@ async fn build_outcome(edge: &Edge, sender: &LocalSigner, destination: &str) -> 
         received_at: Utc::now(),
         source_key_id: None,
         link_key_id: None,
+        // CIRISEdge#499 — federation arrival (no scope table in this fixture).
+        arrival_scope: None,
     };
     edge.dispatch_inbound_observed_outcome_for_test(frame).await
 }


### PR DESCRIPTION
## v18.0.0 — scope-native addressing, end to end (CIRISEdge#499)

26 commits. Makes the Reticulum destination hash scope-native across **every** plane edge carries — messages, A/V, blobs, and holdings — then builds the runtime that drives it and the harness that proves it.

Major because #499 changes wire-visible behaviour on **armed** nodes. Unarmed deployments are byte-identical and make no new calls.

### The headline: the acceptance criterion is measured, not argued

`bench-mesh/` runs separate containers, each a distinct edge occurrence with its own federation seed, transport identity and sealed KV, over a real network with real announce-based rooting.

**`conformance.rotation_frame_loss` passes**: `missing_seqs: []`, `delivery_ratio: 1.0`, `epochs_observed: [1,2]` across a real mid-stream `add_member`. **Zero frames lost**, with cross-process MLS (X-Wing 0x004D, KeyPackage and Welcome over the wire) and ffmpeg-encoded H.264 through the real seal path. `nonmember_cannot_fetch` passes *and is falsifiable*, paired with `member_can_fetch`. `scope.seal` passes: `sealed: 1, unretired: 0`.

M=4 through one relay degraded and **the harness said so** — 12 legs reported `ran: false` rather than a fabricated green.

### Substrate

persist **v37.1.0** · verify **v13.6.1** · leviculum **v0.20.0+ciris.1**

Adopted: #713 per-plane projection · #731 object-named accord root · #733 the taking verb · #743 `refusal_reason` + `is_accord_family` · #744 the authority seam **and** recipient verb together · CIRISVerify#259 derivation + exporter labels · leviculum#54 destination retirement.

### What's new

- **`scope_addressing`** — per-member derived addresses, three-phase rotation, `MemberAddress` with no public byte constructor
- **`scope_lifecycle`** — join → advance → seal → **leave**, owning table and transport together so they cannot drift
- **`cohort_addressing` / `av_addressing`** — one `snapshot → install` shape for both group kinds
- **`av_spine`** — join → subscribe → publish → heal, with the publisher owned by value so an epoch cannot move without its addresses
- **`blob_swarm::scope` / `swarm::scope`** — scoped fetch, serve, and holdings
- **`mls::cohort_group`** — per-cohort MLS with durable-before-emittable, plus join (#500)
- **`family_gates`** — one total family→gates map, unknown loud and closed
- **`contextual_integrity`** — every `WithholdReason` attributed to the CI parameter it defends, **exhaustive with no wildcard**
- **`lxmf_serve`** — LXMF propagation host serve-path, wired into the event loop (#169)

### The compile-time guard, which earned itself

`contextual_integrity::parameter_of` matches `WithholdReason` exhaustively with no wildcard. Adding a gate without saying which commitment it defends **fails the build** — and it fired unprompted on another agent's four new reasons an hour after it shipped.

### Errors this cut made and caught

Recorded because the green board was repeatedly weaker evidence than it looked:

- **`family_gates` shipped as dead code** with zero callers while its commit claimed it replaced the inline checks — four genuine, mutation-verified tests that all exercised the module *directly*. Wiring it then exposed that it conflated persist's `Unknown` (a known answer: "no family") with unknown-family, which maximally gated `trust:*` and turned **13 unrelated tests red**.
- **A registered-destination leak** in rotation bookkeeping: a second rotation overwrote a pending-seal entry, leaving an address registered-but-unattributed for the process lifetime.
- **`remove_group` never retired**, so teardown left the same disclosure through a different door.
- **Three subset-only defects** that `--all-features` structurally cannot see.
- **A merge silently dropped four reasons** from the CI test array — 44 variants, 40 listed, and it compiled.
- **leviculum#55 was filed on a false premise** (`grep 'pub fn'` misses `pub async fn`), disproved by the maintainer compiling a consumer.

### Rulings consumed

**CIRISConstitution#91** — CC 5.4.6 binds the *packet*, so scoped addresses are one-hop **by ruling**, not by limitation. Recorded at `send_to_scoped_destination` so nobody "fixes" it by announcing. Federation visibility is now an explicit opt-in (`federation_visible`); point-to-point is the baseline, which is why one-hop costs an unlisted node nothing.

**LXMF propagation ≠ RNS transit** — the transit bar is wide *because* a relay "carries ciphertext and forgets". A propagation node **retains**, and durably learns who has mail waiting and when they collect it. Roster is cohort membership: self, family, communities.

### Testing

1166 lib tests · clippy `-D warnings` clean including `--features "transport-reticulum lxmf"` · `--no-default-features` and `--features transport-http` clean under `-D warnings` · every load-bearing assertion mutation-verified.

### Open upstream, none blocking

CIRISPersist#746 (`group_key_id` namespace) · leviculum#55 follow-ups · a ruling on the LXMF roster's source before that serve path goes live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013m8X99Y4X891Tn8EZM1fdN
