### PR TITLE
test(#458): accord_carrier fixtures — hybrid edge-under-test, classical senders

### DIFF
--- a/tests/accord_carrier_verify.rs
+++ b/tests/accord_carrier_verify.rs
@@ -196,6 +196,11 @@ impl FedKey {
         dir
     }
 
+    /// Classical-only signer — what envelope SENDERS use. Their directory
+    /// records deliberately carry no ML-DSA-65 pubkey (see `signed_record`),
+    /// and a hybrid-signed envelope against a classical-only record is a
+    /// HARD verify error ("PQC signature without pubkey"), not a
+    /// policy-fallback case — so senders must stay classical here.
     async fn local_signer(&self, base: &std::path::Path) -> Arc<LocalSigner> {
         let seed_dir = self.write_seed_dir(base);
         let (classical, _pqc) = ciris_keyring::load_local_seed(ciris_keyring::LocalSeedConfig {
@@ -207,6 +212,32 @@ impl FedKey {
         .await
         .expect("load_local_seed");
         Arc::new(LocalSigner::new(self.key_id.clone(), classical, None))
+    }
+
+    /// Hybrid signer — what the EDGE-UNDER-TEST uses. Edge's
+    /// acceptance-attestation producer refuses a classical-only signer
+    /// (CIRISEdge#458: persist's Strict admission rejects hybrid-pending
+    /// rows, so the emit is refused loudly at the source instead); with a
+    /// classical-only `me` the edge emits NO acceptance attestation and
+    /// every propagate-count assertion in this file reads 0.
+    async fn hybrid_local_signer(&self, base: &std::path::Path) -> Arc<LocalSigner> {
+        let seed_dir = self.write_seed_dir(base);
+        let (classical, _pqc) = ciris_keyring::load_local_seed(ciris_keyring::LocalSeedConfig {
+            key_id: self.key_id.clone(),
+            key_path: seed_dir.join("ed25519.seed"),
+            pqc_key_id: None,
+            pqc_key_path: None,
+        })
+        .await
+        .expect("load_local_seed");
+        let pqc: Arc<dyn ciris_keyring::PqcSigner> = Arc::new(
+            ciris_keyring::MlDsa65SoftwareSigner::from_seed_bytes(
+                &self.seed,
+                format!("{}-pqc", self.key_id),
+            )
+            .expect("ml_dsa_65 from seed"),
+        );
+        Arc::new(LocalSigner::new(self.key_id.clone(), classical, Some(pqc)))
     }
 
     /// Sign the given canonical bytes with this identity's seed.
@@ -317,10 +348,14 @@ async fn build_edge(
     directory: Arc<SqliteBackend>,
     queue: Arc<SqliteBackend>,
 ) -> Edge {
-    let signer = me.local_signer(tmp.path()).await;
-    // Test fixtures are Ed25519-only (no ML-DSA-65 seed); relax the
-    // default `HybridPolicy::Strict` so verify accepts hybrid-pending
-    // rows. Same pattern as `tests/content_fetch.rs::test_edge_config`.
+    // Hybrid: the acceptance-attestation producer requires the PQC half
+    // (CIRISEdge#458). SENDER fixtures stay Ed25519-only, hence the
+    // relaxed envelope policy below.
+    let signer = me.hybrid_local_signer(tmp.path()).await;
+    // Sender fixtures are Ed25519-only (no ML-DSA-65 in their directory
+    // rows); relax the default `HybridPolicy::Strict` so verify accepts
+    // hybrid-pending envelopes. Same pattern as
+    // `tests/content_fetch.rs::test_edge_config`.
     let config = EdgeConfig {
         hybrid_policy: HybridPolicy::Ed25519Fallback,
         ..EdgeConfig::default()


### PR DESCRIPTION
Fixes the 4 red `accord_carrier_verify` tests on main (the only failing job in run 32208909796 / 32208927233): `c0289f4` made the acceptance-attestation producer refuse classical-only signers, and this file was the third and last classical-only fixture holdout after `federation_announcement` + `steward_topology`.

**Why scoped, not wholesale:** hybridizing every `FedKey` signer reds 9/10 — a hybrid-signed envelope against this file's deliberately Ed25519-only sender records is a HARD verify error ("PQC signature without pubkey — both required together"), not a policy-fallback case. So `hybrid_local_signer` is used only by `build_edge` (the emit path needs the PQC half); envelope senders keep classical `local_signer`, preserving the file's `Ed25519Fallback` envelope-verify design.

**Verified:** 10/10 under `--features "transport-reticulum test-anchor"`; clippy `-D warnings` clean on the target.

**Known follow-up (not in scope):** `emit_delivery_refusal_attestation` still has the optional-PQC (`if let Some(pqc)`) pattern. Persist has no DeliveryRefusal admission surface, so the #458 Strict-admission rationale doesn't apply there today — making refusals hybrid-mandatory is a deliberate policy decision, flagged rather than smuggled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FejjcCbAbRFpLkmcgCDLEY