### PR TITLE
v18.3.0 — adopt persist v38.0.0 + leviculum v0.23.0+ciris.1 (the #508 arc closes upstream)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "18.2.0"
+version = "18.3.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]
@@ -213,7 +213,18 @@ publish = false
 # de-projects (retires) it — closing the "accepted-but-not-projected" gap that was
 # the #336 offline/pre-announce last mile. Edge threads the announce `epoch` into
 # the write-through and adopts the signed apply in `src/replication/bridge.rs`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.1.0", version = "37", features = ["sqlite", "encrypted-kv"] }
+# v38.0.0 — the constitutional-ledger MAJOR. Edge-side impact: #748 retires
+# `TrustScoring::trust_score`'s decorative `recursion_depth` (edge drops the
+# dispatch threading; the pyo3 `trust_resolver` callback keeps its two-arg
+# contract via install-time capture), #721 `remove_peer_record` takes
+# `reason` + `acting_under_delegation_id` (edge synthesizes at the uniffi
+# boundary), #746 `RecipientBasis::GroupIdNotFederationKeyed` adopted in
+# `basis_tag`. NOT consumed by edge: #723 witness_diversity BAND, #671
+# GenesisPurgeAuthority, #709 seated-steward quorum, the ledgers +
+# registry_key_escrows families (additive), capsule ABI 3→4 (edge compares
+# persist's own ASYNC_EXECUTOR_ABI_VERSION const — tracks automatically).
+# persist v38 keeps CIRISVerify v13.6.1 — no cross-cdylib skew.
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v38.0.0", version = "38", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -602,8 +613,20 @@ tempfile       = { version = "3", optional = true }
 # crate semver is now 0.16. CHANGELOG-gotcha lesson from their release: grep for
 # conflict markers before tagging (prose doesn't compile). Adoption sequenced in #484:
 # awaited variants next, then #482 item-1 buffer_unordered dispatcher.
-leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.20.0+ciris.1", version = "0.20", optional = true }
-leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.20.0+ciris.1", version = "0.20", optional = true }
+# v0.23.0+ciris.1 (CIRISEdge#508 arc) — first fixes from the live-canonical
+# incident, filed as leviculum#56–#60: #56 the completion mirror never evicts a
+# LIVE link (cap is an alarm, not an evictor; also deletes an O(n) scan under
+# the registry lock per link close), #59 resource events classified by what
+# they carry (sender-side intermediate ResourceCompleted +
+# ResourceTransferStarted → Data; receiver-side/final stay Control — completion
+# futures unaffected, registry observes at dispatch before the sink), #60 drop
+# ladder (1,2,4,8… not per-event WARN) + 80% pre-threshold warn +
+# `plane_stats()`/`PlaneStats` (additive API). #57 answered with analysis, #58
+# scoped (still open). API edge consumes is otherwise UNCHANGED. Upstream
+# catch-up carries per-interface-type IFAC size defaults (Codeberg #293) —
+# edge passes explicit config, unaffected.
+leviculum-core = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.23.0+ciris.1", version = "0.23", optional = true }
+leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.23.0+ciris.1", version = "0.23", optional = true }
 # v15.20.0 (CIRISEdge#169) — LXMF store-and-forward propagation. The
 # `leviculum-lxmf` workspace member (same pinned tag) ships the whole
 # LXMF wire protocol: propagation-node discovery/upload/`/get` codecs,
@@ -613,7 +636,7 @@ leviculum-std  = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.20.0+
 # features keep `pow` on (the stamp/ticket cost we validate at
 # admission). Gated behind the `lxmf` feature — see the `[features]`
 # block. Edge INTEGRATES this crate's protocol; it never reimplements it.
-leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.20.0+ciris.1", version = "0.20", optional = true }
+leviculum-lxmf = { git = "https://github.com/CIRISAI/leviculum", tag = "v0.23.0+ciris.1", version = "0.23", optional = true }
 
 # v0.11.0 (CIRISEdge#31) — Identity FFI QR codec. `qrcodegen` is the
 # canonical pure-Rust QR encoder (Apache-2.0, no_std, zero unsafe in
@@ -1250,7 +1273,7 @@ async-trait        = "0.1"
 # `default_outbound_pipeline::<InlineTextEnvelope>()` (Classify +
 # Scrub) over the persist pipeline surface. Dev-deps only; the normal
 # edge build does not pull these.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v37.1.0", version = "37", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v38.0.0", version = "38", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.2.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.2.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.2.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.2.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.2.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.2.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.2.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.3.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.3.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.3.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.3.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.3.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.3.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ classifiers = [
 # an install-time index requirement (so the "unresolvable from PyPI" shape is by
 # design, not a regression).
 dependencies = [
-    "ciris-persist>=37,<38",
+    "ciris-persist>=38,<39",
 ]
 dynamic = ["version"]
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -93,9 +93,12 @@ pub const DEFAULT_BLACKHOLE_PRUNE_INTERVAL_SECONDS: u64 = 3600;
 /// mapping with the full CEWP L0/L1 tier vocabulary. The
 /// `disk_budget_bytes` field is **advisory** at the edge tier (persist
 /// or the host enforces capacity-gated admission); the
-/// `trust_recursion_depth` is **consulted** at `dispatch_inbound`'s
-/// trust short-circuit (it's the `recursion_depth` argument to
-/// `TrustScoring::trust_score`, replacing v0.19.6's hardcoded `0`).
+/// `trust_recursion_depth` is edge-tier POLICY VOCABULARY only: persist
+/// v38.0.0 (#748) retired the decorative `recursion_depth` argument from
+/// `TrustScoring::trust_score` (no attenuation rule was ever specified;
+/// transitive propagation stays the consumer's, AV-29), so the value now
+/// reaches only the Python `trust_resolver` callback (captured at
+/// `install_trust_resolver` time) — never persist's trait.
 /// L2+ tiers are deferred to a post-v1.0 cut.
 ///
 /// Transport-posture translation (Roaming / Full / Gateway / AP) is
@@ -187,9 +190,10 @@ impl AgentMode {
     }
 
     /// CIRISEdge#51 (v0.20.0 RC1) — default trust recursion depth for
-    /// the mode. Consumed at [`dispatch_inbound`]'s trust short-circuit
-    /// as the `recursion_depth` argument to
-    /// `TrustScoring::trust_score` (replacing v0.19.6's hardcoded `0`).
+    /// the mode. Since persist v38.0.0 (#748) retired the trait's
+    /// `recursion_depth` argument, this reaches only the Python
+    /// `trust_resolver` callback (see `install_trust_resolver`) — it is
+    /// edge policy vocabulary, not a persist input.
     /// Client = 0 (no inbound dispatch), Proxy = 0 (strict — direct
     /// attestations only), Server = 1 (friend-of-friends — walks one
     /// `delegates_to` hop). L2+ tiers deferred to a post-v1.0 cut.
@@ -439,10 +443,12 @@ pub struct EdgeConfig {
     /// (CEWP tier as security boundary).
     pub disk_budget_bytes: u64,
     /// CIRISEdge#51 (v0.20.0 RC1) — CEWP L0/L1 trust-graph recursion
-    /// depth for the [`dispatch_inbound`] short-circuit. Threaded
-    /// into `TrustScoring::trust_score(key_id, recursion_depth)` as
-    /// the second arg (replacing v0.19.6's hardcoded `0`). Defaults
-    /// from [`AgentMode::default_trust_recursion_depth`]: Client = 0,
+    /// depth. persist v38.0.0 (#748) retired the trait's
+    /// `recursion_depth` argument (`TrustScoring::trust_score(key_id)`
+    /// now), so this field feeds ONLY the Python `trust_resolver`
+    /// callback's second argument (captured at
+    /// `install_trust_resolver` time — the callback API is unchanged).
+    /// Defaults from [`AgentMode::default_trust_recursion_depth`]: Client = 0,
     /// Proxy = 0 (strict direct trust), Server = 1 (friend-of-
     /// friends — one `delegates_to` hop). Operator override on
     /// `init_edge_runtime` (the new `trust_recursion_depth` kwarg)
@@ -1904,9 +1910,10 @@ impl Edge {
 
     /// CIRISEdge#51 (v0.20.0 RC1) — CEWP L0/L1 trust-graph recursion
     /// depth sourced from [`EdgeConfig::trust_recursion_depth`].
-    /// Threaded into `dispatch_inbound`'s `TrustScoring::trust_score`
-    /// call; exposed here so hosts can mirror the same depth on
-    /// out-of-band trust queries.
+    /// Since persist v38.0.0 (#748) the `TrustScoring` trait takes no
+    /// depth; this feeds the Python `trust_resolver` callback's second
+    /// argument and is exposed here so hosts can mirror the same depth
+    /// on out-of-band trust queries.
     #[must_use]
     pub fn trust_recursion_depth(&self) -> u8 {
         self.config.trust_recursion_depth
@@ -3598,7 +3605,6 @@ impl Edge {
             trust_scoring_ref,
             trust_threshold,
             trust_short_circuit_enabled,
-            self.config.trust_recursion_depth,
             self.config.agent_mode,
             self.config.l1_cdn_edge_enabled,
             self.config.l1_cdn_edge_external_uri_base.clone(),
@@ -4278,10 +4284,6 @@ impl Edge {
         let trust_scoring = self.trust_scoring.clone();
         let trust_threshold = self.config.trust_threshold;
         let trust_short_circuit_enabled = self.config.trust_short_circuit_enabled;
-        // CIRISEdge#51 (v0.20.0 RC1) — capture into the dispatcher loop
-        // so each spawned `dispatch_inbound` task gets the operator-
-        // configured recursion depth (CEWP L0/L1 0/1 default).
-        let trust_recursion_depth = self.config.trust_recursion_depth;
         // CIRISEdge#52 (v0.20.1) — multimedia tier knobs threaded
         // into each dispatched envelope. `agent_mode` gates the
         // L1-as-CDN-edge prefetch arm; the URI base is `Option`
@@ -4400,7 +4402,6 @@ impl Edge {
                             trust_scoring_clone.as_ref(),
                             trust_threshold,
                             trust_short_circuit_enabled,
-                            trust_recursion_depth,
                             agent_mode_for_dispatch,
                             l1_cdn_edge_enabled,
                             l1_cdn_edge_external_uri_base_clone,
@@ -5000,11 +5001,10 @@ async fn dispatch_inbound(
     trust_scoring: Option<&Arc<dyn ciris_persist::federation::TrustScoring>>,
     trust_threshold: f64,
     trust_short_circuit_enabled: bool,
-    // CIRISEdge#51 (v0.20.0 RC1) — trust-graph recursion depth threaded
-    // through to `TrustScoring::trust_score(key_id, recursion_depth)`.
-    // v0.19.6 hardcoded `0` (strict direct trust); v0.20.0 RC1 honours
-    // `EdgeConfig::trust_recursion_depth` (CEWP L0/L1 default 0/1).
-    trust_recursion_depth: u8,
+    // persist v38.0.0 (#748) retired `TrustScoring::trust_score`'s
+    // decorative `recursion_depth` argument; the depth knob no longer
+    // threads through dispatch (it feeds only the Python
+    // `trust_resolver` callback, captured at `install_trust_resolver`).
     // CIRISEdge#52 (v0.20.1) — multimedia tier: agent_mode gates
     // L1-as-CDN-edge (only `Server`/L1 acts); the cdn-edge knobs are
     // captured here so the dispatch sub-arm on `ContributionSubmit`
@@ -5252,9 +5252,7 @@ async fn dispatch_inbound(
     // SQL-backed) `trust_score` call per envelope.
     if trust_short_circuit_enabled && trust_threshold > 0.0 {
         if let Some(scorer) = trust_scoring {
-            let score = scorer
-                .trust_score(&envelope.signing_key_id, trust_recursion_depth)
-                .await;
+            let score = scorer.trust_score(&envelope.signing_key_id).await;
             let observed = match score {
                 Ok(s) => s,
                 Err(ciris_persist::federation::TrustScoringError::KeyNotFound(_)) => {

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -962,7 +962,7 @@ impl PyEdge {
     /// effective gate becomes:
     ///
     /// ```text
-    /// trust_score(signing_key_id, recursion_depth) < threshold
+    /// trust_score(signing_key_id) < threshold
     ///   ⇒ envelope dropped, "trust_short_circuited" event emitted
     /// ```
     ///
@@ -1016,8 +1016,16 @@ impl PyEdge {
                     }
                     Ok(())
                 })?;
+                // persist v38.0.0 (#748) retired the trait's
+                // `recursion_depth` argument; the Python callback's
+                // two-arg contract is preserved by capturing the
+                // configured depth HERE (it was always the same
+                // config-sourced value on every call).
                 let scoring: Arc<dyn ciris_persist::federation::TrustScoring> =
-                    Arc::new(PyTrustScoringAdapter { callback: cb });
+                    Arc::new(PyTrustScoringAdapter {
+                        callback: cb,
+                        depth: self.inner.trust_recursion_depth(),
+                    });
                 self.inner.install_trust_scoring_override(Some(scoring));
                 Ok(())
             }
@@ -3085,6 +3093,14 @@ fn scope_to_pydict<'py>(
 /// `AdmissionGate` unknown-key discipline).
 struct PyTrustScoringAdapter {
     callback: Py<PyAny>,
+    /// `EdgeConfig::trust_recursion_depth`, captured at
+    /// `install_trust_resolver` time. persist v38.0.0 (#748) retired
+    /// the `recursion_depth` argument from
+    /// `TrustScoring::trust_score`; the Python callback keeps its
+    /// `(signing_key_id, recursion_depth)` contract by reading the
+    /// depth from here instead — behaviour-identical, because the
+    /// dispatch path only ever passed this same config value.
+    depth: u8,
 }
 
 /// CIRISEdge#219 — `Arc<dyn RNodeChannelFactory>` adapter wrapping a
@@ -3259,8 +3275,11 @@ impl ciris_persist::federation::TrustScoring for PyTrustScoringAdapter {
     async fn trust_score(
         &self,
         key_id: &str,
-        recursion_depth: u8,
     ) -> Result<f64, ciris_persist::federation::TrustScoringError> {
+        // persist v38.0.0 (#748): the trait no longer carries a depth;
+        // the Python callback's second argument comes from the depth
+        // captured at install time.
+        let recursion_depth = self.depth;
         let key_id_owned = key_id.to_owned();
         // `block_in_place` keeps the dispatch_inbound future on its
         // current worker but moves the GIL-attach into a blocking context.
@@ -4356,9 +4375,9 @@ pub fn init_edge_runtime(
     // `trust_recursion_depth`). `Some(_)` pins the per-deployment
     // value AFTER `AgentMode::apply_defaults` runs, so a curated
     // server (e.g.) can pin depth = 0 even though L1 default is 1.
-    // `trust_recursion_depth` is clamped to `u8`'s range; persist's
-    // `TrustScoring::trust_score(_, recursion_depth: u8)` consumes it
-    // verbatim.
+    // `trust_recursion_depth` is clamped to `u8`'s range; since persist
+    // v38.0.0 (#748) retired the trait's depth argument it feeds only
+    // the Python `trust_resolver` callback's second argument.
     disk_budget_bytes: Option<u64>,
     trust_recursion_depth: Option<u8>,
     // v2.3.0 (CIRISEdge#100) — Reticulum shared-instance mode. When

--- a/src/ffi/uniffi_impl.rs
+++ b/src/ffi/uniffi_impl.rs
@@ -400,6 +400,15 @@ pub fn peer_add(
 /// permitted; the row is hidden from reads, the canonical knowledge
 /// stays in memory, and the init reseed does NOT un-hide it (persist
 /// preserves `removed_at` across the idempotent `add_peer_record`).
+///
+/// persist v38.0.0 (CIRISPersist#721) — a removal is an announced,
+/// attributed act: `remove_peer_record` now REQUIRES a `reason` and
+/// records `acting_under_delegation_id`, and both faces emit
+/// `admin_action:peer_removal` in-transaction. This mobile surface has
+/// exactly one caller class (the device operator acting on their own
+/// node), so the reason is synthesized at the boundary rather than
+/// widening the FFI signature; plumbing an operator-typed reason
+/// through the bindings is a host-UI follow-up, not this seam's call.
 pub fn peer_remove(
     handle: crate::EdgePeerHandle,
     hard: bool,
@@ -415,8 +424,13 @@ pub fn peer_remove(
     let directory = current_federation_directory()?;
     let key_id = handle.key_id;
     block_on_runtime(&edge, async move {
+        let reason = if hard {
+            "operator hard-remove via edge mobile FFI peer_remove"
+        } else {
+            "operator soft-remove via edge mobile FFI peer_remove"
+        };
         directory
-            .remove_peer_record(&key_id, hard)
+            .remove_peer_record(&key_id, hard, reason, None)
             .await
             .map_err(map_federation_err)
     })

--- a/src/swarm/scope.rs
+++ b/src/swarm/scope.rs
@@ -169,6 +169,18 @@ fn basis_tag(basis: RecipientBasis) -> &'static str {
         RecipientBasis::Unbounded => "unbounded",
         RecipientBasis::NoRosterForScope => "no_roster_for_scope",
         RecipientBasis::GroupUnresolvable => "group_unresolvable",
+        // persist v38.0.0 (CIRISPersist#746) — a scope-address-table id
+        // (`cohort:*` / `av-stream:*`) in the federation-key parameter
+        // is refused BY NAME, never answered as a confident
+        // `GroupUnresolvable` about a group that was never asked about.
+        // Edge never hands one over (the `ContentScope::Group` branch
+        // resolves via the address table, and the Federation branch's
+        // `group_key_id` is provably unread — see
+        // `federation_branch_never_reads_the_group_key_id`), so this
+        // arm firing means a caller wired the wrong id space; the tag
+        // names that remedy instead of flattening it into
+        // "membership list broken".
+        RecipientBasis::GroupIdNotFederationKeyed => "group_id_not_federation_keyed",
         RecipientBasis::NotRosterKeyed => "not_roster_keyed",
         _ => "unknown_basis",
     }

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -340,6 +340,17 @@ const REVERSE_PATH_NO_PROGRESS_WINDOW: Duration = Duration::from_secs(6);
 /// mobile's ~90 s live window; a stalled transfer fails earlier via the
 /// no-progress window).
 const REVERSE_PATH_MAX_TRANSFER: Duration = Duration::from_secs(45);
+/// Defensive size bound on the `sent_resource_progress` mirror. leviculum
+/// v0.22 (#59) moved `ResourceTransferStarted` onto the droppable data
+/// plane while `ResourceCompleted` (the entry's remover) stays on the
+/// control plane, so a saturated node can deliver Started/Progress AFTER
+/// their own completion and strand an entry (the pre-existing
+/// `ResourceProgress` window, widened). Past this threshold the insert arm
+/// prunes entries idle beyond [`REVERSE_PATH_MAX_TRANSFER`] — a live
+/// transfer refreshes `last_update` every progress tick, so only orphans
+/// qualify. 4096 entries ≈ 200 KB worst case: far above any realistic
+/// concurrent-send envelope, cheap enough that the prune almost never runs.
+const SENT_RESOURCE_PROGRESS_PRUNE_THRESHOLD: usize = 4096;
 /// No-progress window for the OUTBOUND-dial path — a freshly-dialed link we
 /// control, so more lenient than the churn-prone reverse path.
 const DIAL_NO_PROGRESS_WINDOW: Duration = Duration::from_secs(30);
@@ -6145,6 +6156,19 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             );
         }
         // TransferStarted + Progress both mean "parts are flowing" → Transferring.
+        //
+        // leviculum v0.22 (#59) reclassified `ResourceTransferStarted` from the
+        // lossless control plane to the droppable data plane (`ResourceProgress`
+        // was Data already). Both now ride a DIFFERENT channel than the Control
+        // `ResourceCompleted` that removes this entry, so under saturation a
+        // queued Started/Progress can arrive AFTER its own completion and
+        // re-insert a stale entry no one will ever remove (the waiter that
+        // owns the other removal has already returned). The insert stays (it
+        // is the self-healing arm when the `ResourceAdvertised` insert was
+        // lost to a control-plane drop), but the map gets a defensive bound:
+        // past the cap, entries idle beyond the reverse-path hard transfer
+        // cap are pruned — a live transfer refreshes `last_update` on every
+        // progress tick, so only orphans qualify.
         NodeEvent::ResourceTransferStarted {
             resource_hash,
             is_sender,
@@ -6156,7 +6180,11 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             ..
         } => {
             if is_sender {
-                ctx.sent_resource_progress.lock().await.insert(
+                let mut guard = ctx.sent_resource_progress.lock().await;
+                if guard.len() >= SENT_RESOURCE_PROGRESS_PRUNE_THRESHOLD {
+                    guard.retain(|_, p| p.last_update.elapsed() < REVERSE_PATH_MAX_TRANSFER);
+                }
+                guard.insert(
                     resource_hash,
                     ResourceSendProgress {
                         stage: ResourceSendStage::Transferring,

--- a/tests/trust_recursion_depth_wired.rs
+++ b/tests/trust_recursion_depth_wired.rs
@@ -1,14 +1,21 @@
 //! CIRISEdge#51 (v0.20.0 RC1) — `EdgeConfig::trust_recursion_depth`
-//! is threaded into `dispatch_inbound`'s
-//! `TrustScoring::trust_score(key_id, recursion_depth)` call. v0.19.6
-//! hardcoded `0` (strict direct trust); the CEWP L0/L1 default of
-//! `1` for `AgentMode::Server` (friend-of-friends) now reaches the
-//! resolver via the config field.
+//! wiring, revised for persist v38.0.0 (CIRISPersist#748): the
+//! `TrustScoring::trust_score` trait retired its decorative
+//! `recursion_depth` argument (no impl consumed it and no attenuation
+//! rule was ever specified), so "the config depth reaches the
+//! resolver" is no longer an assertable — or even expressible — claim
+//! at this seam. What remains load-bearing, and what this file pins:
 //!
-//! Uses a recording `TrustScoring` impl that captures the
-//! `recursion_depth` argument so the test asserts byte-equivalence
-//! between `EdgeConfig::trust_recursion_depth` and the value the
-//! resolver observes.
+//! - the `dispatch_inbound` trust short-circuit consults the wired
+//!   scorer EXACTLY ONCE per envelope, with the sender's key_id;
+//! - `AgentMode::apply_defaults` still sets the CEWP tier depth and
+//!   `Edge::trust_recursion_depth()` still surfaces it (the knob now
+//!   feeds only the pyo3 `trust_resolver` callback's second argument,
+//!   captured at `install_trust_resolver` time);
+//! - configuring a non-zero depth does not perturb dispatch.
+//!
+//! Uses a recording `TrustScoring` impl that captures the key_id per
+//! call.
 
 #![cfg(feature = "transport-reticulum")]
 
@@ -34,11 +41,11 @@ use ciris_persist::store::sqlite::SqliteBackend;
 use sha2::{Digest, Sha256};
 use tokio::sync::mpsc;
 
-// ─── Recording scorer — captures (key_id, recursion_depth) calls ─────
+// ─── Recording scorer — captures key_id per call ─────────────────────
 
 #[derive(Default)]
 struct RecordingScorer {
-    calls: Mutex<Vec<(String, u8)>>,
+    calls: Mutex<Vec<String>>,
     score: f64,
 }
 
@@ -49,8 +56,8 @@ impl RecordingScorer {
             score,
         }
     }
-    fn last_depth(&self) -> Option<u8> {
-        self.calls.lock().unwrap().last().map(|(_, d)| *d)
+    fn last_key(&self) -> Option<String> {
+        self.calls.lock().unwrap().last().cloned()
     }
     fn call_count(&self) -> usize {
         self.calls.lock().unwrap().len()
@@ -59,15 +66,8 @@ impl RecordingScorer {
 
 #[async_trait]
 impl TrustScoring for RecordingScorer {
-    async fn trust_score(
-        &self,
-        key_id: &str,
-        recursion_depth: u8,
-    ) -> Result<f64, TrustScoringError> {
-        self.calls
-            .lock()
-            .unwrap()
-            .push((key_id.to_string(), recursion_depth));
+    async fn trust_score(&self, key_id: &str) -> Result<f64, TrustScoringError> {
+        self.calls.lock().unwrap().push(key_id.to_string());
         Ok(self.score)
     }
 }
@@ -252,10 +252,12 @@ async fn dispatch(
 // ─── Tests ──────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn dispatch_inbound_uses_config_trust_recursion_depth_for_score_lookup_l0() {
-    // L0 / Proxy default (recursion depth = 0). Above-threshold so
-    // the envelope reaches the scoring branch; we don't care about
-    // the outcome, only that the resolver observed depth = 0.
+async fn dispatch_inbound_consults_the_wired_scorer_once_with_the_sender_key() {
+    // Above-threshold so the envelope reaches the scoring branch. The
+    // scorer must be consulted EXACTLY once, with the sender's key_id
+    // — the assertable remainder of the retired depth-threading claim
+    // (persist v38.0.0 / CIRISPersist#748: `trust_score` takes only
+    // the key).
     let tmp = tempfile::tempdir().expect("tempdir");
     let (edge, remote, local_key_id, recorder) =
         build_edge_with_recursion_depth(&tmp, 0, 0.9).await;
@@ -265,61 +267,46 @@ async fn dispatch_inbound_uses_config_trust_recursion_depth_for_score_lookup_l0(
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     assert_eq!(recorder.call_count(), 1, "exactly one score lookup");
     assert_eq!(
-        recorder.last_depth(),
-        Some(0),
-        "EdgeConfig::trust_recursion_depth = 0 must reach the resolver as 0"
+        recorder.last_key().as_deref(),
+        Some("remote-peer"),
+        "the scorer must be asked about the envelope's signing key"
     );
 }
 
 #[tokio::test]
-async fn dispatch_inbound_uses_config_trust_recursion_depth_for_score_lookup_l1() {
-    // L1 / Server default (recursion depth = 1, friend-of-friends).
-    // This is the load-bearing assertion for the v0.20.0 RC1 wiring:
-    // the value must flow EdgeConfig → dispatch_inbound → scorer.
-    let tmp = tempfile::tempdir().expect("tempdir");
-    let (edge, remote, local_key_id, recorder) =
-        build_edge_with_recursion_depth(&tmp, 1, 0.9).await;
-    dispatch(&edge, &remote, &local_key_id)
-        .await
-        .expect("dispatch");
-    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-    assert_eq!(recorder.call_count(), 1, "exactly one score lookup");
-    assert_eq!(
-        recorder.last_depth(),
-        Some(1),
-        "EdgeConfig::trust_recursion_depth = 1 (L1 friend-of-friends) \
-         must reach the resolver verbatim"
-    );
-}
-
-#[tokio::test]
-async fn dispatch_inbound_uses_operator_pinned_recursion_depth_override() {
-    // Operator override scenario: a curated server pins depth = 0
-    // (strict direct trust) even though L1 default is 1. The
-    // override flow is `apply_defaults` → operator field write →
-    // EdgeConfig → dispatch_inbound. Pinned at depth = 2 here to
-    // exercise a non-default-tier value (covers the contract shape
-    // for future L2+ deployments).
+async fn configured_nonzero_depth_does_not_perturb_dispatch() {
+    // Operator override scenario: the depth knob remains configurable
+    // (it feeds the pyo3 `trust_resolver` callback's second argument),
+    // and setting a non-default value must not change the dispatch
+    // path's scorer contract. Pinned at depth = 2 (a non-default-tier
+    // value, covering the contract shape for future L2+ deployments).
     let tmp = tempfile::tempdir().expect("tempdir");
     let (edge, remote, local_key_id, recorder) =
         build_edge_with_recursion_depth(&tmp, 2, 0.9).await;
+    assert_eq!(
+        edge.trust_recursion_depth(),
+        2,
+        "operator-pinned depth must survive to the accessor"
+    );
     dispatch(&edge, &remote, &local_key_id)
         .await
         .expect("dispatch");
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     assert_eq!(
-        recorder.last_depth(),
-        Some(2),
-        "operator-pinned depth must override the AgentMode default"
+        recorder.call_count(),
+        1,
+        "a configured depth must not change the single-lookup contract"
     );
 }
 
 #[tokio::test]
 async fn agent_mode_server_apply_defaults_threads_depth_one_into_edge_config() {
     // End-to-end shape: build an `EdgeConfig` via `AgentMode::Server
-    // .apply_defaults`, then verify the Edge built around it sees
-    // depth = 1 at the dispatcher. This pins the integration between
-    // the AgentMode default and the dispatch-inbound wiring.
+    // .apply_defaults`, then verify the Edge built around it surfaces
+    // depth = 1 and still consults the scorer on dispatch. This pins
+    // the integration between the AgentMode default and the config
+    // surface (the depth itself no longer crosses the TrustScoring
+    // trait — persist v38.0.0 / CIRISPersist#748).
     let tmp = tempfile::tempdir().expect("tempdir");
 
     let steward = FedKey::new("steward-fed", 0x01);
@@ -372,9 +359,9 @@ async fn agent_mode_server_apply_defaults_threads_depth_one_into_edge_config() {
         .expect("dispatch");
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     assert_eq!(
-        recorder.last_depth(),
-        Some(1),
-        "Server-tier depth must propagate to the resolver"
+        recorder.call_count(),
+        1,
+        "the Server-tier config must still route dispatch through the scorer"
     );
 }
 


### PR DESCRIPTION
The dual adoption, sweep-validated: the full acceptance sweep passes at **100%** on this tree (M=1: 23 legs, M=2: 31, M=4: 47 — zero contract violations), exercising leviculum v0.23's changed internals (alarm-not-evict completion mirror, payload-classified resource events) under real mesh load.

**persist v38.0.0** (major): the only compile break was persist answering edge's own #748 (decorative `recursion_depth` deleted — edge's threading removed, Python callback contract preserved via install-time capture). #746's `GroupIdNotFederationKeyed` named-refusal adopted explicitly; #721's `remove_peer_record` reason threaded through uniffi with honest operator reasons; producers verified against unchanged admission shapes; exactly one `ciris-verify-core` in the graph (no cdylib split).

**leviculum v0.23.0+ciris.1**: three of the five #508-arc issues LANDED upstream — #56 (live-link eviction → alarm), #59 (resource events classified by payload), #60 (drop ladder + pre-threshold warns + plane_stats). Every API edge consumes unchanged; the one visible ordering shift (Started/Progress may trail Completed) hardened with a bounded prune.

Closes #508 (the live-canonical wedge): every mechanism in its causal chain is now fixed upstream, shipped edge-side (the v18.0.1 capacity knob), or explicitly owned by open upstream issues (leviculum#57 analysis, #58 scoped).

Gates: clippy -D warnings (pre-push set); lib **1216/0**; edge_node 7/0; trust/peer-mutation/accord suites green; pin-skew hook passed; evidence TSV regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FejjcCbAbRFpLkmcgCDLEY