### PR TITLE
v18.2.0 — the delivery model, complete: no carve-outs, no unimplemented planes, spec = code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "18.1.0"
+version = "18.2.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/FSD/CIRIS_EDGE_TRANSPORT.md
+++ b/FSD/CIRIS_EDGE_TRANSPORT.md
@@ -1,7 +1,7 @@
 # CIRISEdge — Transport & Replication Protocol
 
 > **What this is.** `ciris-edge` is the transport and replication layer of the
-> CIRIS Epistemic Web ([CEWP](https://ciris.ai/cewp)). It moves the 14 signed
+> CIRIS Epistemic Web ([CEWP](https://ciris.ai/cewp)). It moves the 15 signed
 > envelope kinds of the CEG grammar between federation peers over any medium
 > (Reticulum mesh, HTTPS, packet radio), decides *who is allowed to learn a
 > claim exists*, and attributes every inbound byte to a cryptographic identity
@@ -31,7 +31,7 @@ layers 4–6 and is where those three properties are *enforced on the wire*.
 
 | OSI | CEG / CIRIS realization | Owned by |
 |---|---|---|
-| 7 Application | The CEG grammar — semantic claims: the 14 `EnvelopeKind`s, attestations, dimensions | persist / verify (grammar); edge transports it |
+| 7 Application | The CEG grammar — semantic claims: the 15 `EnvelopeKind`s, attestations, dimensions | persist / verify (grammar); edge transports it |
 | 6 Presentation | Wire codec (CRPL framing, JCS canonicalization, `Signed*` wrappers) + **hybrid crypto** (Ed25519 + ML-DSA-65) | edge (framing) / verify (crypto) |
 | 5 Session | **Anti-entropy replication session** — Summary → Diff → Deliver, per `(peer, kind)` | **edge** (§4) |
 | 4 Transport | Authenticated, encrypted links + the `Transport` trait; **source attribution at ingest** | **edge** (§5) |
@@ -47,11 +47,12 @@ layers 4–6 and is where those three properties are *enforced on the wire*.
 
 ---
 
-## 2. The 14 EnvelopeKinds
+## 2. The 15 EnvelopeKinds
 
-Every load-bearing claim is a signed wire artifact. Edge replicates exactly 14
-kinds — the `EnvelopeKind` enum ([`protocol.rs:81`](../src/replication/protocol.rs)),
-1:1 with persist's `put_*` admission surface. Each kind is its own anti-entropy
+Every load-bearing claim is a signed wire artifact. Edge replicates exactly 15
+kinds — the `EnvelopeKind` enum ([`protocol.rs:90`](../src/replication/protocol.rs)),
+1:1 with persist's admission surface (`EnvelopeKind::ALL`, `protocol.rs:188`,
+order-pinned by `REPLICATION_POLICY_HASH`). Each kind is its own anti-entropy
 stream, so a partition on one kind never gates convergence on another.
 
 | # | Kind | Purpose | persist admit | Wire | Flags |
@@ -70,16 +71,34 @@ stream, so a partition on one kind never gates convergence on another.
 | 12 | `OrgMembership` | Authz binding (user/org/role) | `put_org_membership` | v2 | |
 | 13 | `PartnerRecord` | License+Partner, M-of-N steward quorum | `put_partner_record` | v2 | |
 | 14 | `TransportDestination` | Reachability address (hybrid-signed) | `put_signed_transport_destination` | v2 | **bootstrap** |
+| 15 | `AccordQuorumEvidence` | Steward-quorum evidence bundle (proposal + participations) projecting `RoleWithdrawals` | `apply_replicated_accord_evidence` (re-tally) | v2 | **cursor-served** |
 
 - **`consentable`** = **only `Attestation`.** It is the sole kind whose flow to a
   recipient is gated by a consent grant (§6). Every other kind is a *structural
   plane* that replicates by policy, never by end-user consent
   ([`resolved_state.rs:36`](../src/replication/resolved_state.rs)).
 - **`bootstrap`** = exactly `{Key, IdentityOccurrence, TransportDestination}`
-  ([`protocol.rs:203`](../src/replication/protocol.rs)) — the self-authenticating
-  kinds a fresh peer must deliver to introduce itself, exempt from the attribution
-  gate (§5.4). A test asserts this set is *exactly* those three over all 14 kinds.
-- Kinds 1–10 ride wire version `0x01`; the 4 operational kinds require `0x02`.
+  (`is_bootstrap`, [`protocol.rs:228`](../src/replication/protocol.rs)) — the
+  self-authenticating kinds a fresh peer must deliver to introduce itself, exempt
+  from the attribution gate (§5.4). A proptest asserts this set is *exactly*
+  those three over all 15 kinds (§5.4).
+- **`cursor-served`** = **only `AccordQuorumEvidence`** (`is_cursor_served`,
+  `protocol.rs:263`, pinned over `ALL` by
+  `cursor_served_is_exactly_accord_quorum_evidence`, `protocol.rs:672`). A bundle
+  is an aggregate whose hash moves as each participation lands, so persist keeps
+  it out of the `signed_wire_index` (`persist_index_kind` → `None`,
+  `protocol.rs:319`). It is therefore **never advertised by content-hash** —
+  `list_envelope_refs` returns empty for it
+  ([`bridge.rs:1202`](../src/replication/bridge.rs); advertising a ref would be
+  the listed-then-unfetchable LIST-vs-FETCH class) — and converges over the
+  dedicated cursor path `CursorPull → Deliver`, resuming on `evidence_at`
+  (§4.1). The receiver **re-tallies** each bundle against its own roster
+  (`apply_accord_quorum_evidence` → persist `apply_replicated_accord_evidence`,
+  `bridge.rs:3189`), so the cursor is an optimization, never a trust input.
+- Kinds 1–10 ride wire version `0x01`; the 5 post-v1 kinds (`Organization`,
+  `OrgMembership`, `PartnerRecord`, `TransportDestination`,
+  `AccordQuorumEvidence`) require `0x02` (`min_wire_version`,
+  `protocol.rs:346`) — v1-only peers serde-reject their unknown tags.
 
 ---
 
@@ -92,34 +111,114 @@ narrowest to widest ([persist `types.rs` `cohort_scope`](../../CIRISPersist/src/
 
 `self` 🪞 → `family` 🏡 → `community` 🏘️ → `affiliations` 🤝 → `species` 🧬 → `biosphere` 🌍 → `federation` 🌐
 
+**What the seven scopes map to on the wire.** The lattice above is persist's
+policy vocabulary. Edge's wire `CohortScope` — the field an `EdgeEnvelope`
+actually carries — has exactly **4 variants**
+([`cohort_scope.rs:73`](../src/cohort_scope.rs)): `Public`, `SelfOnly`,
+`Family`, `Cohort { cohort_id }`. `affiliations` / `species` / `biosphere` are
+**inexpressible in an `EdgeEnvelope`**. The mapping onto persist's tokens is
+`Public → federation`, `SelfOnly → self`, `Family → family`,
+`Cohort{..} → community` — one mapping, lifted from `CohortScope::crypto_tier`
+so the projection axis and the crypto-tier axis cannot drift
+(`persist_scope_token`, [`swarm/scope.rs:129`](../src/swarm/scope.rs)). Note
+the promotion: an edge-side `Public` is persist's *widest* scope
+(`federation`), not a mid-lattice tier.
+
 ### 3.2 The projection taxonomy
 
-A `cohort_scope` (plus authority + whether the claim is a tombstone) resolves to
-one of three **projections** — the rule for *who advertises and receives* it
-(persist `namespace::projection_for`, consumed at
-[`bridge.rs:728`](../src/replication/bridge.rs)):
+Projection is a function of **four inputs** — `projection_for(plane,
+cohort_scope, authority, is_tombstone)` (persist `namespace::projection_for`;
+edge feeds it at [`bridge.rs:2058`](../src/replication/bridge.rs), totality
+pinned over all four axes by `check_cohort_scope_projection`
+([`field_conformance.rs:265`](../src/field_conformance.rs))). It resolves to one
+of **five projections** — the rule for *who advertises and receives* a claim:
 
 | Projection | Meaning | Who advertises |
 |---|---|---|
 | **`SelfOwn`** | Publish-your-own (KERI shape) — the structurally-invisible identity plane | Only the subject node (`attesting_key_id ∈ self_set`) |
-| **`Cohort`** | Hold-and-forward over a `community`/`affiliations` roster | The anti-entropy cohort |
-| **`Global`** | Commons + tombstone gossip reaching the whole federation | Own ∪ cohort (widest enumerable, so tombstones are never out-run) |
+| **`Cohort`** | Hold-and-forward over a roster | The anti-entropy cohort |
+| **`Global`** | Commons + widest-audience gossip | Own ∪ cohort (widest enumerable) |
+| **`Capability(token)`** | Role-keyed audience (e.g. `trace:*` → `infra:serve` holders) | Cohort candidate set; narrowed per recipient at send/fetch by the token-holder check |
+| **`Subject`** | Subject-keyed audience (e.g. `scores:*` about you) | Cohort candidate set; narrowed per recipient at send/fetch by the data-subject grant |
 
-**Resolution rule** (`projection_for`):
+`Capability`/`Subject` audiences are not enumerable from a roster, so they
+enumerate the `Cohort` candidate set and the fail-closed per-recipient gates cut
+it down ([`bridge.rs:1565`](../src/replication/bridge.rs); all five variants
+branched at `bridge.rs:1948`).
+
+**Resolution rule** (`projection_for`, live-scope inputs):
 
 ```
-is_tombstone (withdraw / recant / supersede)        → Global   # anti-rollback, overrides all
 self | family                                        → SelfOwn  # structural invisibility
 community | affiliations                             → Cohort
 species | biosphere | federation                     → Global iff authority.is_trust_root(), else Cohort
 unrecognized scope                                   → Cohort   # conservative negative default
 ```
 
+**Tombstones project at a per-plane CEILING, not unconditionally `Global`.**
+`is_tombstone → tombstone_ceiling(plane, authority)` (CIRISPersist#713; pinned
+at [`field_conformance.rs:344-378`](../src/field_conformance.rs)). Key-plane
+tombstones stay `Global` — verify-relevance is unbounded, anti-rollback wins.
+But a non-trust-root `self`-scope `TransportDestination` tombstone projects
+**`Cohort`, NOT `Global`**: *widening a tombstone would disclose more than the
+original fact* — "this route was withdrawn" reveals the route existed
+(`field_conformance.rs:354`). On the Attestation plane every family's ceiling
+is still an advertised projection (`Global`/`Cohort`/`Capability`/`Subject` —
+never `SelfOwn`), so a withdraw always advertises, at its plane's audience
+([`bridge.rs:7333-7343`](../src/replication/bridge.rs)).
+
+**Where resolution runs.** Per-record `projection_for` resolution runs on the
+**Attestation plane only** (`attestation_projection`,
+[`bridge.rs:2039`](../src/replication/bridge.rs) — value-keyed on the record's
+`dimension` + `cohort_scope` + tombstone status). Every other plane advertises
+under a constant, resolved once per plane
+([`bridge.rs:1174`](../src/replication/bridge.rs)):
+
+- `SelfOwn` — `Key`, `IdentityOccurrence`, `TransportDestination`
+  (`bridge.rs:1671/1699/1722`);
+- `Global` — `Revocation` (`bridge.rs:2772`), `IdentityOccurrenceRevocation`
+  (`bridge.rs:1750`), `FamilyMembershipRevocation` +
+  `CommunityMembershipRevocation` (`bridge.rs:2811`);
+- `Cohort` — `Family`, `Community`, `LocationProof` (rows filtered to the
+  cohort roster, `bridge.rs:2806`);
+- unfiltered public-operational — `Organization`, `OrgMembership`,
+  `PartnerRecord` (`in_scope = |_| true`, `bridge.rs:2936`);
+- not advertised at all — `AccordQuorumEvidence` (the cursor plane, §2).
+
+The projection gate applies on both advertise and fetch paths
+(`attestation_is_advertised`, `bridge.rs:1912`, and the per-record re-gate in
+`fetch_envelope_bytes_for_peer`, `bridge.rs:977`) — a ref a peer could not be
+served is neither listed to it nor resolvable by it.
+
 > **Structural invisibility (Part 5 §5.2, normative).** A `self`/`family` claim
 > projects `SelfOwn` and emits **no `holds_bytes:sha256:*` directory attestation** —
 > "outsiders cannot route to it, read it, or even learn that it exists." This is
 > the *unconditional* privacy promise; at-rest encryption is defense-in-depth on
 > top, never a substitute.
+
+### 3.3 Scope-native gates are STAGED (armed, not unconditional)
+
+The `#499` scope-native gates — the fountain holdings gate and the blob scope
+router — are **default-open until a `ScopeAddressTable` is installed**. Both
+read the identical arming condition `is_scope_native`
+([`swarm/scope.rs:435`](../src/swarm/scope.rs),
+[`blob_swarm/scope.rs:316`](../src/blob_swarm/scope.rs)): a deployment with no
+table has no scope roster to resolve anyone against, so a gate over it could
+only refuse everything — it therefore behaves byte-identically to pre-#499
+(every held content announced to every cohort peer;
+[`swarm/scope.rs:90-99`](../src/swarm/scope.rs) — "refusing every holding on a
+node that cannot resolve a roster would not be fail-closed, it would be
+fail-broken"). Default-open is the **deliberate production state**: installing
+the table is operator **opt-in** (`EdgeBuilder::scope_native_addressing`,
+[`edge.rs:6388`](../src/edge.rs)) because scoped destinations are one-hop by
+CC 5.4.6 (CIRISConstitution#91) — a real reach trade, chosen, never inherited
+from a default. The derivation itself is shipped, not pending: CIRISVerify#259
+is closed and `ScopePrivacyDeriver` reproduces verify v13.4.0's
+`k_destination` + `derive_destination` byte-for-byte
+([`scope_addressing.rs:907`](../src/scope_addressing.rs)). Installing the one
+table arms every scope-native path at once — transport inbound admission, blob
+router + serve gate, swarm holdings gate — so "which addresses I answer on" and
+"which I send to" cannot drift ([`edge.rs:6214`](../src/edge.rs)).
 
 ---
 
@@ -133,17 +232,27 @@ reacts to the *type* of the inbound message
 
 ### 4.1 Roles & messages
 
-- **`SessionRole`**: `Initiator` (emits the first `Summary`; the only role for
-  which `start_round` is valid) · `Responder` (reacts to an inbound `Summary`).
-- **Messages** (`ReplicationMessage`, `#[serde(tag="type")]`,
-  [`protocol.rs:356`](../src/replication/protocol.rs)):
+- **`SessionRole`** ([`session.rs:47`](../src/replication/session.rs)):
+  `Initiator` (the only role for which `start_round` is valid) · `Responder`
+  (reacts to inbound messages).
+- **`start_round` has THREE opening moves**: a content-hash kind opens with
+  `Summary` (`session.rs:268`); a self-publishing initiator adds a proactive
+  `Deliver` alongside it (#927/#380, `session.rs:275`); a **cursor-served kind
+  opens with `CursorPull`, never a Summary** (`session.rs:259-267`).
+- **Messages** (`ReplicationMessage`, `#[serde(tag="type")]`, **six** variants,
+  [`protocol.rs:492`](../src/replication/protocol.rs)):
 
 | Message | Fields | Meaning |
 |---|---|---|
 | `Summary` | `kind`, `refs: [(envelope_hash, seq)]` | "Here are the hashes I hold for `kind`." |
 | `Diff` | `kind`, `want: [envelope_hash]` | "I want these — you have them, I don't." |
-| `Fetch` | `kind`, `want: [envelope_hash]` | Explicit on-demand fetch (hashes learned out-of-band). |
+| `Fetch` | `kind`, `want: [envelope_hash]` | **Responder-only status**: edge parses and serves `Fetch` (`on_fetch` → the `Diff` path, `session.rs:581`) but no production path produces one — `Pull` superseded its initiating role, and every `Fetch` constructor in-tree is `#[cfg(test)]`. Kept for wire compat. |
 | `Deliver` | `kind`, `envelopes: [signed_bytes]` | The requested signed envelopes. |
+| `Pull` (#462) | `kind`, `subject_key_id` | Subject-scoped RECEIVE-axis discovery ([`protocol.rs:440`](../src/replication/protocol.rs)): "which `kind` records do you hold where `subject_key_id` is data-subject or sender?" Answered with a subject-scoped `Summary` (projection-gated, `capacity:*` G2-carved); the ordinary Diff/Deliver flow carries the bytes. **Fail-closed to `peer == subject`**: a requester not authenticated as the subject is served nothing ([`bridge.rs:943`](../src/replication/bridge.rs)). |
+| `CursorPull` (#474) | `kind`, `since: Option<evidence_at>` | Cursor request for the index-less accord plane ([`protocol.rs:464`](../src/replication/protocol.rs)). Answered DIRECTLY with a `Deliver` of bundles past the watermark. **Stateless `since: None` is always correct** — the receiver re-tallies on apply, so a from-the-beginning replay is a `Duplicate`, never a double-count; the cursor is an optimization, not a trust input. |
+
+Both `Pull` and `CursorPull` are post-v1 verbs: v1 peers serde-refuse the
+unknown `type` tag (coordinated by the `SERVE_ADVERTISE_POLICY_HASH` re-pin).
 
 ### 4.2 The round
 
@@ -162,34 +271,75 @@ sequenceDiagram
     Note over A,B: each side apply()s inbound Deliver → Applied{admitted, refused, staleness}
 ```
 
+Two additional openings share the same session machinery:
+
+- **Subject pull** (#462): `A→B: Pull(kind, subject)` → `B→A: Summary(subject's
+  refs)` → the ordinary Diff/Deliver flow above. The Pull only seeds `on_summary`
+  with a subject-scoped ref set; every byte is still served through the
+  per-record serve gate (`session.rs:425-454`).
+- **Cursor round** (#474): `A→B: CursorPull(kind, since)` → `B→A:
+  Deliver(bundles past since)` — no Summary/Diff phase exists for the
+  index-less accord plane; the answering Deliver is solicited
+  (`awaiting_cursor_deliver`, `session.rs:173-178`), and an empty result still
+  completes the round cleanly.
+
 ### 4.3 State transitions
 
 ```mermaid
 stateDiagram-v2
     [*] --> Idle
-    Idle --> AwaitingReply: start_round (Initiator) / emit Summary
+    Idle --> AwaitingReply: start_round (Initiator) / emit Summary — or CursorPull for a cursor kind
     Idle --> Replying: on Summary (Responder) / emit Summary+Diff
     AwaitingReply --> Delivering: on Diff / emit Deliver
     Replying --> Delivering: on Diff / emit Deliver
     Delivering --> Complete: on Deliver / apply → Applied
     AwaitingReply --> Complete: on Deliver / apply → Applied
-    Complete --> Idle: reset() (keeps peer summary + proactive ledger)
-    Idle --> Refused: kind mismatch → UnexpectedMessage
+    Complete --> Idle: coordinator reset() (keeps peer summary + proactive ledger)
 ```
+
+> **This diagram is ILLUSTRATIVE.** The session is **message-typed, not
+> phase-gated**: `on_message` dispatches on the inbound message's *type*
+> ([`session.rs:373-396`](../src/replication/session.rs)) with no phase check,
+> so two legal transitions run off-diagram. (1) A **bare `Deliver` with no
+> round in flight** — the #927 proactive push — is applied, not refused:
+> `on_deliver` distinguishes solicited from unsolicited and admits both,
+> DEBUG-logging the bootstrap planes and WARN-logging the rest
+> (`session.rs:599-647`). (2) A **refused message leaves session state
+> UNTOUCHED** — every kind-mismatch check early-returns `UnexpectedMessage`
+> before any mutation (`session.rs:415/441/461/547/605`), and the coordinator
+> maps it to `DriveStep::Refused` without resetting
+> ([`coordinator.rs:347`](../src/replication/coordinator.rs)). **"Refused" is
+> an outcome, not a state**: the only reset is the coordinator's, on
+> `Complete`/`SendThenComplete` (`coordinator.rs:266-271`).
 
 | Inbound | Handler | Emits | Notes |
 |---|---|---|---|
-| *(none, Initiator)* | `start_round` | `Summary` (+ proactive `Deliver` per #380/#927) | Only valid for `Initiator` |
-| `Summary` | `on_summary` | `Summary` (Responder) + `Diff` | Records remote summary; `want = local ∖ remote` |
-| `Diff` / `Fetch` | `on_diff` / `on_fetch` | `Deliver` | Fetch each wanted hash from the provider |
+| *(none, Initiator)* | `start_round` | `Summary` (+ proactive `Deliver` per #380/#927) — or `CursorPull` for a cursor kind (`session.rs:259`) | Only valid for `Initiator` |
+| `Summary` | `on_summary` | `Summary` (Responder) + `Diff` | Records remote summary; **`want = remote ∖ local`** (`diff_refs`, [`summary.rs:253`](../src/replication/summary.rs)) — local side is the peer-blind `local_holdings`, not the send-gated offer (#414, `session.rs:465-471`) |
+| `Diff` / `Fetch` | `on_diff` / `on_fetch` | `Deliver` (byte-bounded, §4.4) | Fetch each wanted hash from the provider; unfetchable wants are logged LOUD, never inferred from a short count (#429) |
+| `Pull` | `on_pull` | `Summary` (subject-scoped refs) | #462; entitlement fail-closed to `peer == subject` at the provider (`bridge.rs:943`) |
+| `CursorPull` | `on_cursor_pull` | `Deliver` (bundles past `since`) | #474; empty result is a well-formed empty `Deliver` (`session.rs:410-423`) |
 | `Deliver` | `on_deliver` | *(applies)* → `Applied{admitted, refused, staleness}` | Sets `completed`; tallies admits/refusals |
-| *wrong kind* | any | — | `UnexpectedMessage` → `DriveStep::Refused` |
+| *wrong kind* | any | — | `UnexpectedMessage` → `DriveStep::Refused`; session state untouched |
 
 The coordinator maps each `ReplicationOutcome` to a **`DriveStep`**
 ([`coordinator.rs`](../src/replication/coordinator.rs)): `SendThenWait` · `SendThenComplete`
 (initiator-final, #380) · `Complete(RoundReport)` · `Refused`. The responder drain
 is bounded (`RESPONDER_REPLY_SEND_TIMEOUT`, #373); assembly latency is O(1) in
 consent reads via a per-round memo (#400).
+
+### 4.4 Byte budgets
+
+Two constants bound what a single round can put on the wire
+([`session.rs`](../src/replication/session.rs)):
+
+| Constant | Value | Bounds |
+|---|---|---|
+| `MAX_DELIVER_ENVELOPE_BYTES` (`session.rs:73`) | 512 KiB | The raw-envelope total packed into ONE `Deliver` answering a `Diff`/`Fetch` (`pack_bounded_deliver`, `session.rs:517-539`). The remainder is honest deferral: never-admitted hashes stay in the peer's `want`, so the next round's re-diff carries them — and the reported `BoundedBy` staleness stays truthful. Caps the frame's fragment count so reassembly survives packet loss (#414/#932). |
+| `PROACTIVE_PUSH_BUDGET_BYTES` (`session.rs:189`) | 256 KiB | The per-round batch of the #927/#380 proactive initiator push (delta-aware, oldest-seq first; spillover converges over subsequent rounds, `session.rs:313-327`). Replaced the v13.7.0 unbounded full-set push that re-blasted megabytes every 30 s on the Attestation plane. |
+
+Both budgets bound the *batch*, never strand an envelope: a single envelope
+larger than the whole budget still ships, alone (the transport fragments it).
 
 ---
 
@@ -254,8 +404,10 @@ the link's transport identity (`transport_authenticated`) instead of dropping.
 **Safe by construction:** these kinds self-authenticate at persist admission
 (`signer_acts_for`), grant no trust, and are served no `trace:*` — the trace-serve
 gate stays strictly `Rooted ∧ owns_key`. Every non-bootstrap unattributed frame
-still drops (`#317`). A proptest over all 14 kinds proves the carve-out admits
-*exactly* the three.
+still drops (`#317`). A proptest over all 15 kinds × link presence proves the
+carve-out admits *exactly* the three
+(`bootstrap_carve_out_source_holds_over_all_kinds`,
+[`edge.rs:8488`](../src/edge.rs)).
 
 ---
 
@@ -275,6 +427,21 @@ By construction, the fan-out recipient axis can never exceed the consent grant: 
 `ResolvedRecipient` is the only key the serve path accepts, and it is unforgeable
 without a `list_consent_peers` hit. This is the wire-level expression of Nissenbaum's
 "the recipient must not exceed the transmission principle."
+
+**Serve-time field stripping is deliberately NOT an edge operation.** A
+`StripField` consent restriction resolves to a **no-op at the serve layer**
+([`bridge.rs:2309-2314`](../src/replication/bridge.rs)): edge's wire is
+content-addressed and signed — the recipient fetches by content-hash and
+re-verifies the hybrid signature at `put_attestation`, so stripping a field at
+serve time would break both (#397). The strip is applied at **persist
+PROMOTION**, before the row is signed
+(`promote_attestation_with_transforms`); edge's field-conformance harness
+accounts for the deferral explicitly rather than skipping it
+(`DEFERRED_PENDING_PLANE`,
+[`field_conformance.rs:110-129`](../src/field_conformance.rs)). Edge still pins
+persist's transform-algebra hash so a vocabulary change is a build failure
+first (`lib.rs` `PERSIST_TRANSFORM_ALGEBRA_HASH`) — it just never *applies*
+strip on the serve path.
 
 ---
 
@@ -328,7 +495,10 @@ one the network cannot express breaking.*
    carve-out (§5.4) never carves out `Attestation`; `#337` hijack refusal is checked
    first.
 5. **Consent narrows, never widens** — the fan-out recipient set ⊆ `list_consent_peers`.
-6. **Tombstones win** — every revocation projects `Global` (anti-rollback).
+6. **Tombstones win at their plane's ceiling** — a tombstone projects
+   `tombstone_ceiling(plane, authority)`, never narrower than the live fact it
+   retracts (anti-rollback) and never wider (widening a tombstone would
+   disclose more than the original fact — §3.2, CIRISPersist#713).
 7. **PQC-mandatory** — hybrid Ed25519 + ML-DSA-65 for authenticity; item-2 requires
    the ML-DSA transport binding.
 
@@ -337,4 +507,7 @@ one the network cannot express breaking.*
 *Grounded in [Constitution Part 5](../../CIRISConstitution/constitution/part_5_transport_substrate.md),
 [Part 2 (grammar)](../../CIRISConstitution/constitution/part_2_the_grammar.md),
 [Part 3 (namespace)](../../CIRISConstitution/constitution/part_3_the_namespace.md), and the
-code as of edge v14.3.0. Section anchors cite `src/…:line` for navigation.*
+code as of edge v18.0.2 (2026-08 doc audit: every claim re-verified against the
+code; the v14.3.0 revision taught 14 kinds / 4 messages / three projections /
+unconditional tombstone-Global, all superseded above). Section anchors cite
+`src/…:line` for navigation.*

--- a/benches/realtime_av_rekey.rs
+++ b/benches/realtime_av_rekey.rs
@@ -147,7 +147,7 @@ fn fresh_synthetic_peer(idx: usize) -> SyntheticPeer {
         key_id: format!("peer-{idx:06}"),
         advertised: PeerKexPubkeys {
             x25519_pub: x_pub,
-            mlkem768_pub: Some(mlkem_pub),
+            mlkem768_pub: mlkem_pub,
         },
     }
 }

--- a/docs/LIGHTNET_DARKNET.md
+++ b/docs/LIGHTNET_DARKNET.md
@@ -213,9 +213,15 @@ Tracked as the bench-mesh 100% program; each seam has an owner-track:
 
 ## 7. Spec debt
 
-[`FSD/CIRIS_EDGE_TRANSPORT.md`](../FSD/CIRIS_EDGE_TRANSPORT.md) predates
-scope-native addressing and does not yet describe the derived group plane,
-`announce-suppress` inheritance, or the A/V addressing verbs. Until it does,
-CC Part 5 §5.4.4–5.4.6 and this document are the authorities on the two-plane
-design; the FSD remains the authority on the 14 EnvelopeKinds and the
-anti-entropy state machine.
+The [`FSD/CIRIS_EDGE_TRANSPORT.md`](../FSD/CIRIS_EDGE_TRANSPORT.md) refresh
+landed (2026-08, re-pinned to v18.0.2): it now covers the 15 EnvelopeKinds
+(including the #474 cursor plane), all six wire messages (`Pull`,
+`CursorPull`), the five-projection taxonomy with per-plane tombstone ceilings,
+the wire `CohortScope` mapping, and — for the scope-native plane — the §3.3
+arming condition (default-open until a `ScopeAddressTable` is installed, the
+deliberate opt-in production state). Residual gap: the FSD still does not
+specify the derived group plane's full lifecycle (epoch rotation /
+convergence sealing), `announce-suppress` inheritance, or the A/V addressing
+verbs — for those, CC Part 5 §5.4.4–5.4.6 and this document remain the
+authorities. The FSD is the authority on the EnvelopeKinds, projections, and
+the anti-entropy session.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -358,7 +358,10 @@ restoring cross-wheel installability for the persist v3.5.4+ chain.
   - D18 verify → edge linkage (CIRISEdge#37 follow-on).
   - Leviculum-fork accessor exposure (#44; gap-stubs functional).
 - **v1.1.x**:
-  - L2+ trust recursion depths.
+  - ~~L2+ trust recursion depths.~~ *(Retro-note, 2026-08: the depth knob
+    shipped as `EdgeConfig::delegation_graph_max_depth` — default 4,
+    `src/edge.rs` — threaded per CIRISEdge#51; L2+ CEWP *tier* semantics
+    remain deferred.)*
   - L1-as-CDN-edge full HTTP fetch (the prefetch stub at v0.20.1 is
     wire-shape + dispatch-path locked; full implementation deferred).
 - **Production deployments** per

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.1.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.1.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.1.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.1.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.1.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.1.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.1.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.2.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.2.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.2.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.2.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.2.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.2.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.2.0

--- a/src/blob_swarm/scope.rs
+++ b/src/blob_swarm/scope.rs
@@ -65,10 +65,34 @@
 //! [`SwarmScheduler::fetch_blob`]: super::SwarmScheduler::fetch_blob
 //! [`ApplyOutcome`]: crate::replication::summary::ApplyOutcome
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use crate::cohort_scope::CohortScope;
 use crate::scope_addressing::{InboundAddress, MemberAddress, ScopeAddressTable};
+
+/// v18 — has the unarmed-gate staging WARN fired this process?
+static BLOB_SCOPE_GATE_UNARMED_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// v18 — say ONCE (per process) that the blob serve gate is riding the staged
+/// default-open state, so "staged open" is never mistaken for "armed and
+/// passing". The default itself is INTENTIONAL and must not flip — production
+/// rides it; arming is an OPERATOR OPT-IN (install the MLS
+/// [`ScopeAddressTable`] via `EdgeBuilder::scope_native_addressing`; the
+/// CIRISVerify#259 `ScopePrivacyDeriver` is shipped, nothing upstream pends).
+fn warn_blob_scope_gate_unarmed() {
+    if !BLOB_SCOPE_GATE_UNARMED_WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            "blob serve scope gate UNARMED — scope-native addressing is not \
+             installed, so this node rides the pre-#499 staged state: every \
+             arrival is treated as the federation address and every blob request \
+             is admitted without a scope check. This is the deliberate default; \
+             arming is an OPERATOR OPT-IN — install the MLS ScopeAddressTable via \
+             EdgeBuilder::scope_native_addressing (the CIRISVerify#259 \
+             ScopePrivacyDeriver is shipped). Warned once per process."
+        );
+    }
+}
 
 // ─── What "this blob's scope" means to the addressing layer ─────────
 
@@ -542,12 +566,19 @@ impl ServeAdmission {
 /// address for anyone to arrive on, so every request would arrive as
 /// `None` and a gate would refuse all non-public content on every
 /// existing deployment. Additive, not disruptive.
+///
+/// v18 — the UNARMED state is no longer silent: the first consultation
+/// emits one process-lifetime WARN naming the staged state (see
+/// [`warn_blob_scope_gate_unarmed`]). The default itself is INTENTIONAL
+/// and unchanged — production rides it, and
+/// `the_gate_is_disarmed_when_no_table_is_installed` pins it.
 pub fn admit_blob_serve(
     scope_native: bool,
     arrival: Option<&InboundAddress>,
     content: Option<&ContentScope>,
 ) -> ServeAdmission {
     if !scope_native {
+        warn_blob_scope_gate_unarmed();
         return ServeAdmission::Admit;
     }
 
@@ -961,6 +992,13 @@ mod tests {
         assert!(admit_blob_serve(true, Some(&own), Some(&community_content())).is_admitted());
     }
 
+    /// v18 PIN — "no table ⇒ default-open" is INTENTIONAL, not an oversight.
+    /// Production rides this staged state: arming is an operator OPT-IN
+    /// (install the table via `EdgeBuilder::scope_native_addressing`), and a
+    /// future "fix" that flips this default fail-closed would refuse every
+    /// non-public blob on every existing deployment (a legacy node cannot
+    /// produce a non-`None` arrival). If you are here to flip it: that is the
+    /// arming EVENT, done by installing the table — not by editing this gate.
     #[test]
     fn the_gate_is_disarmed_when_no_table_is_installed() {
         // The no-regression case at the gate. A legacy node cannot produce
@@ -974,7 +1012,9 @@ mod tests {
             assert_eq!(
                 admit_blob_serve(false, None, content),
                 ServeAdmission::Admit,
-                "a deployment with no address table must serve exactly as pre-#499",
+                "a deployment with no address table must serve exactly as pre-#499 \
+                 — the INTENTIONAL staged default; do not flip it here (arming = \
+                 installing the ScopeAddressTable, an operator opt-in)",
             );
         }
     }

--- a/src/cohort_scope.rs
+++ b/src/cohort_scope.rs
@@ -54,9 +54,30 @@ use serde::{Deserialize, Serialize};
 // resolves through persist's `crypto_tier()` rather than enumerating
 // the 7-value lattice so future `affiliations` semantic changes flow
 // without wire-format churn.
+use ciris_persist::federation::types::cohort_scope as persist_scope;
 pub use ciris_persist::federation::types::cohort_scope::{
     crypto_tier as persist_crypto_tier, CryptoTier,
 };
+
+/// THE `"self"` scope token — single authority for the string form of
+/// [`CohortScope::SelfOnly`], routed through persist's lattice const
+/// (`cohort_scope::SELF`, the CC 4.4.3.2.1 authority) rather than a
+/// re-typed literal.
+///
+/// Consumers that DELIBERATELY share this exact token:
+///
+/// - [`CohortScope::kind_token`] — telemetry / structured logging;
+/// - the [`CohortScope::crypto_tier`] lattice call — persist's
+///   `"self"` affiliation row (InvisibleEncrypted);
+/// - the WW2 witness-leaf filter
+///   (`crate::holonomic::wholeness_witness::WW2_SELF_COHORT_SCOPE`) —
+///   self-private leaves are filtered BEFORE Merkle construction, so a
+///   drifted token there would silently PUBLISH self-scoped content;
+/// - the serde wire tag (`#[serde(rename = "self")]` on
+///   [`CohortScope::SelfOnly`]) — an attribute literal serde cannot
+///   take from a const; `tests::serde_self_tag_matches_token` pins it
+///   equal to this const so a drift fails loudly.
+pub const SELF_SCOPE_TOKEN: &str = persist_scope::SELF;
 
 /// Wire-form cohort-scope discriminator for the federation's locality
 /// dividend (CIRISEdge#48-A; FSD `FEDERATION_SCALING_MODEL.md`).
@@ -102,8 +123,11 @@ impl CohortScope {
     pub fn kind_token(&self) -> &'static str {
         match self {
             Self::Public => "public",
-            Self::SelfOnly => "self",
+            Self::SelfOnly => SELF_SCOPE_TOKEN,
             Self::Family => "family",
+            // NOTE: "cohort" here vs. "community" in `crypto_tier` is a
+            // DELIBERATE two-table divergence — see the comment on the
+            // `crypto_tier` Cohort arm before "unifying" them.
             Self::Cohort { .. } => "cohort",
         }
     }
@@ -180,10 +204,21 @@ impl CohortScope {
     #[must_use]
     pub fn crypto_tier(&self) -> CryptoTier {
         match self {
-            Self::Public => persist_crypto_tier("federation", None),
-            Self::SelfOnly => persist_crypto_tier("self", None),
-            Self::Family => persist_crypto_tier("family", None),
-            Self::Cohort { .. } => persist_crypto_tier("community", None),
+            Self::Public => persist_crypto_tier(persist_scope::FEDERATION, None),
+            Self::SelfOnly => persist_crypto_tier(SELF_SCOPE_TOKEN, None),
+            Self::Family => persist_crypto_tier(persist_scope::FAMILY, None),
+            // DELIBERATE DIVERGENCE (do NOT unify with `kind_token`):
+            // edge's wire/telemetry token for this variant is "cohort"
+            // (the serde tag + `kind_token`, wire-locked since v0.19.1),
+            // but persist's CC 4.4.3.2.1 lattice names the CommunityDek
+            // row "community". Feeding edge's wire token into the
+            // lattice (`persist_crypto_tier("cohort", ..)`) would fall
+            // through persist's negative-default arm to `Plaintext` — a
+            // silent at-rest ENCRYPTION DOWNGRADE for cohort-scoped
+            // content. Two consumers, two vocabularies, one bridge
+            // (this arm). Pinned by
+            // `tests::cohort_wire_token_vs_persist_lattice_token_diverge_deliberately`.
+            Self::Cohort { .. } => persist_crypto_tier(persist_scope::COMMUNITY, None),
         }
     }
 
@@ -371,6 +406,42 @@ mod tests {
         assert_eq!(CohortScopeEnforcement::Strict.as_str(), "strict");
         assert_eq!(CohortScopeEnforcement::WarnOnly.as_str(), "warn_only");
         assert_eq!(CohortScopeEnforcement::Off.as_str(), "off");
+    }
+
+    /// Audit pin — the serde wire tag for `SelfOnly` is an attribute
+    /// literal (`#[serde(rename = "self")]`) that cannot reference
+    /// [`SELF_SCOPE_TOKEN`]; this test is the drift alarm keeping the
+    /// wire tag equal to the one-authority token (which itself routes
+    /// through persist's lattice const).
+    #[test]
+    fn serde_self_tag_matches_token() {
+        let json = serde_json::to_string(&CohortScope::SelfOnly).unwrap();
+        assert_eq!(json, format!(r#"{{"kind":"{SELF_SCOPE_TOKEN}"}}"#));
+        assert_eq!(CohortScope::SelfOnly.kind_token(), SELF_SCOPE_TOKEN);
+    }
+
+    /// Audit pin — `kind_token` says "cohort" while `crypto_tier`
+    /// resolves through persist's "community" lattice row. These are
+    /// two DELIBERATELY different tables: edge's wire/telemetry
+    /// vocabulary (wire-locked "cohort" since v0.19.1) vs. persist's
+    /// CC 4.4.3.2.1 at-rest lattice vocabulary ("community" →
+    /// CommunityDek). The third assertion is WHY they must not be
+    /// merged: persist's lattice has no "cohort" row, so edge's wire
+    /// token would fall through the negative-default arm to Plaintext
+    /// — a silent at-rest encryption downgrade.
+    #[test]
+    fn cohort_wire_token_vs_persist_lattice_token_diverge_deliberately() {
+        let c = CohortScope::Cohort {
+            cohort_id: "alpha".into(),
+        };
+        assert_eq!(c.kind_token(), "cohort");
+        assert_eq!(c.crypto_tier(), CryptoTier::CommunityDek);
+        assert_eq!(
+            persist_crypto_tier(c.kind_token(), None),
+            CryptoTier::Plaintext,
+            "persist's lattice does NOT know edge's wire token — the \
+             divergence is load-bearing, not an oversight"
+        );
     }
 
     // ─── v6.0.0 (CIRISEdge#175) — FSD §2.1 / §3.2 surface ───────────

--- a/src/directory_cache.rs
+++ b/src/directory_cache.rs
@@ -87,9 +87,26 @@ pub struct DirectoryRecord {
     /// ML-DSA-65 public key bytes (the
     /// `EncodedVerifyingKey<MlDsa65>` form).
     pub ml_dsa_pk: Vec<u8>,
-    /// X-Wing public key (X25519 + ML-KEM-768 halves). Optional
-    /// because some directory entries — e.g. read-only governance
-    /// keys — may carry only ML-DSA-65.
+    /// X-Wing public key (X25519 + ML-KEM-768 halves).
+    ///
+    /// `Option` is DELIBERATE (CIRISEdge#481 item 7, investigated):
+    /// a legitimate absent state exists. Signature-only directory
+    /// entries — governance/steward keys resolved SOLELY as the
+    /// CIRISEdge#331 (E8) inviter-signature trust input via
+    /// [`DirectoryCache::welcome_wrap_lookup`] — carry only
+    /// ML-DSA-65 and are never KEX recipients. Precisely who may
+    /// lack it: entries whose identity never acts as an HPKE/KEX
+    /// recipient (they verify, they don't decrypt).
+    ///
+    /// This field is NOT a KEX input and MUST never become one: peer
+    /// KEX pubkeys are resolved through persist's
+    /// `resolve_encryption_keys` (both halves required) in
+    /// `Edge::resolve_peer_kex_pubkeys`, and
+    /// `PeerKexPubkeys.mlkem768_pub` is a required `Vec<u8>` (#481
+    /// item 4) whose only Option-accepting constructor
+    /// (`PeerKexPubkeys::from_advertisement`) refuses absence with a
+    /// typed error — so an absent key here structurally cannot reach
+    /// KEX construction.
     pub x_wing_pk: Option<XWingPublic>,
     /// Caller-tagged identity type.
     pub identity_type: IdentityType,

--- a/src/directory_cache.rs
+++ b/src/directory_cache.rs
@@ -22,6 +22,15 @@
 //!   stream) is deferred to v6.1.0 — v6.0.0 ships the cache with a
 //!   public [`DirectoryCache::insert`] / [`DirectoryCache::remove`]
 //!   API for the v6.1.0 wiring agent to drive against.
+//!
+//! # Revocation coherency
+//!
+//! The cache is no longer fill-only: [`DirectoryCache::invalidate`] /
+//! [`DirectoryCache::invalidate_all`] are the eviction surface for
+//! revocation events. Intended producer: the replication bridge's
+//! `with_revocation_observer` hook (revocation → `revoked_key_id` →
+//! `cache.invalidate(key_id)`), registered by the runtime coordinator
+//! at bridge build.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -158,6 +167,42 @@ impl DirectoryCache {
         g.remove(federation_id)
     }
 
+    /// Invalidate (drop) the cached record for a revoked key. Returns
+    /// the dropped record, or `None` if the key was not cached.
+    ///
+    /// The cache was originally fill-only: a key revoked after admission
+    /// kept being served (to Welcome wrap, the emission layer, scope
+    /// echo) until process restart. This is the revocation-coherency
+    /// surface closing that gap.
+    ///
+    /// INTENDED WIRING — the replication bridge's revocation observer:
+    /// `FederationDirectoryReplicationBridge::with_revocation_observer`
+    /// fires with the signed revocation's `revoked_key_id`; the
+    /// coordinator registers, at bridge build,
+    /// `Some(Arc::new(move |k: &str| { cache.invalidate(k); }))`.
+    /// (Not wired here: the bridge is owned by a sibling workstream and
+    /// no non-bridge path in this module's callers receives revocation
+    /// events.)
+    ///
+    /// Semantically identical to [`Self::remove`]; named separately so
+    /// call sites read as cache-coherency on revocation, not roster
+    /// mutation.
+    pub fn invalidate(&self, federation_id: &str) -> Option<DirectoryRecord> {
+        self.remove(federation_id)
+    }
+
+    /// Drop EVERY cached record, returning how many were dropped. For
+    /// events with no per-key enumeration of the blast radius (e.g. a
+    /// trust-root change / re-genesis): the safe posture is an empty
+    /// cache that anti-entropy refills, never a cache serving keys the
+    /// new root no longer stands behind.
+    pub fn invalidate_all(&self) -> usize {
+        let mut g = self.inner.write();
+        let n = g.len();
+        g.clear();
+        n
+    }
+
     /// Lookup a directory record by `federation_id`.
     #[must_use]
     pub fn get(&self, federation_id: &str) -> Option<DirectoryRecord> {
@@ -234,6 +279,32 @@ mod tests {
         let cache = DirectoryCache::new();
         cache.insert(rec("alice", 0xaa));
         assert!(cache.get("bob").is_none());
+    }
+
+    /// Audit item — the revocation-coherency surface: `invalidate`
+    /// drops exactly the revoked key's record (the shape the
+    /// bridge-side revocation observer drives with `revoked_key_id`).
+    #[test]
+    fn invalidate_drops_revoked_key_only() {
+        let cache = DirectoryCache::new();
+        cache.insert(rec("alice", 0xaa));
+        cache.insert(rec("bob", 0xbb));
+        let dropped = cache.invalidate("alice").expect("alice was cached");
+        assert_eq!(dropped.federation_id, "alice");
+        assert!(cache.get("alice").is_none(), "revoked key no longer served");
+        assert!(cache.get("bob").is_some(), "unrevoked key untouched");
+        // Idempotent — a second revocation observation is a no-op.
+        assert!(cache.invalidate("alice").is_none());
+    }
+
+    #[test]
+    fn invalidate_all_empties_cache_and_counts() {
+        let cache = DirectoryCache::new();
+        cache.insert(rec("alice", 0xaa));
+        cache.insert(rec("bob", 0xbb));
+        assert_eq!(cache.invalidate_all(), 2);
+        assert!(cache.is_empty());
+        assert_eq!(cache.invalidate_all(), 0);
     }
 
     #[test]

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -98,12 +98,19 @@ pub const DEFAULT_BLACKHOLE_PRUNE_INTERVAL_SECONDS: u64 = 3600;
 /// `TrustScoring::trust_score`, replacing v0.19.6's hardcoded `0`).
 /// L2+ tiers are deferred to a post-v1.0 cut.
 ///
-/// Transport-posture translation (Roaming / Full / Gateway / AP)
-/// remains deferred — the v0.12.0 Leviculum interface-diversity work
-/// did not surface a `reticulum_default_posture` enum on EdgeConfig,
-/// so the v0.18.0 cut configures only the listener bind + outbound
-/// queue cap. Transport-posture follow-up tracks the v0.19.0
-/// observability cut.
+/// Transport-posture translation (Roaming / Full / Gateway / AP) is
+/// DERIVED, not configured — no posture enum will ever exist
+/// (CIRISEdge#514). Announce policy is normative (CC 5.4.6:
+/// group-scoped destinations never announce; federation visibility is
+/// the #499 opt-in). Transit/relay is CONFERRED, not configured (the
+/// #430 `infra:transport` gate + #492 per-interface transit
+/// declarations); serving is `infra:serve` conferral (#386). The
+/// mapping falls out: Roaming ≡ `Client`; Full ≡ `Server` + conferred
+/// roles; Gateway ≡ `infra:transport` conferral + interface transit
+/// scope; AP ≡ member-only transit on a local interface. A node's
+/// behavior = `AgentMode` (local resources) × conferred capabilities
+/// (directory) × per-interface transit declarations × normative
+/// announce policy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AgentMode {
     /// Egress-only posture; the edge runtime does not bind a
@@ -522,6 +529,17 @@ pub struct EdgeConfig {
     /// via [`Edge::refresh_canonical_retirements`] regardless of this
     /// flag or of operator config.
     pub baked_canonical_genesis_enabled: bool,
+    /// Phase 2 typed ephemeral request→response — how long
+    /// `Edge::send::<M>` waits for the correlated
+    /// [`crate::MessageType::EphemeralResponse`] (or `OpaqueResponse`)
+    /// reply when `M::Response` is a real struct (not `()`). Elapsing
+    /// returns [`EdgeError::Unreachable`] and removes the pending
+    /// waiter. Fire-and-forget sends (`type Response = ()`) never
+    /// consult this — transport-Delivered IS their outcome. Default
+    /// 30_000 ms (matches the `send_opaque_request` convention of
+    /// caller-tier timeouts; this one is config-tier because `send`'s
+    /// signature carries no timeout parameter).
+    pub ephemeral_response_timeout_ms: u64,
 }
 
 impl Default for EdgeConfig {
@@ -615,6 +633,10 @@ impl Default for EdgeConfig {
             // persist's baked genesis bundle, ON by default (the #380
             // promise). `false` = the pre-#281 operator-only posture.
             baked_canonical_genesis_enabled: true,
+            // Phase 2 typed ephemeral correlation — 30 s, generous
+            // enough for a Reticulum link establish + round trip;
+            // tests shorten it to pin the timeout path.
+            ephemeral_response_timeout_ms: 30_000,
         }
     }
 }
@@ -744,6 +766,15 @@ type ErasedHandlerFn = Arc<
 
 struct RegisteredHandler {
     erased: ErasedHandlerFn,
+    /// Phase 2 — `true` iff this handler's `M::Response` is a real
+    /// struct (not `()`) AND `M` rides the Ephemeral class AND `M` is
+    /// not `OpaqueRequest` (the opaque plane owns that wire type's
+    /// reply — the kind-keyed handler / 501 responder — so a typed
+    /// reply here would race it with a second envelope). When set, the
+    /// dispatcher ships the handler's serialized response back as a
+    /// correlated [`MessageType::EphemeralResponse`] instead of
+    /// discarding it (the pre-Phase-2 behavior).
+    sends_typed_reply: bool,
 }
 
 // ─── Edge ───────────────────────────────────────────────────────────
@@ -783,6 +814,17 @@ pub(crate) type OpaqueRequestHandlerFn =
 /// oneshot. Mirrors the `content_fetch_pending` correlation pattern.
 type OpaqueRequestPendingMap =
     std::sync::Mutex<HashMap<[u8; 32], oneshot::Sender<crate::messages::OpaqueResponse>>>;
+
+/// Phase 2 typed ephemeral request→response correlation map — the
+/// closure of the v0.8.0 "correlation not wired" carve-out. Keyed by
+/// the request envelope's `body_sha256` (the token the responder
+/// echoes into the reply's `in_reply_to`); resolves with the RAW
+/// response body bytes — the waiting `Edge::send::<M>` knows
+/// `M::Response` statically and deserializes, so edge holds no typed
+/// struct here. Mirrors [`OpaqueRequestPendingMap`], including the
+/// insert-before-send discipline that closes the
+/// response-beats-waiter race.
+type EphemeralResponsePendingMap = std::sync::Mutex<HashMap<[u8; 32], oneshot::Sender<Vec<u8>>>>;
 
 /// CIRISEdge#22 Tier 3 (v0.17.0) — projection of a verified envelope
 /// onto the wire surface the `subscribe_feed` AsyncIterator delivers.
@@ -1051,6 +1093,12 @@ pub struct Edge {
     /// CC 0.7 opaque request→response correlation map (CIRISEdge#241).
     /// Keyed by the request envelope `body_sha256`.
     opaque_request_pending: Arc<OpaqueRequestPendingMap>,
+    /// Phase 2 typed ephemeral request→response correlation map. Keyed
+    /// by the request envelope `body_sha256`; resolved by the
+    /// `MessageType::EphemeralResponse` dispatch arm (and, for
+    /// `send::<OpaqueRequest>`, by the `OpaqueResponse` arm's typed
+    /// fallback) with the raw response body bytes.
+    ephemeral_response_pending: Arc<EphemeralResponsePendingMap>,
     /// CIRISEdge#22 Tier 3 (v0.17.0) — broadcast channel carrying every
     /// verified inbound `EdgeEnvelope` for the `subscribe_feed`
     /// AsyncIterator surface. Construction is unconditional; emission
@@ -2046,14 +2094,46 @@ impl Edge {
             })
         });
 
+        // Phase 2 — whether dispatch ships the handler's response back
+        // as a correlated `EphemeralResponse`. `()` responses stay
+        // fire-and-forget (serialized `()` is `null` — shipping it
+        // would be wire noise the sender never awaits); non-Ephemeral
+        // classes answer through the durable-ACK path instead; the
+        // OpaqueRequest wire type is answered by the opaque plane's
+        // kind-keyed responder, never by this leg.
+        let sends_typed_reply = std::any::TypeId::of::<M::Response>()
+            != std::any::TypeId::of::<()>()
+            && matches!(M::DELIVERY, Delivery::Ephemeral)
+            && M::TYPE != MessageType::OpaqueRequest;
+
         let mut handlers = self.handlers.lock().await;
-        handlers.insert(M::TYPE, RegisteredHandler { erased });
+        handlers.insert(
+            M::TYPE,
+            RegisteredHandler {
+                erased,
+                sends_typed_reply,
+            },
+        );
         Ok(())
     }
 
     /// Send an ephemeral message. Caller-owned retry — failure is
     /// visible (OQ-09 closure). Compile-time: `M::DELIVERY` must be
     /// `Ephemeral`; runtime check rejects `Durable` mis-use.
+    ///
+    /// # Request→response (Phase 2)
+    ///
+    /// - `type Response = ()` (fire-and-forget): returns `Ok(())` as
+    ///   soon as the transport reports `Delivered`.
+    /// - A real `M::Response`: registers a correlation waiter keyed on
+    ///   the request envelope's `body_sha256` BEFORE the send, then
+    ///   awaits the peer's correlated reply (a
+    ///   [`crate::MessageType::EphemeralResponse`] envelope — or an
+    ///   `OpaqueResponse` for `send::<OpaqueRequest>`) up to
+    ///   [`EdgeConfig::ephemeral_response_timeout_ms`]. Requires the
+    ///   inbound dispatch loop to be running (`Edge::run` or
+    ///   [`Self::spawn_background_listeners`]) so the reply is
+    ///   observed.
     #[tracing::instrument(
         name = "edge.send",
         skip(self, msg),
@@ -2086,19 +2166,7 @@ impl Edge {
         msg: M,
         cohort_scope: Option<CohortScope>,
     ) -> Result<M::Response, EdgeError> {
-        if !matches!(M::DELIVERY, Delivery::Ephemeral) {
-            let declared = match M::DELIVERY {
-                Delivery::Ephemeral => "Ephemeral",
-                Delivery::Durable { .. } => "Durable",
-                Delivery::Federation { .. } => "Federation",
-                Delivery::Mandatory { .. } => "Mandatory",
-            };
-            return Err(EdgeError::DeliveryClassMismatch(
-                M::TYPE,
-                declared,
-                "Ephemeral",
-            ));
-        }
+        ensure_ephemeral_class::<M>()?;
 
         // CIRISEdge#48-A (v0.19.1) — producer-side recipient
         // enforcement BEFORE building the signed envelope. Point-to-
@@ -2116,6 +2184,21 @@ impl Edge {
         }
         let transport = &self.transports[0];
         let envelope_size = envelope_bytes.len() as u64;
+
+        // Phase 2 — typed ephemeral request→response correlation (the
+        // closure of the v0.8.0 "correlation not wired" carve-out).
+        //
+        // `type Response = ()` marks fire-and-forget: transport
+        // `Delivered` IS the outcome, no waiter is registered, and the
+        // Delivered arm below returns `Ok(())` directly. A real
+        // `M::Response` registers a waiter — INSERT BEFORE SEND (see
+        // `register_ephemeral_waiter` for the race this closes).
+        let unit = unit_response::<M>();
+        let waiter = if unit.is_none() {
+            Some(self.register_ephemeral_waiter(&envelope_bytes)?)
+        } else {
+            None
+        };
 
         // CIRISEdge#29 — record the send-path attempt against the
         // tracker. Failure-class capture covers both the
@@ -2190,25 +2273,25 @@ impl Edge {
                     error = %e,
                     "transport send error",
                 );
+                // Phase 2 — the request never left; retire the waiter.
+                self.retire_ephemeral_waiter(waiter.as_ref());
                 return Err(EdgeError::Transport(e));
             }
         };
 
         match outcome {
             TransportSendOutcome::Delivered => {
-                // Phase 1 simplification: ephemeral request-response is
-                // not yet wired through a correlation channel. Lens
-                // cutover doesn't need request-response on the outbound
-                // side; the inbound side does (handlers return typed
-                // responses, edge serializes back). Returning a default
-                // response here is incorrect for real ephemeral
-                // request-response — TODO Phase 2: wire correlation
-                // via in_reply_to + body_sha256 + a oneshot map.
-                Err(EdgeError::Config(
-                    "ephemeral request-response correlation not wired (Phase 2)".into(),
-                ))
+                // Phase 2 — fire-and-forget (`type Response = ()`):
+                // transport `Delivered` IS the success outcome.
+                if let Some(u) = unit {
+                    return Ok(u);
+                }
+                let (correlation, rx) = waiter.expect("waiter registered for non-unit Response");
+                self.await_typed_ephemeral_response::<M>(correlation, rx)
+                    .await
             }
             TransportSendOutcome::Reject { class, detail } => {
+                self.retire_ephemeral_waiter(waiter.as_ref());
                 Err(EdgeError::Unreachable(format!("reject {class}: {detail}")))
             }
             // §24 NAT-traversal (#169): a store-and-forward queue is a
@@ -2216,12 +2299,111 @@ impl Edge {
             // observe a wake-up-fetch delivery, so a queued send on the
             // ephemeral path is a config error (callers wanting
             // store-and-forward use the durable path).
-            TransportSendOutcome::Queued => Err(EdgeError::Config(
-                "store-and-forward queued send is not valid on the ephemeral request-response \
-                 path (use send_durable)"
-                    .into(),
-            )),
+            TransportSendOutcome::Queued => {
+                self.retire_ephemeral_waiter(waiter.as_ref());
+                Err(EdgeError::Config(
+                    "store-and-forward queued send is not valid on the ephemeral \
+                     request-response path (use send_durable)"
+                        .into(),
+                ))
+            }
         }
+    }
+
+    /// Phase 2 — register the correlation waiter for a typed ephemeral
+    /// request. Keys the pending map on the request envelope's
+    /// `body_sha256` (the token the responder echoes into the reply's
+    /// `in_reply_to`) — and MUST run BEFORE the transport send:
+    /// otherwise a response that arrives before the waiter is in the
+    /// map is dropped on the floor and the send hangs to timeout (the
+    /// response-beats-waiter race the opaque loop already closes with
+    /// the same insert-before-send discipline).
+    fn register_ephemeral_waiter(
+        &self,
+        envelope_bytes: &[u8],
+    ) -> Result<([u8; 32], oneshot::Receiver<Vec<u8>>), EdgeError> {
+        let envelope: EdgeEnvelope = serde_json::from_slice(envelope_bytes)
+            .map_err(|e| EdgeError::Config(format!("re-parse own envelope: {e}")))?;
+        let correlation = envelope_body_sha256(&envelope);
+        let (tx, rx) = oneshot::channel();
+        self.ephemeral_response_pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .insert(correlation, tx);
+        Ok((correlation, rx))
+    }
+
+    /// Phase 2 — await the correlated reply the inbound dispatcher
+    /// resolves (the `MessageType::EphemeralResponse` arm, or the
+    /// `OpaqueResponse` arm's typed fallback for
+    /// `send::<OpaqueRequest>`), bounded by
+    /// [`EdgeConfig::ephemeral_response_timeout_ms`]. Every exit is
+    /// loud; the timeout exit retires the pending entry.
+    async fn await_typed_ephemeral_response<M: Message>(
+        &self,
+        correlation: [u8; 32],
+        rx: oneshot::Receiver<Vec<u8>>,
+    ) -> Result<M::Response, EdgeError> {
+        let timeout_ms = self.config.ephemeral_response_timeout_ms;
+        match tokio::time::timeout(std::time::Duration::from_millis(timeout_ms), rx).await {
+            Ok(Ok(bytes)) => serde_json::from_slice::<M::Response>(&bytes).map_err(|e| {
+                EdgeError::Config(format!(
+                    "typed ephemeral response deserialize ({}): {e}",
+                    std::any::type_name::<M::Response>(),
+                ))
+            }),
+            Ok(Err(_recv)) => Err(EdgeError::Config(
+                "ephemeral response correlation channel dropped".into(),
+            )),
+            Err(_elapsed) => {
+                self.take_pending_ephemeral(&correlation);
+                Err(EdgeError::Unreachable(format!(
+                    "ephemeral request timed out awaiting typed response after {timeout_ms}ms",
+                )))
+            }
+        }
+    }
+
+    /// Phase 2 — retire an in-flight waiter on a non-success send exit
+    /// (transport error / wire reject / store-and-forward queue). Same
+    /// discipline as `send_opaque_request`'s failure arms.
+    fn retire_ephemeral_waiter(&self, waiter: Option<&([u8; 32], oneshot::Receiver<Vec<u8>>)>) {
+        if let Some((correlation, _)) = waiter {
+            self.take_pending_ephemeral(correlation);
+        }
+    }
+
+    /// Phase 2 — remove (and return) a pending typed-ephemeral waiter.
+    /// Shared by the send error/reject/timeout exits and the test seam.
+    fn take_pending_ephemeral(&self, correlation: &[u8; 32]) -> Option<oneshot::Sender<Vec<u8>>> {
+        self.ephemeral_response_pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(correlation)
+    }
+
+    /// Phase 2 test seam — resolve a pending typed-ephemeral waiter
+    /// with raw response-body bytes, as the inbound dispatcher would.
+    /// Returns `true` iff a waiter was registered AND accepted the
+    /// bytes. Mirrors [`Self::complete_pending_fetch_for_test`].
+    #[doc(hidden)]
+    pub fn complete_pending_ephemeral_for_test(
+        &self,
+        correlation: [u8; 32],
+        response_body_json: Vec<u8>,
+    ) -> bool {
+        self.take_pending_ephemeral(&correlation)
+            .is_some_and(|tx| tx.send(response_body_json).is_ok())
+    }
+
+    /// Phase 2 test seam — number of in-flight typed-ephemeral waiters.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn pending_ephemeral_len_for_test(&self) -> usize {
+        self.ephemeral_response_pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .len()
     }
 
     /// Send a durable message. Edge-owned retry; the returned handle
@@ -3020,33 +3202,28 @@ impl Edge {
             pending.insert(sha256, tx);
         }
 
-        // Build + send the ContentFetch envelope. We use the typed
-        // `crate::MessageType::ContentFetch` body shape — the
-        // existing Edge::send returns `EdgeError::Config(...)` for
-        // ephemeral request/response (the v0.8.0 "Phase 2"
-        // correlation not wired carve-out), which is exactly the
-        // success-of-transport path. We map that one specific error
-        // back to Ok so the caller's await proceeds.
+        // Build + send the ContentFetch envelope. Phase 2 closed the
+        // v0.8.0 carve-out: `ContentFetch::Response = ()`, so a
+        // transport-Delivered send now returns `Ok(())` directly (no
+        // more string-matching a Config error as the success path).
+        // The response correlation deliberately STAYS on this method's
+        // sha256-keyed pending map, NOT the body_sha256/in_reply_to
+        // loop: ContentBody / ContentMiss are separate envelopes that
+        // ANY holder may answer with (two response shapes,
+        // multi-responder), which the point-to-point typed-response
+        // loop can't subsume.
         let fetch = crate::messages::ContentFetch {
             sha256,
             response_hint: None,
         };
-        match self.send(peer_key_id, fetch).await {
-            Ok(()) => {}
-            Err(EdgeError::Config(s))
-                if s.contains("ephemeral request-response correlation not wired") =>
-            {
-                // Transport accepted the bytes — proceed to await.
-            }
-            Err(e) => {
-                // Send failed — clean the pending entry and surface.
-                let mut pending = self
-                    .content_fetch_pending
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                pending.remove(&sha256);
-                return Err(e);
-            }
+        if let Err(e) = self.send(peer_key_id, fetch).await {
+            // Send failed — clean the pending entry and surface.
+            let mut pending = self
+                .content_fetch_pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            pending.remove(&sha256);
+            return Err(e);
         }
 
         match tokio::time::timeout(timeout, rx).await {
@@ -3144,24 +3321,18 @@ impl Edge {
             chunk_sha256,
             response_hint: None,
         };
-        match self.send(peer_key_id, fetch).await {
-            Ok(()) => {}
-            Err(EdgeError::Config(s))
-                if s.contains("ephemeral request-response correlation not wired") =>
-            {
-                // Same v0.17.0 carve-out as fetch_content — transport
-                // accepted the bytes; the correlation rides our
-                // pending-map, not the transport's request/response
-                // primitive.
-            }
-            Err(e) => {
-                let mut pending = self
-                    .blob_chunk_fetch_pending
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                pending.remove(&key);
-                return Err(e);
-            }
+        // Phase 2 — `BlobChunkFetch::Response = ()`, so Delivered is
+        // `Ok(())` directly (same migration as `fetch_content`; the
+        // chunk correlation rides this method's (blob, chunk)-keyed
+        // pending map because any holder may answer with either
+        // BlobChunkBody or BlobChunkMiss).
+        if let Err(e) = self.send(peer_key_id, fetch).await {
+            let mut pending = self
+                .blob_chunk_fetch_pending
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            pending.remove(&key);
+            return Err(e);
         }
 
         match tokio::time::timeout(timeout, rx).await {
@@ -3406,7 +3577,8 @@ impl Edge {
             &self.opaque_subscribers,
             &self.opaque_handlers,
             &self.opaque_request_pending,
-            self.transports.first(),
+            &self.ephemeral_response_pending,
+            &self.transports,
             self.config.max_content_body_bytes,
             &directory,
             Some(&self.reachability),
@@ -4081,7 +4253,10 @@ impl Edge {
         let opaque_subs = self.opaque_subscribers.clone();
         let opaque_handlers = self.opaque_handlers.clone();
         let opaque_request_pending = self.opaque_request_pending.clone();
-        let response_transport = self.transports.first().cloned();
+        let ephemeral_response_pending = self.ephemeral_response_pending.clone();
+        // The full transport set — dispatch selects the reply transport
+        // per frame (arrival affinity, first-configured fallback).
+        let reply_transports = self.transports.clone();
         let max_content_body_bytes = self.config.max_content_body_bytes;
         let reachability = self.reachability.clone();
         let detector = self.detector.clone();
@@ -4170,7 +4345,8 @@ impl Edge {
                     let opaque_subs_clone = opaque_subs.clone();
                     let opaque_handlers_clone = opaque_handlers.clone();
                     let opaque_request_pending_clone = opaque_request_pending.clone();
-                    let response_transport_clone = response_transport.clone();
+                    let ephemeral_response_pending_clone = ephemeral_response_pending.clone();
+                    let reply_transports_clone = reply_transports.clone();
                     let reach_clone = reachability.clone();
                     let directory_clone = verify_clone.directory();
                     let detector_clone = detector.clone();
@@ -4203,7 +4379,8 @@ impl Edge {
                             &opaque_subs_clone,
                             &opaque_handlers_clone,
                             &opaque_request_pending_clone,
-                            response_transport_clone.as_ref(),
+                            &ephemeral_response_pending_clone,
+                            &reply_transports_clone,
                             max_content_body_bytes,
                             &directory_clone,
                             Some(&reach_clone),
@@ -4711,6 +4888,21 @@ fn first_bytes_hex(bytes: &[u8]) -> String {
     hex::encode(&bytes[..bytes.len().min(8)])
 }
 
+/// Reply-path transport affinity — pick the transport a response
+/// should ship on: the one the request ARRIVED on when it is in the
+/// configured set, else the first configured transport (the historical
+/// `transports[0]` behavior). `None` only when no transport is
+/// configured at all.
+fn select_reply_transport(
+    transports: &[Arc<dyn Transport>],
+    arrival: crate::transport::TransportId,
+) -> Option<&Arc<dyn Transport>> {
+    transports
+        .iter()
+        .find(|t| t.id() == arrival)
+        .or_else(|| transports.first())
+}
+
 /// Inbound dispatch: verify → maybe-ACK-match → `ContentBody`
 /// AV-13/integrity gate (CIRISEdge#21 v0.8.0) → `FederationAnnouncement`
 /// `AccordCarrier` 2-of-3 multi-sig wire-layer gate (CIRISEdge#19,
@@ -4730,7 +4922,8 @@ fn first_bytes_hex(bytes: &[u8]) -> String {
         opaque_subscribers,
         opaque_handlers,
         opaque_request_pending,
-        response_transport,
+        ephemeral_response_pending,
+        transports,
         directory,
         reachability,
         detector,
@@ -4766,7 +4959,14 @@ async fn dispatch_inbound(
     // ship the OpaqueResponse back to the request sender.
     opaque_handlers: &std::sync::Mutex<HashMap<u32, OpaqueRequestHandlerFn>>,
     opaque_request_pending: &OpaqueRequestPendingMap,
-    response_transport: Option<&Arc<dyn Transport>>,
+    // Phase 2 — typed ephemeral request→response correlation map
+    // (mirrors `opaque_request_pending`; resolved with raw body bytes).
+    ephemeral_response_pending: &EphemeralResponsePendingMap,
+    // The FULL configured transport set — the reply legs (opaque
+    // responder, typed-reply leg) prefer the transport the request
+    // ARRIVED on and fall back to the first configured one, so a
+    // request arriving on transport #2 is no longer answered on #1.
+    transports: &[Arc<dyn Transport>],
     max_content_body_bytes: usize,
     directory: &Arc<dyn VerifyDirectory>,
     reachability: Option<&Arc<ReachabilityTracker>>,
@@ -4836,6 +5036,10 @@ async fn dispatch_inbound(
 ) {
     let received_at = frame.received_at;
     let transport = frame.transport;
+    // Reply-path transport affinity — answer on the medium the request
+    // arrived on when it is configured; fall back to the first
+    // configured transport (the historical behavior).
+    let response_transport = select_reply_transport(transports, transport);
     // CIRISEdge#499 — the receive-side ADMISSION FACT, resolved by the transport
     // ahead of any parse (see `InboundFrame::arrival_scope`). Captured here, at
     // the top, so every serve gate below reads the same value and none of them
@@ -5731,7 +5935,15 @@ async fn dispatch_inbound(
     // outbound row; dropping" arm swallows every OpaqueResponse before
     // it reaches its correlation — breaking `send_opaque_request`'s
     // round-trip (the #240 mesh-control-plane response leg).
-    if envelope.message_type != MessageType::OpaqueResponse {
+    //
+    // Phase 2 — EXCLUDE `EphemeralResponse` for the exact same reason:
+    // its `in_reply_to` is the typed request→response correlation
+    // token, and without this guard the ACK matcher would swallow
+    // every typed reply before it reached its pending `Edge::send`.
+    if !matches!(
+        envelope.message_type,
+        MessageType::OpaqueResponse | MessageType::EphemeralResponse
+    ) {
         if let Some(in_reply_to) = envelope.in_reply_to {
             match queue.match_ack_to_outbound(&in_reply_to).await {
                 Ok(Some(row)) => {
@@ -5921,10 +6133,28 @@ async fn dispatch_inbound(
                     if let Some(tx) = tx {
                         let _ = tx.send(resp);
                     } else {
-                        tracing::debug!(
-                            transport = ?transport,
-                            "OpaqueResponse with no matching pending request (late/duplicate)",
-                        );
+                        // Phase 2 fallback — a typed
+                        // `Edge::send::<OpaqueRequest>` registers in
+                        // the TYPED pending map, not the opaque one,
+                        // but the responder still answers with an
+                        // `OpaqueResponse` envelope (it cannot know
+                        // which surface dialed). Resolve the typed
+                        // waiter with the raw body bytes; the waiter
+                        // deserializes to `OpaqueRequest::Response`.
+                        let typed_tx = {
+                            let mut pending = ephemeral_response_pending
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            pending.remove(&correlation)
+                        };
+                        if let Some(typed_tx) = typed_tx {
+                            let _ = typed_tx.send(envelope.body.get().as_bytes().to_vec());
+                        } else {
+                            tracing::debug!(
+                                transport = ?transport,
+                                "OpaqueResponse with no matching pending request (late/duplicate)",
+                            );
+                        }
                     }
                 } else {
                     tracing::warn!(
@@ -5940,6 +6170,42 @@ async fn dispatch_inbound(
                     "OpaqueResponse body parse failed at dispatch",
                 );
             }
+        }
+    }
+
+    // Phase 2 — `EphemeralResponse` → correlate back to the pending
+    // typed `Edge::send::<M>` via the envelope `in_reply_to` (the
+    // request's body_sha256). Mirrors the OpaqueResponse arm above;
+    // resolves with the RAW body bytes because the waiter knows
+    // `M::Response` statically and deserializes on its side — edge
+    // holds no typed struct for the payload (MISSION §1.3). Every
+    // non-resolving case is logged: a missing token is a protocol
+    // fault (warn), a missing waiter is late/duplicate/timed-out
+    // traffic (debug).
+    if envelope.message_type == MessageType::EphemeralResponse {
+        if let Some(correlation) = envelope.in_reply_to {
+            let tx = {
+                let mut pending = ephemeral_response_pending
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                pending.remove(&correlation)
+            };
+            if let Some(tx) = tx {
+                let _ = tx.send(envelope.body.get().as_bytes().to_vec());
+            } else {
+                tracing::debug!(
+                    transport = ?transport,
+                    sender_key_id = %envelope.signing_key_id,
+                    "EphemeralResponse with no matching pending request \
+                     (late / duplicate / already timed out)",
+                );
+            }
+        } else {
+            tracing::warn!(
+                transport = ?transport,
+                sender_key_id = %envelope.signing_key_id,
+                "EphemeralResponse missing in_reply_to correlation token",
+            );
         }
     }
 
@@ -6143,22 +6409,52 @@ async fn dispatch_inbound(
         }
     }
 
+    // CIRISEdge#21 `prefer_chunked` — the hint is ADVISORY AND
+    // CURRENTLY IGNORED (edge-core ships no chunked ContentFetch
+    // responder; chunked transfer rides the BlobChunk* swarm plane).
+    // Log at debug when a requester sets it so the ignored preference
+    // is observable rather than silently dead.
+    if envelope.message_type == MessageType::ContentFetch {
+        if let Ok(fetch) =
+            serde_json::from_str::<crate::messages::ContentFetch>(envelope.body.get())
+        {
+            if fetch
+                .response_hint
+                .as_ref()
+                .is_some_and(|h| h.prefer_chunked)
+            {
+                tracing::debug!(
+                    sender_key_id = %envelope.signing_key_id,
+                    sha256 = %hex::encode(&fetch.sha256[..8]),
+                    "ContentFetch prefer_chunked hint set — advisory and ignored: \
+                     responders always answer whole-file ContentBody (chunked \
+                     transfer rides the BlobChunkFetch/BlobChunkBody plane)",
+                );
+            }
+        }
+    }
+
     // Application handler dispatch.
     let registered = {
         let handlers = handlers.lock().await;
         handlers
             .get(&envelope.message_type)
-            .map(|h| h.erased.clone())
+            .map(|h| (h.erased.clone(), h.sends_typed_reply))
     };
-    let Some(erased) = registered else {
+    let Some((erased, sends_typed_reply)) = registered else {
         // The CC 0.7 opaque wire types are dispatched above (subscriber
         // fan-out for OpaqueEvent, kind-keyed handler + 501 for
-        // OpaqueRequest, correlation for OpaqueResponse) — a missing
-        // typed `Handler<M>` entry for them is expected, not an error.
-        // Suppress the `no handler registered` warning for those.
+        // OpaqueRequest, correlation for OpaqueResponse), and the
+        // Phase-2 EphemeralResponse is consumed by its correlation arm
+        // — a missing typed `Handler<M>` entry for them is expected,
+        // not an error. Suppress the `no handler registered` warning
+        // for those.
         if !matches!(
             envelope.message_type,
-            MessageType::OpaqueEvent | MessageType::OpaqueRequest | MessageType::OpaqueResponse
+            MessageType::OpaqueEvent
+                | MessageType::OpaqueRequest
+                | MessageType::OpaqueResponse
+                | MessageType::EphemeralResponse
         ) {
             tracing::warn!(
                 message_type = ?envelope.message_type,
@@ -6177,13 +6473,32 @@ async fn dispatch_inbound(
     };
 
     match (erased)(&envelope, ctx).await {
-        Ok(_response_bytes) => {
-            // Phase 1: response bytes are computed but not wired back
-            // through the transport's response channel. Lens cutover
-            // doesn't need outbound responses (lens always receives,
-            // never replies). When Phase 2 wires register_handler
-            // responses through the transport, this is where the
-            // response envelope assembles + signs + ships back.
+        Ok(response_bytes) => {
+            // Phase 2 — a typed `Handler<M>` whose `M::Response` is a
+            // real struct (and `M` rides the Ephemeral class) answers
+            // the sender through a correlated `EphemeralResponse`
+            // envelope, mirroring the OpaqueResponse responder leg.
+            // `()` responses stay fire-and-forget: no reply envelope
+            // (serialized `()` is `null`, and the sender never awaits
+            // one).
+            if sends_typed_reply {
+                if let Some(reply_transport) = response_transport {
+                    ship_typed_ephemeral_reply(
+                        reply_transport,
+                        signer,
+                        &envelope.signing_key_id,
+                        body_sha256,
+                        response_bytes,
+                    )
+                    .await;
+                } else {
+                    tracing::warn!(
+                        message_type = ?envelope.message_type,
+                        "typed handler produced a response but no transport is \
+                         configured to ship it back",
+                    );
+                }
+            }
         }
         Err(e) => {
             tracing::error!(
@@ -6191,6 +6506,71 @@ async fn dispatch_inbound(
                 error = %e,
                 "handler error",
             );
+        }
+    }
+}
+
+/// Phase 2 — build + sign + ship the correlated
+/// [`MessageType::EphemeralResponse`] envelope carrying a typed
+/// handler's serialized `M::Response` back to the requester. Mirrors
+/// the OpaqueResponse responder leg at the OpaqueRequest dispatch arm;
+/// every failure path is loud (no silent drops, MISSION §6
+/// anti-pattern 7).
+async fn ship_typed_ephemeral_reply(
+    transport: &Arc<dyn Transport>,
+    signer: &Arc<LocalSigner>,
+    requester_key_id: &str,
+    request_body_sha256: [u8; 32],
+    response_bytes: Vec<u8>,
+) {
+    // The erased handler serialized `M::Response` with serde_json, so
+    // the bytes are UTF-8 JSON; wrap them as a RawValue body without
+    // re-interpreting (edge holds no typed struct for the payload).
+    let body_json = match String::from_utf8(response_bytes) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(error = %e, "typed reply: response bytes are not UTF-8 JSON");
+            return;
+        }
+    };
+    let raw = match serde_json::value::RawValue::from_string(body_json) {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(error = %e, "typed reply: response bytes are not valid JSON");
+            return;
+        }
+    };
+    match build_envelope(
+        MessageType::EphemeralResponse,
+        &signer.key_id,
+        requester_key_id,
+        &raw,
+        Some(request_body_sha256),
+    ) {
+        Ok(mut resp_env) => {
+            if let Err(e) = sign_envelope(signer, &mut resp_env).await {
+                tracing::warn!(error = %e, "typed reply: EphemeralResponse sign failed");
+            } else {
+                match serde_json::to_vec(&resp_env) {
+                    Ok(bytes) => {
+                        if let Err(e) = transport.send(requester_key_id, &bytes).await {
+                            tracing::warn!(
+                                error = %e,
+                                "typed reply: EphemeralResponse transport send failed",
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            "typed reply: EphemeralResponse serialize failed",
+                        );
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, "typed reply: EphemeralResponse envelope build failed");
         }
     }
 }
@@ -6726,6 +7106,7 @@ impl EdgeBuilder {
             opaque_next_id: Arc::new(AtomicU64::new(1)),
             opaque_handlers: Arc::new(std::sync::Mutex::new(HashMap::new())),
             opaque_request_pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
+            ephemeral_response_pending: Arc::new(std::sync::Mutex::new(HashMap::new())),
             verified_envelope_tx,
             content_fetch_pending,
             blob_chunk_fetch_pending,
@@ -6906,6 +7287,41 @@ fn transport_error_class(e: &TransportError) -> &'static str {
         // addressing/rooting fault the belt heals on the next verified announce.
         TransportError::NoRouteToPeer { .. } => "no_route_to_peer",
     }
+}
+
+/// Compile-time-declared delivery-class gate for `Edge::send` — the
+/// runtime check rejecting a non-`Ephemeral` `Message` on the
+/// ephemeral entry point with a typed
+/// [`EdgeError::DeliveryClassMismatch`].
+fn ensure_ephemeral_class<M: Message>() -> Result<(), EdgeError> {
+    if matches!(M::DELIVERY, Delivery::Ephemeral) {
+        return Ok(());
+    }
+    let declared = match M::DELIVERY {
+        Delivery::Ephemeral => "Ephemeral",
+        Delivery::Durable { .. } => "Durable",
+        Delivery::Federation { .. } => "Federation",
+        Delivery::Mandatory { .. } => "Mandatory",
+    };
+    Err(EdgeError::DeliveryClassMismatch(
+        M::TYPE,
+        declared,
+        "Ephemeral",
+    ))
+}
+
+/// Phase 2 — `()`-response detection for the typed ephemeral send.
+///
+/// Rust lacks stable specialization, so the mechanism is a `TypeId`
+/// check through `Any::downcast` (`M::Response: 'static` is already a
+/// [`Message`] trait bound): zero-touch on the ~30 existing `Message`
+/// impls, no new trait item, and the compiler folds it to a constant
+/// comparison. Returns `Some(resp)` iff `M::Response` IS `()` — the
+/// fire-and-forget marker — so the caller can return it directly on
+/// transport `Delivered` without registering a correlation waiter.
+fn unit_response<M: Message>() -> Option<M::Response> {
+    let unit: Box<dyn std::any::Any> = Box::new(());
+    unit.downcast::<M::Response>().ok().map(|b| *b)
 }
 
 fn message_type_str(mt: &MessageType) -> String {
@@ -8486,7 +8902,7 @@ mod inbound_ingest_tests {
     }
 
     proptest! {
-        /// CIRISEdge#402 — the carve-out decision, EXHAUSTIVELY over ALL 14 kinds
+        /// CIRISEdge#402 — the carve-out decision, EXHAUSTIVELY over ALL 15 kinds
         /// × link presence × arbitrary link ids. The security invariant, stated
         /// as one equation: a routing source is produced IFF the frame's kind is
         /// a self-authenticating bootstrap kind (`is_bootstrap`) AND the link
@@ -8650,6 +9066,236 @@ mod inbound_ingest_tests {
         assert!(
             std::sync::Arc::ptr_eq(&cell.get().expect("still installed"), &second),
             "same-object re-install is a no-op"
+        );
+    }
+}
+
+/// Phase 2 — the typed ephemeral request→response correlation loop
+/// (the closure of the v0.8.0 "correlation not wired" carve-out).
+/// Field-provenance discipline: these drive the REAL `Edge::send`
+/// entry point over a real builder (keyring seed + sqlite directory),
+/// with only the transport mocked — the exact seam production varies.
+#[cfg(test)]
+mod ephemeral_correlation_tests {
+    use super::*;
+    use crate::transport::NullTransport;
+
+    async fn build_edge(
+        key_id: &str,
+        transport: Arc<dyn Transport>,
+        timeout_ms: u64,
+    ) -> (Arc<Edge>, tempfile::TempDir) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let seeds = tmp.path().join("seeds");
+        std::fs::create_dir_all(&seeds).expect("seed dir");
+        let mut seed = [0u8; 32];
+        for (i, b) in seed.iter_mut().enumerate() {
+            *b = u8::try_from(i).expect("in range") ^ 0xa5;
+        }
+        std::fs::write(seeds.join("ed25519.seed"), seed).expect("write seed");
+        let edge =
+            EdgeBuilder::from_keyring_seed_dir(key_id, seeds, tmp.path().join("edge.sqlite"))
+                .await
+                .expect("builder")
+                .transport(transport)
+                .config(EdgeConfig {
+                    ephemeral_response_timeout_ms: timeout_ms,
+                    cohort_scope_enforcement: CohortScopeEnforcement::Off,
+                    ..EdgeConfig::default()
+                })
+                .build()
+                .expect("build edge");
+        (Arc::new(edge), tmp)
+    }
+
+    /// The `()`-response mechanism itself: `unit_response` detects
+    /// exactly the fire-and-forget marker, never a real response type.
+    #[test]
+    fn unit_response_detects_only_unit() {
+        assert!(
+            unit_response::<crate::messages::ContentFetch>().is_some(),
+            "ContentFetch declares Response = ()",
+        );
+        assert!(
+            unit_response::<crate::messages::OpaqueRequest>().is_none(),
+            "OpaqueRequest declares Response = OpaqueResponse",
+        );
+    }
+
+    /// THE bug this wave fixes: a `type Response = ()` send returned
+    /// `Err(Config("…not wired…"))` ON THE SUCCESS PATH, after the
+    /// bytes were signed, shipped, and counted. Delivered → `Ok(())`.
+    #[tokio::test]
+    async fn unit_response_send_returns_ok_on_delivered() {
+        let (edge, _tmp) = build_edge("edge-unit-send", Arc::new(NullTransport), 30_000).await;
+        let fetch = crate::messages::ContentFetch {
+            sha256: [7u8; 32],
+            response_hint: None,
+        };
+        edge.send("peer-x", fetch).await.expect(
+            "type Response = () must return Ok(()) on transport Delivered — \
+             the Phase-1 'correlation not wired' Config error is gone",
+        );
+        assert_eq!(
+            edge.pending_ephemeral_len_for_test(),
+            0,
+            "fire-and-forget registers no correlation waiter",
+        );
+    }
+
+    /// A transport whose `send` resolves the correlated response
+    /// BEFORE returning `Delivered`. Pins insert-before-send: were the
+    /// waiter registered after the send, the response would find no
+    /// entry and the call would hang to timeout (the
+    /// response-beats-waiter race).
+    struct RespondBeforeReturn {
+        edge: Arc<std::sync::OnceLock<Arc<Edge>>>,
+        resolved_while_in_send: Arc<std::sync::atomic::AtomicBool>,
+    }
+
+    #[async_trait::async_trait]
+    impl Transport for RespondBeforeReturn {
+        fn id(&self) -> crate::transport::TransportId {
+            crate::transport::TransportId("race-mock")
+        }
+        async fn send(
+            &self,
+            _destination_key_id: &str,
+            envelope_bytes: &[u8],
+        ) -> Result<TransportSendOutcome, crate::TransportError> {
+            let envelope: EdgeEnvelope =
+                serde_json::from_slice(envelope_bytes).expect("parse own request envelope");
+            let correlation = envelope_body_sha256(&envelope);
+            let edge = self.edge.get().expect("edge installed").clone();
+            let response = crate::messages::OpaqueResponse {
+                kind: 9,
+                status: 200,
+                payload: b"pong".to_vec(),
+            };
+            let resolved = edge.complete_pending_ephemeral_for_test(
+                correlation,
+                serde_json::to_vec(&response).expect("serialize response"),
+            );
+            self.resolved_while_in_send
+                .store(resolved, std::sync::atomic::Ordering::SeqCst);
+            Ok(TransportSendOutcome::Delivered)
+        }
+        async fn listen(
+            &self,
+            _sink: mpsc::Sender<InboundFrame>,
+        ) -> Result<(), crate::TransportError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn response_beating_send_return_is_not_lost() {
+        let edge_cell: Arc<std::sync::OnceLock<Arc<Edge>>> = Arc::new(std::sync::OnceLock::new());
+        let resolved_flag = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let transport = Arc::new(RespondBeforeReturn {
+            edge: edge_cell.clone(),
+            resolved_while_in_send: resolved_flag.clone(),
+        });
+        // 2 s timeout: a regression (insert-after-send) fails FAST as a
+        // timeout instead of stalling the suite for the default 30 s.
+        let (edge, _tmp) = build_edge("edge-race-send", transport, 2_000).await;
+        edge_cell.set(edge.clone()).ok().expect("install edge once");
+
+        let resp = edge
+            .send(
+                "peer-x",
+                crate::messages::OpaqueRequest {
+                    kind: 9,
+                    payload: b"ping".to_vec(),
+                },
+            )
+            .await
+            .expect("response resolved during transport.send must still be returned");
+        assert_eq!(resp.status, 200);
+        assert_eq!(resp.payload, b"pong".to_vec());
+        assert!(
+            resolved_flag.load(std::sync::atomic::Ordering::SeqCst),
+            "the waiter must already be registered when transport.send runs \
+             (insert-before-send)",
+        );
+        assert_eq!(edge.pending_ephemeral_len_for_test(), 0, "waiter consumed");
+    }
+
+    /// No responder → the awaited reply times out, surfaces as
+    /// `Unreachable`, and the pending entry is retired (no leak).
+    #[tokio::test]
+    async fn typed_send_timeout_removes_pending_waiter() {
+        let (edge, _tmp) = build_edge("edge-timeout-send", Arc::new(NullTransport), 100).await;
+        let err = edge
+            .send(
+                "peer-x",
+                crate::messages::OpaqueRequest {
+                    kind: 3,
+                    payload: b"never answered".to_vec(),
+                },
+            )
+            .await
+            .expect_err("no responder → timeout");
+        assert!(
+            matches!(err, EdgeError::Unreachable(_)),
+            "timeout surfaces as Unreachable, got {err:?}",
+        );
+        assert_eq!(
+            edge.pending_ephemeral_len_for_test(),
+            0,
+            "the timeout exit must retire the pending waiter",
+        );
+    }
+
+    /// Reply-path transport affinity: the reply ships on the medium
+    /// the request arrived on; an unknown arrival falls back to the
+    /// first configured transport; no transports → None.
+    struct IdOnly(crate::transport::TransportId);
+
+    #[async_trait::async_trait]
+    impl Transport for IdOnly {
+        fn id(&self) -> crate::transport::TransportId {
+            self.0
+        }
+        async fn send(
+            &self,
+            _d: &str,
+            _b: &[u8],
+        ) -> Result<TransportSendOutcome, crate::TransportError> {
+            Ok(TransportSendOutcome::Delivered)
+        }
+        async fn listen(
+            &self,
+            _s: mpsc::Sender<InboundFrame>,
+        ) -> Result<(), crate::TransportError> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn reply_transport_prefers_arrival_medium() {
+        use crate::transport::TransportId;
+        let transports: Vec<Arc<dyn Transport>> = vec![
+            Arc::new(IdOnly(TransportId("medium-a"))),
+            Arc::new(IdOnly(TransportId("medium-b"))),
+        ];
+        let picked = select_reply_transport(&transports, TransportId("medium-b"))
+            .expect("configured set is non-empty");
+        assert_eq!(
+            picked.id(),
+            TransportId("medium-b"),
+            "a request arriving on medium-b is answered on medium-b, not transports[0]",
+        );
+        let fallback = select_reply_transport(&transports, TransportId("medium-zzz"))
+            .expect("configured set is non-empty");
+        assert_eq!(
+            fallback.id(),
+            TransportId("medium-a"),
+            "unknown arrival medium falls back to the first configured transport",
+        );
+        assert!(
+            select_reply_transport(&[], TransportId("medium-a")).is_none(),
+            "no transports configured → nothing to reply on",
         );
     }
 }

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1784,9 +1784,14 @@ impl Edge {
                 "resolve_peer_kex_pubkeys({occurrence_key_id}): ml-kem-768 base64 decode: {e}"
             ))
         })?;
+        // CIRISEdge#481 item 4 — `PeerKexPubkeys.mlkem768_pub` is required;
+        // this construction proves presence because persist's
+        // `EncryptionPubkeys.ml_kem_768_base64` is itself a required field
+        // (a row without it doesn't deserialize) and the decode above
+        // already failed loudly on malformed bytes.
         Ok(Some(crate::transport::federation_session::PeerKexPubkeys {
             x25519_pub,
-            mlkem768_pub: Some(mlkem768_pub),
+            mlkem768_pub,
         }))
     }
 

--- a/src/family_gates.rs
+++ b/src/family_gates.rs
@@ -288,10 +288,15 @@ mod tests {
     /// mutation-verified unit with no callers is a green board over a dead
     /// protection, and it is the exact trap this repo keeps hitting.
     ///
-    /// So this asserts through the CALL SITES instead: the two public
-    /// predicates the serve path actually consults must agree with
-    /// `gates_for`, including on the unknown case. Re-inlining a `matches!`
-    /// at either site reds this.
+    /// So this asserts through the CALL SITES instead: the predicates that
+    /// consult this fold must agree with `gates_for`, including on the
+    /// unknown case. Re-inlining a `matches!` at a site reds this.
+    ///
+    /// NB (CIRISEdge#505 / v37.1.0): `dimension_half_is_gated` is no longer
+    /// the accord CARRIAGE pre-filter — that is persist's `is_accord_family`,
+    /// over BOTH namespaces, consumed by the bridge's `attestation_is_accord`
+    /// (source-asserted there). What this pins is the accord HALF of the fold
+    /// itself, so the wiring cannot drift while it still has readers.
     #[test]
     fn the_serve_paths_predicates_read_this_module_and_not_a_local_matches() {
         use crate::replication::accord_relay_gate::AccordRelayGate;
@@ -305,9 +310,9 @@ mod tests {
         ] {
             let expected = gates_for(dimension);
             assert_eq!(
-                AccordRelayGate::dimension_is_gated(dimension),
+                AccordRelayGate::dimension_half_is_gated(dimension),
                 expected.accord_relay_gated,
-                "the relay gate's pre-filter must read gates_for for {dimension:?} \
+                "the dimension half-test must read gates_for for {dimension:?} \
                  — an inline matches! returns false on an unknown family and CARRIES it",
             );
         }

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -1455,9 +1455,10 @@ impl PyEdge {
         };
         let dict = pyo3::types::PyDict::new(py);
         dict.set_item("x25519_pub_base64", b64.encode(kex.x25519_pub))?;
-        if let Some(mlkem) = kex.mlkem768_pub {
-            dict.set_item("ml_kem_768_pub_base64", b64.encode(mlkem))?;
-        }
+        // CIRISEdge#481 item 4 — `mlkem768_pub` is a required field, so
+        // the dict ALWAYS carries both halves (as the docstring above
+        // has promised since v2.4.0).
+        dict.set_item("ml_kem_768_pub_base64", b64.encode(kex.mlkem768_pub))?;
         Ok(Some(dict))
     }
 
@@ -6508,6 +6509,10 @@ fn seal_av_outer(
 /// remains as an explicit HNDL-strict marker for realtime A/V + key_grant DEK
 /// distribution. `"classical"` is REJECTED with `PyValueError` — the classical
 /// X25519-only KEX is retired (there is no negotiable quantum-vulnerable path).
+/// `peer_mlkem768_pub=None` is likewise REJECTED with `PyValueError` at
+/// `PeerKexPubkeys` construction (#481 item 4 — the ML-KEM-less peer is
+/// unrepresentable; the parameter stays `Option` only so the downgrade attempt
+/// parses to a typed, logged refusal instead of a `TypeError`).
 ///
 /// Returns `(handshake_msg_json_bytes, session_key, negotiated_algorithm_wire_id)`.
 /// The handshake JSON round-trips through
@@ -6524,10 +6529,12 @@ fn federation_session_initiate(
         FederationSession, KexAlgorithm, PeerKexPubkeys, SessionHandshakeMsg,
     };
     let x_pub = fixed_bytes::<32>("peer_x25519_pub", peer_x25519_pub)?;
-    let peer = PeerKexPubkeys {
-        x25519_pub: x_pub,
-        mlkem768_pub: peer_mlkem768_pub.map(<[u8]>::to_vec),
-    };
+    // CIRISEdge#481 item 4 — the ML-KEM-less peer is unrepresentable by
+    // `PeerKexPubkeys`; a Python `None` is refused HERE, at construction,
+    // with the typed `HybridRequiredButPeerLacksMlkem` (surfaced as
+    // `ValueError`, the same class the retired-"classical" refusal uses).
+    let peer = PeerKexPubkeys::from_advertisement(x_pub, peer_mlkem768_pub.map(<[u8]>::to_vec))
+        .map_err(|e| PyValueError::new_err(format!("peer_mlkem768_pub: {e}")))?;
     let requested = match algorithm {
         "hybrid" => KexAlgorithm::Hybrid,
         "hybrid-required" => KexAlgorithm::HybridRequired,
@@ -6905,9 +6912,11 @@ pub struct PyAvSession {
 }
 
 /// Convert a Python member tuple (`key_id`, `x25519_pub`,
-/// `mlkem768_pub`) into the Rust [`Member`] shape, enforcing the HNDL
-/// pre-check (mlkem768_pub MUST be Some). Failing here surfaces
-/// `PyValueError` before the openmls layer is invoked.
+/// `mlkem768_pub`) into the Rust [`Member`] shape. The HNDL pre-check
+/// is structural (CIRISEdge#481 item 4): `PeerKexPubkeys` requires the
+/// ML-KEM-768 half, so a `None` is refused by
+/// `PeerKexPubkeys::from_advertisement` at construction and surfaces
+/// as `PyValueError` before the openmls layer is invoked.
 fn member_from_py(
     label: &str,
     key_id: String,
@@ -6917,17 +6926,15 @@ fn member_from_py(
     use crate::transport::federation_session::PeerKexPubkeys;
     use crate::transport::realtime_av_mls::Member;
     let x = fixed_bytes::<32>(&format!("{label}.x25519_pub"), x25519_pub)?;
-    let Some(mlkem) = mlkem768_pub else {
-        return Err(PyValueError::new_err(format!(
-            "{label}: ML-KEM-768 pubkey required by ciphersuite 0x004D (HNDL discipline) — peer {key_id}"
-        )));
-    };
+    let kex_pubkeys = PeerKexPubkeys::from_advertisement(x, mlkem768_pub.map(<[u8]>::to_vec))
+        .map_err(|e| {
+            PyValueError::new_err(format!(
+                "{label}: {e} — ciphersuite 0x004D requires ML-KEM-768; peer {key_id}"
+            ))
+        })?;
     Ok(Member {
         key_id,
-        kex_pubkeys: PeerKexPubkeys {
-            x25519_pub: x,
-            mlkem768_pub: Some(mlkem.to_vec()),
-        },
+        kex_pubkeys,
     })
 }
 

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2517,32 +2517,69 @@ impl PyEdge {
     }
 }
 
-/// Parse a wire-stable kind string into [`crate::replication::EnvelopeKind`].
-/// The token set is the 10 `#[serde(rename_all = "snake_case")]`
-/// variants per FSD §3.3.
+/// The comma-separated valid-token list for [`parse_envelope_kind`]'s error
+/// message — GENERATED from `EnvelopeKind::ALL`, so it names every accepted
+/// token (all 15) and can never go stale against the enum. (The hand-written
+/// predecessor listed 10 of 15 and omitted `accord_quorum_evidence` even
+/// after the parser accepted it.)
+fn envelope_kind_wire_tokens() -> String {
+    crate::replication::EnvelopeKind::ALL
+        .map(crate::replication::EnvelopeKind::as_wire_str)
+        .join(", ")
+}
+
+/// Parse a wire-stable kind string into [`crate::replication::EnvelopeKind`]
+/// — the exact inverse of `EnvelopeKind::as_wire_str`, TOTAL over
+/// `EnvelopeKind::ALL` by construction: the accepted set is derived from the
+/// enum (never a hand-copied match, which shipped accepting 11 of 15 kinds —
+/// the operator surface silently could not open the organization /
+/// org_membership / partner_record / transport_destination planes), and the
+/// error string is generated from the same source
+/// ([`envelope_kind_wire_tokens`]). A new variant is parseable the moment it
+/// joins `ALL`.
 fn parse_envelope_kind(s: &str) -> PyResult<crate::replication::EnvelopeKind> {
+    crate::replication::EnvelopeKind::ALL
+        .into_iter()
+        .find(|k| k.as_wire_str() == s)
+        .ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "unknown EnvelopeKind: {s:?} (valid: {})",
+                envelope_kind_wire_tokens()
+            ))
+        })
+}
+
+#[cfg(test)]
+mod parse_envelope_kind_tests {
+    use super::{envelope_kind_wire_tokens, parse_envelope_kind};
     use crate::replication::EnvelopeKind;
-    match s {
-        "key" => Ok(EnvelopeKind::Key),
-        "attestation" => Ok(EnvelopeKind::Attestation),
-        "revocation" => Ok(EnvelopeKind::Revocation),
-        "identity_occurrence" => Ok(EnvelopeKind::IdentityOccurrence),
-        "family" => Ok(EnvelopeKind::Family),
-        "community" => Ok(EnvelopeKind::Community),
-        "identity_occurrence_revocation" => Ok(EnvelopeKind::IdentityOccurrenceRevocation),
-        "family_membership_revocation" => Ok(EnvelopeKind::FamilyMembershipRevocation),
-        "community_membership_revocation" => Ok(EnvelopeKind::CommunityMembershipRevocation),
-        "location_proof" => Ok(EnvelopeKind::LocationProof),
-        // CIRISEdge#474 — activation surface for the accord-quorum-evidence cursor
-        // plane: without this an operator cannot register a
-        // `(peer, accord_quorum_evidence)` Initiator, so the plane never opens.
-        "accord_quorum_evidence" => Ok(EnvelopeKind::AccordQuorumEvidence),
-        other => Err(PyValueError::new_err(format!(
-            "unknown EnvelopeKind: {other:?} (valid: key, attestation, revocation, \
-             identity_occurrence, family, community, \
-             identity_occurrence_revocation, family_membership_revocation, \
-             community_membership_revocation, location_proof)"
-        ))),
+
+    /// `parse_envelope_kind` round-trips EVERY wire kind (`parse(as_wire_str(k))
+    /// == k` over `ALL` — a new variant is covered the moment it exists), and
+    /// the error's valid-token list names all 15 (generated, not hand-kept).
+    #[test]
+    fn parse_envelope_kind_round_trips_every_wire_kind() {
+        for kind in EnvelopeKind::ALL {
+            let parsed = parse_envelope_kind(kind.as_wire_str())
+                .unwrap_or_else(|_| panic!("{kind:?}: every ALL token must parse"));
+            assert_eq!(parsed, kind, "{kind:?}: parse must invert as_wire_str");
+        }
+        assert!(
+            parse_envelope_kind("hostile_takeover").is_err(),
+            "unknown tokens refuse"
+        );
+        let tokens = envelope_kind_wire_tokens();
+        for kind in EnvelopeKind::ALL {
+            assert!(
+                tokens.contains(kind.as_wire_str()),
+                "the error's valid list must name {kind:?}"
+            );
+        }
+        assert_eq!(
+            tokens.matches(", ").count(),
+            EnvelopeKind::ALL.len() - 1,
+            "exactly one token per kind"
+        );
     }
 }
 

--- a/src/ffi/uniffi_impl_routing.rs
+++ b/src/ffi/uniffi_impl_routing.rs
@@ -221,11 +221,21 @@ pub fn routing_blackhole_remove(identity_hash: Vec<u8>) -> Result<(), crate::Edg
 /// NULL`) are NEVER pruned — operators must call
 /// `routing_blackhole_remove` to drop them.
 ///
-/// TODO (deferred from v0.16.1): wire a background pruner task at
-/// `init_edge_runtime` time, configurable via
-/// `EdgeConfig::blackhole_prune_interval_seconds` (default 3600).
-/// Until that lands, operators are expected to call this from the
-/// host's housekeeping loop on whatever cadence they prefer.
+/// Expired-rule reclamation runs on three complementary paths:
+///
+/// 1. OPPORTUNISTIC — the transport's send-path deny-list consult
+///    removes an expired rule the moment it is consulted (amortized,
+///    no background task; `consult_and_prune_blackhole` in
+///    `transport::reticulum`). An expired rule on a hot dial path can
+///    no longer accrete unboundedly.
+/// 2. BACKGROUND — `Edge::run` spawns a pruner loop at
+///    `EdgeConfig::blackhole_prune_interval_seconds` cadence (v0.18.0;
+///    0 disables, and the spawn is skipped when no
+///    `Arc<dyn BlackholeRules>` backend is wired). Sweeps rules for
+///    identities that are never dialed.
+/// 3. MANUAL — this FFI call, for hosts whose runtime shape does not
+///    drive `Edge::run`'s task graph, or for on-demand cleanup right
+///    after editing the deny-list.
 pub fn routing_blackhole_prune_expired() -> Result<u64, crate::EdgeBindingsError> {
     #[cfg(feature = "_reticulum-module")]
     {

--- a/src/holonomic/fountain_defaults.rs
+++ b/src/holonomic/fountain_defaults.rs
@@ -151,6 +151,11 @@ pub const DEFAULT_MIN_VIABLE_SYMBOLS: u32 = 5;
 /// floor. At R = 30 the exact survival floor is
 /// [`recommended_reconstruction_probability`] — see the module-level
 /// table.
+///
+/// SINGLE AUTHORITY: `crate::swarm::runtime::DEFAULT_TARGET_HOLDERS`
+/// re-exports this const (the converger drives holder count toward
+/// THIS target; the survival table above is computed at it, so the
+/// two planes must move together).
 pub const DEFAULT_TARGET_HOLDERS: u32 = 30;
 
 /// The recommended fountain replication policy bundled as one

--- a/src/holonomic/wholeness_witness.rs
+++ b/src/holonomic/wholeness_witness.rs
@@ -125,7 +125,13 @@ pub const WW2_ANONYMOUS_NAMESPACE_PREFIX: &str = "anonymous";
 
 /// §19.1 WW-2 — cohort scope whose leaves are filtered out before
 /// Merkle construction (self-private content).
-pub const WW2_SELF_COHORT_SCOPE: &str = "self";
+///
+/// Routed through the single `"self"`-token authority
+/// [`crate::cohort_scope::SELF_SCOPE_TOKEN`] (which itself routes
+/// through persist's lattice const) — the WW2 filter compares this
+/// against the wire scope token, and a re-typed literal drifting here
+/// would silently PUBLISH self-scoped leaves into the Merkle witness.
+pub const WW2_SELF_COHORT_SCOPE: &str = crate::cohort_scope::SELF_SCOPE_TOKEN;
 
 /// Failure to canonicalize a witness. The error is rare in practice
 /// (serde_json over a fixed-shape struct), but propagating it lets

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -42,6 +42,15 @@ pub struct LocalSigner {
     pub classical: Arc<dyn HardwareSigner>,
     /// `None` during hybrid-pending bootstrap; `Some` once the
     /// `pqc_completed_at` row is filled in.
+    ///
+    /// DELIBERATELY still `Option` (CIRISEdge#481 item 5): the #458
+    /// refusal-path tests need classical-only signers to exist as
+    /// fixture witnesses, and every seam already refuses the degraded
+    /// state at runtime (persist #620 keystore "no classical-only
+    /// paths", edge init hard-refusal, the #458 emit refusal). Making
+    /// this required would delete the witnesses those refusal tests
+    /// exercise, not close a gap — unlike `PeerKexPubkeys.mlkem768_pub`
+    /// (#481 item 4), where the absent state had no legitimate owner.
     pub pqc: Option<Arc<dyn PqcSigner>>,
     /// CIRISEdge#31 — ratchet identifier surfaced via
     /// `current_ratchet_id`. Generated once at construction (the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -255,12 +255,17 @@ mod yubico_attestation_root_hash_tests {
 pub const PERSIST_NAMESPACE_MANIFEST_VERSION: &str = "0.3.0";
 
 /// Pinned SHA-256 of persist's closed **transform algebra** (CIRISPersist#519,
-/// `transform::TRANSFORM_ALGEBRA_HASH`). Edge applies the per-family declared
-/// transforms (`strip_field` + shape ops) at the serve/projection path from the
-/// manifest, never a hand-rolled op list (CIRISEdge#411 §3). Pinning the algebra
-/// hash makes a persist change to the op vocabulary — a new strip, a changed
-/// shape op — a BUILD failure at edge first, forcing a deliberate re-review of
-/// edge's serve-time transform application before the wire behavior can drift.
+/// `transform::TRANSFORM_ALGEBRA_HASH`). Edge does NOT apply `strip_field` at
+/// the serve path — serve-time stripping is unsound on edge's content-addressed
+/// signed wire (the recipient fetches by content-hash and re-verifies the hybrid
+/// signature, so a strip breaks both; #397). The strip is a persist
+/// PROMOTION-side transform (`promote_attestation_with_transforms`); at edge's
+/// serve layer `StripField` deliberately resolves to a no-op
+/// (`bridge.rs` `recipient_capability` collection) and the deferral is accounted
+/// for in `field_conformance::DEFERRED_PENDING_PLANE`. Pinning the algebra hash
+/// makes a persist change to the op vocabulary — a new strip, a changed shape
+/// op — a BUILD failure at edge first, forcing a deliberate re-review of that
+/// no-op boundary before the wire behavior can drift.
 pub const PERSIST_TRANSFORM_ALGEBRA_HASH: &str =
     "b7bd779468f4ad1ab551a5fd2dc0392df01e6f2e0ed393f924a806ed49686b4b";
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@ mod replication_policy_hash_tests {
 /// CIRISEdge#397 / persist v21.2.0 (CIRISPersist#510 P1) — the closed consent
 /// grammar's cross-repo drift witness. persist validates every
 /// `consent:replication:v1` grant against an exhaustive, fail-closed grammar
-/// (the 14 kinds, `strip_field` signed-post-transform) and exports it as
+/// (the 15 kinds, `strip_field` signed-post-transform) and exports it as
 /// [`ciris_persist::federation::consent_grammar::CONSENT_GRAMMAR_HASH`]. Edge
 /// pins it now so that when edge later implements serve-side
 /// `recipient_capability` enforcement (#396 item 6), the op vocabulary is drawn

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -61,6 +61,18 @@ pub enum MessageType {
     /// on receipt (the generic successor of the ripped inline-text
     /// subscriber pattern). No `Response`.
     OpaqueEvent,
+    /// Phase 2 typed ephemeral response — the closure of the v0.8.0
+    /// "ephemeral request-response correlation not wired" carve-out.
+    /// Body: the serialized `M::Response` of the requesting [`Message`]
+    /// impl — deliberately NOT a per-type discriminator: the requester
+    /// knows `M::Response` statically and deserializes; edge never
+    /// interprets the payload (MISSION §1.3). Correlated back to the
+    /// pending `Edge::send::<M>` via the envelope `in_reply_to` (the
+    /// request envelope's `body_sha256` — the same loop as
+    /// [`Self::OpaqueResponse`]). Excluded from the durable-ACK matcher
+    /// exactly like `OpaqueResponse`: its `in_reply_to` is
+    /// request/response correlation, not a durable-send ACK.
+    EphemeralResponse,
     /// Build-manifest publication primitive → registry. Durable.
     BuildManifestPublication,
     /// Data-subject access request — DSAR chain. Durable, requires_ack.
@@ -1525,10 +1537,15 @@ pub struct HintShape {
     /// if the held body exceeds this hint.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_body_bytes: Option<u64>,
-    /// If `true`, the requester prefers a chunked response (Phase 2
-    /// `ContentChunk`). Phase 1 responders ignore this — they always
-    /// answer with whole-file [`ContentBody`]. The field exists so
-    /// Phase 2 receivers can branch without a wire break.
+    /// If `true`, the requester prefers a chunked response. **Advisory
+    /// and currently IGNORED** — edge-core ships no chunked
+    /// `ContentFetch` responder: responders always answer with a
+    /// whole-file [`ContentBody`] (chunked transfer rides the separate
+    /// `BlobChunkFetch` / `BlobChunkBody` swarm plane, CIRISEdge#55).
+    /// The receive-side dispatcher logs at `debug` when the flag is
+    /// set so the ignored preference is observable rather than
+    /// silently dead. The field exists so a future chunked responder
+    /// can branch without a wire break.
     #[serde(default)]
     pub prefer_chunked: bool,
 }

--- a/src/mls/cohort_group.rs
+++ b/src/mls/cohort_group.rs
@@ -125,15 +125,19 @@ use super::scope_state::{ScopeStateProvider, ScopeStateProviderError};
 /// public field is the whole reason the snapshot approach works).
 type MemStorage = <LibcruxProvider as OpenMlsProvider>::StorageProvider;
 
-/// The MLS ciphersuite cohort groups are pinned to: `0x004D` —
+/// The MLS ciphersuite EVERY edge MLS group is pinned to: `0x004D` —
 /// X-Wing (ML-KEM-768 + X25519) | ChaCha20-Poly1305 | SHA-256 |
 /// Ed25519.
 ///
-/// Same pin as `transport::realtime_av_mls::CIPHERSUITE_ID`,
-/// duplicated rather than imported per the workstream file boundary.
-/// If one moves the other must move with it — a cohort group and an
-/// A/V group in the same deployment negotiating different suites
-/// would be a silent interop break.
+/// SINGLE AUTHORITY for the pin.
+/// `transport::realtime_av_mls::CIPHERSUITE_ID` RE-EXPORTS this
+/// constant (it was previously a duplicated literal, per a since-
+/// retired workstream file boundary). A divergence between the cohort
+/// plane and the A/V plane would be a SILENT PQC DOWNGRADE surface —
+/// 0x004D is the hybrid post-quantum suite, so the plane whose pin
+/// slipped to a classical suite would negotiate without ML-KEM cover
+/// and nothing would fail loudly. The two planes are therefore pinned
+/// by construction, not by comment.
 pub const CIPHERSUITE_ID: u16 = 0x004D;
 
 /// The openmls enum value [`CIPHERSUITE_ID`] maps to.

--- a/src/mls/welcome_wrap.rs
+++ b/src/mls/welcome_wrap.rs
@@ -147,7 +147,12 @@ pub struct FederationDirectoryEntry {
     pub ml_dsa_pk: Vec<u8>,
     /// Inviter's X-Wing public key (for outgoing wraps — unused
     /// during inbound verification but included for parity with the
-    /// substrate-tier directory).
+    /// substrate-tier directory). `Option` is deliberate (CIRISEdge#481
+    /// item 7): signature-only entries (governance/steward keys that
+    /// verify but never decrypt) legitimately lack it, and it is not a
+    /// KEX input — the wrap path takes its recipient key
+    /// (`invitee_pk`) as a required argument, and `PeerKexPubkeys`
+    /// (#481 item 4) cannot be constructed from an absent key.
     pub x_wing_pk: Option<XWingRecipientPublic>,
 }
 

--- a/src/outbound.rs
+++ b/src/outbound.rs
@@ -497,10 +497,18 @@ async fn dispatch_one(
     config: &DispatcherConfig,
     reachability: Option<&Arc<ReachabilityTracker>>,
 ) {
-    // Transport selection: first configured transport for now.
-    // TODO Phase 2 — per-row transport preference based on
-    // destination's reachability map.
-    let transport = &transports[0];
+    // Per-row transport selection (the Phase-2 closure of the
+    // "first configured transport for now" placeholder): consult the
+    // destination's per-medium reachability and prefer the medium
+    // that has actually worked for this peer; fall back to the first
+    // configured transport when nothing has measured success.
+    let transport_ids: Vec<crate::transport::TransportId> =
+        transports.iter().map(|t| t.id()).collect();
+    let transport = &transports[preferred_transport_index(
+        &transport_ids,
+        &row.destination_key_id,
+        reachability.map(|t| &**t),
+    )];
     let outcome = transport
         .send(&row.destination_key_id, &row.envelope_bytes)
         .await;
@@ -652,6 +660,48 @@ async fn dispatch_one(
     }
 }
 
+/// Per-row transport preference for the durable dispatcher (the
+/// Phase-2 closure of the `transports[0]` placeholder), consulting the
+/// [`ReachabilityTracker`] the send/dispatch hook sites populate.
+///
+/// Minimal honest rule: among the configured transports, prefer the
+/// one with the highest success ratio for this destination among media
+/// that have MEASURED SUCCESS in the rolling window (`attempts > 0 &&
+/// ratio > 0`). When nothing has measured success — a fresh peer, or a
+/// window where everything failed — fall back to index 0 (the
+/// historical default): per the [`crate::reachability::PeerMediumReachability::ratio`]
+/// contract, "no measurement" must not be read as "unreachable", and
+/// an all-failing window gives no basis to prefer any other medium
+/// over the configured-first one. Ties keep the earlier-configured
+/// transport (deterministic). Single-transport deployments
+/// short-circuit to 0 without touching the tracker.
+fn preferred_transport_index(
+    transport_ids: &[crate::transport::TransportId],
+    destination_key_id: &str,
+    reachability: Option<&ReachabilityTracker>,
+) -> usize {
+    if transport_ids.len() <= 1 {
+        return 0;
+    }
+    let Some(tracker) = reachability else {
+        return 0;
+    };
+    let snapshot = tracker.snapshot(destination_key_id);
+    let mut best: Option<(usize, f64)> = None;
+    for (idx, id) in transport_ids.iter().enumerate() {
+        if let Some(medium) = snapshot.get(id) {
+            if medium.attempts > 0 {
+                let ratio = medium.ratio();
+                // (`map_or`, not 1.82's `is_none_or` — MSRV is 1.75.)
+                if ratio > 0.0 && best.map_or(true, |(_, b)| ratio > b) {
+                    best = Some((idx, ratio));
+                }
+            }
+        }
+    }
+    best.map_or(0, |(idx, _)| idx)
+}
+
 /// Run the periodic-sweep tasks. Spawned alongside `run_dispatcher`.
 pub async fn run_sweeps(
     queue: Arc<dyn OutboundHandle>,
@@ -680,5 +730,100 @@ pub async fn run_sweeps(
                 }
             }
         }
+    }
+}
+
+/// Per-row transport preference (the Phase-2 `transports[0]` closure)
+/// — unit-driven on the exact selection function `dispatch_one` calls,
+/// against a real [`ReachabilityTracker`] populated through the same
+/// `record_attempt` surface the production hook sites use.
+#[cfg(test)]
+mod transport_preference_tests {
+    use super::*;
+    use crate::transport::TransportId;
+
+    const RETICULUM: TransportId = TransportId("pref-reticulum");
+    const HTTP: TransportId = TransportId("pref-http");
+
+    fn failure() -> AttemptOutcome {
+        AttemptOutcome::SendFailure {
+            error_class: "timeout".to_string(),
+        }
+    }
+
+    #[test]
+    fn single_transport_short_circuits_to_zero() {
+        let tracker = ReachabilityTracker::new(300);
+        // Even a recorded success elsewhere cannot move a
+        // single-transport deployment off index 0.
+        tracker.record_attempt("peer-1", HTTP, AttemptOutcome::SendSuccess);
+        assert_eq!(
+            preferred_transport_index(&[RETICULUM], "peer-1", Some(&tracker)),
+            0
+        );
+    }
+
+    #[test]
+    fn no_tracker_falls_back_to_first() {
+        assert_eq!(
+            preferred_transport_index(&[RETICULUM, HTTP], "peer-1", None),
+            0
+        );
+    }
+
+    #[test]
+    fn unmeasured_peer_falls_back_to_first() {
+        let tracker = ReachabilityTracker::new(300);
+        assert_eq!(
+            preferred_transport_index(&[RETICULUM, HTTP], "peer-unmeasured", Some(&tracker)),
+            0,
+            "no measurement must not be read as unreachable — historical default wins",
+        );
+    }
+
+    #[test]
+    fn measured_success_on_second_medium_is_preferred() {
+        let tracker = ReachabilityTracker::new(300);
+        tracker.record_attempt("peer-1", RETICULUM, failure());
+        tracker.record_attempt("peer-1", HTTP, AttemptOutcome::SendSuccess);
+        assert_eq!(
+            preferred_transport_index(&[RETICULUM, HTTP], "peer-1", Some(&tracker)),
+            1,
+            "the medium that has actually worked for this peer wins over transports[0]",
+        );
+    }
+
+    #[test]
+    fn all_failing_window_falls_back_to_first() {
+        let tracker = ReachabilityTracker::new(300);
+        tracker.record_attempt("peer-1", RETICULUM, failure());
+        tracker.record_attempt("peer-1", HTTP, failure());
+        assert_eq!(
+            preferred_transport_index(&[RETICULUM, HTTP], "peer-1", Some(&tracker)),
+            0,
+            "an all-failing window gives no basis to leave the configured-first default",
+        );
+    }
+
+    #[test]
+    fn higher_ratio_wins_and_ties_keep_first() {
+        let tracker = ReachabilityTracker::new(300);
+        // RETICULUM: 1/2 = 0.5; HTTP: 2/2 = 1.0 → HTTP.
+        tracker.record_attempt("peer-1", RETICULUM, AttemptOutcome::SendSuccess);
+        tracker.record_attempt("peer-1", RETICULUM, failure());
+        tracker.record_attempt("peer-1", HTTP, AttemptOutcome::SendSuccess);
+        tracker.record_attempt("peer-1", HTTP, AttemptOutcome::SendSuccess);
+        assert_eq!(
+            preferred_transport_index(&[RETICULUM, HTTP], "peer-1", Some(&tracker)),
+            1
+        );
+        // Tie (both 1/1) → earlier-configured transport, deterministic.
+        let tie = ReachabilityTracker::new(300);
+        tie.record_attempt("peer-2", RETICULUM, AttemptOutcome::SendSuccess);
+        tie.record_attempt("peer-2", HTTP, AttemptOutcome::SendSuccess);
+        assert_eq!(
+            preferred_transport_index(&[RETICULUM, HTTP], "peer-2", Some(&tie)),
+            0
+        );
     }
 }

--- a/src/replication/accord_relay_gate.rs
+++ b/src/replication/accord_relay_gate.rs
@@ -223,11 +223,13 @@ pub enum RelayRefusal {
     /// [`AccordRootClaim::NotAccord`] — persist says this row is not on the
     /// `accord:*` family at all, so it "is not this predicate's to judge" and
     /// the verb refuses it. Unreachable through
-    /// `FederationDirectoryReplicationBridge::accord_relay_withholds`, whose
-    /// `attestation_is_accord` early-out already used persist's own
-    /// [`attestation_family`] classifier — and kept anyway so a DIRECT caller of
-    /// the public entry point below fails CLOSED with a name, rather than
-    /// falling through to an allow.
+    /// `FederationDirectoryReplicationBridge::accord_relay_withholds` BY SHARED
+    /// PREDICATE (CIRISEdge#505 / v37.1.0): its `attestation_is_accord`
+    /// early-out is persist's `is_accord_family`, over both namespaces — and
+    /// `accord_root_claim` calls that same function for its own family test, so
+    /// a row the pre-filter admits cannot classify `NotAccord` here. Kept
+    /// anyway so a DIRECT caller of the public entry point below fails CLOSED
+    /// with a name, rather than falling through to an allow.
     ObjectNotAccord,
     /// [`AccordRootClaim::Unnamed`] — the row IS on the `accord:*` family and
     /// **nothing in it names the accord it acts under**: no signed
@@ -635,27 +637,34 @@ impl AccordRelayGate {
         }
     }
 
-    /// Is `dimension` in the `accord:*` family — i.e. is this gate the one that
-    /// decides its carriage?
+    /// The **DIMENSION HALF ONLY** of the `accord:*` family test — is this
+    /// `dimension` string relay-gated per [`crate::family_gates::gates_for`]?
     ///
-    /// persist's OWN classifier
-    /// ([`attestation_family`], public since v36.1.0 for exactly this fold), never
-    /// an edge-side `dimension.starts_with("accord:")`. The registry decides
-    /// which family a dimension is in; a second spelling here is two owners for
-    /// one wire fact. [`AttestationFamily`] is `#[non_exhaustive]`, so a future
-    /// decided family is additive policy rather than a build break — and
-    /// `objection:*`, the reserved-prefix sibling, is deliberately NOT in this
-    /// family (CIRISPersist#713).
+    /// **NEVER a carriage pre-filter.** The family rides BOTH namespaces —
+    /// persist's admission comment (`check_reserved_prefix_admission`) is
+    /// explicit: *"`accord:invoke:*` as a TYPE, `accord:human_dignity:v1` as a
+    /// `scores` DIMENSION"* — and using this dimension-only half to decide
+    /// whether a ROW reaches the gate is exactly the CIRISEdge#505
+    /// under-gating hole: every `accord:invoke:*` row in the
+    /// `attestation_type` namespace skipped the CC 4.2.1 relay gate and was
+    /// carried unexamined. Row-level family classification has ONE owner,
+    /// [`ciris_persist::federation::trust_root::is_accord_family`], consumed
+    /// by the bridge's `attestation_is_accord` — and a source-assertion test
+    /// there (`the_carriage_pre_filter_reads_is_accord_family_not_the_dimension_half`)
+    /// pins that the pre-filter reads it and not this.
     ///
-    /// **Reads [`crate::family_gates::gates_for`], not a local `matches!`.**
-    /// That is the whole point of the fold: an inline
-    /// `matches!(.., Accord)` returns `false` for a family this build
-    /// predates, which SKIPS the relay gate and CARRIES the row — permissive
-    /// on exactly the case `#[non_exhaustive]` exists to warn about.
-    /// `gates_for`'s wildcard is maximally gated instead, so an unknown
-    /// family is withheld and says so.
+    /// What survives here is the WIRING PIN for [`crate::family_gates`]: the
+    /// accord half of `gates_for`'s fold, exercised by that module's
+    /// through-the-call-site test and the dimension matrix below, so the fold
+    /// cannot silently drift from persist's registry (`objection:*` stays out
+    /// of the family — CIRISPersist#713; an inline `matches!` would return
+    /// `false` for a family this build predates). `#[cfg(test)]` plus the
+    /// `dimension_half_` name are the fence: in a production build this fn
+    /// does not exist, so a future caller reaching for it as a carriage
+    /// pre-filter gets a compile error, not the #505 hole.
+    #[cfg(test)]
     #[must_use]
-    pub fn dimension_is_gated(dimension: &str) -> bool {
+    pub(crate) fn dimension_half_is_gated(dimension: &str) -> bool {
         crate::family_gates::gates_for(dimension).accord_relay_gated
     }
 
@@ -921,17 +930,38 @@ mod tests {
         attested: &str,
         accord_root: Option<&str>,
     ) -> serde_json::Value {
+        typed_accord_row_value("scores", Some(dimension), attesting, attested, accord_root)
+    }
+
+    /// [`accord_row_value`] with the `attestation_type` namespace open too —
+    /// CIRISEdge#505 / CIRISPersist#743: the family rides BOTH namespaces
+    /// (*"`accord:invoke:*` as a TYPE, `accord:human_dignity:v1` as a `scores`
+    /// DIMENSION"* — persist's own admission comment), and a fixture that can
+    /// only spell the dimension shape can only ever test half of it.
+    /// `dimension: None` omits the key entirely, which is the exact wire shape
+    /// an `accord:invoke:*` row carries. The type is stamped into the signed
+    /// `row` mirror as well as the column, else `check_row_column_binding`
+    /// refuses the fixture for divergence rather than judging its family.
+    fn typed_accord_row_value(
+        attestation_type: &str,
+        dimension: Option<&str>,
+        attesting: &str,
+        attested: &str,
+        accord_root: Option<&str>,
+    ) -> serde_json::Value {
         let mut envelope = serde_json::json!({
-            "dimension": dimension,
             "asserted_at": "2026-01-01T00:00:00Z",
             "row": {
                 "attestation_id": "att-1",
                 "attesting_key_id": attesting,
-                "attestation_type": "scores",
+                "attestation_type": attestation_type,
                 "attested_key_id": attested,
                 "cohort_scope": "federation",
             },
         });
+        if let Some(dim) = dimension {
+            envelope["dimension"] = serde_json::json!(dim);
+        }
         if let Some(root) = accord_root {
             envelope["accord_root"] = serde_json::json!(root);
         }
@@ -939,7 +969,7 @@ mod tests {
             "attestation_id": "att-1",
             "attesting_key_id": attesting,
             "attested_key_id": attested,
-            "attestation_type": "scores",
+            "attestation_type": attestation_type,
             "asserted_at": "2026-01-01T00:00:00Z",
             "attestation_envelope": envelope,
             "original_content_hash": "0".repeat(64),
@@ -1235,10 +1265,11 @@ mod tests {
     }
 
     /// [`AccordRootClaim::NotAccord`] fails CLOSED at the gate's public entry
-    /// point. It is unreachable through the bridge (whose `attestation_is_accord`
-    /// early-out is persist's own [`attestation_family`] classifier, and `under`
-    /// implies `starts_with`), but the arm must not be an allow: a direct caller
-    /// of a `pub` predicate is a caller.
+    /// point. It is unreachable through the bridge by SHARED PREDICATE
+    /// (CIRISEdge#505 / v37.1.0: the bridge's `attestation_is_accord` early-out
+    /// is persist's `is_accord_family` over both namespaces, the exact family
+    /// test `accord_root_claim` itself calls), but the arm must not be an
+    /// allow: a direct caller of a `pub` predicate is a caller.
     #[test]
     fn a_row_that_is_not_accord_at_all_fails_closed_with_its_own_leg() {
         let row = accord_row("scores:reputation:v1", "holder-a", "someone", None);
@@ -1406,15 +1437,18 @@ mod tests {
 
     // ── The gate: fail-closed, and the family classifier ─────────────────
 
-    /// The dimension classifier is persist's, and it covers `accord:*` WITHOUT
-    /// covering `objection:*` (which #713 deliberately left on the
-    /// conservative row) — pinned here so an edge-side widening cannot happen
-    /// by accident.
+    /// The DIMENSION-HALF matrix (CIRISEdge#505: the half-test, never the
+    /// carriage pre-filter — see `dimension_half_is_gated`'s doc): it covers
+    /// `accord:*` WITHOUT covering `objection:*` (which #713 deliberately left
+    /// on the conservative row) — pinned here so an edge-side widening cannot
+    /// happen by accident.
     #[test]
     fn only_accord_dimensions_are_gated() {
-        assert!(AccordRelayGate::dimension_is_gated("accord:lifecycle:v1"));
-        assert!(AccordRelayGate::dimension_is_gated("accord:halt:v1"));
-        assert!(AccordRelayGate::dimension_is_gated(
+        assert!(AccordRelayGate::dimension_half_is_gated(
+            "accord:lifecycle:v1"
+        ));
+        assert!(AccordRelayGate::dimension_half_is_gated("accord:halt:v1"));
+        assert!(AccordRelayGate::dimension_half_is_gated(
             "accord:human_dignity:v1"
         ));
         for other in [
@@ -1431,7 +1465,7 @@ mod tests {
             "accord",
         ] {
             assert!(
-                !AccordRelayGate::dimension_is_gated(other),
+                !AccordRelayGate::dimension_half_is_gated(other),
                 "{other} must NOT be gated by the accord relay predicate"
             );
         }
@@ -1824,6 +1858,104 @@ mod tests {
              gate that refuses everything"
         );
         assert_eq!(gate.cached_len(), 1, "…and that one DID reach the resolver");
+    }
+
+    /// CIRISEdge#505 / CIRISPersist#743 — **a TYPE-namespace row is JUDGED,
+    /// never skipped**, and a row on BOTH namespaces is gated ONCE.
+    ///
+    /// The pre-filter fix (bridge's `attestation_is_accord` → persist's
+    /// `is_accord_family`) only puts `accord:invoke:*`-TYPED rows in front of
+    /// this gate; this pins what the gate DOES with one, on the exact wire
+    /// shape such a row produces: the namespace in `attestation_type` (column
+    /// AND signed mirror) and no `dimension` key at all. The gate needs no
+    /// type-namespace surface of its own — persist's `accord_root_claim`
+    /// (which `may_relay_accord_attestation` and
+    /// [`AccordRelaySubject::of_row`] both read) takes the TYPE arm of its own
+    /// `is_accord_family` call and reads the signed `accord_root` envelope key,
+    /// available on every namespace. Asserted here rather than assumed.
+    #[tokio::test]
+    async fn the_type_namespace_row_is_judged_not_skipped_and_both_namespaces_gate_once() {
+        let us = "t-node";
+        let signer = "t-holder";
+        let second = "t-holder-second";
+        let root = "t-accord";
+        let backend = Arc::new(MemoryBackend::new());
+        for who in [us, signer, second, root] {
+            backend.put_public_key(key(who)).await.expect("register");
+        }
+        // Both signers SEATED, so a leg that stopped judging would surface as
+        // a different answer (`no_trust_edge` / a relay), never hide behind a
+        // fail-safe default (the five-refusal test's own discipline).
+        seed_family(&backend, root, &[signer, second]).await;
+        let dir: Arc<dyn FederationDirectory> = backend;
+        let gate = AccordRelayGate::new(dir, Some(us.to_owned()));
+        let t0 = now();
+
+        // (a) The TYPE-namespace row: `accord:invoke:*` as the type, NO
+        // dimension, naming its accord with the signed key. The subject is the
+        // signed root + the bound signer — persist's type arm, not a skip.
+        let invoke = typed_accord_row_value(
+            "accord:invoke:notify:halt",
+            None,
+            signer,
+            signer,
+            Some(root),
+        );
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&invoke),
+            Ok(subject(root, signer)),
+            "the TYPE arm names the root from the signed `accord_root` key"
+        );
+        assert_eq!(
+            gate.may_relay_attestation(&invoke, t0).await,
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge),
+            "the row is EVALUATED on its merits (seated signer, no consent edge \
+             seeded ⇒ leg 2) — before CIRISEdge#505 it never reached this gate"
+        );
+        assert_eq!(
+            gate.cached_len(),
+            1,
+            "…and it DID reach the resolver: one (root, signer) verdict cached"
+        );
+
+        // (a′) The same shape naming NO accord is refused on ITS merits too —
+        // fail-closed, with the object leg an operator can act on. The old
+        // pre-filter would have CARRIED this row unexamined.
+        assert_eq!(
+            gate.may_relay_attestation(
+                &typed_accord_row_value("accord:invoke:notify:halt", None, signer, signer, None),
+                t0
+            )
+            .await,
+            RelayDecision::Refused(RelayRefusal::ObjectRootUnnamed),
+            "a type-namespace row naming no accord is REFUSED, never skipped or carried"
+        );
+        assert_eq!(gate.cached_len(), 1, "an unjudgeable row parks no verdict");
+
+        // (d) BOTH namespaces accord-shaped: one row ⇒ ONE subject ⇒ ONE
+        // cached verdict — gated once, no second evaluation for the second
+        // namespace. (A second signer, so the single new entry is visible.)
+        let both = typed_accord_row_value(
+            "accord:invoke:notify:halt",
+            Some("accord:human_dignity:v1"),
+            second,
+            second,
+            Some(root),
+        );
+        assert_eq!(
+            AccordRelaySubject::of_attestation(&both),
+            Ok(subject(root, second)),
+            "two namespaces, ONE subject — the signed root answers for both"
+        );
+        assert_eq!(
+            gate.may_relay_attestation(&both, t0).await,
+            RelayDecision::Refused(RelayRefusal::NoTrustEdge),
+        );
+        assert_eq!(
+            gate.cached_len(),
+            2,
+            "one row on BOTH namespaces adds exactly ONE verdict — gated once"
+        );
     }
 
     /// The ORDERING, not the equivalence.

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -864,7 +864,7 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         // content-hash-index; it rides the `persist_row_hash` wire. Resolve it
         // with NO cache: this retires the last in-memory fetch cache, so every
         // plane's fetch is now a direct persist read.
-        if kind == EnvelopeKind::Revocation {
+        if kind.is_row_hash_served() {
             return self.fetch_revocation_bytes(envelope_hash).await;
         }
         None

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -4191,6 +4191,7 @@ mod tests {
     ///   matching the subject-Pull LIST gate);
     /// - an advertised (federation-scope) row → unaffected for the same peer.
     #[tokio::test]
+    #[allow(clippy::too_many_lines)] // e2e security scenario: full fixture + both peers + both verdicts
     async fn foreign_self_scope_attestation_is_not_served_by_direct_fetch() {
         let local = "this-node";
         let producer = "other-producer";

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -558,27 +558,30 @@ impl FederationDirectoryReplicationBridge {
         self
     }
 
-    /// Workstream F — is this row in the `accord:*` family, i.e. is its
-    /// carriage the relay gate's to decide?
+    /// Workstream F / CIRISEdge#505 / CIRISPersist#743 — is this row on the
+    /// `accord:*` family, in EITHER namespace, i.e. is its carriage the relay
+    /// gate's to decide?
     ///
-    /// persist's own classifier, via
-    /// [`AccordRelayGate::dimension_is_gated`](crate::replication::accord_relay_gate::AccordRelayGate::dimension_is_gated)
-    /// — the same `namespace::attestation_family` fold
-    /// [`Self::attestation_requires_serve`] took in v17.7.0, and for the same
-    /// reason: a `dimension.starts_with("accord:")` here would be a second
-    /// owner for one wire fact. `objection:*` is deliberately NOT in this
-    /// family (CIRISPersist#713 — the co-scrub argument covers `accord:` only).
-    /// CIRISEdge#505 / CIRISPersist#743 — is this row on the `accord:*`
-    /// family, in EITHER namespace?
+    /// **The two-namespace rule.** The family rides BOTH namespaces a row can
+    /// carry it on, and persist's admission comment
+    /// (`check_reserved_prefix_admission`, the CIRISPersist#733 placement note)
+    /// is explicit: *"The `accord:*` family rides BOTH namespaces —
+    /// `accord:invoke:*` as a TYPE, `accord:human_dignity:v1` as a `scores`
+    /// DIMENSION"*. So this pre-filter reads the exact two fields persist's own
+    /// admission reads — the `attestation_type` column
+    /// (`/attestation_type`, persist's `row.attestation_type`) and the signed
+    /// envelope dimension (`/attestation_envelope/dimension`, persist's
+    /// `admission::envelope_dimension`) — and hands both to persist's own
+    /// classifier, [`ciris_persist::federation::trust_root::is_accord_family`].
+    /// `objection:*` is deliberately NOT in this family (CIRISPersist#713 —
+    /// the co-scrub argument covers `accord:` only).
     ///
     /// This read only the `dimension` until v37.1.0, and that was a live
-    /// under-gating hole: persist's own admission comment is explicit that the
-    /// family rides both namespaces — *"`accord:invoke:*` as a TYPE,
-    /// `accord:human_dignity:v1` as a `scores` DIMENSION"* — so every
-    /// `accord:invoke:*` row carried in the `attestation_type` namespace
-    /// skipped the CC 4.2.1 relay gate entirely. A false NEGATIVE: the gate
-    /// never carried something it should have refused once it looked, it
-    /// failed to look.
+    /// under-gating hole: every `accord:invoke:*` row carried in the
+    /// `attestation_type` namespace skipped the CC 4.2.1 relay gate entirely —
+    /// advertised, fetched and subject-pulled with no carriage check. A false
+    /// NEGATIVE: the gate never carried something it should have refused once
+    /// it looked, it failed to look.
     ///
     /// Persist now owns the question (`is_accord_family`), so edge stops
     /// spelling it. Edge widening the pre-filter itself would have put a
@@ -5109,6 +5112,39 @@ mod tests {
         seed_raw_attestation(backend, &id, attester, scored, "scores", envelope).await;
     }
 
+    /// CIRISEdge#505 / CIRISPersist#743 — an `accord:*` row in the **TYPE
+    /// namespace**: `attestation_type = "accord:invoke:…"`, NO `dimension` key
+    /// at all, naming its accord with the signed `accord_root` envelope key.
+    ///
+    /// This is the OTHER half of persist's two-namespace admission rule
+    /// (*"`accord:invoke:*` as a TYPE, `accord:human_dignity:v1` as a `scores`
+    /// DIMENSION"*), and the wire shape the pre-#505 pre-filter never showed
+    /// the relay gate. The invoke shape is self-attesting
+    /// (`attested_key_id` = the holder — persist #733: "the SELF-ATTESTING
+    /// HOLDER"), and admission requires the attesting key's `identity_type` to
+    /// be `accord_holder` (CC 3.4.1) plus the signed root
+    /// (`check_accord_root_binding`) — the fixture goes through the REAL write
+    /// door, so it carries what the field must carry.
+    async fn seed_accord_invoke(backend: &MemoryBackend, holder: &str, accord_root: &str) {
+        let id = uuid::Uuid::new_v4().to_string();
+        let envelope = serde_json::json!({
+            "id": id,
+            "attesting_key_id": holder,
+            "attested_key_id": holder,
+            "attestation_type": "accord:invoke:notify:halt",
+            "accord_root": accord_root,
+        });
+        seed_raw_attestation(
+            backend,
+            &id,
+            holder,
+            holder,
+            "accord:invoke:notify:halt",
+            envelope,
+        )
+        .await;
+    }
+
     /// Seed a `withdraws` composer tombstoning `target_id` — the CEG un-trust
     /// primitive. Shape mirrors persist's own `fix_withdraws` witness: the
     /// composer references its target through `references_attestation_id`
@@ -7677,10 +7713,15 @@ mod tests {
     /// the gate itself derives, so a test always aims at the row the gate will
     /// actually judge. (It previously matched the UNSIGNED top-level
     /// `attesting_key_id` column, which is not what the gate reads.)
+    /// `ty` discriminates the NAMESPACE the row rides (CIRISEdge#505): one
+    /// holder can hold both a dimension-namespace row (`ty = "scores"`) and a
+    /// type-namespace row (`ty = "accord:invoke:…"`) under the same root, and
+    /// `(root, signer)` alone no longer picks one.
     async fn locate_accord_hash(
         bridge: &FederationDirectoryReplicationBridge,
         root: &str,
         signer: &str,
+        ty: &str,
     ) -> [u8; 32] {
         use crate::replication::accord_relay_gate::AccordRelaySubject;
         for r in bridge.list_envelope_refs(EnvelopeKind::Attestation).await {
@@ -7693,13 +7734,14 @@ mod tests {
             };
             let inner = v.get("attestation").unwrap_or(&v);
             if FederationDirectoryReplicationBridge::attestation_is_accord(inner)
+                && inner.get("attestation_type").and_then(|t| t.as_str()) == Some(ty)
                 && AccordRelaySubject::of_attestation(inner)
                     .is_ok_and(|s| s.root_ref == root && s.signer_key_id == signer)
             {
                 return r.envelope_hash;
             }
         }
-        panic!("the seeded accord row by {signer} under {root} appears in the local view");
+        panic!("the seeded {ty} accord row by {signer} under {root} appears in the local view");
     }
 
     /// Workstream F, the whole property in one scenario — and deliberately BOTH
@@ -7707,13 +7749,18 @@ mod tests {
     /// a gate that is dead (the #435 / v13.10.0 lesson), while a gate only ever
     /// seen allowing proves nothing about carriage at all.
     ///
-    /// One node, one accord root, one peer, and three rows:
+    /// One node, one accord root, one peer, and five rows — the family's BOTH
+    /// namespaces (CIRISEdge#505: `accord:invoke:*` as a TYPE,
+    /// `accord:human_dignity:v1`-style rows as a `scores` DIMENSION), each with
+    /// an allow and a refuse so neither namespace can pass by being skipped:
     ///
     /// | row | expectation |
     /// |---|---|
-    /// | `accord:*` by a SEATED holder | advertised AND served — persist's `may_relay` holds |
-    /// | `accord:*` by an UNSEATED holder | withheld from BOTH paths, booked `accord_relay_signer_not_seated` |
-    /// | a non-`accord:` row | untouched — this gate narrows exactly one dimension family |
+    /// | dimension-namespace `accord:*` by a SEATED holder | advertised AND served — persist's `may_relay` holds |
+    /// | dimension-namespace `accord:*` by an UNSEATED holder | withheld from BOTH paths, booked `accord_relay_signer_not_seated` |
+    /// | TYPE-namespace `accord:invoke:*` by a SEATED holder | advertised AND served — the pre-filter admits it AND the gate allows it |
+    /// | TYPE-namespace `accord:invoke:*` by an UNSEATED holder | withheld from BOTH paths — pre-#505 this row skipped the gate and was CARRIED |
+    /// | a non-`accord:` row | untouched — this gate narrows exactly one family |
     ///
     /// The trust state is seeded the way persist's own
     /// `exercise_accord_relay_eligibility` seeds it: a KEYLESS family whose
@@ -7790,13 +7837,20 @@ mod tests {
         )
         .await;
 
-        // The rows: one accord row per holder, plus a non-accord row.
+        // The rows: per holder, one accord row in EACH namespace (dimension +
+        // type — CIRISEdge#505), plus a non-accord row.
         seed_accord_lifecycle(&backend, seated, root).await;
         seed_accord_lifecycle(&backend, unseated, root).await;
+        seed_accord_invoke(&backend, seated, root).await;
+        seed_accord_invoke(&backend, unseated, root).await;
         seed_advertised_attestation(&backend, producer).await;
 
-        let seated_hash = locate_accord_hash(&bridge, root, seated).await;
-        let unseated_hash = locate_accord_hash(&bridge, root, unseated).await;
+        let seated_hash = locate_accord_hash(&bridge, root, seated, "scores").await;
+        let unseated_hash = locate_accord_hash(&bridge, root, unseated, "scores").await;
+        let seated_invoke_hash =
+            locate_accord_hash(&bridge, root, seated, "accord:invoke:notify:halt").await;
+        let unseated_invoke_hash =
+            locate_accord_hash(&bridge, root, unseated, "accord:invoke:notify:halt").await;
         let bridge = bridge
             .with_local_key_id(Some(local.to_string()))
             .with_accord_relay_gate(Some(Arc::new(AccordRelayGate::new(
@@ -7837,6 +7891,46 @@ mod tests {
                 .await
                 .is_none(),
             "…and cannot be obtained by fetching a hash learned out-of-band"
+        );
+
+        // (B/D) THE TYPE NAMESPACE (CIRISEdge#505) — the same allow/refuse
+        // pair for `accord:invoke:*` rows, whose family membership rides the
+        // `attestation_type` and NOT the dimension. Before the pre-filter fix
+        // these rows never reached the gate at all, so the UNSEATED holder's
+        // row below was advertised and served — the under-gating hole.
+        assert!(
+            offer.iter().any(|r| r.envelope_hash == seated_invoke_hash),
+            "a seated holder's TYPE-namespace accord row is ADVERTISED — the \
+             pre-filter admits it to the gate and the gate allows it"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &seated_invoke_hash,
+                    Some(peer)
+                )
+                .await
+                .is_some(),
+            "…and SERVED on the direct-fetch twin"
+        );
+        assert!(
+            !offer
+                .iter()
+                .any(|r| r.envelope_hash == unseated_invoke_hash),
+            "an UNSEATED holder's TYPE-namespace accord row is withheld from the \
+             offer — pre-#505 the pre-filter skipped the gate and CARRIED it"
+        );
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &unseated_invoke_hash,
+                    Some(peer)
+                )
+                .await
+                .is_none(),
+            "…and cannot be obtained by fetching its hash out-of-band either"
         );
 
         // The refusal is LOUD and NAMES ITS BRANCH (CIRISEdge#425/#433) — and
@@ -7901,9 +7995,31 @@ mod tests {
             "attestation_type": "accord:invoke:notify:halt",
             "attestation_envelope": { "dimension": "trust:example:v1" },
         });
+        // The shape a TYPE-namespace row actually produces on the wire: the
+        // namespace travels as the type and there is NO `dimension` key at all
+        // (persist's `is_accord_family` takes `Option<&str>` for exactly this
+        // row — `None` is not a dimension-arm match, never an error).
+        let by_type_no_dimension = serde_json::json!({
+            "attestation_type": "accord:invoke:notify:halt",
+            "attestation_envelope": { "accord_root": "humanity-accord" },
+        });
+        // BOTH fields accord-shaped — one row, one family membership, and the
+        // caller consults ONE gate for it (the gate resolves ONE subject; see
+        // accord_relay_gate's
+        // `the_type_namespace_row_is_judged_not_skipped_and_both_namespaces_gate_once`).
+        let by_both = serde_json::json!({
+            "attestation_type": "accord:invoke:notify:halt",
+            "attestation_envelope": { "dimension": "accord:human_dignity:v1" },
+        });
         let neither = serde_json::json!({
             "attestation_type": "scores",
             "attestation_envelope": { "dimension": "trust:example:v1" },
+        });
+        // Non-accord in the TYPE namespace with no dimension — the
+        // `delegates_to` / `withdraws` wire shape must keep bypassing the gate.
+        let neither_no_dimension = serde_json::json!({
+            "attestation_type": "delegates_to",
+            "attestation_envelope": { "scope": ["infra:attest"] },
         });
 
         assert!(FederationDirectoryReplicationBridge::attestation_is_accord(
@@ -7915,9 +8031,71 @@ mod tests {
              skipping it is the CIRISEdge#505 under-gating hole",
         );
         assert!(
+            FederationDirectoryReplicationBridge::attestation_is_accord(&by_type_no_dimension),
+            "…including with NO dimension key at all, which is the exact wire \
+             shape an `accord:invoke:*` row carries",
+        );
+        assert!(
+            FederationDirectoryReplicationBridge::attestation_is_accord(&by_both),
+            "a row accord-shaped on BOTH namespaces is on the family",
+        );
+        assert!(
             !FederationDirectoryReplicationBridge::attestation_is_accord(&neither),
             "and a non-accord row must still bypass the gate, so this cannot \
              pass by gating everything",
+        );
+        assert!(
+            !FederationDirectoryReplicationBridge::attestation_is_accord(&neither_no_dimension),
+            "a non-accord TYPE with no dimension bypasses too — widening to \
+             `None`-dimension rows must not have gated the structural verbs",
+        );
+    }
+
+    /// **THE CIRISEdge#505 RE-OPEN FENCE** — a source assertion, in the style
+    /// of `skip_serializing_if_fields_are_never_read_by_json_key_with_an_empty_default`.
+    ///
+    /// The behavioural test above proves the pre-filter's ANSWERS; this pins
+    /// its READS, because on every constructible fixture today the answers
+    /// cannot distinguish persist's `is_accord_family` from a re-inlined
+    /// prefix check or from the dimension-half helper the pre-filter consulted
+    /// before v37.1.0 (`AccordRelayGate::dimension_half_is_gated`, the fenced
+    /// remnant) — the three diverge exactly when a third namespace arm or a
+    /// registry change lands, which is when the second spelling bites.
+    #[test]
+    fn the_carriage_pre_filter_reads_is_accord_family_not_the_dimension_half() {
+        let src = include_str!("bridge.rs");
+        let start = src
+            .find("fn attestation_is_accord")
+            .expect("the pre-filter exists");
+        let end = src[start..].find("\n    }").expect("the fn body closes");
+        let body = &src[start..start + end];
+        assert!(
+            body.contains("is_accord_family"),
+            "attestation_is_accord must delegate to persist's `is_accord_family` — \
+             the ONE owner of the two-namespace accord family test (CIRISPersist#743)"
+        );
+        for (path, mirror_of) in [
+            ("\"/attestation_type\"", "`row.attestation_type`"),
+            (
+                "\"/attestation_envelope/dimension\"",
+                "`admission::envelope_dimension`",
+            ),
+        ] {
+            assert!(
+                body.contains(path),
+                "attestation_is_accord must read {path} — the exact field persist's \
+                 admission reads via {mirror_of}; dropping either re-opens CIRISEdge#505"
+            );
+        }
+        assert!(
+            !body.contains("dimension_half_is_gated") && !body.contains("dimension_is_gated"),
+            "the dimension-half helper is NOT a carriage classifier — routing the \
+             pre-filter through it is the CIRISEdge#505 under-gating hole verbatim"
+        );
+        assert!(
+            !body.contains("starts_with"),
+            "no edge-side prefix spelling — persist owns the family test \
+             (the CIRISPersist#731/#733 two-owners drift)"
         );
     }
 
@@ -8023,8 +8201,8 @@ mod tests {
         seed_accord_lifecycle(&backend, holder, accord_a).await;
         seed_accord_lifecycle(&backend, holder, accord_b).await;
 
-        let own_accord_hash = locate_accord_hash(&bridge, accord_a, holder).await;
-        let other_accord_hash = locate_accord_hash(&bridge, accord_b, holder).await;
+        let own_accord_hash = locate_accord_hash(&bridge, accord_a, holder, "scores").await;
+        let other_accord_hash = locate_accord_hash(&bridge, accord_b, holder, "scores").await;
         assert_ne!(
             own_accord_hash, other_accord_hash,
             "two distinct rows, differing only in the accord they name"
@@ -8215,8 +8393,8 @@ mod tests {
         seed_accord_scored(&backend, holder, scored, accord_a).await;
         seed_accord_scored(&backend, holder, scored, accord_b).await;
 
-        let on_a = locate_accord_hash(&bridge, accord_a, holder).await;
-        let on_b = locate_accord_hash(&bridge, accord_b, holder).await;
+        let on_a = locate_accord_hash(&bridge, accord_a, holder, "scores").await;
+        let on_b = locate_accord_hash(&bridge, accord_b, holder, "scores").await;
         assert_ne!(
             on_a, on_b,
             "the two rows are distinct on the wire — the `accord_root` key is inside the \
@@ -8342,7 +8520,7 @@ mod tests {
         // outright ("cannot judge"). Without one, nothing consults the
         // predicate.
         seed_accord_lifecycle(&backend, holder, root).await;
-        let hash = locate_accord_hash(&bridge, root, holder).await;
+        let hash = locate_accord_hash(&bridge, root, holder, "scores").await;
         let bridge = bridge.with_local_key_id(Some(local.to_string()));
 
         assert!(

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -880,14 +880,33 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         }
     }
 
-    /// CIRISEdge#416 — RAW holdings for the RECEIVE-diff axis. The Attestation
-    /// plane uses the unfiltered [`Self::list_attestation_holdings`] ("what I
-    /// hold"), NOT the projection-filtered advertise view; every other plane's
-    /// advertise view equals its holdings for round convergence, so they keep the
-    /// default ([`Self::list_envelope_refs`]).
+    /// CIRISEdge#416 — RAW holdings for the RECEIVE-diff axis: "what I hold",
+    /// NOT "what I advertise". The `want = remote ∖ holdings` diff must see
+    /// every row local state holds, or a held-but-not-advertised row sits in
+    /// `want` forever — re-fetched and re-applied as `Duplicate` every round
+    /// (the CIRISAgent#932 non-convergence).
+    ///
+    /// v18 sweep: FOUR planes filter their advertise below their holdings, not
+    /// one. Attestation (`attestation_is_advertised`, per-record) was fixed by
+    /// #416 itself; the three `SelfOwn` publish-own planes — Key /
+    /// IdentityOccurrence / TransportDestination — filter their advertise to
+    /// `subjects_for_projection(SelfOwn)`, so a FOREIGN-subject row this node
+    /// admitted (exactly what those planes replicate IN) was invisible to its
+    /// own holdings view and never converged. Each now has an unfiltered
+    /// holdings twin (the filter belongs to advertise only). The remaining
+    /// planes keep the advertise default: the membership/tombstone planes
+    /// project `Global` (own ∪ cohort — the widest set this node can
+    /// enumerate), `Revocation` likewise, and the three Cohort-scoped planes
+    /// (Family / Community / LocationProof) assume advertise == holdings for
+    /// rows the node would ever be re-offered — a cohort-filter residual of the
+    /// same class is conceivable there and is deliberately left to its own
+    /// audit rather than silently widened here.
     async fn list_holdings(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
         match kind {
             EnvelopeKind::Attestation => self.list_attestation_holdings().await,
+            EnvelopeKind::Key => self.list_key_holdings().await,
+            EnvelopeKind::IdentityOccurrence => self.list_identity_occurrence_holdings().await,
+            EnvelopeKind::TransportDestination => self.list_transport_destination_holdings().await,
             _ => self.list_envelope_refs(kind).await,
         }
     }
@@ -905,10 +924,24 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         kind: EnvelopeKind,
         since: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Vec<Vec<u8>> {
-        if kind != EnvelopeKind::AccordQuorumEvidence {
+        // v18 — gated on the PREDICATE, not a kind literal, so this site and
+        // `is_cursor_served` cannot drift. NOTE: the body below is
+        // accord-specific; a future second cursor kind passes this gate and
+        // MUST add its own dispatch here (the protocol.rs over-ALL pin makes
+        // widening the predicate a deliberate act, and
+        // `cursor_arm_set_equals_the_predicate_over_all` binds this site).
+        if !kind.is_cursor_served() {
             return Vec::new();
         }
         let limit = self.effective_page_limit().await;
+        // v18 — the +1 TRUNCATION SENTINEL: ask persist for one bundle more
+        // than we serve. The cursor session opens from `since: None` each
+        // round, so an `operational_page_limit` / mesh-config relief smaller
+        // than the plane PERMANENTLY truncates the evidence plane at page one
+        // — until v18 with NO log. Serving `limit` of `limit + 1` read rows
+        // makes "the page limit bit" a fact, not a guess (`len == limit` alone
+        // cannot distinguish an exactly-full plane from a truncated one).
+        let serve_max = usize::try_from(limit).unwrap_or(usize::MAX);
         match self
             .directory
             .list_signed_accord_quorum_evidence_since(
@@ -921,14 +954,52 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                 // each bundle (`apply_accord_quorum_evidence`), so at-least-once
                 // is correct here and a skip would be silent evidence loss.
                 since.map(|ts| (ts, String::new())),
-                limit,
+                limit.saturating_add(1),
             )
             .await
         {
-            Ok(bundles) => bundles
-                .iter()
-                .filter_map(|b| serde_json::to_vec(b).ok())
-                .collect(),
+            Ok(mut bundles) => {
+                if bundles.len() > serve_max {
+                    bundles.truncate(serve_max);
+                    tracing::warn!(
+                        page_limit = limit,
+                        since = ?since,
+                        "accord-quorum-evidence cursor page TRUNCATED at the page \
+                         limit — at least one more bundle exists beyond this page. \
+                         A session resuming from its high-water drains the backlog \
+                         over rounds, but an operator `operational_page_limit` or \
+                         mesh-config relief below the plane's size truncates a \
+                         `since: None` cold pull at page one EVERY round — the \
+                         evidence plane never fully serves (CIRISEdge#474)"
+                    );
+                }
+                let mut out = Vec::with_capacity(bundles.len());
+                for b in &bundles {
+                    match serde_json::to_vec(b) {
+                        Ok(bytes) => out.push(bytes),
+                        Err(e) => {
+                            // v18 — was a silent `filter_map(.. .ok())` two lines
+                            // from the loud read-error arm below: a bundle that
+                            // will not serialize is OMITTED from every cursor page
+                            // and never replicates from this node. Loud + booked
+                            // (#433), mirroring `advertise_since`.
+                            tracing::warn!(
+                                error = %e,
+                                "accord-quorum-evidence bundle could not be \
+                                 serialized for the wire — OMITTED from this cursor \
+                                 page; it will not replicate from this node \
+                                 (CIRISEdge#474/#433)"
+                            );
+                            self.withhold(
+                                crate::observability::WithholdReason::RowNotSerializable,
+                                "<unattributed>",
+                                "accord_evidence_since: to_vec failed",
+                            );
+                        }
+                    }
+                }
+                out
+            }
             Err(e) => {
                 tracing::warn!(
                     error = %e,
@@ -974,6 +1045,7 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
     /// listing gate, so a peer excluded from the listing cannot obtain a
     /// `trace:*` envelope anyway by Diff/Fetch-ing a hash it learned
     /// out-of-band.
+    #[allow(clippy::too_many_lines)] // the serve-side twin set: five gates + the v18 projection twin
     async fn fetch_envelope_bytes_for_peer(
         &self,
         kind: EnvelopeKind,
@@ -1026,6 +1098,54 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                     .await
                 {
                     return None;
+                }
+                // v18 — the PROJECTION twin (the last un-twinned advertise gate).
+                // `attestation_is_advertised` structurally hides a `SelfOwn`-
+                // projecting row this node did not produce (a `self`/`family`
+                // attestation is published by its own producer, never relayed —
+                // the structural-invisibility discipline), but until now ONLY on
+                // the listing: a peer that learned the hash out-of-band was
+                // served the bytes anyway. The twin matches the advertise gate's
+                // semantics INCLUDING the v16 first-party override: a peer that
+                // is this row's author or data-subject fetches its OWN testimony
+                // (the same carve `pull_ref_is_serveable` grants the subject-Pull
+                // LIST — the #462 recovery right), and that carve deliberately
+                // bypasses the whole advertise predicate, malformed-scope decline
+                // included, so LIST and FETCH agree on the subject-Pull axis.
+                // An unattributed fetch has no first party and fails closed.
+                //
+                // The booked reason BORROWS `RecipientNotInSendSet` — the
+                // closest documented audience-membership variant (the enum is a
+                // closed operator vocabulary; no variant names the projection
+                // gate, and widening the enum is not this change's to make). The
+                // `detail` string names the true branch so a ledger reader is
+                // not misled toward the consent plane.
+                let first_party =
+                    peer_key_id.is_some_and(|p| Self::attestation_is_first_party_to(inner, p));
+                if !first_party {
+                    let self_set: HashSet<String> = self
+                        .self_provider
+                        .as_ref()
+                        .map(|p| p())
+                        .unwrap_or_default()
+                        .into_iter()
+                        .collect();
+                    if !Self::attestation_is_advertised(inner, &self_set) {
+                        self.withhold(
+                            crate::observability::WithholdReason::RecipientNotInSendSet,
+                            peer_label,
+                            "projection: row not advertised by this node (SelfOwn fetch twin)",
+                        );
+                        tracing::debug!(
+                            peer = peer_label,
+                            envelope_hash = %hex::encode(&envelope_hash[..8]),
+                            "attestation withheld from direct fetch — the projection \
+                             structurally hides this row from third parties (SelfOwn \
+                             publish-own; only a first party may fetch it) (v18 \
+                             projection twin)"
+                        );
+                        return None;
+                    }
                 }
             }
             if let Some(peer) = peer_key_id {
@@ -1205,6 +1325,13 @@ impl FederationDirectoryReplicationBridge {
             // (`persist_index_kind` → None), so a ref here would be listed-then-
             // unfetchable (the LIST-vs-FETCH divergence class). It converges over
             // the dedicated cursor path (`CursorPull` → `Deliver`) instead.
+            //
+            // v18 — this arm IS `EnvelopeKind::is_cursor_served` in match form:
+            // the match must stay exhaustive (a new kind must decide its
+            // advertise read here), so the predicate cannot replace the arm.
+            // `cursor_arm_set_equals_the_predicate_over_all` asserts the arm-set
+            // equals the predicate over `ALL` — widening one without the other
+            // reds there, not on the wire.
             EnvelopeKind::AccordQuorumEvidence => Vec::new(),
         }
     }
@@ -1226,6 +1353,7 @@ impl FederationDirectoryReplicationBridge {
     /// [`Self::is_non_retainable_score`] carve) and `list_attestations_by`
     /// (records BY the subject — authorship recovery, no carve: mine to recover).
     /// Non-replicated / cohort kinds are not subject-pullable and return empty.
+    #[allow(clippy::too_many_lines)] // five per-plane arms + the v18 loud-read/booking mirrors
     async fn subject_holdings_inner(
         &self,
         kind: EnvelopeKind,
@@ -1241,56 +1369,110 @@ impl FederationDirectoryReplicationBridge {
                 });
             }
         };
+        // v18 (the #429 class) — a persist read error on this path used to be an
+        // `unwrap_or_default()`: the subject was told "no testimony" with no warn
+        // and no counter, indistinguishable from a genuinely empty axis. Every
+        // read below now warns like the cursor plane's serve read does
+        // (`accord_evidence_since`); the served result stays empty-for-this-round
+        // (the requester re-pulls next round), never a panic.
+        macro_rules! subject_read {
+            ($fut:expr, $what:literal) => {
+                match $fut.await {
+                    Ok(rows) => rows,
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            subject = %subject_key_id,
+                            concat!(
+                                "subject-Pull ", $what, " read FAILED — serving an \
+                                 EMPTY axis this round (a transient read error, NOT \
+                                 a statement the subject has no testimony; the \
+                                 requester re-pulls next round) (CIRISEdge#462/#429)"
+                            )
+                        );
+                        Vec::new()
+                    }
+                }
+            };
+        }
+        // v18 — a row that cleared every gate but would not content-hash was a
+        // bare `if let Some(..)`: absent from the Pull with no trace. The
+        // advertise twins book the identical failure (`advertise_since`,
+        // `list_attestations`); these sites now mirror them.
+        let book_unhashable = |detail: &str| {
+            self.withhold(
+                crate::observability::WithholdReason::RowNotSerializable,
+                subject_key_id,
+                detail,
+            );
+        };
         match kind {
             EnvelopeKind::Key => {
-                if let Ok(Some(record)) = self.directory.lookup_public_key(subject_key_id).await {
-                    let seq = Self::ms_seq(record.valid_from);
-                    if let Some((hash, _)) = content_hash_of(&SignedKeyRecord { record }) {
-                        push(hash, seq);
+                match self.directory.lookup_public_key(subject_key_id).await {
+                    Ok(Some(record)) => {
+                        let seq = Self::ms_seq(record.valid_from);
+                        match content_hash_of(&SignedKeyRecord { record }) {
+                            Some((hash, _)) => push(hash, seq),
+                            None => book_unhashable("subject_holdings/key: content_hash_of failed"),
+                        }
+                    }
+                    Ok(None) => {} // no key row for the subject — a normal absence
+                    Err(e) => {
+                        tracing::warn!(
+                            error = %e,
+                            subject = %subject_key_id,
+                            "subject-Pull key lookup FAILED — serving an EMPTY axis \
+                             this round (transient, NOT 'no testimony') \
+                             (CIRISEdge#462/#429)"
+                        );
                     }
                 }
             }
             EnvelopeKind::IdentityOccurrence => {
-                for row in self
-                    .directory
-                    .list_signed_identity_occurrences_for(subject_key_id)
-                    .await
-                    .unwrap_or_default()
-                {
+                for row in subject_read!(
+                    self.directory
+                        .list_signed_identity_occurrences_for(subject_key_id),
+                    "identity-occurrence"
+                ) {
                     let seq = Self::ms_seq(row.identity_occurrence.asserted_at);
-                    if let Some((hash, _)) = content_hash_of(&row) {
-                        push(hash, seq);
+                    match content_hash_of(&row) {
+                        Some((hash, _)) => push(hash, seq),
+                        None => book_unhashable("subject_holdings/idocc: content_hash_of failed"),
                     }
                 }
             }
             EnvelopeKind::TransportDestination => {
-                for row in self
-                    .directory
-                    .list_signed_transport_destinations_for(subject_key_id)
-                    .await
-                    .unwrap_or_default()
-                {
+                for row in subject_read!(
+                    self.directory
+                        .list_signed_transport_destinations_for(subject_key_id),
+                    "transport-destination"
+                ) {
                     let td = &row.transport_destination;
                     let seq = if td.epoch > 0 {
                         td.epoch
                     } else {
                         Self::ms_seq(td.asserted_at)
                     };
-                    if let Some((hash, _)) = content_hash_of(&row) {
-                        push(hash, seq);
+                    match content_hash_of(&row) {
+                        Some((hash, _)) => push(hash, seq),
+                        None => {
+                            book_unhashable("subject_holdings/transport: content_hash_of failed");
+                        }
                     }
                 }
             }
             EnvelopeKind::IdentityOccurrenceRevocation => {
-                for row in self
-                    .directory
-                    .list_signed_identity_occurrence_revocations_for(subject_key_id)
-                    .await
-                    .unwrap_or_default()
-                {
+                for row in subject_read!(
+                    self.directory
+                        .list_signed_identity_occurrence_revocations_for(subject_key_id),
+                    "identity-occurrence-revocation"
+                ) {
                     let seq = Self::ms_seq(row.identity_occurrence_revocation.revoked_at);
-                    if let Some((hash, _)) = content_hash_of(&row) {
-                        push(hash, seq);
+                    match content_hash_of(&row) {
+                        Some((hash, _)) => push(hash, seq),
+                        None => {
+                            book_unhashable("subject_holdings/idocc-rev: content_hash_of failed");
+                        }
                     }
                 }
             }
@@ -1298,37 +1480,39 @@ impl FederationDirectoryReplicationBridge {
                 // DATA-SUBJECT axis — records ABOUT the subject (the 84-family
                 // revocation-reachability set), MINUS the G2 self-non-retainable
                 // scores.
-                for att in self
-                    .directory
-                    .list_attestations_for(subject_key_id)
-                    .await
-                    .unwrap_or_default()
-                {
+                for att in subject_read!(
+                    self.directory.list_attestations_for(subject_key_id),
+                    "attestation (data-subject axis)"
+                ) {
                     if Self::is_non_retainable_score(&att) {
                         continue;
                     }
                     let seq = Self::ms_seq(att.asserted_at);
-                    if let Some((hash, _)) = content_hash_of(&att) {
-                        if self.pull_ref_is_serveable(&att, subject_key_id).await {
-                            push(hash, seq);
+                    match content_hash_of(&att) {
+                        Some((hash, _)) => {
+                            if self.pull_ref_is_serveable(&att, subject_key_id).await {
+                                push(hash, seq);
+                            }
                         }
+                        None => book_unhashable("subject_holdings/att-for: content_hash_of failed"),
                     }
                 }
                 // SENDER axis — records BY the subject (authorship recovery). No
                 // G2 carve (an attestation I authored is mine to recover, even a
                 // `capacity:*` score I asserted about someone else) — but the SAME
                 // serve gate, so a ref and its bytes always agree.
-                for att in self
-                    .directory
-                    .list_attestations_by(subject_key_id)
-                    .await
-                    .unwrap_or_default()
-                {
+                for att in subject_read!(
+                    self.directory.list_attestations_by(subject_key_id),
+                    "attestation (sender axis)"
+                ) {
                     let seq = Self::ms_seq(att.asserted_at);
-                    if let Some((hash, _)) = content_hash_of(&att) {
-                        if self.pull_ref_is_serveable(&att, subject_key_id).await {
-                            push(hash, seq);
+                    match content_hash_of(&att) {
+                        Some((hash, _)) => {
+                            if self.pull_ref_is_serveable(&att, subject_key_id).await {
+                                push(hash, seq);
+                            }
                         }
+                        None => book_unhashable("subject_holdings/att-by: content_hash_of failed"),
                     }
                 }
             }
@@ -1357,16 +1541,37 @@ impl FederationDirectoryReplicationBridge {
     /// about the subject serve unconditionally, while a `trace:*` row still
     /// requires the subject to hold `infra:serve`. `peer == subject` here (enforced
     /// by [`Self::subject_holdings`]).
+    /// (Projection sweep, v18: every row this gate sees is FIRST-PARTY to the
+    /// requester by construction — `subject_holdings_inner` lists only rows
+    /// ABOUT or BY the subject, and `subject_holdings` pins requester == subject
+    /// — so the fetch twin's first-party carve keeps `fetch_envelope_bytes_for_peer`
+    /// in agreement with this LIST on every ref it discloses. No projection gate
+    /// is needed here.)
     async fn pull_ref_is_serveable(&self, att: &Attestation, requester: &str) -> bool {
         let Ok(value) = serde_json::to_value(att) else {
-            return false; // an unserializable row is not disclosed
+            // An unserializable row is not disclosed — and it is BOOKED, exactly
+            // as the advertise twins book the identical failure (#433: eligible
+            // and not served is the ledger's definition; was a bare `false`).
+            self.withhold(
+                crate::observability::WithholdReason::RowNotSerializable,
+                requester,
+                "pull_ref_is_serveable: to_value failed",
+            );
+            return false;
         };
         if Self::attestation_requires_serve(&value) {
             // `trace:*` — E3 confidentiality. Withheld while the plane is paused,
             // and served only to a subject that itself holds `infra:serve`.
             if self.trace_plane_paused().await {
+                // Booked via the shared #440 helper — the subject-Pull twin of
+                // the advertise (:config-paused-advertise) and direct-fetch
+                // (:config-paused-fetch) sites; its own throttle key so neither
+                // exit can silence this one's log. Was a bare `false`.
+                self.withhold_config_paused(requester, "config-paused-subject-pull");
                 return false;
             }
+            // `peer_has_serve_capability` books its OWN per-leg reason at the
+            // deciding branch (#433) — no re-count here, same as the twins.
             if !self.peer_has_serve_capability(requester).await {
                 return false;
             }
@@ -1673,9 +1878,22 @@ impl FederationDirectoryReplicationBridge {
             .subjects_for_projection(Projection::SelfOwn)
             .into_iter()
             .collect();
+        let limit = self.effective_page_limit().await;
+        self.list_keys_page(Some(&subjects), limit).await
+    }
+
+    /// The Key plane's since-cursor page, with the `SelfOwn` publish filter as
+    /// a PARAMETER: `Some(subjects)` is the advertise view ([`Self::list_keys`]),
+    /// `None` is the raw holdings view ([`Self::list_key_holdings`], #416 — the
+    /// filter belongs to advertise only).
+    async fn list_keys_page(
+        &self,
+        subjects: Option<&HashSet<String>>,
+        limit: u32,
+    ) -> Vec<EnvelopeRef> {
         let rows: Vec<KeyAdvertiseRow> = self
             .directory
-            .list_signed_key_records_since(None, self.effective_page_limit().await)
+            .list_signed_key_records_since(None, limit)
             .await
             .unwrap_or_default()
             .into_iter()
@@ -1686,11 +1904,22 @@ impl FederationDirectoryReplicationBridge {
             .collect();
         self.advertise_since(
             &rows,
-            |row| subjects.contains(&row.record.key_id),
+            // (`map_or(true, ..)`, not `is_none_or` — MSRV 1.75.)
+            |row| subjects.map_or(true, |s| s.contains(&row.record.key_id)),
             |row| Self::ms_seq(row.admitted_at),
             // Already hash-correct: `KeyAdvertiseRow` #[serde(skip)]s admitted_at.
             |row| row,
         )
+    }
+
+    /// CIRISEdge#416 (v18 sweep) — the RAW Key holdings: every key row in local
+    /// state, UNFILTERED. See [`Self::list_holdings`] for why the SelfOwn
+    /// publish filter must not shape the receive-diff view, and
+    /// [`Self::list_attestation_holdings`] for why the page limit is the RAW
+    /// configured one (relief bounds offers, never self-knowledge).
+    async fn list_key_holdings(&self) -> Vec<EnvelopeRef> {
+        self.list_keys_page(None, self.config.operational_page_limit)
+            .await
     }
 
     /// IdentityOccurrence plane — `SelfOwn` (publish-own): the node's OWN KEX
@@ -1701,17 +1930,40 @@ impl FederationDirectoryReplicationBridge {
             .subjects_for_projection(Projection::SelfOwn)
             .into_iter()
             .collect();
+        let limit = self.effective_page_limit().await;
+        self.list_identity_occurrences_page(Some(&subjects), limit)
+            .await
+    }
+
+    /// The IdentityOccurrence plane's since-cursor page — the `SelfOwn` filter
+    /// as a parameter, mirroring [`Self::list_keys_page`] (#416 sweep).
+    async fn list_identity_occurrences_page(
+        &self,
+        subjects: Option<&HashSet<String>>,
+        limit: u32,
+    ) -> Vec<EnvelopeRef> {
         let rows = self
             .directory
-            .list_signed_identity_occurrences_since(None, self.effective_page_limit().await)
+            .list_signed_identity_occurrences_since(None, limit)
             .await
             .unwrap_or_default();
         self.advertise_since(
             &rows,
-            |row| subjects.contains(&row.occurrence.identity_occurrence.occurrence_key_id),
+            |row| {
+                subjects.map_or(true, |s| {
+                    s.contains(&row.occurrence.identity_occurrence.occurrence_key_id)
+                })
+            },
             |row| Self::ms_seq(row.occurrence.identity_occurrence.asserted_at),
             |row| &row.occurrence,
         )
+    }
+
+    /// CIRISEdge#416 (v18 sweep) — the RAW IdentityOccurrence holdings,
+    /// unfiltered. See [`Self::list_holdings`].
+    async fn list_identity_occurrence_holdings(&self) -> Vec<EnvelopeRef> {
+        self.list_identity_occurrences_page(None, self.config.operational_page_limit)
+            .await
     }
 
     /// TransportDestination plane — `SelfOwn` (publish-own): the node's OWN
@@ -1724,14 +1976,30 @@ impl FederationDirectoryReplicationBridge {
             .subjects_for_projection(Projection::SelfOwn)
             .into_iter()
             .collect();
+        let limit = self.effective_page_limit().await;
+        self.list_transport_destinations_page(Some(&subjects), limit)
+            .await
+    }
+
+    /// The TransportDestination plane's since-cursor page — the `SelfOwn`
+    /// filter as a parameter, mirroring [`Self::list_keys_page`] (#416 sweep).
+    async fn list_transport_destinations_page(
+        &self,
+        subjects: Option<&HashSet<String>>,
+        limit: u32,
+    ) -> Vec<EnvelopeRef> {
         let rows = self
             .directory
-            .list_signed_transport_destinations_since(None, self.effective_page_limit().await)
+            .list_signed_transport_destinations_since(None, limit)
             .await
             .unwrap_or_default();
         self.advertise_since(
             &rows,
-            |row| subjects.contains(&row.destination.transport_destination.occurrence_key_id),
+            |row| {
+                subjects.map_or(true, |s| {
+                    s.contains(&row.destination.transport_destination.occurrence_key_id)
+                })
+            },
             |row| {
                 if row.destination.transport_destination.epoch > 0 {
                     row.destination.transport_destination.epoch
@@ -1741,6 +2009,13 @@ impl FederationDirectoryReplicationBridge {
             },
             |row| &row.destination,
         )
+    }
+
+    /// CIRISEdge#416 (v18 sweep) — the RAW TransportDestination holdings,
+    /// unfiltered. See [`Self::list_holdings`].
+    async fn list_transport_destination_holdings(&self) -> Vec<EnvelopeRef> {
+        self.list_transport_destinations_page(None, self.config.operational_page_limit)
+            .await
     }
 
     /// IdentityOccurrenceRevocation plane — tombstone → `Global` (anti-rollback,
@@ -2582,6 +2857,16 @@ impl FederationDirectoryReplicationBridge {
         for att in &attestations {
             // Skip only an unparseable/unhashable row (never a projection filter).
             let Some((hash, _bytes)) = content_hash_of(&att.attestation) else {
+                // v18 (#433) — the sibling advertise sweep (`list_attestations`)
+                // books this identical failure; a bare `continue` here made the
+                // HOLDINGS view silently blind to a held row, which re-enters it
+                // into `want` every round (the #416 non-convergence shape, by a
+                // different door).
+                self.withhold(
+                    crate::observability::WithholdReason::RowNotSerializable,
+                    "<unattributed>",
+                    "list_attestation_holdings: content_hash_of failed",
+                );
                 continue;
             };
             if !seen.insert(hash) {
@@ -3242,13 +3527,41 @@ impl FederationDirectoryReplicationBridge {
     /// a wire field. Supersession is `(epoch, asserted_at)`-monotonic, so a
     /// replayed older frame is `Refused`, not applied.
     ///
-    /// `Refused { reason }` is fail-closed and re-offerable — it is NOT a
-    /// transport error (the record is simply inadmissible: older epoch, or a
-    /// same-`(epoch, asserted_at)` content conflict), so we return `true`
-    /// (the frame was handled; do not retry-storm the sender). A genuine gate
-    /// failure (bad signature / unknown attesting key / not-acts-for) surfaces
-    /// as `Err` from persist → `false` → the frame is rejected. A parse failure
-    /// (a pre-v17 bare row from an un-upgraded peer) is also `false` — such a
+    /// ## The `Refused { reason }` mapping (v18 — the refusal-laundering fix)
+    ///
+    /// Until v18 this arm returned `Admitted` for EVERY persist `Refused` — the
+    /// deliberate old-`bool`-world anti-retry-storm shape — which made this the
+    /// ONE plane whose refusals evaded the #425 choke: `apply_refusals_by_kind`
+    /// under-counted, and a same-clock CONTENT CONFLICT read as an admit in
+    /// metrics. Worse, its `reason.contains("conflict")` discriminator was DEAD:
+    /// all three persist backends emit the SAME "does not supersede" reason
+    /// string for a stale epoch and for a same-clock fork (the word "conflict"
+    /// never appears), so every fork debug-logged as a routine stale epoch.
+    ///
+    /// The mapping now mirrors the Key plane's [`key_outcome_to_apply`]
+    /// precedent, and NOTHING retries on any outcome (the #425 choke counts and
+    /// logs; re-offering is driven by the want-diff, not by this value), so the
+    /// no-retry property is kept by construction:
+    ///
+    /// - `Inserted` / `Superseded` → `Admitted` (state changed);
+    /// - `Unchanged` → `Duplicate` (idempotent replay — was mis-counted as an
+    ///   admit);
+    /// - `Refused`, STALE (we hold a strictly newer `(epoch, asserted_at)`) →
+    ///   `Duplicate`, DELIBERATELY: it is routine non-progress the choke logs at
+    ///   DEBUG. Mapping it to `Refused` would WARN per redelivery every round —
+    ///   the log-noise analogue of the retry storm — while `Duplicate` still
+    ///   counts truthfully as non-admitted (`inc_duplicate`, never
+    ///   `inc_applied`). This is the documented compromise;
+    /// - `Refused`, SAME-CLOCK FORK (equal `(epoch, asserted_at)`, different
+    ///   content — the split-truth signal) → `ApplyOutcome::Refused`, loud at
+    ///   the choke AND counted on `apply_refusals_by_kind`. Because persist's
+    ///   reason string cannot distinguish the two, the classification re-reads
+    ///   the stored row's clock; an unreadable/absent stored row classifies to
+    ///   the LOUD arm (never launder what we cannot classify).
+    ///
+    /// A genuine gate failure (bad signature / unknown attesting key /
+    /// not-acts-for) surfaces as `Err` from persist → `Refused`. A parse failure
+    /// (a pre-v17 bare row from an un-upgraded peer) is `Deserialize` — such a
     /// peer's routes simply do not replicate until it adopts v17, which is the
     /// intended breaking behavior, not a silent bare-row admit.
     async fn apply_transport_destination(&self, bytes: &[u8]) -> ApplyOutcome {
@@ -3262,31 +3575,66 @@ impl FederationDirectoryReplicationBridge {
                 .await
             {
                 Ok(TransportDestinationApplyOutcome::Refused { reason }) => {
-                    // Fail-closed + re-offerable: a stale epoch is routine, but a
-                    // same-`(epoch, asserted_at)` CONTENT conflict is a split-truth
-                    // signal that must be loud (CIRISEdge#425 MEDIUM). We keep the
-                    // frame "handled" (return `Admitted`) either way so it does not
-                    // retry-storm the sender, but a conflict WARNs while a stale
-                    // epoch DEBUGs. Keyed on the low-cardinality reason, never the
-                    // attacker-influenced key_id / dest (CIRISEdge#337 §4).
-                    if reason.contains("conflict") {
-                        tracing::warn!(
-                            occurrence_key_id = %signed.transport_destination.occurrence_key_id,
-                            reason = %reason,
-                            "replicated route CONTENT CONFLICT at same (epoch, asserted_at) — \
-                             split-truth signal, not applied (CIRISEdge#338/#425)"
-                        );
-                    } else {
-                        tracing::debug!(
-                            occurrence_key_id = %signed.transport_destination.occurrence_key_id,
-                            reason = %reason,
-                            "replicated route refused (fail-closed, re-offerable): stale epoch \
-                             — not applied (CIRISEdge#338)"
-                        );
+                    let td = &signed.transport_destination;
+                    // Classify stale-vs-fork from the STORED row's clock (persist's
+                    // reason string is identical for both). `None` = the stored row
+                    // could not be read or was not found — unclassifiable, and an
+                    // unclassifiable refusal goes to the loud arm.
+                    let stored_clock = self
+                        .directory
+                        .list_signed_transport_destinations_for(&td.occurrence_key_id)
+                        .await
+                        .ok()
+                        .and_then(|rows| {
+                            rows.into_iter()
+                                .find(|r| {
+                                    r.transport_destination.transport_kind == td.transport_kind
+                                })
+                                .map(|r| {
+                                    (
+                                        r.transport_destination.epoch,
+                                        r.transport_destination.asserted_at,
+                                    )
+                                })
+                        });
+                    match stored_clock {
+                        Some(stored) if stored > (td.epoch, td.asserted_at) => {
+                            // STALE — routine; keyed on the low-cardinality reason,
+                            // never the attacker-influenced key_id/dest (#337 §4).
+                            tracing::debug!(
+                                occurrence_key_id = %td.occurrence_key_id,
+                                reason = %reason,
+                                "replicated route refused (fail-closed, re-offerable): stale \
+                                 (epoch, asserted_at) — not applied; counted as Duplicate, \
+                                 see the mapping doc (CIRISEdge#338)"
+                            );
+                            ApplyOutcome::Duplicate
+                        }
+                        _ => {
+                            // SAME-CLOCK FORK (or unclassifiable) — split truth.
+                            tracing::warn!(
+                                occurrence_key_id = %td.occurrence_key_id,
+                                reason = %reason,
+                                classified = stored_clock.is_some(),
+                                "replicated route CONTENT CONFLICT at same (epoch, \
+                                 asserted_at) — split-truth signal, not applied \
+                                 (CIRISEdge#338/#425; `classified=false` = the stored row \
+                                 could not be re-read, refusing loud rather than laundering)"
+                            );
+                            ApplyOutcome::Refused(format!(
+                                "TransportDestination: supersession refused \
+                                 (same-clock content conflict or unclassifiable): {reason}"
+                            ))
+                        }
                     }
-                    ApplyOutcome::Admitted
                 }
-                Ok(_) => ApplyOutcome::Admitted,
+                // v18 — `Unchanged` is persist's byte-identical idempotent no-op:
+                // the exact `Duplicate` semantics (was mis-counted as an admit).
+                Ok(TransportDestinationApplyOutcome::Unchanged) => ApplyOutcome::Duplicate,
+                Ok(
+                    TransportDestinationApplyOutcome::Inserted
+                    | TransportDestinationApplyOutcome::Superseded,
+                ) => ApplyOutcome::Admitted,
                 Err(e) => ApplyOutcome::Refused(format!(
                     "TransportDestination: authenticated apply gate rejected (signature / \
                      attesting-key / acts-for, CIRISEdge#337 CRITICAL-2): {e}"
@@ -3827,6 +4175,405 @@ mod tests {
             "list_attestation_holdings MUST contain the held row (#416 convergence \
              invariant) even though the advertise view excludes it"
         );
+    }
+
+    /// v18 SECURITY — the SelfOwn fetch-path projection twin. A FOREIGN-produced
+    /// `cohort_scope:"self"` attestation is structurally hidden by
+    /// `attestation_is_advertised`, and until v18 the direct fetch never
+    /// consulted that gate: any consent-included peer that learned the hash
+    /// out-of-band was served the bytes byte-for-byte. Field-exact scenario:
+    /// - a third-party peer IN the consent set, fetching by hash → refused AND
+    ///   booked (isolating the projection twin — consent cannot be the refuser);
+    /// - the row's own producer/subject → served (the v16 first-party override,
+    ///   matching the subject-Pull LIST gate);
+    /// - an advertised (federation-scope) row → unaffected for the same peer.
+    #[tokio::test]
+    async fn foreign_self_scope_attestation_is_not_served_by_direct_fetch() {
+        let local = "this-node";
+        let producer = "other-producer";
+        let third = "third-peer";
+        let (backend, bridge) =
+            make_bridge(&[local.to_string(), producer.to_string(), third.to_string()]);
+        let metrics = crate::observability::EdgeMetrics::new();
+        let publish_set = vec![local.to_string()];
+        let selector: CohortProvider = Arc::new(move || publish_set.clone());
+        let bridge = bridge
+            .with_local_key_id(Some(local.to_string()))
+            .with_self_provider(Some(selector))
+            .with_metrics(Some(metrics.clone()));
+        for kid in [local, producer, third] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+        }
+        // BOTH fetching peers are consent-included by this node, so a refusal
+        // below can only be the projection twin, never the #396 item-1 bound.
+        seed_consent_membership(&backend, local, third).await;
+        seed_consent_membership(&backend, local, producer).await;
+        // The hidden row: self-scoped, produced by ANOTHER node (held here via
+        // replication; advertised only by its own producer).
+        let hidden_id = uuid::Uuid::new_v4().to_string();
+        seed_scoped_attestation(
+            &backend,
+            &hidden_id,
+            producer,
+            producer,
+            "scores",
+            "self",
+            serde_json::json!({ "dimension": "identity:example:v1" }),
+        )
+        .await;
+        // An ADVERTISED control row `third` is NOT first-party to (attester =
+        // local, subject = producer): federation scope → projected → served.
+        seed_delegates_to(
+            &backend,
+            local,
+            producer,
+            &serde_json::json!(["infra:attest"]),
+        )
+        .await;
+
+        // Locate both rows by CONTENT via the raw holdings view.
+        let mut hidden_hash = None;
+        let mut advertised_hash = None;
+        for r in bridge.list_attestation_holdings().await {
+            let bytes = bridge
+                .fetch_envelope_bytes(EnvelopeKind::Attestation, &r.envelope_hash)
+                .await
+                .expect("holdings resolve to bytes");
+            let v: serde_json::Value = serde_json::from_slice(&bytes).expect("wire json");
+            // Read the scope through the bridge's ONE reader (#727 discipline —
+            // a raw `.get("cohort_scope")` here trips the skip_serializing_if
+            // source guard, and rightly so).
+            if FederationDirectoryReplicationBridge::attestation_cohort_scope(&v) == "self" {
+                hidden_hash = Some(r.envelope_hash);
+            } else if v
+                .get("attestation_type")
+                .and_then(serde_json::Value::as_str)
+                == Some("delegates_to")
+            {
+                advertised_hash = Some(r.envelope_hash);
+            }
+        }
+        let hidden_hash = hidden_hash.expect("the self-scoped row is held");
+        let advertised_hash = advertised_hash.expect("the delegates_to row is held");
+
+        // The advertise view excludes the hidden row for the third party…
+        assert!(
+            !bridge
+                .list_attestations(Some(third))
+                .await
+                .iter()
+                .any(|r| r.envelope_hash == hidden_hash),
+            "a foreign self-scoped row must not be advertised to a third party"
+        );
+        // …and (v18) the direct fetch now AGREES: refused + booked.
+        let before = metrics.withholds(crate::observability::WithholdReason::RecipientNotInSendSet);
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(EnvelopeKind::Attestation, &hidden_hash, Some(third))
+                .await
+                .is_none(),
+            "SECURITY: a consent-included third party must NOT obtain a \
+             structurally-hidden self-scope row by fetching its hash out-of-band \
+             (the v18 projection twin)"
+        );
+        assert!(
+            metrics.withholds(crate::observability::WithholdReason::RecipientNotInSendSet) > before,
+            "the projection-twin refusal must be BOOKED on the withhold ledger \
+             (borrowing the closest documented audience-membership reason)"
+        );
+        // An UNATTRIBUTED fetch has no first party — fail-closed.
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(EnvelopeKind::Attestation, &hidden_hash, None)
+                .await
+                .is_none(),
+            "an unattributed fetch of a hidden row fails closed"
+        );
+        // The first party (author AND subject) still recovers its own testimony
+        // — the v16 override the twin must preserve.
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &hidden_hash,
+                    Some(producer)
+                )
+                .await
+                .is_some(),
+            "the first party fetches its own self-scope row (v16 override intact)"
+        );
+        // Advertised rows are unaffected: the same third party still fetches a
+        // projected row it is NOT first-party to.
+        assert!(
+            bridge
+                .fetch_envelope_bytes_for_peer(
+                    EnvelopeKind::Attestation,
+                    &advertised_hash,
+                    Some(third)
+                )
+                .await
+                .is_some(),
+            "an advertised (federation-scope) row still serves the same peer — \
+             the twin narrows nothing the advertise gate would have served"
+        );
+    }
+
+    /// v18 (#416 sweep) — the SelfOwn-plane HOLDINGS views are UNFILTERED. A
+    /// held-but-unpublished KEY (a foreign subject's row this node admitted via
+    /// replication) must appear in `list_holdings(Key)` even though the
+    /// advertise view excludes it — else the round's `want = remote ∖ holdings`
+    /// re-wants it forever (round 2 re-fetches, re-applies `Duplicate`, never
+    /// converges). Drives the two-round shape: remote advertises, local
+    /// computes `want` from holdings → empty on the second round.
+    #[tokio::test]
+    async fn held_but_unpublished_key_leaves_want_on_the_second_round() {
+        use crate::replication::summary::diff_refs;
+        let this_node = "this-node";
+        let foreign = "foreign-subject";
+        let (backend, bridge) = make_bridge(&[foreign.to_string()]);
+        for k in [this_node, foreign] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+        }
+        // This node publishes only its OWN key.
+        let publish_set = vec![this_node.to_string()];
+        let selector: CohortProvider = Arc::new(move || publish_set.clone());
+        let bridge = bridge.with_self_provider(Some(selector));
+
+        // The REMOTE view: the foreign subject's own node advertises its key.
+        // Same backend = the same stored row bytes, exactly as after round 1
+        // replicated it here.
+        let remote_dir: Arc<dyn FederationDirectory> = backend.clone();
+        let remote_cohort: CohortProvider = Arc::new(Vec::new);
+        let foreign_set = vec![foreign.to_string()];
+        let remote_selector: CohortProvider = Arc::new(move || foreign_set.clone());
+        let remote = FederationDirectoryReplicationBridge::new(remote_dir, remote_cohort)
+            .with_self_provider(Some(remote_selector));
+        let remote_refs = remote.list_envelope_refs(EnvelopeKind::Key).await;
+        assert_eq!(
+            remote_refs.len(),
+            1,
+            "the remote advertises the foreign key"
+        );
+
+        // The ADVERTISE view here excludes the foreign key (SelfOwn publish-own)…
+        let advertise = bridge.list_envelope_refs(EnvelopeKind::Key).await;
+        assert!(
+            !diff_refs(&advertise, &remote_refs).is_empty(),
+            "precondition: the advertise view does NOT cover the remote ref — \
+             using it as the diff basis is exactly the pre-v18 non-convergence"
+        );
+        // …and the HOLDINGS view covers it: round 2's want is EMPTY.
+        let holdings = bridge.list_holdings(EnvelopeKind::Key).await;
+        assert!(
+            diff_refs(&holdings, &remote_refs).is_empty(),
+            "v18: `want = remote ∖ holdings` must be empty for a held \
+             foreign-subject key — the round converges instead of re-fetching \
+             it forever (#416 on the Key plane)"
+        );
+    }
+
+    /// v18 — a deterministic, REALLY-signed `SignedTransportDestination` (the
+    /// same JCS + Ed25519 + bound ML-DSA-65 construction persist verifies;
+    /// `sign_attestation_envelope` is the generic hybrid envelope signer).
+    /// `attesting == occurrence` (self-asserted, the `signer_acts_for` self
+    /// path — the same shape `self_route.rs` emits in production).
+    fn sign_transport_destination_fixture(
+        key_id: &str,
+        dest: &str,
+        epoch: u64,
+        asserted_at: chrono::DateTime<Utc>,
+    ) -> ciris_persist::federation::self_at_login::SignedTransportDestination {
+        use ciris_persist::federation::self_at_login::{
+            BindingProvenance, SignedTransportDestination, TransportDestination,
+        };
+        use ciris_verify_core::transport_binding::TransportBindingSignature;
+        let row = TransportDestination {
+            occurrence_key_id: key_id.to_string(),
+            transport_kind: "reticulum".to_string(),
+            destination: dest.to_string(),
+            asserted_at,
+            last_seen_at: None,
+            transport_ed25519_pubkey_base64: Some(B64.encode([0xbb; 32])),
+            transport_x25519_pubkey_base64: Some(B64.encode([0xcc; 32])),
+            binding_provenance: BindingProvenance::Rooted,
+            epoch,
+            retired_at: None,
+        };
+        let envelope = serde_json::to_value(&row).expect("route row serializes");
+        let (_hash, ed_sig, pqc_sig) = sign_attestation_envelope(key_id, &envelope);
+        SignedTransportDestination {
+            attesting_key_id: key_id.to_string(),
+            transport_destination: row,
+            signed_envelope: envelope,
+            signature: TransportBindingSignature {
+                ed25519_signature_base64: ed_sig,
+                mldsa65_signature_base64: pqc_sig,
+            },
+        }
+    }
+
+    /// v18 (#416 sweep, TransportDestination arm) — same convergence shape as
+    /// the Key-plane test, driven through the REAL signed-route admission.
+    #[tokio::test]
+    async fn held_but_unpublished_route_is_in_holdings() {
+        let this_node = "this-node";
+        let foreign = "foreign-subject";
+        let (backend, bridge) = make_bridge(&[foreign.to_string()]);
+        for k in [this_node, foreign] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(k, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+        }
+        let publish_set = vec![this_node.to_string()];
+        let selector: CohortProvider = Arc::new(move || publish_set.clone());
+        let bridge = bridge.with_self_provider(Some(selector));
+        // Admit the FOREIGN node's signed route exactly as replication would.
+        let now = Utc::now().trunc_subsecs(6);
+        let signed = sign_transport_destination_fixture(foreign, "aa00", 3, now);
+        let outcome = bridge
+            .apply_envelope_bytes(
+                EnvelopeKind::TransportDestination,
+                &serde_json::to_vec(&signed).expect("wire"),
+                None,
+            )
+            .await;
+        assert!(
+            outcome.is_admitted(),
+            "signed route admits, got {outcome:?}"
+        );
+
+        assert!(
+            bridge
+                .list_envelope_refs(EnvelopeKind::TransportDestination)
+                .await
+                .is_empty(),
+            "the advertise view excludes the foreign route (SelfOwn publish-own)"
+        );
+        assert_eq!(
+            bridge
+                .list_holdings(EnvelopeKind::TransportDestination)
+                .await
+                .len(),
+            1,
+            "v18: the holdings view contains the held foreign route (#416 on the \
+             TransportDestination plane)"
+        );
+    }
+
+    /// v18 — the TransportDestination refusal-laundering fix: persist outcomes
+    /// map HONESTLY (`Unchanged` → Duplicate; stale → Duplicate, quiet;
+    /// same-clock content FORK → Refused, loud) instead of everything reading
+    /// `Admitted` in metrics. Nothing here retries on any outcome — the #425
+    /// choke counts and logs, and re-offers are want-diff-driven.
+    #[tokio::test]
+    async fn apply_transport_destination_counts_refusals_honestly() {
+        let key = "route-owner";
+        let (backend, bridge) = make_bridge(&[]);
+        backend
+            .put_public_key(SignedKeyRecord {
+                record: fixture_key_record(key, identity_type::AGENT),
+            })
+            .await
+            .expect("seed key");
+        let t5 = Utc::now().trunc_subsecs(6);
+        let current = sign_transport_destination_fixture(key, "aa00", 5, t5);
+        let wire = |s: &ciris_persist::federation::self_at_login::SignedTransportDestination| {
+            serde_json::to_vec(s).expect("wire")
+        };
+
+        // Fresh insert → Admitted.
+        let r = bridge
+            .apply_envelope_bytes(EnvelopeKind::TransportDestination, &wire(&current), None)
+            .await;
+        assert_eq!(r, ApplyOutcome::Admitted, "fresh signed route admits");
+
+        // Byte-identical replay → persist `Unchanged` → Duplicate (was
+        // mis-counted as an admit).
+        let r = bridge
+            .apply_envelope_bytes(EnvelopeKind::TransportDestination, &wire(&current), None)
+            .await;
+        assert_eq!(
+            r,
+            ApplyOutcome::Duplicate,
+            "an idempotent replay is a Duplicate, not an admit"
+        );
+
+        // STALE: strictly older (epoch, asserted_at) → Duplicate (routine
+        // non-progress; deliberately NOT the loud Refused arm — see the
+        // mapping doc), and NEVER Admitted.
+        let stale =
+            sign_transport_destination_fixture(key, "bb11", 3, t5 - chrono::Duration::seconds(10));
+        let r = bridge
+            .apply_envelope_bytes(EnvelopeKind::TransportDestination, &wire(&stale), None)
+            .await;
+        assert_eq!(
+            r,
+            ApplyOutcome::Duplicate,
+            "a stale-epoch re-offer counts as Duplicate — quiet, and no longer \
+             laundered into the admit metrics"
+        );
+
+        // SAME-CLOCK FORK: equal (epoch, asserted_at), DIFFERENT content →
+        // the split-truth signal must surface as a LOUD Refused at the #425
+        // choke and count on `apply_refusals_by_kind`.
+        let fork = sign_transport_destination_fixture(key, "cc22", 5, t5);
+        let r = bridge
+            .apply_envelope_bytes(EnvelopeKind::TransportDestination, &wire(&fork), None)
+            .await;
+        assert!(
+            matches!(r, ApplyOutcome::Refused(_)),
+            "a same-clock content fork is a REFUSAL (split truth), got {r:?}"
+        );
+    }
+
+    /// v18 — the cursor-plane arm-set is BOUND to the predicate: the kinds
+    /// `list_envelope_refs_inner` declines to advertise by construction (and
+    /// `accord_evidence_since` answers) are EXACTLY `is_cursor_served` over
+    /// `ALL`. Widening the predicate without visiting the bridge's dispatch
+    /// (or vice versa) reds here, not on the wire.
+    #[tokio::test]
+    async fn cursor_arm_set_equals_the_predicate_over_all() {
+        let cursor_kinds: Vec<EnvelopeKind> = EnvelopeKind::ALL
+            .into_iter()
+            .filter(|k| k.is_cursor_served())
+            .collect();
+        assert_eq!(
+            cursor_kinds,
+            vec![EnvelopeKind::AccordQuorumEvidence],
+            "the `EnvelopeKind::AccordQuorumEvidence => Vec::new()` advertise arm \
+             and `accord_evidence_since`'s accord-specific body are written for \
+             EXACTLY this set — a new cursor kind must visit BOTH dispatch sites \
+             in bridge.rs (see the comments naming this test)"
+        );
+        let (_backend, bridge) = make_bridge(&[]);
+        for kind in EnvelopeKind::ALL {
+            if kind.is_cursor_served() {
+                assert!(
+                    bridge.list_envelope_refs(kind).await.is_empty(),
+                    "a cursor-served kind must never advertise content-hash refs \
+                     (listed-then-unfetchable otherwise): {kind:?}"
+                );
+            } else {
+                assert!(
+                    bridge.accord_evidence_since(kind, None).await.is_empty(),
+                    "a non-cursor kind must never be answered by the cursor serve \
+                     path: {kind:?}"
+                );
+            }
+        }
     }
 
     /// Bridge dedupes the same key when listed across multiple cohort

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -338,12 +338,11 @@ impl ReplicationCoordinator {
                 refused,
                 staleness,
             }),
-            ReplicationOutcome::RoundComplete { kind } => DriveStep::Complete(RoundReport {
-                kind,
-                admitted: 0,
-                refused: 0,
-                staleness: StalenessSignal::Unknown,
-            }),
+            // (An unproduced `RoundComplete` variant used to be mapped here to a
+            // Complete report with `staleness: Unknown` — dead code that would
+            // have DISGUISED unknown staleness as a cleanly completed round had
+            // anything ever produced it. Deleted; `Applied` and
+            // `SendAndComplete` are the only completion outcomes.)
             ReplicationOutcome::UnexpectedMessage => DriveStep::Refused,
         }
     }

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -254,14 +254,33 @@ impl EnvelopeKind {
     /// CIRISEdge#474 — is this kind served over the dedicated CURSOR path
     /// (`CursorPull` → `Deliver`, resume on `evidence_at`) rather than the
     /// content-hash Summary/Diff/Fetch flow? EXACTLY the kinds with no
-    /// `signed_wire_index` entry ([`Self::persist_index_kind`] → None AND not
-    /// [`Self::Revocation`], which is index-less but rides `persist_row_hash`).
-    /// Currently only [`Self::AccordQuorumEvidence`]; checked over `ALL` in a test
-    /// so a future cursor kind is a deliberate widening, never an accident. An
-    /// Initiator round for such a kind opens with a `CursorPull`, not a Summary.
+    /// `signed_wire_index` entry ([`Self::persist_index_kind`] → None) that are
+    /// not [`Self::is_row_hash_served`] (Revocation is index-less but rides
+    /// `persist_row_hash` on the content-hash flow). Currently only
+    /// [`Self::AccordQuorumEvidence`]; checked over `ALL` in a test — and the
+    /// serve/advertise manifest's `advertise`/`receive` cursor cells are DERIVED
+    /// from this predicate in `serve_policy`'s tests, so a future cursor kind
+    /// reds that module until the manifest (and its pinned hash) move
+    /// deliberately. An Initiator round for such a kind opens with a
+    /// `CursorPull`, not a Summary.
     #[must_use]
     pub fn is_cursor_served(self) -> bool {
         matches!(self, Self::AccordQuorumEvidence)
+    }
+
+    /// CIRISEdge#396 item 3 — is this kind index-less in persist's
+    /// `signed_wire_index` yet still served on the content-hash
+    /// Summary/Diff/Fetch flow, riding `persist_row_hash` as its envelope hash?
+    /// EXACTLY [`Self::Revocation`]. This is the THIRD serve basis alongside
+    /// content-hash-indexed ([`Self::persist_index_kind`] → Some) and
+    /// cursor-served ([`Self::is_cursor_served`]); every kind has exactly one
+    /// of the three (pinned over `ALL` in
+    /// `every_kind_has_exactly_one_serve_basis`). The bridge's fetch path
+    /// resolves these kinds via their dedicated `persist_row_hash` read, never
+    /// the content-hash point-read.
+    #[must_use]
+    pub fn is_row_hash_served(self) -> bool {
+        matches!(self, Self::Revocation)
     }
 
     /// The kinds a subject sweep issues a `Pull` for — the
@@ -314,8 +333,9 @@ impl EnvelopeKind {
             Self::Key => "Key",
             Self::Attestation => "Attestation",
             // Both are absent from persist's content-hash `signed_wire_index`:
-            // Revocation rides `persist_row_hash`; AccordQuorumEvidence rides the
-            // cursor path (#474). Neither has a content-hash point-read.
+            // Revocation rides `persist_row_hash` (`is_row_hash_served`);
+            // AccordQuorumEvidence rides the cursor path (`is_cursor_served`,
+            // #474). Neither has a content-hash point-read.
             Self::Revocation | Self::AccordQuorumEvidence => return None,
             Self::IdentityOccurrence => "IdentityOccurrence",
             Self::Family => "Family",
@@ -692,9 +712,65 @@ mod tests {
             EnvelopeKind::AccordQuorumEvidence.as_wire_str(),
             "accord_quorum_evidence"
         );
-        // Revocation is index-less but is NOT cursor-served (different wire).
+        // Revocation is index-less but is NOT cursor-served — it is the one
+        // row-hash-served kind (a different wire basis).
         assert!(EnvelopeKind::Revocation.persist_index_kind().is_none());
         assert!(!EnvelopeKind::Revocation.is_cursor_served());
+        assert!(EnvelopeKind::Revocation.is_row_hash_served());
+    }
+
+    /// The three serve bases partition `ALL`: every kind is EXACTLY ONE of
+    /// content-hash-indexed (`persist_index_kind` → Some), row-hash-served
+    /// (`is_row_hash_served` — Revocation), or cursor-served
+    /// (`is_cursor_served` — AccordQuorumEvidence). A new kind that lands in
+    /// zero or two bases is a taxonomy bug this test refuses; the Revocation
+    /// partition previously lived only in prose (3 doc sites + a bridge
+    /// `== Revocation` literal), which is how prose drifts.
+    #[test]
+    fn every_kind_has_exactly_one_serve_basis() {
+        for kind in EnvelopeKind::ALL {
+            let bases = [
+                kind.persist_index_kind().is_some(),
+                kind.is_row_hash_served(),
+                kind.is_cursor_served(),
+            ];
+            assert_eq!(
+                bases.iter().filter(|b| **b).count(),
+                1,
+                "{kind:?}: must be exactly one of content-hash-indexed / \
+                 row-hash-served / cursor-served, got {bases:?}"
+            );
+            // Membership pin: row-hash-served is EXACTLY Revocation.
+            assert_eq!(
+                kind.is_row_hash_served(),
+                matches!(kind, EnvelopeKind::Revocation),
+                "{kind:?}: row-hash-served iff it is Revocation"
+            );
+        }
+    }
+
+    /// CIRISEdge#441 — `bridge::is_removal_kind` (the removal-receipt ledger's
+    /// membership predicate) is EXACTLY the four typed removal planes, pinned
+    /// over `ALL` so widening the removal class is a deliberate edit here, not
+    /// an accident. Asserted against the pub fn itself (defined in
+    /// `bridge.rs`), i.e. through the same symbol its call sites
+    /// (coordinator/bridge) consult.
+    #[test]
+    fn is_removal_kind_is_exactly_the_four_removal_planes() {
+        for kind in EnvelopeKind::ALL {
+            let expected = matches!(
+                kind,
+                EnvelopeKind::Revocation
+                    | EnvelopeKind::IdentityOccurrenceRevocation
+                    | EnvelopeKind::FamilyMembershipRevocation
+                    | EnvelopeKind::CommunityMembershipRevocation
+            );
+            assert_eq!(
+                crate::replication::bridge::is_removal_kind(kind),
+                expected,
+                "{kind:?}: removal-class iff one of the four typed removal planes"
+            );
+        }
     }
 
     /// CIRISEdge#462 — `is_subject_pullable` is EXACTLY the five replicated kinds
@@ -739,36 +815,39 @@ mod tests {
         assert!(matches!(r, Err(ProtocolError::Decode(_))));
     }
 
-    /// All ten `EnvelopeKind` variants round-trip via JSON — kind
-    /// values are wire-load-bearing per FSD §3.3.
+    /// EVERY `EnvelopeKind` variant's wire token is pinned + round-trips via
+    /// JSON — kind values are wire-load-bearing per FSD §3.3. The expected
+    /// table is an EXHAUSTIVE match (no wildcard) iterated over `ALL`, so a
+    /// new variant refuses to compile until its token is pinned here — the
+    /// hand-written 10-of-15 array this replaces silently left the five
+    /// post-v1 kinds unpinned.
     #[test]
     fn envelope_kind_wire_values_are_stable() {
-        let cases = [
-            (EnvelopeKind::Key, "key"),
-            (EnvelopeKind::Attestation, "attestation"),
-            (EnvelopeKind::Revocation, "revocation"),
-            (EnvelopeKind::IdentityOccurrence, "identity_occurrence"),
-            (EnvelopeKind::Family, "family"),
-            (EnvelopeKind::Community, "community"),
-            (
-                EnvelopeKind::IdentityOccurrenceRevocation,
-                "identity_occurrence_revocation",
-            ),
-            (
-                EnvelopeKind::FamilyMembershipRevocation,
-                "family_membership_revocation",
-            ),
-            (
-                EnvelopeKind::CommunityMembershipRevocation,
-                "community_membership_revocation",
-            ),
-            (EnvelopeKind::LocationProof, "location_proof"),
-        ];
-        for (kind, wire) in cases {
+        for kind in EnvelopeKind::ALL {
+            let wire = match kind {
+                EnvelopeKind::Key => "key",
+                EnvelopeKind::Attestation => "attestation",
+                EnvelopeKind::Revocation => "revocation",
+                EnvelopeKind::IdentityOccurrence => "identity_occurrence",
+                EnvelopeKind::Family => "family",
+                EnvelopeKind::Community => "community",
+                EnvelopeKind::IdentityOccurrenceRevocation => "identity_occurrence_revocation",
+                EnvelopeKind::FamilyMembershipRevocation => "family_membership_revocation",
+                EnvelopeKind::CommunityMembershipRevocation => "community_membership_revocation",
+                EnvelopeKind::LocationProof => "location_proof",
+                EnvelopeKind::Organization => "organization",
+                EnvelopeKind::OrgMembership => "org_membership",
+                EnvelopeKind::PartnerRecord => "partner_record",
+                EnvelopeKind::TransportDestination => "transport_destination",
+                EnvelopeKind::AccordQuorumEvidence => "accord_quorum_evidence",
+            };
+            // The serde rename, the manifest key, and the pin all agree.
+            assert_eq!(kind.as_wire_str(), wire, "{kind:?}: as_wire_str drifted");
             let m = ReplicationMessage::Summary(SummaryMessage { kind, refs: vec![] });
             let bytes = m.to_bytes();
             let s = std::str::from_utf8(&bytes).unwrap();
-            assert!(s.contains(wire), "expected `{wire}` in {s}");
+            let cell = format!(r#""kind":"{wire}""#);
+            assert!(s.contains(&cell), "expected `{cell}` in {s}");
             assert_eq!(ReplicationMessage::from_bytes(&bytes).unwrap(), m);
         }
     }
@@ -797,27 +876,22 @@ mod tests {
     }
 
     /// Wire-stability sanity: confirm no two kinds collide on their
-    /// serde rename. Catches accidental duplicates if a future
-    /// variant is added with a typo.
+    /// serde rename, over ALL kinds (not a hand-copied subset). Catches
+    /// accidental duplicates if a future variant is added with a typo, and
+    /// that the serde rename always equals `as_wire_str`.
     #[test]
     fn envelope_kind_wire_values_are_unique() {
         use std::collections::HashSet;
-        let kinds = [
-            EnvelopeKind::Key,
-            EnvelopeKind::Attestation,
-            EnvelopeKind::Revocation,
-            EnvelopeKind::IdentityOccurrence,
-            EnvelopeKind::Family,
-            EnvelopeKind::Community,
-            EnvelopeKind::IdentityOccurrenceRevocation,
-            EnvelopeKind::FamilyMembershipRevocation,
-            EnvelopeKind::CommunityMembershipRevocation,
-            EnvelopeKind::LocationProof,
-        ];
-        let wires: HashSet<String> = kinds
-            .iter()
-            .map(|k| serde_json::to_string(k).unwrap())
-            .collect();
-        assert_eq!(wires.len(), kinds.len(), "wire-name collision detected");
+        let mut wires: HashSet<String> = HashSet::new();
+        for kind in EnvelopeKind::ALL {
+            let serde_wire = serde_json::to_string(&kind).unwrap();
+            assert_eq!(
+                serde_wire,
+                format!("\"{}\"", kind.as_wire_str()),
+                "{kind:?}: serde rename and as_wire_str must agree"
+            );
+            assert!(wires.insert(serde_wire), "wire-name collision on {kind:?}");
+        }
+        assert_eq!(wires.len(), EnvelopeKind::ALL.len());
     }
 }

--- a/src/replication/serve_policy.rs
+++ b/src/replication/serve_policy.rs
@@ -21,18 +21,29 @@ use super::protocol::EnvelopeKind;
 /// The per-kind serve/advertise policy edge (the responder) enforces.
 fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
     // `advertise`: the projection scope the bridge fans a kind out over.
-    //   - `per_record_projection` — persist `projection_for` decides per row
-    //     (SelfOwn / Cohort / Global from the record's own dimension/cohort_scope).
-    //   - `cohort` / `global` — the operator cohort set / the whole plane.
+    //   - `per_record_projection` — the bridge decides PER ROW (the Attestation
+    //     plane's `attestation_projection`: SelfOwn / Cohort / Capability /
+    //     Subject / Global from the record's own dimension/cohort_scope).
+    //   - `self_own` / `cohort` / `global` — ONE constant projection for the
+    //     whole plane (the node's own publish set / the operator cohort set /
+    //     the widest own∪cohort set).
     //   - `bulk_since` — the paginated since-cursor operational reads.
+    //   - `cursor:evidence_at` — the dedicated cursor plane (never
+    //     content-hash-advertised).
     // `serve`: `public` (public signed envelope) or a `capability:*` gate.
     let (advertise, serve) = match kind {
+        // These five planes do NOT consult a per-record projection: the bridge
+        // hardcodes ONE `Projection` constant per plane (`list_keys` /
+        // `list_identity_occurrences` / `list_transport_destinations` →
+        // `Projection::SelfOwn`; `list_identity_occurrence_revocations` /
+        // `list_revocations` → `Projection::Global`, the #311 tombstone rule).
+        // The manifest states that truth — the earlier `per_record_projection`
+        // claim here described a mechanism these planes never had.
         EnvelopeKind::Key
         | EnvelopeKind::IdentityOccurrence
-        | EnvelopeKind::TransportDestination
-        | EnvelopeKind::IdentityOccurrenceRevocation
-        | EnvelopeKind::Revocation => ("per_record_projection", "public"),
-        // E3: the trace plane is the sole capability-gated serve path.
+        | EnvelopeKind::TransportDestination => ("self_own", "public"),
+        // E3: the trace plane is the sole capability-gated serve path — and the
+        // ONE plane whose projection is genuinely decided per row.
         EnvelopeKind::Attestation => (
             "per_record_projection",
             "trace:* → capability:infra:serve; else public",
@@ -40,9 +51,13 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
         EnvelopeKind::Family | EnvelopeKind::Community | EnvelopeKind::LocationProof => {
             ("cohort", "public")
         }
-        EnvelopeKind::FamilyMembershipRevocation | EnvelopeKind::CommunityMembershipRevocation => {
-            ("global", "public")
-        }
+        // The four `global` planes: the two tombstone planes above join the two
+        // membership-revocation planes here — all four fan out over the
+        // hardcoded widest own∪cohort set (`Projection::Global`).
+        EnvelopeKind::IdentityOccurrenceRevocation
+        | EnvelopeKind::Revocation
+        | EnvelopeKind::FamilyMembershipRevocation
+        | EnvelopeKind::CommunityMembershipRevocation => ("global", "public"),
         EnvelopeKind::Organization | EnvelopeKind::OrgMembership | EnvelopeKind::PartnerRecord => {
             ("bulk_since", "public")
         }
@@ -130,8 +145,19 @@ pub fn serve_advertise_policy_sha256() -> String {
 // appended (advertise `cursor:evidence_at`, serve `public`, receive
 // `cursor_pull:evidence_at` — the cursor plane, NOT a subject Pull). CIRISServer
 // re-pins from 6f683311… to this value alongside persist's v31 REPLICATION_POLICY_HASH.
+// (was 328d73b0…)
+//
+// serve-policy audit — re-pinned: the `advertise` column now states the TRUTH
+// for the five planes the bridge fans out over ONE hardcoded `Projection`
+// constant (they never consulted a per-record projection): Key /
+// IdentityOccurrence / TransportDestination → `self_own`,
+// IdentityOccurrenceRevocation / Revocation → `global` (the #311 tombstone
+// rule). `per_record_projection` now names only the Attestation plane, the one
+// whose projection is genuinely decided per row. NO serve-path behavior
+// changed — this is the manifest catching up to the code it witnesses.
+// **CIRISServer must mirror**: re-pin from 328d73b0… to this value.
 pub const SERVE_ADVERTISE_POLICY_HASH: &str =
-    "328d73b0a6a5c7e2d1272b81e245ecceeca1d837dd08b0415105e1661ff4a699";
+    "20499cabaf1c0566b5a8d66f8d03c8a980b760c733e83444b7345a7733f22d74";
 
 #[cfg(test)]
 mod tests {
@@ -148,9 +174,13 @@ mod tests {
         );
     }
 
-    /// CIRISEdge#462 — the RECEIVE axis witness: EXACTLY the five replicated
-    /// kinds answer a subject Pull (`subject_pull:*`), every other kind is `none`,
-    /// and the Attestation plane is the one that names both axes + the G2 carve.
+    /// CIRISEdge#462 — the RECEIVE axis witness, DERIVED from the protocol
+    /// predicate: the manifest's `subject_pull:*` kinds are exactly
+    /// `EnvelopeKind::is_subject_pullable` over `ALL` (wire names via
+    /// `as_wire_str`, in `ALL` order). This is what makes the doc claim on
+    /// `is_subject_pullable` true: widening the predicate reds this test until
+    /// the manifest column moves (and the pinned hash flips deliberately) —
+    /// the earlier hardcoded 5-string vec asserted nothing about the predicate.
     #[test]
     fn only_the_five_replicated_kinds_answer_a_subject_pull() {
         let manifest = serve_advertise_manifest();
@@ -160,17 +190,17 @@ mod tests {
             .filter(|p| p["receive"].as_str().unwrap().starts_with("subject_pull"))
             .map(|p| p["kind"].as_str().unwrap())
             .collect();
+        let expected: Vec<&str> = EnvelopeKind::ALL
+            .into_iter()
+            .filter(|k| k.is_subject_pullable())
+            .map(EnvelopeKind::as_wire_str)
+            .collect();
         assert_eq!(
-            pullable,
-            vec![
-                "key",
-                "attestation",
-                "identity_occurrence",
-                "identity_occurrence_revocation",
-                "transport_destination",
-            ],
-            "exactly the five replicated kinds are subject-pullable (RECEIVE axis)"
+            pullable, expected,
+            "the manifest's subject_pull kinds must be EXACTLY \
+             EnvelopeKind::is_subject_pullable over ALL (RECEIVE axis)"
         );
+        assert_eq!(expected.len(), 5, "the five replicated kinds");
         // The Attestation plane is the one that sweeps both axes + carves scores.
         let att = policies
             .iter()
@@ -181,33 +211,91 @@ mod tests {
         assert!(recv.contains("G2"), "the score carve is witnessed: {recv}");
     }
 
-    /// CIRISEdge#474 — the accord-quorum-evidence plane appears in the manifest as
-    /// a CURSOR plane: advertise `cursor:evidence_at`, serve `public`, receive
-    /// `cursor_pull:*` (NOT `subject_pull:*`, so it stays out of the five
-    /// subject-pullable kinds), and never capability-gated.
+    /// CIRISEdge#474 — the cursor-plane witness, DERIVED from the protocol
+    /// predicate: for EVERY kind in `ALL`, its manifest row is a cursor plane
+    /// (advertise `cursor:evidence_at`, receive `cursor_pull:*`, serve
+    /// `public`) iff `is_cursor_served` says so. Adding a cursor kind
+    /// therefore reds this module until the manifest moves — the earlier
+    /// version looked up one hardcoded row and never consulted the predicate.
     #[test]
     fn accord_quorum_evidence_is_a_public_cursor_plane() {
         let manifest = serve_advertise_manifest();
         let policies = manifest["policies"].as_array().unwrap();
-        let aqe = policies
-            .iter()
-            .find(|p| p["kind"] == "accord_quorum_evidence")
-            .expect("accord_quorum_evidence is in the 15-kind manifest");
-        assert_eq!(aqe["advertise"], "cursor:evidence_at");
-        assert_eq!(aqe["serve"], "public");
-        let recv = aqe["receive"].as_str().unwrap();
-        assert!(
-            recv.starts_with("cursor_pull:"),
-            "cursor receive axis: {recv}"
+        for kind in EnvelopeKind::ALL {
+            let row = policies
+                .iter()
+                .find(|p| p["kind"] == kind.as_wire_str())
+                .unwrap_or_else(|| panic!("{kind:?} missing from the manifest"));
+            let advertise = row["advertise"].as_str().unwrap();
+            let recv = row["receive"].as_str().unwrap();
+            assert_eq!(
+                advertise == "cursor:evidence_at",
+                kind.is_cursor_served(),
+                "{kind:?}: cursor advertise cell iff is_cursor_served"
+            );
+            assert_eq!(
+                recv.starts_with("cursor_pull:"),
+                kind.is_cursor_served(),
+                "{kind:?}: cursor_pull receive cell iff is_cursor_served"
+            );
+            if kind.is_cursor_served() {
+                assert_eq!(row["serve"], "public");
+                assert!(
+                    !recv.starts_with("subject_pull"),
+                    "{kind:?}: NOT a subject pull — stays out of the five: {recv}"
+                );
+                assert!(
+                    !row["serve"].as_str().unwrap().contains("capability:"),
+                    "the cursor plane is public, never capability-gated"
+                );
+            }
+        }
+        // The predicate currently names exactly one cursor plane.
+        assert!(EnvelopeKind::AccordQuorumEvidence.is_cursor_served());
+    }
+
+    /// CIRISEdge#393 item 3 — the manifest's columns are TEST-LOCKED to the
+    /// `protocol.rs` predicates over `EnvelopeKind::ALL`: the manifest covers
+    /// exactly `ALL` (in order), and each row's `receive` cell agrees with
+    /// `is_subject_pullable` / `is_cursor_served` — `none` exactly when
+    /// neither holds. So a predicate edit in protocol.rs reds THIS module
+    /// until the manifest (and `SERVE_ADVERTISE_POLICY_HASH`) move
+    /// deliberately, and a manifest edit that contradicts the predicates
+    /// cannot land at all: the columns can no longer drift from the code that
+    /// enforces them.
+    #[test]
+    fn manifest_columns_are_derived_from_the_protocol_predicates() {
+        let manifest = serve_advertise_manifest();
+        let policies = manifest["policies"].as_array().unwrap();
+        assert_eq!(
+            policies.len(),
+            EnvelopeKind::ALL.len(),
+            "one manifest row per kind in ALL"
         );
-        assert!(
-            !recv.starts_with("subject_pull"),
-            "NOT a subject pull — stays out of the five: {recv}"
-        );
-        assert!(
-            !aqe["serve"].as_str().unwrap().contains("capability:"),
-            "the accord plane is public, never capability-gated"
-        );
+        for (row, kind) in policies.iter().zip(EnvelopeKind::ALL) {
+            assert_eq!(
+                row["kind"],
+                kind.as_wire_str(),
+                "manifest rows ride in ALL order (the order is hashed)"
+            );
+            let recv = row["receive"].as_str().unwrap();
+            assert_eq!(
+                recv.starts_with("subject_pull:"),
+                kind.is_subject_pullable(),
+                "{kind:?}: receive is subject_pull:* iff is_subject_pullable"
+            );
+            assert_eq!(
+                recv.starts_with("cursor_pull:"),
+                kind.is_cursor_served(),
+                "{kind:?}: receive is cursor_pull:* iff is_cursor_served"
+            );
+            if !kind.is_subject_pullable() && !kind.is_cursor_served() {
+                assert_eq!(
+                    recv, "none",
+                    "{kind:?}: neither predicate holds → the receive cell is `none`"
+                );
+            }
+        }
     }
 
     /// The load-bearing E3 fact must hold in the manifest: exactly ONE kind is

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -102,14 +102,13 @@ pub enum ReplicationOutcome {
         refused: usize,
         staleness: StalenessSignal,
     },
-    /// The round is complete for this kind from this side's
-    /// perspective. The other direction's round may still be in
-    /// flight; the caller tracks that independently.
-    RoundComplete { kind: EnvelopeKind },
-    /// The peer sent an unexpected message for the current state
-    /// (e.g. a Deliver before any Diff was exchanged). NOT a fatal
-    /// error — the session resets to idle and the caller can decide
-    /// whether to retry or drop the peer.
+    /// The peer sent a message this session refuses — in practice a message
+    /// whose `kind` mismatches this `(peer, kind)` session (the only refusal
+    /// the `on_*` arms produce), or a `start_round` on a Responder. NOT a
+    /// fatal error, and NOT a state transition: the refusal is
+    /// message-typed — the session's round state is left untouched, and only
+    /// the coordinator resets the session (its auto-reset on round
+    /// Complete). The caller can decide whether to retry or drop the peer.
     UnexpectedMessage,
 }
 
@@ -244,11 +243,23 @@ impl Session {
 
     /// Start a round. Only valid for [`SessionRole::Initiator`] —
     /// responders wait for an inbound Summary via [`Self::on_message`].
+    /// A Responder `start_round` is refused with
+    /// [`ReplicationOutcome::UnexpectedMessage`] (state untouched).
     pub fn start_round(&mut self, provider: &dyn StateProvider) -> ReplicationOutcome {
-        debug_assert!(
-            matches!(self.role, SessionRole::Initiator),
-            "start_round() is initiator-only"
-        );
+        if !matches!(self.role, SessionRole::Initiator) {
+            // Release-safe guard (was a `debug_assert!` that compiled OUT of
+            // release builds, so a mis-scheduled production Responder would
+            // have emitted a bogus Summary-as-initiator instead of refusing).
+            // `UnexpectedMessage` is the existing message-typed refusal the
+            // coordinator already maps to `DriveStep::Refused` and the
+            // scheduler to `RoundEvent::Refused` — the non-fatal shape a
+            // scheduler bug deserves; panicking a production node would not be.
+            tracing::error!(
+                kind = ?self.kind,
+                "start_round() called on a Responder session — refused (initiator-only)"
+            );
+            return ReplicationOutcome::UnexpectedMessage;
+        }
         // CIRISEdge#474 — the accord-quorum-evidence plane has no content-hash
         // index, so its round opens with a CURSOR pull, not a Summary. `since:
         // None` pulls all (bounded by the responder's page limit); the receiver's
@@ -621,10 +632,14 @@ impl Session {
         // does for the content-hash planes.
         let solicited = self.diff_want_count.is_some() || self.awaiting_cursor_deliver;
         if !solicited && !deliver.envelopes.is_empty() {
-            let bootstrap_plane = matches!(
-                self.kind,
-                EnvelopeKind::Key | EnvelopeKind::IdentityOccurrence
-            );
+            // CIRISEdge#402/#406 — the bootstrap classification is the SINGLE
+            // predicate `EnvelopeKind::is_bootstrap` (ALL-pinned in protocol.rs),
+            // never an inline kind list: the local list this replaces had already
+            // drifted (it omitted TransportDestination, so a #927 proactive push
+            // of the peer's own transport binding was mislabeled a WARN-class
+            // unsolicited write). Source-asserted through this call site in
+            // `the_unsolicited_deliver_classification_reads_is_bootstrap`.
+            let bootstrap_plane = self.kind.is_bootstrap();
             if bootstrap_plane {
                 tracing::debug!(
                     kind = ?self.kind,
@@ -1837,5 +1852,66 @@ mod tests {
         let (envelopes, dropped) = responder.pack_bounded_deliver(&[a, b], &provider);
         assert!(dropped.is_empty(), "no unfetchable want → no drop");
         assert_eq!(envelopes.len(), 2, "both fetchable wants pack");
+    }
+
+    /// `start_round` on a Responder is REFUSED release-safe (the old guard was
+    /// a `debug_assert!` that compiled out of release builds): it returns the
+    /// message-typed `UnexpectedMessage`, sends nothing, and leaves the
+    /// session's round state untouched — a mis-scheduled `start_round` must
+    /// not emit a bogus Summary-as-initiator nor complete anything.
+    #[test]
+    fn responder_start_round_is_refused_release_safe() {
+        let provider = provider_with(&[(EnvelopeKind::Key, h(1), b"e1".to_vec(), 1)]);
+        let mut s = Session::new(SessionRole::Responder, EnvelopeKind::Key);
+        assert_eq!(
+            s.start_round(&provider),
+            ReplicationOutcome::UnexpectedMessage,
+            "a Responder never opens a round"
+        );
+        assert!(!s.is_complete(), "the refusal is not a state transition");
+        // The session still services its real job afterwards: an inbound
+        // Summary produces the ordinary {Summary, Diff} responder step.
+        let applier = applier_for(&[]);
+        let out = s.on_message(
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Key,
+                refs: vec![],
+            }),
+            &provider,
+            &applier,
+            None,
+        );
+        assert!(
+            matches!(out, ReplicationOutcome::Send(ref m) if m.len() == 2),
+            "state untouched — the responder round proceeds normally, got {out:?}"
+        );
+    }
+
+    /// The unsolicited-Deliver bootstrap classification reads
+    /// `EnvelopeKind::is_bootstrap` THROUGH THE CALL SITE, never a local
+    /// `matches!` (the family_gates.rs model: a source assertion through the
+    /// call site so re-inlining the predicate reds the build). The inline list
+    /// this locks out had ALREADY drifted once — it omitted
+    /// TransportDestination, mislabeling #927 proactive pushes of the peer's
+    /// own transport binding at WARN. The membership itself is ALL-pinned in
+    /// protocol.rs (`is_bootstrap_is_exactly_the_three_bootstrap_kinds`); this
+    /// pins the WIRING, which log-level-only behavior cannot observe.
+    #[test]
+    fn the_unsolicited_deliver_classification_reads_is_bootstrap() {
+        let src = include_str!("session.rs");
+        let start = src.find("fn on_deliver").expect("on_deliver exists");
+        let end = src[start..]
+            .find("pub fn is_complete")
+            .expect("is_complete follows on_deliver");
+        let body = &src[start..start + end];
+        assert!(
+            body.contains("let bootstrap_plane = self.kind.is_bootstrap();"),
+            "on_deliver must classify via EnvelopeKind::is_bootstrap"
+        );
+        assert!(
+            !body.contains("matches!"),
+            "on_deliver must not re-inline a kind list — the inline matches! \
+             drifted from is_bootstrap once already (TransportDestination)"
+        );
     }
 }

--- a/src/swarm/runtime.rs
+++ b/src/swarm/runtime.rs
@@ -78,8 +78,19 @@ use crate::messages::MessageType;
 use crate::transport::Transport;
 
 /// `target_holders` default — the recommended `H` from §R-policy
-/// (CEG 1.0 §R / [`crate::holonomic::fountain_defaults::DEFAULT_TARGET_HOLDERS`]).
-pub const DEFAULT_TARGET_HOLDERS: u32 = 30;
+/// (CEG 1.0 §R).
+///
+/// RE-EXPORTED from the fountain-policy authority
+/// [`crate::holonomic::fountain_defaults::DEFAULT_TARGET_HOLDERS`]
+/// (previously a duplicated `= 30` literal). The two planes share the
+/// number BY DESIGN: the fountain plane derives the survival-floor
+/// target (`C₁ = N + K` × churn margin, with the §R reconstruction-
+/// probability table computed AT this holder count), and this swarm
+/// converger EXISTS to drive the observed holder count toward exactly
+/// that target. Two literals agreeing by luck would let the converger
+/// steady-state at a count the survival math was not computed for, so
+/// it is one `const` with one owner.
+pub use crate::holonomic::fountain_defaults::DEFAULT_TARGET_HOLDERS;
 
 /// `min_viable` default — the survival floor below which the
 /// converger emits `RepairNeeded`. Matches §R-policy's

--- a/src/swarm/scope.rs
+++ b/src/swarm/scope.rs
@@ -103,6 +103,7 @@
 //! [`FountainHoldingClaim`]: crate::holonomic::swarm_rarity::FountainHoldingClaim
 //! [`BlobScopeRouter::is_scope_native`]: crate::blob_swarm::BlobScopeRouter::is_scope_native
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use ciris_persist::federation::namespace::{
@@ -471,10 +472,21 @@ impl HoldingsScopeGate {
     /// # Arming
     ///
     /// `is_scope_native() == false` ⇒ [`HoldingAnnounce::Announce`]
-    /// unconditionally, with no table probe, **no directory call** and no
-    /// log. See the module docs: additive, not disruptive. The early
-    /// return is byte-identical to pre-#499 and pre-#744 alike — an
-    /// unarmed node performs no `.await` on this path at all.
+    /// unconditionally, with no table probe and **no directory call**. See
+    /// the module docs: additive, not disruptive. The early return is
+    /// byte-identical to pre-#499 and pre-#744 alike — an unarmed node
+    /// performs no `.await` on this path at all.
+    ///
+    /// v18 — the UNARMED state is no longer silent: the FIRST consultation
+    /// of an unarmed gate emits one process-lifetime WARN naming the
+    /// staged state and what arming requires — installing the MLS
+    /// [`ScopeAddressTable`], an OPERATOR OPT-IN via
+    /// `EdgeBuilder::scope_native_addressing` (the deriver itself shipped
+    /// with CIRISVerify#259's `ScopePrivacyDeriver`; nothing upstream is
+    /// pending). One atomic flag, no throttle table, no behavior change —
+    /// production deliberately rides unarmed until the operator opts in,
+    /// and an operator reading logs must be able to tell "staged open"
+    /// from "armed and passing".
     ///
     /// # The two halves of CIRISPersist#744, and why they are one change
     ///
@@ -531,6 +543,7 @@ impl HoldingsScopeGate {
     ) -> HoldingAnnounce {
         // ARMING — the byte-identical early return. No probe, no await.
         let Some(table) = self.table.as_ref() else {
+            warn_holdings_scope_gate_unarmed();
             return HoldingAnnounce::Announce;
         };
 
@@ -632,8 +645,34 @@ impl HoldingsScopeGate {
                     // hash-map probe and no derivation. See the
                     // "seam edge cannot yet supply" note above for why
                     // persist's verb is NOT asked here.
+                    //
+                    // v18 audit note — `SelfOwn` announced-to-roster is a
+                    // DELIBERATE reading, not the attestation plane's
+                    // "structurally invisible" collapsed by accident. A
+                    // holdings claim is publish-own BY CONSTRUCTION (the
+                    // announcing node is the claim's producer), so the
+                    // SelfOwn publisher restriction is trivially satisfied;
+                    // what remains is the AUDIENCE, and persist bounds it
+                    // to the record's OWN roster — the family's MLS group
+                    // for family scope (the same set the blob serve gate
+                    // admits on the family address), and the owner's own
+                    // device set for `self` scope (the single-owner
+                    // boundary, CIRISConstitution#23). The residual trust
+                    // assumption is the TABLE INSTALLER's: a `self`-scope
+                    // group's roster must be only the owner's nodes — this
+                    // gate cannot verify that. Pinned by
+                    // `family_holding_withheld_from_outsider_while_federation_still_flows`.
                     Projection::Cohort | Projection::SelfOwn => {
                         if table.send_address(scope, group_id, peer_key_id).is_some() {
+                            if projection == Projection::SelfOwn {
+                                tracing::debug!(
+                                    peer = %peer_key_id,
+                                    content_kind = scope.kind_token(),
+                                    "SelfOwn-projected holding announced to its OWN \
+                                     group roster (deliberate — see the v18 audit \
+                                     note at this site)"
+                                );
+                            }
                             HoldingAnnounce::Announce
                         } else {
                             HoldingAnnounce::Withhold(HoldingRefusal::PeerNotInRoster {
@@ -798,6 +837,27 @@ fn withhold_detail(content_id: &str) -> String {
     format!("fountain:{prefix}")
 }
 
+/// v18 — has the unarmed-gate staging WARN fired this process?
+static HOLDINGS_SCOPE_GATE_UNARMED_WARNED: AtomicBool = AtomicBool::new(false);
+
+/// v18 — say ONCE (per process) that the holdings scope gate is riding the
+/// staged default-open state. The default itself is INTENTIONAL and must not
+/// flip (production rides it; `unarmed_gate_announces_everything` pins it) —
+/// this only makes the state legible, so "staged open" can never again be
+/// mistaken for "armed and passing".
+fn warn_holdings_scope_gate_unarmed() {
+    if !HOLDINGS_SCOPE_GATE_UNARMED_WARNED.swap(true, Ordering::Relaxed) {
+        tracing::warn!(
+            "fountain holdings scope gate UNARMED — scope-native addressing is not \
+             installed, so this node rides the pre-#499 staged state: every held \
+             content is announced to every cohort peer, with no scope filter. This \
+             is the deliberate default; arming is an OPERATOR OPT-IN — install the \
+             MLS ScopeAddressTable via EdgeBuilder::scope_native_addressing (the \
+             CIRISVerify#259 ScopePrivacyDeriver is shipped). Warned once per process."
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -955,6 +1015,15 @@ mod tests {
     /// A node with NO address table announces everything, including
     /// content whose scope is unknown AND content that is family-scoped.
     /// This is the pre-#499 deployment and it must not change.
+    ///
+    /// v18 PIN — "no table ⇒ default-open" is INTENTIONAL, not an
+    /// oversight: production rides this staged state, and arming is an
+    /// operator OPT-IN (`EdgeBuilder::scope_native_addressing` installs the
+    /// MLS table; the CIRISVerify#259 deriver is shipped). A future "fix"
+    /// that flips this default fail-closed would dark every holding on
+    /// every existing deployment. If you are here to flip it: that is the
+    /// arming event, done by installing the table — not by editing the
+    /// gate.
     #[tokio::test]
     async fn unarmed_gate_announces_everything() {
         let g = HoldingsScopeGate::new(None, None);

--- a/src/transport/av_spine/tests.rs
+++ b/src/transport/av_spine/tests.rs
@@ -95,7 +95,7 @@ fn fresh_joiner_xwing() -> (PeerKexPubkeys, OwnKexKeys) {
     (
         PeerKexPubkeys {
             x25519_pub: x_pk,
-            mlkem768_pub: Some(mlkem_pk.clone()),
+            mlkem768_pub: mlkem_pk.clone(),
         },
         OwnKexKeys {
             x25519_priv: x_sk,

--- a/src/transport/federation_session.rs
+++ b/src/transport/federation_session.rs
@@ -52,12 +52,21 @@
 //!   without X25519 is out-of-spec; honoring it would create a degraded
 //!   ciphersuite an attacker could force by stripping the X25519 half.
 //!
-//! `PeerKexPubkeys.mlkem768_pub` remains `Option` (rather than being made
-//! non-optional) because directory-sourced advertisements are represented
-//! with `None` and rejected at their CONSTRUCTION boundary — the FFI Member
-//! conversion and the A/V-MLS bridge both HNDL-pre-check `mlkem768_pub` is
-//! present. The retirement above enforces the same invariant at the two KEX
-//! verbs, so a classical-only peer is refused wherever it enters.
+//! **`PeerKexPubkeys.mlkem768_pub` is REQUIRED (CIRISEdge#481 item 4).**
+//! In a 100% PQC fleet the ML-KEM-less peer no longer exists, so the type
+//! no longer represents it: the field is `Vec<u8>`, not `Option`. The one
+//! seam through which "maybe-absent" ML-KEM material may still approach
+//! this type — Option-shaped FFI tuples and deserializers — is
+//! [`PeerKexPubkeys::from_advertisement`], which refuses absence with the
+//! typed [`SessionError::HybridRequiredButPeerLacksMlkem`] at CONSTRUCTION.
+//! The illegal state is unrepresentable rather than policy-checked: the
+//! old `Hybrid → Classical` fallback arm in [`FederationSession::initiate`]
+//! is gone because its predicate (`mlkem768_pub.is_some()`) can no longer
+//! be false. `OwnKexKeys.mlkem768_priv/pub` deliberately REMAIN `Option`:
+//! [`FederationSession::respond`]'s refusal paths
+//! ([`SessionError::HybridResponderMissingMlkem`]) need degraded local-key
+//! fixtures to exist as test witnesses, mirroring the #481 item-5 decision
+//! for `LocalSigner.pqc`.
 
 use ciris_crypto::hybrid_kex::{
     self, ClassicalHandshakeMsg, HybridHandshakeMsg, KEX_ALGORITHM_CLASSICAL_V1,
@@ -110,17 +119,50 @@ impl KexAlgorithm {
     }
 }
 
-/// What a peer publishes for KEX. X25519 is required (fallback safety);
-/// ML-KEM-768 is optional (a peer at older keying levels is admitted via
-/// classical fallback). A peer publishing ONLY the ML-KEM-768 half is
-/// represented by `mlkem768_pub: Some` with `x25519_pub` defaulted —
-/// callers MUST verify the X25519 half is present before constructing
-/// this type from wire input; [`FederationSession::initiate`] additionally
-/// rejects the case at runtime as defense-in-depth.
+/// What a peer publishes for KEX. BOTH halves are required
+/// (CIRISEdge#481 item 4): the hybrid X25519+ML-KEM-768 construction is
+/// mandatory, and a peer that lacks either half is not representable by
+/// this type. A peer publishing ONLY the ML-KEM-768 half is represented
+/// by `x25519_pub` defaulted to all-zero — callers MUST verify the
+/// X25519 half is present before constructing this type from wire
+/// input; [`FederationSession::initiate`] additionally rejects the
+/// all-zero case at runtime as defense-in-depth.
+///
+/// Sources that hold "maybe-absent" ML-KEM material (FFI tuples,
+/// deserializers) MUST construct through
+/// [`PeerKexPubkeys::from_advertisement`], which turns absence into the
+/// typed [`SessionError::HybridRequiredButPeerLacksMlkem`] at the
+/// construction boundary instead of a policy check downstream.
 #[derive(Debug, Clone)]
 pub struct PeerKexPubkeys {
     pub x25519_pub: [u8; 32],
-    pub mlkem768_pub: Option<Vec<u8>>,
+    pub mlkem768_pub: Vec<u8>,
+}
+
+impl PeerKexPubkeys {
+    /// Construct from an Option-shaped KEX advertisement — the ONLY
+    /// seam through which possibly-absent ML-KEM material may approach
+    /// this type (CIRISEdge#481 item 4). Absence is refused HERE, with
+    /// a typed error, so the ML-KEM-less peer is unrepresentable
+    /// everywhere downstream: `initiate` needs no fallback arm, and the
+    /// A/V-MLS roster gates need no `is_none` pre-checks.
+    ///
+    /// # Errors
+    ///
+    /// `mlkem768_pub == None` →
+    /// [`SessionError::HybridRequiredButPeerLacksMlkem`].
+    pub fn from_advertisement(
+        x25519_pub: [u8; 32],
+        mlkem768_pub: Option<Vec<u8>>,
+    ) -> Result<Self, SessionError> {
+        match mlkem768_pub {
+            Some(mlkem768_pub) => Ok(Self {
+                x25519_pub,
+                mlkem768_pub,
+            }),
+            None => Err(SessionError::HybridRequiredButPeerLacksMlkem),
+        }
+    }
 }
 
 /// The local side's KEX private keys. Required for [`FederationSession::respond`].
@@ -234,12 +276,20 @@ pub enum SessionError {
     /// key pair to decapsulate.
     #[error("hybrid responder missing ML-KEM-768 private key")]
     HybridResponderMissingMlkem,
-    /// Caller requested [`KexAlgorithm::HybridRequired`] (HNDL-strict
-    /// mode) against a peer that hasn't advertised ML-KEM-768. Refused
-    /// rather than silently negotiated down to classical — `HybridRequired`
-    /// is the caller asserting the channel content must survive into the
-    /// post-quantum era, and a classical-only outcome would violate that.
-    #[error("HybridRequired mode rejects classical-fallback peer (HNDL discipline)")]
+    /// The peer's KEX advertisement lacks the ML-KEM-768 half. Post-
+    /// CIRISEdge#481 hybrid is unconditionally required (`Hybrid` ≡
+    /// `HybridRequired`), and item 4 made the ML-KEM-less peer
+    /// UNREPRESENTABLE by [`PeerKexPubkeys`] — so this error now fires
+    /// at exactly one place: [`PeerKexPubkeys::from_advertisement`],
+    /// the construction boundary where Option-shaped sources (FFI
+    /// tuples, deserializers) are converted. It can no longer be
+    /// produced by [`FederationSession::initiate`], whose old
+    /// classical-fallback refusal arm this construction-time refusal
+    /// replaced.
+    #[error(
+        "peer KEX advertisement lacks ML-KEM-768 — hybrid X25519+ML-KEM-768 \
+         is mandatory (CIRISEdge#481, HNDL discipline)"
+    )]
     HybridRequiredButPeerLacksMlkem,
     /// CIRISEdge#481 — the classical X25519-only KEX is RETIRED. Fed TM
     /// §3.3 Gap C (harvest-now-decrypt-later) is only closed if there is
@@ -267,15 +317,17 @@ pub struct FederationSession;
 
 impl FederationSession {
     /// Initiator side. Caller supplies the peer's advertised KEX
-    /// pubkeys + the preferred algorithm. Negotiation rules per
-    /// module docs are applied here:
+    /// pubkeys + the preferred algorithm. Post-CIRISEdge#481 there is
+    /// nothing left to negotiate:
     ///
-    /// - `Hybrid` requested + peer has ML-KEM-768 → hybrid
-    /// - `Hybrid` requested + peer lacks ML-KEM-768 → classical fallback
-    /// - `Classical` requested → classical (caller already negotiated down)
-    /// - Peer has ML-KEM-768 but NO X25519 → [`SessionError::MlKemOnlyRejected`]
-    ///   even though the type system tries to make this unrepresentable
-    ///   (defense in depth for callers constructing via deserializers).
+    /// - `Hybrid` | `HybridRequired` → hybrid ([`PeerKexPubkeys`] proves
+    ///   the ML-KEM-768 half exists — item 4 made the ML-KEM-less peer
+    ///   unrepresentable, so the old classical-fallback and
+    ///   refuse-classical-peer arms are structurally gone from here)
+    /// - `Classical` requested → [`SessionError::ClassicalKexRetired`]
+    /// - Peer has ML-KEM-768 but NO X25519 (all-zero `x25519_pub`) →
+    ///   [`SessionError::MlKemOnlyRejected`] — defense in depth for
+    ///   callers constructing via deserializers that default the field.
     ///
     /// Returns the wire message to send the responder PLUS the
     /// initiator's session key.
@@ -289,42 +341,24 @@ impl FederationSession {
         // field to all zeros (which is itself a refusable pubkey — see
         // [Curve25519 small-subgroup attacks]). Treat all-zero as
         // "not advertised" and refuse.
-        if peer.x25519_pub == [0u8; 32] && peer.mlkem768_pub.is_some() {
+        if peer.x25519_pub == [0u8; 32] {
             return Err(SessionError::MlKemOnlyRejected);
         }
-        // CIRISEdge#481 — negotiation AFTER classical retirement. `Hybrid` and
-        // `HybridRequired` are now IDENTICAL on the initiate side: both REQUIRE
-        // the peer to advertise ML-KEM-768, and there is NO classical fallback.
-        // - Hybrid | HybridRequired + peer has ML-KEM → hybrid
-        // - Hybrid | HybridRequired + peer lacks ML-KEM → REJECT (no downgrade)
-        // - Classical (explicitly requested) → REJECT (retired)
-        //
-        // The silent `Hybrid + peer-lacks-ML-KEM → classical` fallback that used
-        // to live here was PRECISELY the downgrade an active attacker forces by
+        // CIRISEdge#481 — nothing to negotiate. `Hybrid` and `HybridRequired`
+        // are IDENTICAL on the initiate side, and item 4 moved the "peer lacks
+        // ML-KEM" refusal to `PeerKexPubkeys::from_advertisement`: by the time
+        // a value of this type exists, the ML-KEM half provably exists. The
+        // silent `Hybrid + peer-lacks-ML-KEM → classical` fallback that used to
+        // live here was PRECISELY the downgrade an active attacker forces by
         // stripping a peer's ML-KEM advertisement; Fed TM §3.3 Gap C is only
-        // closed once that path is gone.
-        let actual = match (requested, peer.mlkem768_pub.is_some()) {
-            (KexAlgorithm::HybridRequired | KexAlgorithm::Hybrid, true) => KexAlgorithm::Hybrid,
-            (KexAlgorithm::HybridRequired | KexAlgorithm::Hybrid, false) => {
-                return Err(SessionError::HybridRequiredButPeerLacksMlkem);
-            }
-            (KexAlgorithm::Classical, _) => return Err(SessionError::ClassicalKexRetired),
-        };
-        match actual {
-            KexAlgorithm::Hybrid => {
-                let mlkem_pub = peer.mlkem768_pub.as_deref().expect("checked above");
-                let (msg, k) = hybrid_kex::initiate_hybrid(&peer.x25519_pub, mlkem_pub)?;
+        // closed once that path is gone — now it is unwritable, not merely
+        // deleted.
+        match requested {
+            KexAlgorithm::Hybrid | KexAlgorithm::HybridRequired => {
+                let (msg, k) = hybrid_kex::initiate_hybrid(&peer.x25519_pub, &peer.mlkem768_pub)?;
                 Ok((SessionHandshakeMsg::Hybrid(msg), SessionKey(k)))
             }
-            // #481 — `actual` is `Hybrid` by construction: the explicit
-            // `Classical` request and the classical-peer case both returned
-            // `Err` above, and `HybridRequired` collapsed to `Hybrid`. The
-            // classical initiate path (`hybrid_kex::initiate_classical`) is
-            // retired and no longer reachable from this verb.
-            KexAlgorithm::Classical | KexAlgorithm::HybridRequired => unreachable!(
-                "post-#481 negotiation yields only Hybrid; classical is retired \
-                 and HybridRequired collapses to Hybrid"
-            ),
+            KexAlgorithm::Classical => Err(SessionError::ClassicalKexRetired),
         }
     }
 
@@ -387,14 +421,10 @@ mod tests {
     fn advertise(own: &OwnKexKeys) -> PeerKexPubkeys {
         PeerKexPubkeys {
             x25519_pub: x25519::public_from_secret(&own.x25519_priv),
-            mlkem768_pub: own.mlkem768_pub.clone(),
-        }
-    }
-
-    fn advertise_classical_only(own: &OwnKexKeys) -> PeerKexPubkeys {
-        PeerKexPubkeys {
-            x25519_pub: x25519::public_from_secret(&own.x25519_priv),
-            mlkem768_pub: None,
+            mlkem768_pub: own
+                .mlkem768_pub
+                .clone()
+                .expect("hybrid fixture always carries ML-KEM-768"),
         }
     }
 
@@ -431,20 +461,46 @@ mod tests {
         );
     }
 
-    /// CIRISEdge#481 — requesting `Hybrid` against a classical-only peer no
-    /// longer falls back to classical; it is REJECTED. This is the exact
-    /// active-downgrade an attacker forces by stripping the ML-KEM
-    /// advertisement (was: `..._falls_back`, which asserted the now-retired
-    /// fallback).
+    /// CIRISEdge#481 item 4 — the classical-only peer is now
+    /// UNREPRESENTABLE by `PeerKexPubkeys`; the refusal the old
+    /// `hybrid_requested_against_classical_only_peer_is_rejected` test
+    /// asserted at `initiate` now fires one layer earlier, at the
+    /// construction boundary. Field-exact fixture: the Option shape is
+    /// EXACTLY what the FFI produces (`peer_mlkem768_pub.map(<[u8]>::
+    /// to_vec)` with Python `None`) — a stripped ML-KEM advertisement
+    /// arriving from outside — with a REAL X25519 half, so the only
+    /// thing being refused is the ML-KEM absence.
     #[test]
-    fn hybrid_requested_against_classical_only_peer_is_rejected() {
+    fn mlkem_absent_advertisement_rejected_at_construction() {
         let responder = fresh_recipient();
-        let peer_view = advertise_classical_only(&responder);
-        let r = FederationSession::initiate(&peer_view, KexAlgorithm::Hybrid);
+        let x25519_pub = x25519::public_from_secret(&responder.x25519_priv);
+        let r = PeerKexPubkeys::from_advertisement(x25519_pub, None);
         assert!(
             matches!(r, Err(SessionError::HybridRequiredButPeerLacksMlkem)),
-            "hybrid vs classical-only peer must reject (no fallback), got {r:?}"
+            "ML-KEM-less advertisement must be refused at construction, got {r:?}"
         );
+    }
+
+    /// CIRISEdge#481 item 4 — the accepting half of the construction
+    /// boundary: a complete advertisement constructs, and the value
+    /// initiates a hybrid session under BOTH `Hybrid` and
+    /// `HybridRequired` (the modes are identical post-#481; this
+    /// preserves the item-2 coverage on the new constructor path).
+    #[test]
+    fn complete_advertisement_constructs_and_initiates_hybrid() {
+        let responder = fresh_recipient();
+        let peer_view = PeerKexPubkeys::from_advertisement(
+            x25519::public_from_secret(&responder.x25519_priv),
+            responder.mlkem768_pub.clone(),
+        )
+        .expect("complete advertisement must construct");
+        for mode in [KexAlgorithm::Hybrid, KexAlgorithm::HybridRequired] {
+            let (msg, initiator_key) =
+                FederationSession::initiate(&peer_view, mode).expect("initiate");
+            assert_eq!(msg.algorithm(), ALGORITHM_HYBRID_V1);
+            let responder_key = FederationSession::respond(&responder, &msg).expect("respond");
+            assert_eq!(initiator_key.as_bytes(), responder_key.as_bytes());
+        }
     }
 
     /// CIRISEdge#481 — the ACTIVE-attacker close: even a WELL-FORMED classical
@@ -476,7 +532,10 @@ mod tests {
         let responder = fresh_recipient();
         let bad_peer_view = PeerKexPubkeys {
             x25519_pub: [0u8; 32],
-            mlkem768_pub: responder.mlkem768_pub.clone(),
+            mlkem768_pub: responder
+                .mlkem768_pub
+                .clone()
+                .expect("hybrid fixture always carries ML-KEM-768"),
         };
         let r = FederationSession::initiate(&bad_peer_view, KexAlgorithm::Hybrid);
         assert!(
@@ -564,21 +623,12 @@ mod tests {
         assert_eq!(initiator_key.as_bytes(), responder_key.as_bytes());
     }
 
-    /// HNDL-strict mode refuses a classical-only peer instead of
-    /// silently degrading. This is the load-bearing assertion for
-    /// CEG §10.5.5 realtime A/V + key_grant DEK distribution: the
-    /// content's HNDL-secrecy is the caller's intent, and the substrate
-    /// honors it by refusal rather than fallback.
-    #[test]
-    fn hybrid_required_refuses_classical_only_peer() {
-        let responder = fresh_recipient();
-        let peer_view = advertise_classical_only(&responder);
-        let r = FederationSession::initiate(&peer_view, KexAlgorithm::HybridRequired);
-        assert!(
-            matches!(r, Err(SessionError::HybridRequiredButPeerLacksMlkem)),
-            "expected HybridRequiredButPeerLacksMlkem, got {r:?}"
-        );
-    }
+    // (was: `hybrid_required_refuses_classical_only_peer` — CIRISEdge#481
+    // item 4 made the classical-only peer UNREPRESENTABLE, so the HNDL-
+    // strict refusal that test asserted is now the construction-time
+    // refusal covered by `mlkem_absent_advertisement_rejected_at_
+    // construction`; there is no weaker representable peer left for
+    // `HybridRequired` to refuse.)
 
     /// HybridRequired still rejects the ML-KEM-only peer view shape
     /// (defense-in-depth — the all-zero X25519 sentinel from upstream
@@ -588,7 +638,10 @@ mod tests {
         let responder = fresh_recipient();
         let bad = PeerKexPubkeys {
             x25519_pub: [0u8; 32],
-            mlkem768_pub: responder.mlkem768_pub.clone(),
+            mlkem768_pub: responder
+                .mlkem768_pub
+                .clone()
+                .expect("hybrid fixture always carries ML-KEM-768"),
         };
         let r = FederationSession::initiate(&bad, KexAlgorithm::HybridRequired);
         assert!(matches!(r, Err(SessionError::MlKemOnlyRejected)));

--- a/src/transport/frame_fragment.rs
+++ b/src/transport/frame_fragment.rs
@@ -107,15 +107,28 @@ const MAX_FRAGMENTS: usize = u16::MAX as usize;
 /// not counted in the `u16` `data` length, so this ceiling is exact.
 const WIRE_ENVELOPE_MAX_BYTES: usize = u16::MAX as usize;
 
+/// THE transport-level envelope-body budget: the single 8 MiB authority
+/// (AV-13 `MAX_BODY_BYTES`) every transport enforces on an outbound /
+/// inbound envelope body. `transport::http` (extractor layer + both send
+/// paths) and `transport::reticulum` (send path) IMPORT this constant
+/// rather than re-typing the literal, and the receive-side reassembly
+/// ceiling below DERIVES from it — so raising the budget raises the
+/// admissibility checks and the reassembly bound in lockstep. Before this
+/// was the authority, three independent `8 * 1024 * 1024` literals agreed
+/// only by comment; raising the send-side one alone would have produced
+/// frames the receive side structurally refuses to reassemble.
+pub const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
+
 /// SECURITY (v16 review, pre-attribution reassembly OOM): the receive side bounded
 /// only the COUNT of in-flight partials (`max_in_flight`), never their bytes — so
 /// a peer declaring `total = u16::MAX` and streaming fragments (withholding one so
 /// the frame never completes) could pin ~27 MB in a SINGLE partial, and
 /// `max_in_flight` of them ~7 GB, all before the link is even attributed. These
-/// cap a single frame's accumulated payload (matching the transport `MAX_BODY_BYTES`
-/// admissibility ceiling), and the TOTAL resident reassembly memory across all
+/// cap a single frame's accumulated payload (derived from the transport
+/// [`MAX_BODY_BYTES`] admissibility ceiling — equal BY CONSTRUCTION, not by
+/// comment), and the TOTAL resident reassembly memory across all
 /// partials — the hard bound regardless of partial count.
-const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024; // == transport MAX_BODY_BYTES
+const MAX_FRAME_BYTES: usize = MAX_BODY_BYTES;
 const MAX_IN_FLIGHT_BYTES: usize = 4 * MAX_FRAME_BYTES; // 32 MiB global budget
 
 /// CIRISEdge#422 — fragment-ARQ NAK magic. A third, distinct 4-byte tag so a

--- a/src/transport/http.rs
+++ b/src/transport/http.rs
@@ -71,10 +71,12 @@ use tokio::sync::mpsc;
 
 use super::{InboundFrame, Transport, TransportError, TransportId, TransportSendOutcome};
 
-/// Maximum body size accepted on the inbound HTTP route. Mirrors
-/// AV-13 (`MAX_BODY_BYTES = 8 MiB`) at the extractor layer so
-/// oversized payloads reject before allocation.
-const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
+// Maximum body size accepted on the inbound HTTP route (AV-13, 8 MiB),
+// enforced at the extractor layer so oversized payloads reject before
+// allocation. IMPORTED from the single transport-wide authority in
+// `frame_fragment` — not re-typed — so the HTTP admissibility ceiling
+// can never drift from the reassembly budget (one-authority body budget).
+use super::frame_fragment::MAX_BODY_BYTES;
 
 // ─── Legacy plain-HTTP config (pre-CIRISEdge#23) ────────────────────
 //

--- a/src/transport/realtime_av_mls.rs
+++ b/src/transport/realtime_av_mls.rs
@@ -187,7 +187,12 @@ use crate::transport::federation_session::{OwnKexKeys, PeerKexPubkeys};
 /// The MLS ciphersuite this module pins to. `0x004D` — X-Wing
 /// (ML-KEM-768 + X25519) | ChaCha20-Poly1305 | SHA-256 | Ed25519.
 /// See module docs § "0x004D code-point caveat".
-pub const CIPHERSUITE_ID: u16 = 0x004D;
+///
+/// RE-EXPORTED from the single authority
+/// [`crate::mls::cohort_group::CIPHERSUITE_ID`] — an A/V-plane pin
+/// diverging from the cohort-plane pin would be a silent PQC
+/// downgrade, so this module imports rather than duplicates.
+pub use crate::mls::cohort_group::CIPHERSUITE_ID;
 
 /// The openmls enum value the [`CIPHERSUITE_ID`] maps to.
 const CIPHERSUITE: Ciphersuite = Ciphersuite::MLS_256_XWING_CHACHA20POLY1305_SHA256_Ed25519;

--- a/src/transport/realtime_av_mls.rs
+++ b/src/transport/realtime_av_mls.rs
@@ -99,19 +99,22 @@
 //! Durable group state (sqlite-provider, custom storage) is a separate
 //! cut (filed as a follow-up by Layer 2 integration).
 //!
-//! ## HNDL discipline (pre-MLS gate)
+//! ## HNDL discipline (structural, CIRISEdge#481 item 4)
 //!
 //! The 0x004D ciphersuite already requires ML-KEM-768 by spec — a
-//! peer can't even produce a valid KeyPackage without it. This module
-//! adds a **structural pre-check** anyway: every [`Member`] passed to
-//! [`MlsSession::create`] / [`MlsSession::commit_add`] is rejected
-//! before any MLS code runs if its
-//! [`PeerKexPubkeys::mlkem768_pub`] is `None`. The motivation is
-//! defense-in-depth: a caller wiring up a peer's
-//! [`PeerKexPubkeys`] from a federation directory shouldn't have to
-//! introspect openmls's internal errors to learn that the peer is
-//! out-of-spec for this ciphersuite. See
-//! [`MlsError::PeerLacksMlkem`].
+//! peer can't even produce a valid KeyPackage without it. The gate on
+//! the PEER side is now **structural, not policy**: since #481 item 4,
+//! [`PeerKexPubkeys::mlkem768_pub`] is a required `Vec<u8>`, so an
+//! ML-KEM-less [`Member`] is unrepresentable and the old `is_none`
+//! pre-checks in [`MlsSession::create`] / [`MlsSession::commit_add`] /
+//! [`MlsSession::commit_batch`] are gone (absence is refused with a
+//! typed error at `PeerKexPubkeys::from_advertisement`, the one seam
+//! Option-shaped sources — the FFI member tuples — enter through).
+//! [`MlsError::PeerLacksMlkem`] remains for the OWN-key side:
+//! [`OwnKexKeys`] deliberately keeps its `Option` halves (degraded
+//! local-key fixtures are test witnesses for the refusal paths), so
+//! [`MlsSession::process_welcome`] and the X-Wing secret bridge still
+//! HNDL-check them.
 //!
 //! ## Identity binding (impedance with CIRIS federation)
 //!
@@ -210,23 +213,22 @@ const ROOT_SECRET_CONTEXT: &[u8] = b"";
 /// A participant in the MLS group, in CIRIS vocabulary.
 ///
 /// The `kex_pubkeys` field carries the peer's CIRIS-side KEX
-/// advertisement (X25519 + optional ML-KEM-768). For the 0x004D
-/// ciphersuite to operate at all the peer MUST have advertised
-/// ML-KEM-768 — that pre-check is what
-/// [`MlsError::PeerLacksMlkem`] guards. Once the pre-check passes,
-/// the field is **not** threaded into the MLS protocol layer: the
-/// actual ML-KEM ephemeral keys for path encryption are owned by
-/// openmls's `KeyPackage` lifecycle (per-(member, session), not the
-/// peer's long-term federation KEX key). See module docs §
-/// "Identity binding".
+/// advertisement (X25519 + ML-KEM-768 — BOTH required; CIRISEdge#481
+/// item 4 made an ML-KEM-less advertisement unrepresentable, so
+/// holding a `Member` proves the peer is hybrid-capable). The field is
+/// **not** threaded into the MLS protocol layer: the actual ML-KEM
+/// ephemeral keys for path encryption are owned by openmls's
+/// `KeyPackage` lifecycle (per-(member, session), not the peer's
+/// long-term federation KEX key). See module docs § "Identity
+/// binding".
 #[derive(Debug, Clone)]
 pub struct Member {
     /// CIRIS federation `key_id` — used as the `identity` field of
     /// the MLS `BasicCredential`.
     pub key_id: String,
-    /// The peer's advertised CIRIS-side KEX pubkeys. Consulted ONLY
-    /// for the HNDL pre-check (must contain `mlkem768_pub`); not
-    /// threaded into the openmls protocol layer.
+    /// The peer's advertised CIRIS-side KEX pubkeys (hybrid by
+    /// construction); the signed-Welcome path seals under them, and
+    /// they are not threaded into the openmls protocol layer.
     pub kex_pubkeys: PeerKexPubkeys,
 }
 
@@ -320,11 +322,14 @@ impl std::fmt::Debug for RootSecret {
 /// (it is human-readable diagnostic only, not a stable contract).
 #[derive(Debug, thiserror::Error)]
 pub enum MlsError {
-    /// HNDL pre-check failed — the peer named in `key_id` hasn't
-    /// advertised an ML-KEM-768 pubkey, so the 0x004D ciphersuite
-    /// would fail downstream. Refused structurally before any MLS
-    /// code runs.
-    #[error("peer {0} lacks ML-KEM-768 advertisement; required by ciphersuite 0x004D")]
+    /// HNDL pre-check failed — the identity named in `key_id` lacks
+    /// ML-KEM-768 key material, so the 0x004D ciphersuite would fail
+    /// downstream. Post-CIRISEdge#481 item 4 this fires ONLY on the
+    /// OWN-key side ([`OwnKexKeys`], whose halves deliberately stay
+    /// `Option` as refusal-path test witnesses): a PEER advertisement
+    /// without ML-KEM-768 is unrepresentable by [`PeerKexPubkeys`] and
+    /// is refused at its construction boundary instead.
+    #[error("{0} lacks ML-KEM-768 key material; required by ciphersuite 0x004D")]
     PeerLacksMlkem(String),
     /// The 0x004D ciphersuite isn't available in this build of
     /// openmls. Should be impossible at v0.8.1 (X-Wing is shipped
@@ -459,8 +464,9 @@ impl MlsSession {
     /// participants and the calling identity as group creator.
     ///
     /// The creator is identified by `own_key_id` (used as the MLS
-    /// `BasicCredential` identity); each member in `initial_members`
-    /// undergoes the HNDL pre-check before any MLS code runs.
+    /// `BasicCredential` identity). The HNDL gate on the members is
+    /// structural: holding a [`Member`] proves ML-KEM-768 presence
+    /// (CIRISEdge#481 item 4), so no pre-check runs here.
     ///
     /// Returns the new session + the initial-epoch
     /// [`RootSecret`]. Note that openmls's `MlsGroup::new` produces
@@ -471,13 +477,6 @@ impl MlsSession {
         own_key_id: &str,
         initial_members: Vec<Member>,
     ) -> Result<(Self, RootSecret), MlsError> {
-        // HNDL pre-check, BEFORE any MLS code touches the peers.
-        for m in &initial_members {
-            if m.kex_pubkeys.mlkem768_pub.is_none() {
-                return Err(MlsError::PeerLacksMlkem(m.key_id.clone()));
-            }
-        }
-
         let provider = Arc::new(LibcruxProvider::default());
 
         // Mint own signature key pair + credential.
@@ -563,17 +562,13 @@ impl MlsSession {
     /// [`Welcome`] (to ship to the new member) + the new epoch's
     /// [`RootSecret`].
     ///
-    /// Performs the HNDL pre-check on `new_member` before any MLS
-    /// code runs.
+    /// The HNDL gate on `new_member` is structural (holding a
+    /// [`Member`] proves ML-KEM-768 presence — CIRISEdge#481 item 4).
     #[allow(clippy::needless_pass_by_value)]
     pub fn commit_add(
         &mut self,
         new_member: Member,
     ) -> Result<(Commit, Welcome, RootSecret), MlsError> {
-        if new_member.kex_pubkeys.mlkem768_pub.is_none() {
-            return Err(MlsError::PeerLacksMlkem(new_member.key_id.clone()));
-        }
-
         let (kp, sig_pub) = mint_member_key_package(&self.provider, &new_member.key_id)?;
 
         let (commit_msg, welcome_msg, _group_info) = self
@@ -654,8 +649,8 @@ impl MlsSession {
     ///
     /// - `invitee_kex` — the joiner's advertised static X-Wing public key
     ///   (`x25519_pub` + `mlkem768_pub`), the HPKE recipient key `pkR`.
-    ///   Lacking the ML-KEM-768 half is [`MlsError::PeerLacksMlkem`]
-    ///   (same HNDL discipline as the roster gates).
+    ///   Both halves are present by construction (CIRISEdge#481 item 4
+    ///   — a classical-only advertisement is unrepresentable).
     /// - `inviter_signer` — the inviter's long-term ML-DSA-65 federation
     ///   signer. Its public key is what the joiner resolves from the
     ///   federation directory keyed by `inviter_pk_id`; a fresh
@@ -668,7 +663,6 @@ impl MlsSession {
     ///
     /// # Errors
     ///
-    /// - `invitee_kex` lacks ML-KEM-768 → [`MlsError::PeerLacksMlkem`]
     /// - openmls add/serialize failures → as [`Self::commit_add_published`]
     /// - HPKE seal / ML-DSA sign failure → [`MlsError::WelcomeWrapFailed`]
     pub fn commit_add_published_signed(
@@ -680,9 +674,11 @@ impl MlsSession {
         inviter_pk_id: &str,
     ) -> Result<(Commit, SignedWelcome, RootSecret), MlsError> {
         // Bridge the joiner's CIRIS-side KEX advertisement to the HPKE
-        // recipient key BEFORE touching the group, so a classical-only
-        // joiner is refused without a partial epoch advance.
-        let invitee_pk = xwing_public_from_kex(key_id, invitee_kex)?;
+        // recipient key. Infallible post-#481 item 4: the advertisement
+        // provably carries both X-Wing halves, so there is no
+        // classical-only refusal (and no partial-epoch-advance hazard)
+        // left on this path.
+        let invitee_pk = xwing_public_from_kex(invitee_kex);
 
         // Produce the bare openmls Commit + Welcome via the existing
         // (unsigned) path — this owns the roster mutation + epoch advance.
@@ -882,12 +878,14 @@ impl MlsSession {
     /// `secrets` by KeyPackageRef internally). Removes produce no
     /// Welcome entries.
     ///
-    /// ## Atomic HNDL gate
+    /// ## HNDL gate (structural)
     ///
-    /// Every `RosterOp::Add` member is HNDL-pre-checked BEFORE any
-    /// proposal is queued: a single classical-only Add rejects the
-    /// whole batch with [`MlsError::PeerLacksMlkem`] and leaves the
-    /// MLS group at its pre-call epoch. No partial state.
+    /// A classical-only `RosterOp::Add` is unrepresentable: [`Member`]
+    /// carries a required ML-KEM-768 half (CIRISEdge#481 item 4), so
+    /// the old batch-atomic pre-check is gone. Atomicity of the batch
+    /// against a bad op is still guaranteed by the Remove-resolution
+    /// pass below (a not-found Remove fails closed before any proposal
+    /// is queued).
     ///
     /// ## Empty `ops`
     ///
@@ -915,19 +913,6 @@ impl MlsSession {
 
         if ops.is_empty() {
             return Err(MlsError::EmptyBatch);
-        }
-
-        // ── Atomic HNDL gate ─────────────────────────────────────
-        // Walk the whole ops list FIRST, refusing the entire batch
-        // if ANY Add lacks ML-KEM-768. The MLS group's epoch must
-        // stay unchanged on this error so callers can retry after
-        // fixing the bad member.
-        for op in ops {
-            if let RosterOp::Add(m) = op {
-                if m.kex_pubkeys.mlkem768_pub.is_none() {
-                    return Err(MlsError::PeerLacksMlkem(m.key_id.clone()));
-                }
-            }
         }
 
         // ── Resolve all Removes to LeafNodeIndex up front ────────
@@ -1319,21 +1304,14 @@ fn serialize_mls_message(msg: &MlsMessageOut) -> Result<Vec<u8>, MlsError> {
 
 /// Bridge a joiner's CIRIS-side KEX advertisement ([`PeerKexPubkeys`]) to
 /// the HPKE recipient public key ([`XWingRecipientPublic`], `pkR`) the
-/// §3.3 wrap seals under. The X-Wing KEM requires ML-KEM-768; a
-/// classical-only advertisement is refused with the same HNDL discipline
-/// the roster gates use.
-fn xwing_public_from_kex(
-    key_id: &str,
-    kex: &PeerKexPubkeys,
-) -> Result<XWingRecipientPublic, MlsError> {
-    let mlkem768_pub = kex
-        .mlkem768_pub
-        .clone()
-        .ok_or_else(|| MlsError::PeerLacksMlkem(key_id.to_string()))?;
-    Ok(XWingRecipientPublic {
+/// §3.3 wrap seals under. Infallible since CIRISEdge#481 item 4: the
+/// advertisement type requires the ML-KEM-768 half, so the X-Wing KEM's
+/// input is complete by construction.
+fn xwing_public_from_kex(kex: &PeerKexPubkeys) -> XWingRecipientPublic {
+    XWingRecipientPublic {
         x25519_pub: kex.x25519_pub,
-        mlkem768_pub,
-    })
+        mlkem768_pub: kex.mlkem768_pub.clone(),
+    }
 }
 
 /// Bridge a joiner's own CIRIS KEX secret ([`OwnKexKeys`]) to the HPKE
@@ -1553,30 +1531,26 @@ mod tests {
     use super::*;
 
     /// Build a Member whose kex_pubkeys carry both halves (hybrid
-    /// ready). The actual bytes don't matter for these tests — they
-    /// are not consumed by openmls; only the HNDL pre-check looks at
-    /// `mlkem768_pub.is_some()`.
+    /// ready — the only representable kind post-#481 item 4). The
+    /// actual bytes don't matter for these tests; they are not
+    /// consumed by openmls.
     fn hybrid_member(key_id: &str) -> Member {
         Member {
             key_id: key_id.to_string(),
             kex_pubkeys: PeerKexPubkeys {
                 x25519_pub: [1u8; 32],
-                mlkem768_pub: Some(vec![0xAB; 1184]), // ML-KEM-768 pubkey size
+                mlkem768_pub: vec![0xAB; 1184], // ML-KEM-768 pubkey size
             },
         }
     }
 
-    /// Build a Member whose kex_pubkeys carry ONLY the X25519 half —
-    /// expected to fail the HNDL pre-check.
-    fn classical_only_member(key_id: &str) -> Member {
-        Member {
-            key_id: key_id.to_string(),
-            kex_pubkeys: PeerKexPubkeys {
-                x25519_pub: [1u8; 32],
-                mlkem768_pub: None,
-            },
-        }
-    }
+    // (No `classical_only_member` fixture: CIRISEdge#481 item 4 made
+    // the ML-KEM-less Member unrepresentable. The refusal it used to
+    // exercise lives at `PeerKexPubkeys::from_advertisement` — see
+    // `federation_session::tests::
+    // mlkem_absent_advertisement_rejected_at_construction` and the FFI
+    // boundary test `pyo3_av_session_create_rejects_classical_only_
+    // member`.)
 
     fn hybrid_own_keys() -> OwnKexKeys {
         OwnKexKeys {
@@ -1620,29 +1594,11 @@ mod tests {
         }
     }
 
-    /// HNDL discipline: a peer without ML-KEM-768 is refused at
-    /// `create`, before any MLS code runs.
-    #[test]
-    fn peer_lacking_mlkem_refused_at_create() {
-        let bad = vec![hybrid_member("alice"), classical_only_member("bob")];
-        let r = MlsSession::create("creator", bad);
-        assert!(
-            matches!(r, Err(MlsError::PeerLacksMlkem(ref k)) if k == "bob"),
-            "expected PeerLacksMlkem(bob), got {r:?}"
-        );
-    }
-
-    /// HNDL discipline: same at `commit_add`.
-    #[test]
-    fn peer_lacking_mlkem_refused_at_commit_add() {
-        let (mut session, _) = MlsSession::create("creator", vec![hybrid_member("alice")])
-            .expect("create should succeed");
-        let r = session.commit_add(classical_only_member("bob"));
-        assert!(
-            matches!(r, Err(MlsError::PeerLacksMlkem(ref k)) if k == "bob"),
-            "expected PeerLacksMlkem(bob), got {r:?}"
-        );
-    }
+    // (was: `peer_lacking_mlkem_refused_at_create` /
+    // `peer_lacking_mlkem_refused_at_commit_add` — the classical-only
+    // Member those tests fed to `create` / `commit_add` is
+    // unrepresentable post-#481 item 4; the refusal is now typed at
+    // `PeerKexPubkeys::from_advertisement` construction.)
 
     /// `commit_remove` makes the next epoch's `RootSecret` distinct
     /// from the previous epoch's — the leaver, who only ever held
@@ -1935,34 +1891,10 @@ mod tests {
         assert!(!as_strs.contains(&"bob"));
     }
 
-    /// Atomic HNDL gate at the MLS layer: a classical-only Add in
-    /// the batch fails-closed BEFORE any proposal is queued. The
-    /// group's epoch must not advance.
-    #[test]
-    fn mls_commit_batch_hndl_pre_check() {
-        let (mut session, _root0) = MlsSession::create(
-            "creator",
-            vec![hybrid_member("alice"), hybrid_member("bob")],
-        )
-        .expect("create");
-        let pre_epoch = session.epoch();
-        let pre_count = session.member_count();
-
-        let ops = vec![
-            RosterOp::Add(hybrid_member("dave")),
-            RosterOp::Add(classical_only_member("badpeer")),
-            RosterOp::Remove("alice".to_string()),
-        ];
-        let r = session.commit_batch(&ops);
-        assert!(
-            matches!(r, Err(MlsError::PeerLacksMlkem(ref k)) if k == "badpeer"),
-            "expected PeerLacksMlkem(badpeer), got {r:?}"
-        );
-
-        // No partial state — epoch + roster unchanged.
-        assert_eq!(session.epoch(), pre_epoch);
-        assert_eq!(session.member_count(), pre_count);
-    }
+    // (was: `mls_commit_batch_hndl_pre_check` — the classical-only Add
+    // is unrepresentable post-#481 item 4, so the batch HNDL gate is
+    // structural. Batch atomicity against a bad op is still covered by
+    // `mls_commit_batch_remove_unknown_fails_atomically`.)
 
     /// Empty `ops` returns `EmptyBatch` (no silent no-op).
     #[test]
@@ -2084,7 +2016,7 @@ mod tests {
         let (mlkem_sk, mlkem_pk) = ml_kem::generate_keypair().unwrap();
         let pubs = PeerKexPubkeys {
             x25519_pub: x_pk,
-            mlkem768_pub: Some(mlkem_pk.clone()),
+            mlkem768_pub: mlkem_pk.clone(),
         };
         let secret = OwnKexKeys {
             x25519_priv: x_sk,
@@ -2329,33 +2261,11 @@ mod tests {
         );
     }
 
-    /// HNDL discipline, producer side: a classical-only invitee KEX is
-    /// refused BEFORE the roster mutation, so the group epoch does not
-    /// advance (no partial state).
-    #[test]
-    fn signed_welcome_producer_rejects_classical_only_invitee() {
-        let mut inviter = inviter_session();
-        let pre_epoch = inviter.epoch();
-        let signer = MlDsa65Signer::new().unwrap();
-        let (_material, kp) = mint_joiner_key_material("carol").unwrap();
-        let classical_kex = PeerKexPubkeys {
-            x25519_pub: [1u8; 32],
-            mlkem768_pub: None,
-        };
-
-        let err = inviter
-            .commit_add_published_signed("carol", kp, &classical_kex, &signer, "inviter-fed-id")
-            .unwrap_err();
-        assert!(
-            matches!(err, MlsError::PeerLacksMlkem(ref k) if k == "carol"),
-            "got {err:?}"
-        );
-        assert_eq!(
-            inviter.epoch(),
-            pre_epoch,
-            "no partial epoch advance on producer HNDL refusal"
-        );
-    }
+    // (was: `signed_welcome_producer_rejects_classical_only_invitee` —
+    // the classical-only invitee KEX is unrepresentable post-#481
+    // item 4, so the producer-side refusal (and its partial-epoch-
+    // advance hazard) is gone by construction; `xwing_public_from_kex`
+    // is infallible.)
 
     /// The [`SignedWelcome`] wire codec is a faithful round trip, and
     /// fails closed on truncation / bad version.

--- a/src/transport/realtime_av_runtime.rs
+++ b/src/transport/realtime_av_runtime.rs
@@ -964,7 +964,7 @@ mod tests {
             key_id: key_id.to_string(),
             kex_pubkeys: PeerKexPubkeys {
                 x25519_pub: [1u8; 32],
-                mlkem768_pub: Some(vec![0xAB; 1184]),
+                mlkem768_pub: vec![0xAB; 1184],
             },
         }
     }

--- a/src/transport/realtime_av_session.rs
+++ b/src/transport/realtime_av_session.rs
@@ -208,10 +208,13 @@ pub struct EpochRekeyArtifacts {
 /// Errors a rekey or join can surface.
 #[derive(Debug, thiserror::Error)]
 pub enum AvSessionError {
-    /// A member's advertised KEX pubkeys lack the ML-KEM-768 half. The
-    /// 0x004D ciphersuite requires it; the rekey fails-closed before
-    /// any MLS code runs. Preserves the HNDL discipline T2 had.
-    #[error("peer {0} lacks ML-KEM-768 — required by ciphersuite 0x004D (HNDL discipline)")]
+    /// An identity's KEX key material lacks the ML-KEM-768 half. The
+    /// 0x004D ciphersuite requires it; fails-closed before any MLS
+    /// code runs. Post-CIRISEdge#481 item 4 a PEER advertisement
+    /// without ML-KEM-768 is unrepresentable (refused at
+    /// `PeerKexPubkeys` construction), so this reaches callers only
+    /// from the OWN-key side (`OwnKexKeys` on the joiner paths).
+    #[error("{0} lacks ML-KEM-768 — required by ciphersuite 0x004D (HNDL discipline)")]
     PeerLacksMlkem(PeerKeyId),
     /// Welcome bytes are empty or don't parse as an MLS Welcome message.
     #[error("welcome bytes malformed: {0}")]
@@ -502,8 +505,9 @@ impl AvSession {
     /// [`AvSession::process_welcome`] before accepting membership.
     ///
     /// - `invitee_kex` — the joiner's advertised static X-Wing public
-    ///   key (the HPKE recipient key). A classical-only advertisement is
-    ///   [`AvSessionError::PeerLacksMlkem`].
+    ///   key (the HPKE recipient key). Complete by construction:
+    ///   CIRISEdge#481 item 4 made a classical-only advertisement
+    ///   unrepresentable.
     /// - `inviter_signer` — the local node's long-term ML-DSA-65
     ///   federation signer (whatever the joiner's directory holds for
     ///   `inviter_pk_id`).
@@ -713,7 +717,7 @@ mod tests {
         (
             PeerKexPubkeys {
                 x25519_pub: x_pk,
-                mlkem768_pub: Some(mlkem_pk.clone()),
+                mlkem768_pub: mlkem_pk.clone(),
             },
             OwnKexKeys {
                 x25519_priv: x_sk,
@@ -743,25 +747,15 @@ mod tests {
         }
     }
 
-    /// Build a hybrid-ready `Member` with synthetic KEX pubkeys. The
-    /// bytes are not consumed by openmls; only the HNDL pre-check
-    /// looks at `mlkem768_pub.is_some()`.
+    /// Build a hybrid-ready `Member` with synthetic KEX pubkeys (the
+    /// only representable kind post-#481 item 4). The bytes are not
+    /// consumed by openmls.
     fn hybrid_member(key_id: &str) -> Member {
         Member {
             key_id: key_id.to_string(),
             kex_pubkeys: PeerKexPubkeys {
                 x25519_pub: [1u8; 32],
-                mlkem768_pub: Some(vec![0xAB; 1184]), // ML-KEM-768 pubkey size
-            },
-        }
-    }
-
-    fn classical_only_member(key_id: &str) -> Member {
-        Member {
-            key_id: key_id.to_string(),
-            kex_pubkeys: PeerKexPubkeys {
-                x25519_pub: [1u8; 32],
-                mlkem768_pub: None,
+                mlkem768_pub: vec![0xAB; 1184], // ML-KEM-768 pubkey size
             },
         }
     }
@@ -1083,8 +1077,12 @@ mod tests {
     /// Atomic HNDL gate: a batch with one classical-only Add MUST
     /// reject before any proposal is queued. The MlsSession's
     /// group epoch must NOT advance (proof of atomicity).
+    /// (Was the HNDL-breach atomicity test — the classical-only Add it
+    /// used as the failing op is unrepresentable post-#481 item 4, so
+    /// the failing op is now a Remove of an unknown member; the
+    /// atomicity contract under test is unchanged.)
     #[test]
-    fn batch_atomic_fails_closed_on_hndl_breach() {
+    fn batch_atomic_fails_closed_on_invalid_op() {
         let (mut session, dek0) = AvSession::create(
             dummy_stream(),
             "alice",
@@ -1095,15 +1093,18 @@ mod tests {
         let pre_roster_size = session.roster_size();
 
         let ops = vec![
-            RosterOp::Add(hybrid_member("ed")),              // ok
-            RosterOp::Remove("bob".to_string()),             // ok
-            RosterOp::Add(classical_only_member("badpeer")), // FAIL
-            RosterOp::Add(hybrid_member("frank")),           // would-be-ok
+            RosterOp::Add(hybrid_member("ed")),           // ok
+            RosterOp::Remove("bob".to_string()),          // ok
+            RosterOp::Remove("not-a-member".to_string()), // FAIL
+            RosterOp::Add(hybrid_member("frank")),        // would-be-ok
         ];
         let r = session.advance_epoch(RosterDelta::Batch(ops));
         assert!(
-            matches!(r, Err(AvSessionError::PeerLacksMlkem(ref k)) if k == "badpeer"),
-            "expected PeerLacksMlkem(badpeer), got {r:?}"
+            matches!(
+                r,
+                Err(AvSessionError::Mls(MlsError::MemberNotFound(ref k))) if k == "not-a-member"
+            ),
+            "expected Mls(MemberNotFound(not-a-member)), got {r:?}"
         );
 
         // Atomicity proof: the session state is exactly as it was
@@ -1195,34 +1196,10 @@ mod tests {
         assert_eq!(session.roster_size(), 52, "alice + bob + 50 joiners");
     }
 
-    /// HNDL discipline: a member lacking ML-KEM-768 is refused at
-    /// create-time. Same gate the T2 baseline had, now via the
-    /// MLS-layer pre-check.
-    #[test]
-    fn hndl_member_lacking_mlkem_refused_at_create() {
-        let r = AvSession::create(
-            dummy_stream(),
-            "creator",
-            vec![hybrid_member("alice"), classical_only_member("bob")],
-        );
-        assert!(
-            matches!(r, Err(AvSessionError::PeerLacksMlkem(ref k)) if k == "bob"),
-            "expected PeerLacksMlkem(bob), got {r:?}"
-        );
-    }
-
-    /// HNDL discipline: same gate at `advance_epoch(Join)`.
-    #[test]
-    fn hndl_member_lacking_mlkem_refused_at_advance_join() {
-        let (mut session, _dek) =
-            AvSession::create(dummy_stream(), "alice", vec![hybrid_member("bob")]).expect("create");
-
-        let r = session.advance_epoch(RosterDelta::Join(classical_only_member("carol")));
-        assert!(
-            matches!(r, Err(AvSessionError::PeerLacksMlkem(ref k)) if k == "carol"),
-            "expected PeerLacksMlkem(carol), got {r:?}"
-        );
-    }
+    // (was: `hndl_member_lacking_mlkem_refused_at_create` /
+    // `hndl_member_lacking_mlkem_refused_at_advance_join` — the
+    // classical-only Member is unrepresentable post-#481 item 4; the
+    // HNDL gate is structural at `PeerKexPubkeys` construction.)
 
     // ─── Joiner path (CIRISEdge#155 Gap 2) ──────────────────────────
 

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -104,10 +104,12 @@ use crate::verify::{
     HybridPolicy, ProvenanceChain, RootingDirectory, RootingRejection, RootingVerdict,
 };
 
-/// Maximum envelope body size accepted on send. Mirrors AV-13
-/// (`MAX_BODY_BYTES = 8 MiB`); oversized payloads reject before any
-/// link is established.
-const MAX_BODY_BYTES: usize = 8 * 1024 * 1024;
+// Maximum envelope body size accepted on send (AV-13, 8 MiB); oversized
+// payloads reject before any link is established. IMPORTED from the
+// single transport-wide authority in `frame_fragment` — not re-typed —
+// so the send-side admissibility ceiling can never drift from the
+// receive-side reassembly budget (one-authority body budget).
+use super::frame_fragment::MAX_BODY_BYTES;
 
 /// Reticulum app-name for edge's federation destination. The full
 /// destination name is `app_name` + aspects; both halves of a peering
@@ -214,7 +216,12 @@ fn effective_link_keepalive_secs(configured: Option<Duration>) -> Option<u64> {
 /// as sized for "small std platforms … servers override larger via config or
 /// builder" (leviculum-std `config.rs`), but until this knob existed edge
 /// exposed no way to take that advice — the canonical wedged with the default.
-const CONTROL_CHANNEL_CAPACITY_ENV: &str = "CIRIS_EDGE_RETICULUM_CONTROL_CHANNEL_CAPACITY";
+///
+/// `pub` so binaries / harnesses (e.g. `bin/edge_node.rs`) that set or
+/// document the variable reference THIS const instead of re-typing the
+/// env-var name literal (a typo'd retype silently reverts the node to
+/// leviculum's 256 default).
+pub const CONTROL_CHANNEL_CAPACITY_ENV: &str = "CIRIS_EDGE_RETICULUM_CONTROL_CHANNEL_CAPACITY";
 
 /// Lower clamp for [`effective_control_channel_capacity`]. Below leviculum's
 /// own 256 default is already a foot-gun; 16 exists only so a deliberate
@@ -1576,15 +1583,21 @@ pub struct RNodeInterfaceConfig {
     pub airtime_limit_long_pct: Option<f64>,
 }
 
-/// `I2PInterface` configuration — Phase 3 anonymous overlay; gate
-/// exists but runtime support deferred. Empty config for now; the
-/// shape lands when the implementation does.
+/// `I2PInterface` configuration — Phase 3 anonymous overlay; the gate
+/// compiles the TYPED CONFIG SURFACE ONLY. The runtime path is not
+/// implemented: no SAM session is ever established. This is fail-loud,
+/// NOT a silent no-op — supplying an I²P interface to the transport
+/// refuses at construction with a typed `TransportError::Config`
+/// naming the unimplemented state (see `apply_interface_config`'s
+/// `I2p` arm), so a deployment cannot believe it is riding I²P cover
+/// traffic when it is not.
 #[cfg(feature = "transport-reticulum-i2p")]
 #[derive(Debug, Clone, Default)]
 pub struct I2pInterfaceConfig {
-    /// Reserved for the I²P SAM bridge address; v0.12.0 ignored. Marked
-    /// with `#[allow(dead_code)]` so the struct can land without warning.
-    #[allow(dead_code)]
+    /// I²P SAM bridge address the Phase 3 runtime will dial when it
+    /// lands. Parsed and carried so config plumbing round-trips; read
+    /// by the `apply_interface_config` refusal (named in the error) —
+    /// never used to establish a session yet.
     pub sam_addr: Option<SocketAddr>,
 }
 
@@ -2618,6 +2631,17 @@ impl ReticulumTransport {
                 local_named_dest_hash.into_bytes(),
                 crate::cohort_scope::CohortScope::Public,
             );
+            // #489 residual — same wiring-log discipline as the keepalive /
+            // control-channel knobs above: one INFO line per node build so
+            // "is this node announcing, and which destination" is answerable
+            // from logs on BOTH branches (previously only the OFF branch
+            // below spoke).
+            tracing::info!(
+                dest = %local_named_dest_hash,
+                "federation visibility ON — named discovery destination \
+                 registered Public with the announce-suppression policy; its \
+                 auto re-announce survives default-suppression (CIRISEdge#489)"
+            );
         } else {
             tracing::info!(
                 "federation visibility OFF — this node announces nothing and is reachable \
@@ -3277,8 +3301,11 @@ impl ReticulumTransport {
     /// addressing makes the hottest path (`attribute_and_deliver`) *cheaper*
     /// rather than dearer — admission moves ahead of the parse.
     ///
-    /// Returns `None` when no table is installed, which is the production
-    /// state until the derivation lands (CIRISVerify#259).
+    /// Returns `None` when no table is installed. The derivation itself
+    /// SHIPPED (CIRISVerify#259 → verify's scope-privacy derivation,
+    /// adapted by `crate::scope_addressing::ScopePrivacyDeriver`); the
+    /// table stays empty until the operator opts in via
+    /// `EdgeBuilder::scope_native_addressing`, which installs it.
     #[must_use]
     pub fn inbound_scope(&self, dest_hash: &[u8; 16]) -> Option<InboundAddress> {
         self.scope_addresses.get()?.accepts_inbound(dest_hash)
@@ -4341,43 +4368,40 @@ impl ReticulumTransport {
             rows
         };
         let now = chrono::Utc::now();
-        for rec in rows.iter() {
-            if rec.identity_hash != identity_hash {
-                continue;
+        match consult_and_prune_blackhole(store, &rows, identity_hash, now).await {
+            BlackholeConsult::Clear => Ok(()),
+            BlackholeConsult::ExpiredPruned => {
+                // The consulted row was reclaimed — drop the snapshot so
+                // the next dial re-reads a deny-list without it (and does
+                // not re-attempt the remove).
+                self.invalidate_blackhole_cache();
+                Ok(())
             }
-            if let Some(until) = rec.until {
-                if now >= until {
-                    // Expired rule — let send proceed. A background
-                    // pruner (deferred to a follow-up cut) will drop
-                    // it lazily; in the interim operators can call
-                    // `routing_blackhole_prune_expired` manually.
-                    return Ok(());
-                }
+            BlackholeConsult::Blocked { reason, until } => {
+                // Live hit — fire-and-forget the hit-record so the
+                // counter reflects observation. `record_hit` is race-
+                // tolerant (silent no-op if the rule was removed between
+                // our check and the spawned increment), so the spawned
+                // task's outcome doesn't affect correctness.
+                let store_clone = Arc::clone(store);
+                let hash_clone = identity_hash.to_vec();
+                tokio::spawn(async move {
+                    if let Err(e) = store_clone.blackhole_record_hit(&hash_clone).await {
+                        tracing::warn!(
+                            ?hash_clone,
+                            error = %e,
+                            "blackhole_record_hit failed; the rule blocked the send \
+                             correctly but the hits counter did not advance",
+                        );
+                    }
+                });
+                Err(TransportError::PeerBlackholed {
+                    identity_hash: identity_hash.to_vec(),
+                    reason,
+                    until: until.map(|t| t.to_rfc3339()),
+                })
             }
-            // Live hit — fire-and-forget the hit-record so the
-            // counter reflects observation. `record_hit` is race-
-            // tolerant (silent no-op if the rule was removed between
-            // our check and the spawned increment), so the spawned
-            // task's outcome doesn't affect correctness.
-            let store_clone = Arc::clone(store);
-            let hash_clone = identity_hash.to_vec();
-            tokio::spawn(async move {
-                if let Err(e) = store_clone.blackhole_record_hit(&hash_clone).await {
-                    tracing::warn!(
-                        ?hash_clone,
-                        error = %e,
-                        "blackhole_record_hit failed; the rule blocked the send \
-                         correctly but the hits counter did not advance",
-                    );
-                }
-            });
-            return Err(TransportError::PeerBlackholed {
-                identity_hash: rec.identity_hash.clone(),
-                reason: rec.reason.clone(),
-                until: rec.until.map(|t| t.to_rfc3339()),
-            });
         }
-        Ok(())
     }
 
     /// Resolve a `destination_key_id` to a Reticulum peer. Consults
@@ -5427,9 +5451,11 @@ struct EventCtx<'a> {
     /// name on [`ReticulumTransport`]). `attribute_and_deliver` probes its
     /// reverse index once per frame to stamp `InboundFrame::arrival_scope`,
     /// which is the receive-side admission fact the blob serve gate consumes.
-    /// Empty `OnceLock` (the production state until CIRISVerify#259's exporter
-    /// label is specified) ⇒ every frame is stamped `None`, i.e. federation
-    /// arrival, i.e. exactly pre-#499 behaviour.
+    /// Empty `OnceLock` (the default: the derivation shipped —
+    /// CIRISVerify#259 / `ScopePrivacyDeriver` — but the table is only
+    /// installed when the operator opts in via
+    /// `EdgeBuilder::scope_native_addressing`) ⇒ every frame is stamped
+    /// `None`, i.e. federation arrival, i.e. exactly pre-#499 behaviour.
     scope_addresses: &'a OnceLock<Arc<ScopeAddressTable>>,
     /// CIRISEdge#169 — the LXMF serve node, borrowed like every other
     /// sub-protocol's state (the `EventCtx` field pattern).
@@ -8419,16 +8445,106 @@ fn apply_interface_config(
             // Phase 3 per OQ-13 — the gate is on but no runtime path
             // exists yet. Surface a typed config error so builds with
             // the gate enabled fail at construction (not at first
-            // packet) when an I²P interface is supplied.
-            let _ = cfg.sam_addr;
-            Err(TransportError::Config(
-                "I²P interface configured but Phase 3 runtime is not yet implemented; \
-                 the feature gate exists for v0.12.0 typed surface compatibility only. \
-                 See FSD §1.4 OQ-13 for the Phase 3 roadmap."
-                    .into(),
-            ))
+            // packet) when an I²P interface is supplied: the feature
+            // compiling must NEVER read as I²P working.
+            Err(TransportError::Config(format!(
+                "I²P interface configured (sam_addr: {:?}) but the \
+                 transport-reticulum-i2p feature compiles ONLY the typed config \
+                 surface — the Phase 3 runtime is NOT WIRED and no SAM session \
+                 will be established. Remove the I²P interface (or build without \
+                 the feature). See FSD §1.4 OQ-13 for the Phase 3 roadmap.",
+                cfg.sam_addr,
+            )))
         }
     }
+}
+
+// ─── Blackhole consult + opportunistic prune ────────────────────────
+
+/// Verdict of consulting the deny-list snapshot for one identity.
+/// Produced by [`consult_and_prune_blackhole`]; consumed by
+/// `check_blackhole` on the send path.
+enum BlackholeConsult {
+    /// No rule for this identity — send proceeds.
+    Clear,
+    /// A rule matched but its `until` has passed. The spent row was
+    /// reclaimed (best-effort) at consult time — send proceeds, and the
+    /// caller must invalidate its deny-list snapshot cache so the next
+    /// dial does not re-see (and re-prune) the removed row.
+    ExpiredPruned,
+    /// Live rule — send refused; the caller records the hit and builds
+    /// the typed `PeerBlackholed` error.
+    Blocked {
+        /// Operator-readable reason from the rule row.
+        reason: Option<String>,
+        /// Soft-expiry from the rule row (`None` = permanent).
+        until: Option<chrono::DateTime<chrono::Utc>>,
+    },
+}
+
+/// Scan the deny-list snapshot for `identity_hash` and, when the
+/// matching rule is EXPIRED, reclaim its row IMMEDIATELY (opportunistic
+/// prune) instead of letting the send proceed while the row accretes.
+///
+/// Pre-audit, the expired branch returned "proceed" and left the row
+/// for the background pruner / a manual `routing_blackhole_prune_expired`
+/// call — on a hosting shape with neither running, expired rows grew
+/// without bound on a hot send path. The remove is awaited inline (one
+/// row delete) rather than spawned: it is amortized to at most one
+/// round-trip per expired rule, because the caller invalidates its
+/// snapshot cache on the [`BlackholeConsult::ExpiredPruned`] verdict so
+/// subsequent dials never re-consult the reclaimed row. Removal failure
+/// is non-fatal (WARN; the send still proceeds — the rule IS expired).
+///
+/// Permanent rules (`until = None`) never reach the prune branch — they
+/// block forever until an explicit `routing_blackhole_remove`. Rules
+/// for OTHER identities are never touched here, expired or not (the
+/// scan is a consult, not a sweep — the background pruner owns the
+/// sweep). No bounded-size backstop is possible at this seam: the table
+/// is persist's durable `cirislens.blackhole_rules` behind
+/// `Arc<dyn BlackholeRules>`, whose trait surface exposes no capacity
+/// bound — reclamation (this fn + the `Edge::run` pruner) is the bound.
+///
+/// Free fn (not a method) so the audit-required test — insert expired
+/// rule, consult, assert REMOVED — runs against an in-memory
+/// `BlackholeRules` without constructing a live transport.
+async fn consult_and_prune_blackhole(
+    store: &Arc<dyn ciris_persist::federation::BlackholeRules>,
+    rows: &[ciris_persist::federation::BlackholeRecord],
+    identity_hash: &[u8],
+    now: chrono::DateTime<chrono::Utc>,
+) -> BlackholeConsult {
+    for rec in rows {
+        if rec.identity_hash != identity_hash {
+            continue;
+        }
+        if let Some(until) = rec.until {
+            if now >= until {
+                if let Err(e) = store.blackhole_remove(identity_hash).await {
+                    tracing::warn!(
+                        ?identity_hash,
+                        error = %e,
+                        "expired blackhole rule consulted but could not be \
+                         reclaimed; send proceeds — the row lingers until the \
+                         next consult or background prune",
+                    );
+                } else {
+                    tracing::debug!(
+                        ?identity_hash,
+                        until = %until,
+                        "expired blackhole rule reclaimed at consult time \
+                         (opportunistic prune)",
+                    );
+                }
+                return BlackholeConsult::ExpiredPruned;
+            }
+        }
+        return BlackholeConsult::Blocked {
+            reason: rec.reason.clone(),
+            until: rec.until,
+        };
+    }
+    BlackholeConsult::Clear
 }
 
 // ─── Runtime-agnostic timeout helper ────────────────────────────────
@@ -8456,6 +8572,142 @@ async fn with_timeout<F: std::future::Future>(dur: Duration, fut: F) -> Option<F
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Audit item 9 — opportunistic blackhole-rule pruning: an expired
+    /// rule consulted on the send path is REMOVED then, not left to
+    /// accrete for a background task that may never run.
+    mod blackhole_opportunistic_prune {
+        use super::*;
+        use chrono::Utc;
+        use ciris_persist::federation::{BlackholeRecord, BlackholeRules};
+        use std::sync::Mutex as StdMutex;
+
+        /// Minimal in-memory `BlackholeRules` — exactly enough store to
+        /// prove the consult removes (or preserves) rows. Methods the
+        /// consult path never drives are `unreachable!` so an accidental
+        /// call fails the test loudly instead of faking success.
+        struct MemRules(StdMutex<Vec<BlackholeRecord>>);
+
+        impl MemRules {
+            fn with(rows: Vec<BlackholeRecord>) -> Arc<Self> {
+                Arc::new(Self(StdMutex::new(rows)))
+            }
+            fn rows(&self) -> Vec<BlackholeRecord> {
+                self.0.lock().unwrap().clone()
+            }
+        }
+
+        #[async_trait::async_trait]
+        impl BlackholeRules for MemRules {
+            async fn blackhole_list(
+                &self,
+            ) -> Result<Vec<BlackholeRecord>, ciris_persist::federation::Error> {
+                Ok(self.rows())
+            }
+            async fn blackhole_upsert(
+                &self,
+                _identity_hash: &[u8],
+                _until: Option<chrono::DateTime<Utc>>,
+                _reason: Option<&str>,
+            ) -> Result<(), ciris_persist::federation::Error> {
+                unreachable!("consult path never upserts")
+            }
+            async fn blackhole_remove(
+                &self,
+                identity_hash: &[u8],
+            ) -> Result<(), ciris_persist::federation::Error> {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .retain(|r| r.identity_hash != identity_hash);
+                Ok(())
+            }
+            async fn blackhole_record_hit(
+                &self,
+                _identity_hash: &[u8],
+            ) -> Result<(), ciris_persist::federation::Error> {
+                Ok(())
+            }
+            async fn blackhole_prune_expired(
+                &self,
+                _now: chrono::DateTime<Utc>,
+            ) -> Result<u64, ciris_persist::federation::Error> {
+                unreachable!("consult path prunes opportunistically, not by sweep")
+            }
+        }
+
+        fn rule(byte: u8, until: Option<chrono::DateTime<Utc>>) -> BlackholeRecord {
+            BlackholeRecord {
+                identity_hash: vec![byte; 16],
+                until,
+                reason: Some("test".into()),
+                added_at: Utc::now(),
+                hits: 0,
+                persist_row_hash: String::new(),
+            }
+        }
+
+        /// The audit-required shape: insert expired rule → consult →
+        /// assert removed (and the send proceeds).
+        #[tokio::test]
+        async fn expired_rule_is_reclaimed_on_consult() {
+            let mem = MemRules::with(vec![rule(
+                0xAA,
+                Some(Utc::now() - chrono::Duration::seconds(60)),
+            )]);
+            let store: Arc<dyn BlackholeRules> = mem.clone();
+            let rows = store.blackhole_list().await.unwrap();
+            let verdict = consult_and_prune_blackhole(&store, &rows, &[0xAA; 16], Utc::now()).await;
+            assert!(matches!(verdict, BlackholeConsult::ExpiredPruned));
+            assert!(
+                mem.rows().is_empty(),
+                "the expired row must be REMOVED at consult time, not left \
+                 for a background pruner that may never run"
+            );
+        }
+
+        #[tokio::test]
+        async fn live_rule_blocks_and_is_not_pruned() {
+            let mem = MemRules::with(vec![rule(
+                0xAA,
+                Some(Utc::now() + chrono::Duration::seconds(3600)),
+            )]);
+            let store: Arc<dyn BlackholeRules> = mem.clone();
+            let rows = store.blackhole_list().await.unwrap();
+            let verdict = consult_and_prune_blackhole(&store, &rows, &[0xAA; 16], Utc::now()).await;
+            assert!(matches!(verdict, BlackholeConsult::Blocked { .. }));
+            assert_eq!(mem.rows().len(), 1, "a live rule is never reclaimed");
+        }
+
+        #[tokio::test]
+        async fn permanent_rule_blocks_and_is_never_pruned() {
+            let mem = MemRules::with(vec![rule(0xAA, None)]);
+            let store: Arc<dyn BlackholeRules> = mem.clone();
+            let rows = store.blackhole_list().await.unwrap();
+            let verdict = consult_and_prune_blackhole(&store, &rows, &[0xAA; 16], Utc::now()).await;
+            assert!(
+                matches!(verdict, BlackholeConsult::Blocked { until: None, .. }),
+                "until = NULL is the operator's permanent signal"
+            );
+            assert_eq!(mem.rows().len(), 1);
+        }
+
+        #[tokio::test]
+        async fn other_identitys_expired_rule_is_left_alone() {
+            let mem = MemRules::with(vec![rule(
+                0xAA,
+                Some(Utc::now() - chrono::Duration::seconds(60)),
+            )]);
+            let store: Arc<dyn BlackholeRules> = mem.clone();
+            let rows = store.blackhole_list().await.unwrap();
+            // Consult a DIFFERENT identity: verdict Clear, and the scan is
+            // a consult, not a sweep — the unrelated expired row stays for
+            // its own consult / the background pruner.
+            let verdict = consult_and_prune_blackhole(&store, &rows, &[0xBB; 16], Utc::now()).await;
+            assert!(matches!(verdict, BlackholeConsult::Clear));
+            assert_eq!(mem.rows().len(), 1);
+        }
+    }
 
     /// CIRISEdge#460 — the `LinkClosed` severity mapping. Routine turnover
     /// (`Normal`, `Stale`) is `Info`; every fault reason is `Warning`. Pins that
@@ -10130,7 +10382,8 @@ mod scope_native_addressing_tests {
 
         assert!(
             transport.scope_address_table().is_none(),
-            "a fresh transport has no table — production state until CIRISVerify#259",
+            "a fresh transport has no table — the default until the operator \
+             opts in via EdgeBuilder::scope_native_addressing",
         );
 
         let first = Arc::new(ScopeAddressTable::new(Arc::new(StubDeriver)));

--- a/tests/cohort_scope_refusal.rs
+++ b/tests/cohort_scope_refusal.rs
@@ -177,6 +177,10 @@ fn config_with_enforcement(mode: CohortScopeEnforcement) -> EdgeConfig {
     EdgeConfig {
         hybrid_policy: HybridPolicy::Ed25519Fallback,
         cohort_scope_enforcement: mode,
+        // Phase 2 — ephemeral typed sends now genuinely await a
+        // correlated response; no responder is wired in these tests,
+        // so keep the (ignored) await short.
+        ephemeral_response_timeout_ms: 10,
         ..EdgeConfig::default()
     }
 }
@@ -499,11 +503,11 @@ async fn ephemeral_delivery_with_family_scope_to_family_recipient_allowed() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let (edge, fam_recipient, _pub_) =
         build_edge_with_directories(&tmp, CohortScopeEnforcement::Strict, vec![]).await;
-    // `send` returns Err because ephemeral request-response correlation
-    // is not wired (Phase 2 TODO in edge.rs); the cohort_scope check
-    // must NOT block the call before reaching that point — the error
-    // we want to see is the Config(Phase 2) wire, NOT a
-    // CohortScopeRefused.
+    // `send` returns Err because no responder is wired for the
+    // (Phase-2, now real) request-response correlation — the await
+    // times out as `Unreachable`. The cohort_scope check must NOT
+    // block the call before reaching that point: the error we want to
+    // see is the transport/timeout shape, NOT a CohortScopeRefused.
     let err = edge
         .send_with_cohort_scope(
             &fam_recipient,
@@ -514,19 +518,14 @@ async fn ephemeral_delivery_with_family_scope_to_family_recipient_allowed() {
             Some(CohortScope::Family),
         )
         .await
-        .expect_err("ephemeral request-response returns Phase-2 error");
+        .expect_err("no responder wired → the correlation await errors");
     match err {
         EdgeError::CohortScopeRefusedRecipient { .. } => {
             panic!("family recipient must NOT trigger cohort_scope refusal");
         }
-        EdgeError::Config(msg) => {
-            assert!(
-                msg.contains("Phase 2") || msg.contains("correlation"),
-                "expected Phase 2 message; got {msg}"
-            );
-        }
-        // Transport-shaped errors are also acceptable — the test's
-        // point is that we DON'T see a CohortScopeRefusedRecipient.
+        // Transport-shaped errors (including the response-await
+        // timeout) are the expected outcome — the test's point is
+        // that we DON'T see a CohortScopeRefusedRecipient.
         EdgeError::Transport(_) | EdgeError::Unreachable(_) => {}
         other => panic!("unexpected error: {other:?}"),
     }

--- a/tests/https_per_messagetype_roundtrip.rs
+++ b/tests/https_per_messagetype_roundtrip.rs
@@ -480,6 +480,21 @@ async fn https_round_trip_opaque_response() {
 }
 
 #[tokio::test]
+async fn https_round_trip_ephemeral_response() {
+    // v18.2.0 typed ephemeral correlation — `EphemeralResponse` carries a
+    // typed handler's response bytes back to the `Edge::send` waiter,
+    // correlated by `in_reply_to` (excluded from the durable-ACK matcher
+    // exactly like `OpaqueResponse`). The wire body is the handler's own
+    // response serialization; any JSON round-trips.
+    https_envelope_round_trip(
+        0x4E,
+        "EphemeralResponse",
+        br#"{"status":"ok","echo":[4,5,6]}"#,
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn https_round_trip_goal_declaration() {
     https_envelope_round_trip(0x18, "GoalDeclaration", br#"{"goal_id":"g"}"#).await;
 }
@@ -633,6 +648,7 @@ fn all_message_types_have_https_round_trip_test() {
         match t {
             MessageType::OpaqueRequest => "OpaqueRequest",
             MessageType::OpaqueResponse => "OpaqueResponse",
+            MessageType::EphemeralResponse => "EphemeralResponse",
             MessageType::OpaqueEvent => "OpaqueEvent",
             MessageType::BuildManifestPublication => "BuildManifestPublication",
             MessageType::DSARRequest => "DSARRequest",

--- a/tests/observability_metrics.rs
+++ b/tests/observability_metrics.rs
@@ -129,6 +129,11 @@ async fn directory_with(records: Vec<KeyRecord>) -> Arc<SqliteBackend> {
 fn test_edge_config() -> EdgeConfig {
     EdgeConfig {
         hybrid_policy: HybridPolicy::Ed25519Fallback,
+        // Phase 2 — `OpaqueRequest` sends now genuinely await a
+        // correlated response; these tests wire no responder, so a
+        // short timeout keeps each (ignored-result) send from parking
+        // for the 30 s production default.
+        ephemeral_response_timeout_ms: 10,
         ..EdgeConfig::default()
     }
 }
@@ -227,10 +232,10 @@ where
 // ─── Tests ──────────────────────────────────────────────────────────
 
 /// Counter increments on a successful `Edge::send` of an ephemeral
-/// `OpaqueRequest`. Note: `Edge::send` returns Err for OpaqueRequest (the
-/// Phase-2 ephemeral request-response correlation isn't wired); we
-/// expect the transport-side counter to register regardless because the
-/// envelope DID ship before the correlation gap kicks in.
+/// `OpaqueRequest`. Note: with no responder wired, `Edge::send` times
+/// out its (Phase-2, now real) response await and returns
+/// `EdgeError::Unreachable`; the transport-side counter registers
+/// regardless because the envelope DID ship before the await.
 #[tokio::test]
 async fn metrics_counter_increments_on_send() {
     let tmp = tempfile::tempdir().unwrap();

--- a/tests/reachability_integration.rs
+++ b/tests/reachability_integration.rs
@@ -192,6 +192,14 @@ async fn build_edge(
         .queue(queue)
         .signer(signer)
         .transport(transport)
+        // Phase 2 — `OpaqueRequest` sends now genuinely await a
+        // correlated response; these tests wire no responder, so a
+        // short timeout keeps each (ignored-result) send from parking
+        // for the 30 s production default.
+        .config(EdgeConfig {
+            ephemeral_response_timeout_ms: 10,
+            ..EdgeConfig::default()
+        })
         .build()
         .expect("build edge")
 }
@@ -210,13 +218,12 @@ async fn hundred_successful_sends_yield_ratio_one() {
     let edge = build_edge(&tmp, &me, &peer, transport.clone()).await;
 
     // `OpaqueRequest` rides `Delivery::Ephemeral` so `Edge::send` is the
-    // right entry point. We don't actually need a response — the
-    // ephemeral path returns `EdgeError::Config` "correlation not
-    // wired (Phase 2)" on success, which is fine: the tracker hook is
-    // executed BEFORE the correlation-channel check (the hook sits on
-    // the transport.send() result), so the counter increments
-    // regardless of whether the caller-facing `send` ultimately
-    // returns Ok or this Config error.
+    // right entry point. We don't actually need a response — with no
+    // responder wired each send times out its (Phase-2, now real)
+    // correlation await and returns `EdgeError::Unreachable`, which is
+    // fine: the tracker hook sits on the transport.send() result,
+    // BEFORE the response await, so the counter increments regardless
+    // of what the caller-facing `send` ultimately returns.
     for _ in 0..100 {
         let _ = edge
             .send(
@@ -401,6 +408,8 @@ async fn config_window_threads_to_tracker() {
     let transport = Arc::new(ToggleTransport::new(true));
     let cfg = EdgeConfig {
         reachability_window_seconds: 600, // 10 min — non-default
+        // Phase 2 — no responder wired; don't park on the await.
+        ephemeral_response_timeout_ms: 10,
         ..EdgeConfig::default()
     };
     let edge = Edge::builder()

--- a/tests/realtime_av_spine_e2e.rs
+++ b/tests/realtime_av_spine_e2e.rs
@@ -59,7 +59,7 @@ fn fresh_joiner_xwing() -> (PeerKexPubkeys, OwnKexKeys) {
     (
         PeerKexPubkeys {
             x25519_pub: x_pk,
-            mlkem768_pub: Some(mlkem_pk.clone()),
+            mlkem768_pub: mlkem_pk.clone(),
         },
         OwnKexKeys {
             x25519_priv: x_sk,
@@ -128,7 +128,7 @@ fn hybrid_member(key_id: &str) -> Member {
         key_id: key_id.to_string(),
         kex_pubkeys: PeerKexPubkeys {
             x25519_pub: [1u8; 32],
-            mlkem768_pub: Some(vec![0xAB; 1184]),
+            mlkem768_pub: vec![0xAB; 1184],
         },
     }
 }

--- a/tests/reticulum_loopback.rs
+++ b/tests/reticulum_loopback.rs
@@ -38,6 +38,46 @@ use common::{
     build_reticulum_with_retry, directory_with, prime_v7_peer_pair, signed_record, TestFedKey,
 };
 
+// ─── Phase 2 typed round-trip fixture ───────────────────────────────
+//
+// A local `Message` impl with a REAL response type (`Response` is a
+// struct, not `()`), riding an otherwise-unused wire discriminator —
+// `DSARRequest`; nothing else registers or special-cases it in this
+// test topology. Exercises the full typed leg the opaque plane does
+// not cover: `Handler<M>` response bytes shipped back as a correlated
+// `MessageType::EphemeralResponse` envelope.
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+struct EchoReq {
+    text: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq, Eq)]
+struct EchoResp {
+    echoed: String,
+}
+
+impl ciris_edge::handler::Message for EchoReq {
+    const TYPE: MessageType = MessageType::DSARRequest;
+    const DELIVERY: ciris_edge::handler::Delivery = ciris_edge::handler::Delivery::Ephemeral;
+    type Response = EchoResp;
+}
+
+struct Echoer;
+
+#[async_trait::async_trait]
+impl ciris_edge::handler::Handler<EchoReq> for Echoer {
+    async fn handle(
+        &self,
+        msg: EchoReq,
+        _ctx: ciris_edge::handler::HandlerContext,
+    ) -> Result<EchoResp, ciris_edge::handler::HandlerError> {
+        Ok(EchoResp {
+            echoed: format!("echo:{}", msg.text),
+        })
+    }
+}
+
 /// Build a representative signed-shaped envelope. The signatures here
 /// are placeholder strings — the loopback test exercises *transport*
 /// byte-fidelity, not verify; the bytes just have to survive the
@@ -361,22 +401,33 @@ async fn spawn_background_listeners_drives_two_node_opaque_request() {
     let _handles_a = edge_a.spawn_background_listeners(rt_a.handle());
     let _handles_b = edge_b.spawn_background_listeners(rt_b.handle());
 
+    // Phase 2 — a typed Handler<M> on A with a REAL response type.
+    // Registered before the sends so the reply leg is armed when the
+    // request arrives.
+    edge_a
+        .register_handler::<EchoReq, _>(Echoer)
+        .await
+        .expect("register typed EchoReq handler on A");
+
     // Drive the send: B → A. Ship an OpaqueRequest (kind 7) via the
-    // generic ephemeral `send` primitive. The transport accepts + ships
-    // the bytes; the ephemeral request/response correlation channel is
-    // the Phase-2 TODO in `Edge::send`, surfaced as `EdgeError::Config`
-    // — the receiver-side handler observation is what gates this test.
+    // generic ephemeral `send` primitive. Phase 2 wired the
+    // correlation, so this now completes the FULL typed round trip:
+    // B's waiter (keyed on the request envelope's body_sha256) is
+    // resolved by A's correlated OpaqueResponse reply. Pre-Phase-2
+    // this call returned the "correlation not wired" `EdgeError::Config`
+    // ON THE SUCCESS PATH and this test string-matched it.
     let req = OpaqueRequest {
         kind: 7,
         payload: b"v8.0.0 opaque hello".to_vec(),
     };
     assert_eq!(OpaqueRequest::TYPE, MessageType::OpaqueRequest);
-    match edge_b.send("edge-bg-aaaa", req).await {
-        Ok(_resp) => {}
-        Err(ciris_edge::EdgeError::Config(s))
-            if s.contains("ephemeral request-response correlation not wired") => {}
-        Err(e) => panic!("send B → A failed at transport: {e:?}"),
-    }
+    let resp = edge_b
+        .send("edge-bg-aaaa", req)
+        .await
+        .expect("typed opaque round trip B → A → B");
+    assert_eq!(resp.kind, 7);
+    assert_eq!(resp.status, 200, "A's kind-7 handler answers 200");
+    assert_eq!(resp.payload, b"ok".to_vec());
 
     // A's opaque-request handler must fire — proves the background-
     // listener path drove verify + handler dispatch all the way to the
@@ -387,6 +438,24 @@ async fn spawn_background_listeners_drives_two_node_opaque_request() {
         .expect("opaque channel closed without receive");
     assert_eq!(sender_key_id, "edge-bg-bbbb");
     assert_eq!(payload, b"v8.0.0 opaque hello");
+
+    // ── Phase 2 typed round trip: request → Handler<M> → typed reply ──
+    // The reply rides a `MessageType::EphemeralResponse` envelope
+    // (in_reply_to = request body_sha256). This also pins the
+    // durable-ACK exclusion: the queue here is a real persist backend,
+    // so without the ACK-matcher guard the reply would be swallowed by
+    // the "no matching outbound row; dropping" arm and this send would
+    // time out.
+    let typed = edge_b
+        .send(
+            "edge-bg-aaaa",
+            EchoReq {
+                text: "over reticulum".to_string(),
+            },
+        )
+        .await
+        .expect("typed EchoReq round trip B → A → B");
+    assert_eq!(typed.echoed, "echo:over reticulum");
 
     // Tokio runtimes can't be dropped from within an async context,
     // so leak them; the test process exit will reclaim. Holding them


### PR DESCRIPTION
The completion cut from the three-auditor sweep (state machine / namespaces / replication planes + DRY/carve-outs). Everything edge controls is closed; the remainder is filed upstream (persist#748/#749) or tracked for the server (CIRISServer#451).

**Security**: the SelfOwn fetch-path projection twin (a structurally-hidden self-scope attestation was servable by content hash to any consent-set peer — now refused + booked, first-party override preserved). KEX structural closure (#481 item 4: the ML-KEM-less peer is unrepresentable; dead fallback arms compiler-deleted).

**No carve-outs**: every kind-partition predicate single-sourced with through-the-call-site pin tests; the serve-policy manifest is DERIVED from the predicates in tests; the divergent bootstrap list fixed; the #505 dimension-half helper is `#[cfg(test)]`; the deliberate cohort→community crypto-tier divergence pinned as intentional.

**No silent narrowing**: the subject-Pull LIST path books every shortfall; TransportDestination refusals counted honestly (the dead "conflict" string-discriminator replaced with a real clock comparison); cursor-plane truncation warns with counts.

**No unimplemented planes**: the FFI parser is total over all 15 kinds; the three SelfOwn planes' holdings/advertise split fixed (perpetual re-fetch convergence bug); `Edge::send` is a working API (it returned Err ON SUCCESS; four callers string-matched it) with full typed correlation, reply-path transport affinity, and real per-row transport preference. The MessageType maintenance gate fired as designed and got its EphemeralResponse round-trip test.

**One constant, one authority**: 8 MiB budget (compiler-enforced equality), CIPHERSUITE_ID, scope tokens (via persist's lattice), TARGET_HOLDERS. Blackhole rules self-prune; i2p fails loud; the directory cache has its invalidation surface.

**Spec = code**: the transport FSD refreshed from v14.3.0 to v18 truth — 15 kinds, 6 verbs, the correct want-formula, the four-input tombstone-ceiling rule (the old spec taught a privacy regression), budgets, Fetch responder-only, the scope-gate arming condition.

**BREAKING for downstream mirrors**: `SERVE_ADVERTISE_POLICY_HASH` → `20499cabaf1c0566b5a8d66f8d03c8a980b760c733e83444b7345a7733f22d74`. CIRISServer#451 carries it.

Gates: clippy `-D warnings` (pre-push set, all targets) clean; **1216/0** lib tests; https roundtrip 31/0; harness 7/0; census self-test all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FejjcCbAbRFpLkmcgCDLEY