### PR TITLE
docs: the two-plane hybrid — claims mapped to their proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,32 @@ it, the recipient holds `infra:serve`, and it satisfies any `recipient_capabilit
 restriction. The recipient axis *cannot exceed* the transmission principle,
 by construction.
 
+## The two-plane hybrid
+
+Edge realizes the **lightnet/darknet split** of
+[CC 5.4.6](../CIRISConstitution/constitution/part_5_transport_substrate.md): a
+**public identity plane** (announced, rooted, attributable — no anonymity
+claim) and a **derived group plane** (per-group destinations derived from
+directory state members already hold — never announced, so group *existence*
+is structurally invisible to outsiders). Derivation replaces discovery;
+determinism replaces coordination. What that buys — private *manageable*
+groups, decentralized video over member-relays, and the posited
+occurrence-invisible ballot — and the measurement status of each claim, is in
+**[`docs/LIGHTNET_DARKNET.md`](docs/LIGHTNET_DARKNET.md)**. The proofs run as
+the multi-container acceptance bench (**[`bench-mesh/`](bench-mesh/README.md)**,
+real video + real blobs through real relays, in CI).
+
 ## Status
 
-**v14.x** — production CEG-native transport. Reticulum + HTTPS + packet-radio
-transports; the anti-entropy replication engine; the `#393` two-item attribution
-gate (Rooted∧owns_key + hybrid transport binding); the `#402` bootstrap carve-out;
-the `#396` consent-resolved fan-out + serve gates; hybrid Ed25519 + ML-DSA-65
-throughout; PyO3 + UniFFI mobile surfaces. Pinned in lockstep to `ciris-persist`
+**v18.x** — production CEG-native transport, scope-native addressing end to
+end (`#499`), and the A/V mesh spine. Reticulum + HTTPS + packet-radio
+transports; the anti-entropy replication engine; the `#393` two-item
+attribution gate (Rooted∧owns_key + hybrid transport binding); the `#402`
+bootstrap carve-out; the `#396` consent-resolved fan-out + serve gates; MLS
+cohorts (TreeKEM, X-Wing) with scope-derived addressing, seal/retirement, and
+the LXMF serve path (`#169`); mandatory hybrid Ed25519 + ML-DSA-65 on every
+producer (`#458`: no classical-only paths); PyO3 + UniFFI mobile surfaces
+(Android floor: API 24). Pinned in lockstep to `ciris-persist`
 (Registry-of-Record admission) via drift-witnessed policy hashes.
 
 ## Sister repos

