### PR TITLE
v18.0.2 — Android NDK platform 24 (leviculum v0.20.0 if-addrs / getifaddrs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -506,8 +506,13 @@ jobs:
         with:
           timeout_minutes: 20
           max_attempts: 3
+        # --platform 24: leviculum-std v0.20.0 pulls `if-addrs`, whose
+        # getifaddrs/freeifaddrs exist in bionic only from API 24 (Android
+        # 7.0, 2016). cargo-ndk's default (21) left them undefined and the
+        # v18.0.0 tag run's plain lanes failed at link — a TAG-ONLY lane, so
+        # no PR/main run could catch it. 24 is the Android floor now.
           command: >-
-            cargo ndk -t ${{ matrix.abi }} build --release
+            cargo ndk -t ${{ matrix.abi }} --platform 24 build --release
             --features "$MOBILE_BASE_FEATURES"
       - name: save plain .so
         if: matrix.variant == 'plain'
@@ -565,8 +570,12 @@ jobs:
         with:
           timeout_minutes: 20
           max_attempts: 3
+        # --platform 24: same getifaddrs floor as the plain build above. The
+        # PyO3 cdylib's permissive stub-link flags could let the undefined
+        # symbol through to a RUNTIME dlopen failure on <24 devices — pin the
+        # platform so it's resolved at build time on both variants.
           command: >-
-            cargo ndk -t ${{ matrix.abi }} build --release --lib
+            cargo ndk -t ${{ matrix.abi }} --platform 24 build --release --lib
             --features "$MOBILE_PYO3_FEATURES"
 
       - name: verify DT_NEEDED includes libpython3.10.so

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "18.0.1"
+version = "18.0.2"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.0.1
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.0.1
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.0.1
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.0.1
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.0.1
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.0.1
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.0.1
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.0.2
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.0.2
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.0.2
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.0.2
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.0.2
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.0.2
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.0.2


### PR DESCRIPTION
The v18.0.0 tag run's three `android (plain)` lanes failed at link — `undefined symbol: getifaddrs/freeifaddrs` — which blocked the Release job, so v18.0.0 and v18.0.1 have tags but **no Release assets** (v17.10.0's tag run, by contrast, had only the 6 known cohab server-skew reds and released 15 assets).

**Root cause:** `leviculum-std v0.20.0+ciris.1` newly depends on `if-addrs`, whose Android implementation calls `getifaddrs`/`freeifaddrs` — bionic provides them only from **API 24** (Android 7.0, 2016). Both `cargo ndk` invocations passed no `--platform`, so cargo-ndk's default **21** applied. The plain artifact lanes are **tag-only**, so no PR or main run could surface this before the tag.

**Fix:** `--platform 24` on both variants. The plain build fails honestly at link today; the PyO3 cdylib's permissive stub-link flags (`--no-as-needed -lpython3.10` against a stub) could let the same undefined symbol through to a runtime dlopen crash on <24 devices, so it gets the pin too. API 24 is now edge's Android floor.

Cut as **v18.0.2** (bump + evidence TSV regen) so the v18 line gets a Release with full assets; expected tag-run residual reds remain only the 6 cohab (server-skew) jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FejjcCbAbRFpLkmcgCDLEY