--- a/docs/LIGHTNET_DARKNET.md
+++ b/docs/LIGHTNET_DARKNET.md
@@ -1,0 +1,182 @@
+# The lightnet/darknet hybrid — claims, mechanisms, and their proofs
+
+**Status**: living document. Every claim below carries one of four labels —
+**Normative** (the Constitution requires it), **Shipped** (code on `main`
+enforces it), **Measured** (a bench-mesh leg or CI lane demonstrates it on a
+real network), **Posited** (the substrate exists; the end-to-end demonstration
+does not yet). A claim may carry more than one. The discipline of this
+document is that *no claim is promoted without naming the measurement that
+promoted it* — the same fail-loud stance [`MISSION.md`](../MISSION.md) §1.6
+applies to code.
+
+**Canonical source**: [CC 5.4.6 *Position*](../../CIRISConstitution/constitution/part_5_transport_substrate.md)
+(the CIRISConstitution#91 prior-art record). This document maps that
+constitutional positioning onto edge's shipped machinery and its acceptance
+bench. Where vocabulary differs, the Constitution's wins: what we informally
+call the **lightnet** is CC's *public identity plane*; the **darknet** is CC's
+*derived group plane*.
+
+---
+
+## 1. The two-plane split
+
+The design occupies what CC 5.4.6 names the **zero-emission corner** of the
+anonymity trilemma — the *membership-concealment* corner, where reachability
+information flows only to authorized parties, and the impossibility floor
+("whoever relays for you must know how to reach you"; Vasserman et al., CCS
+2009) is satisfied **entirely by members**: members relay for members.
+
+| | **Lightnet — public identity plane** | **Darknet — derived group plane** |
+|---|---|---|
+| What it is | The federation directory: rooted node identities, announced transport destinations, hybrid Ed25519 + ML-DSA-65 keys, quorum trust root, hardware-attested accord holders | Per-group destinations *derived* (per-group HKDF over the cached directory) — never announced, never discoverable |
+| Anonymity claim | **None, by design.** Nodes announce normally; every inbound byte is attributed `Rooted ∧ owns_key` before any handler sees it | Group **existence** is invisible to non-members: no emission exists to observe. The destination hash is "the last non-scope-private identifier" |
+| Announce policy | RNS announces propagate normally | **Normative prohibition** (CC 5.4.6 `announce-suppress`): a group-scoped destination never announces — *including directed announces* (multi-hop path learning is outsider observation; path state is what a subpoena reaches) |
+| Edge machinery | `src/transport/reticulum.rs` attribution gate, rooting, announce install; the federation directory via `ciris-persist` | `ScopeAddressTable` + arrival-scope admission (`src/transport/reticulum.rs`), A/V half in `src/av_addressing.rs` + `src/scope_lifecycle.rs`; the derivation itself is owned by `ciris-verify` (one derivation, no second expectation) |
+
+The hybrid is the point: past systems chose one plane. The identity plane
+gives manageability its root of trust; the group plane gives groups their
+invisibility. Each buys back one of the corner's two historical prices:
+
+1. **Derivation replaces discovery.** Surveyed systems that hide group
+   existence accept *out-of-band address exchange* (the darknet bootstrap
+   problem). Here the group address is a pure function of directory state
+   members already hold — so there is no bootstrap emission at all.
+   *(Shipped: CIRISEdge#499, edge v17.9.0→v18.0.0.)*
+2. **Determinism replaces coordination.** The member-relay ALM tree is a pure
+   function every member computes identically (CC 6.1.6), recovering
+   ⌈log_k N⌉ fan-out without a coordinator that would otherwise have to learn
+   the group exists. Surveyed zero-emission systems accept **linear** fan-out
+   as the corner's price; coordinator-efficient systems uniformly declare
+   group metadata out of scope (RFC 9750 delegates it to exactly this layer).
+   *(Shipped: `AlmJoinPlanner`, TOPOLOGY_VERSION 2; Measured: log-depth
+   curves in [BENCHMARKS.md](BENCHMARKS.md), depth 2/4/5 at N=10/100/1000
+   against bounds 4/6/7.)*
+
+---
+
+## 2. The demonstration instrument
+
+Claims about a network are proven on a network. The acceptance instrument is
+**[`bench-mesh/`](../bench-mesh/README.md)**: separate containers, each a
+distinct edge occurrence with its own identity and keystore, pushing real
+encoded video and a real blob across a real docker network through relays
+while the roster changes. Its census is honest by construction — a leg that
+did not run fails the run — and it runs in CI (`bench-mesh.yml`, weekly +
+dispatch).
+
+First CI datapoint (2026-08-19, K=1 relay, M=2 subscribers, run 32268885154):
+**28 of 28 executed legs passed** — delivery, rooting, cohort join, scope
+install/rotation, non-member refusal, relay address-blindness — with the three
+skipped legs being exactly the two known in-flight seams (§5).
+
+---
+
+## 3. Claim: private, manageable groups
+
+**The claim.** A group whose *existence* outsiders cannot observe, whose
+relays carry only ciphertext and hold no group address, and which is
+nevertheless *manageable*: members are admitted and removed, keys rotate,
+superseded addresses retire, and moderation duties are held by accountable,
+hardware-attested identities — with no coordinator and no out-of-band ritual.
+
+**Why past attempts could not hold all of it at once** (the #91 survey, as
+CC 5.4.6 records): systems that concealed group existence paid with
+out-of-band bootstrap and linear fan-out; systems with efficient fan-out
+pushed group metadata out of scope entirely. Manageability — revocation,
+rotation, retirement, moderation — was the casualty either way.
+
+**The mechanisms and their labels:**
+
+| Property | Mechanism | Label |
+|---|---|---|
+| Group existence invisible | Derived destinations, `announce-suppress` | Normative + Shipped |
+| Non-member cannot fetch | Scope-gated serve; arrival-scope admission | **Measured** (`conformance.nonmember_cannot_fetch`) |
+| Relay holds no group address | Relay serves transit on the identity plane only | **Measured** (`conformance.relay_holds_no_cohort_address`) |
+| Membership + rotation | MLS cohorts (TreeKEM, X-Wing 0x004D), `welcome-wrap` (CC 5.4.4) | Shipped; rotation **Measured** (`conformance.rotation_frame_loss`: zero loss across an epoch advance) |
+| Address retirement | Seal: a superseded epoch's address stops being admitted | Owner half **Measured** (`scope.seal`); network-observed half in flight (§5) |
+| Moderation with accountability | Accord-conferred duty-holders, quorum trust root, revocation planes | Shipped (persist substrate; edge replicates + refuses) |
+
+---
+
+## 4. Claim: decentralized video
+
+**The claim.** Real encoded video from a publisher to N members over
+member-relays at log depth, keys rotating mid-stream, no SFU, no coordinator.
+
+**Labels.** Shipped (the A/V spine: join → subscribe → publish → heal → seal;
+MLS-keyed streams; MDC/SVC codec planes) and **Measured** at K=1/M∈{1,2}:
+real video frames + a 120 KB blob delivered through a relay container with
+byte-intact verification, blob completion ~20–23 ms/peer, zero frame loss
+across a mid-stream epoch advance. **In flight**: M=4 fan-out currently
+wedges on MLS commit ordering under concurrent admissions (§5), and blob
+distribution still uses direct push — the scope-native swarm fetch is the
+designed mechanism (`scope_native_fetch: false` in the leg detail marks it).
+
+---
+
+## 5. Claim: online voting
+
+**The claim — as CC 5.4.6 states it:** N→1 deterministic aggregation under
+the CC 6.1.2.1 dominance gate composes with the MLS-epoch roster,
+steward-binding (CC 6.1.8), quorum-above-time ordering (CC 5.3
+`MergeBallot`), and the CC 5.4.5 member-only witness chain into **a ballot
+process whose *occurrence* is invisible to outsiders** at scopes below
+federation. *"A classical secret ballot hides the vote; structural
+invisibility hides the election."*
+
+**Label: Posited, on shipped substrate.** What exists today: persist's
+`MergeBallot` comparator (V058) and reverse-quorum objection-ballot plane
+(`ballot_envelope`, `record_objection_ballot`, governing-ballot resolution);
+edge's `AccordQuorumEvidence` cursor replication (v16.3.0) and wire-layer
+M-of-N accord threshold verification (measured by `accord_carrier_verify`).
+What does not exist yet: the end-to-end demonstration.
+
+**The planned proof (bench-mesh Track V):** members cast signed ballots
+inside the cohort; every member independently computes the governing tally
+and the census asserts the tallies **byte-equal** across members;
+quorum-above-time resolves concurrent casts; and — the flagship leg — the
+**non-member and the relay observe no election**: no new announces, no
+group-plane emission, no fetchable ballot material, traffic
+indistinguishable from the stream it rides beside.
+
+**What is deliberately NOT claimed:** ballot secrecy *among members* (members
+of a cohort see the cohort's ballots — the reverse-quorum design is
+accountable, not anonymous); anonymity for the identity plane (it is public
+by design); multi-hop anonymity of any kind. If a future amendment wants
+multi-hop, CC 5.4.6 names the nearest admissible relaxation (the Tor
+v3 / I2P b33 blinded-retained-state family) and its non-negotiable rotation
+rule: rotation clocks global, never group-event-driven.
+
+---
+
+## 6. In-flight seams (the gap between Measured and 100%)
+
+Tracked as the bench-mesh 100% program; each seam has an owner-track:
+
+1. **MLS commit ordering at M≥4** — commits fan out unordered; a laggard hits
+   `WrongEpoch` fatally. Fix: bounded hold-buffer in the production cohort
+   layer + non-fatal harness handling + admission pacing. *(Track A.)*
+2. **`seal_retires` measured the impossible thing** — it tried to RNS-dial a
+   derived address through a relay, which CC 5.4.6 now normatively forbids
+   the preconditions of (no announce, so no multi-hop path — by design, not
+   defect). Redesign: probe over the identity-plane rooted link, answered by
+   the production arrival-admission lookup; the live-address probe is the
+   aliveness control that makes "refused" distinguishable from "down."
+   *(Track C.)*
+3. **Census role-contracts** — the deliberate late joiner can never satisfy
+   across-the-advance legs; the census gains per-role expected-leg sets with
+   the honesty rule intact. *(Track D.)*
+4. **Swarm fetch as the blob mechanism** — replace/augment direct push with
+   the scope-native holdings fetch. *(Second wave, after Track A.)*
+5. **Voting legs** — §5's planned proof. *(Track V, after integration.)*
+
+---
+
+## 7. Spec debt
+
+[`FSD/CIRIS_EDGE_TRANSPORT.md`](../FSD/CIRIS_EDGE_TRANSPORT.md) predates
+scope-native addressing and does not yet describe the derived group plane,
+`announce-suppress` inheritance, or the A/V addressing verbs. Until it does,
+CC Part 5 §5.4.4–5.4.6 and this document are the authorities on the two-plane
+design; the FSD remains the authority on the 14 EnvelopeKinds and the
+anti-entropy state machine.


### PR DESCRIPTION
The docs pass for the lightnet/darknet positioning, triggered by the CC 5.4.6 *Position* paragraph landing in CIRISConstitution (#91 prior-art record).

**What was wrong before:** the framing appeared nowhere in edge's docs; README's Status was four majors stale (v14.x); the FSD doesn't describe the derived group plane at all (recorded as spec debt in the new doc, §7).

**The new `docs/LIGHTNET_DARKNET.md`:** maps the constitutional positioning (two-plane split, zero-emission corner, both prices bought back) onto edge's shipped machinery with code anchors, and — the discipline of the document — labels every claim **Normative / Shipped / Measured / Posited**, naming the exact bench-mesh leg or CI run that earned each "Measured". Private manageable groups: three legs already Measured. Decentralized video: Measured at M∈{1,2} (CI run 32268885154, 28/28 executed legs), M=4 wedge honestly recorded. Online voting: Posited on named shipped substrate (MergeBallot, reverse-quorum ballots, AccordQuorumEvidence), with the planned Track-V bench proof spelled out — including what is deliberately NOT claimed (no ballot secrecy among members, no identity-plane anonymity, no multi-hop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FejjcCbAbRFpLkmcgCDLEY