### PR TITLE
fix(ci): the iOS cache SAVE must not gate a release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1134,8 +1134,20 @@ jobs:
           path: dist/${{ matrix.dir }}/ciris_edge.abi3.so
           if-no-files-found: error
       # CIRISEdge#229 — save edge-self-warm on main, per-target.
+      #
+      # RESTORE-ONLY on the macOS lanes (v18.4.1). The save step failed the
+      # v18.4.0 gate AFTER every substantive step passed — build, strip +
+      # install_name fix, and the artifact upload were all green; only this
+      # trailing bookkeeping step reddened the board, which meant a release
+      # gate hung on a cache write. CIRISPersist hit the identical failure on
+      # its `darwin-aarch64` lane 3/3 (v37.1.0, v38.0.0, e119eff) and closed
+      # it the same way in persist v38.2.0/#762: nothing that exists is lost,
+      # because the attempts had warmed nothing. `continue-on-error` rather
+      # than deletion so the lane still reports the write attempt without
+      # gating a release on it; re-enable when the save is resource-bounded.
       - uses: CIRISAI/CIRISCache/save@v1
         if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
         with:
           key: ${{ steps.cachekey.outputs.key }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The v18.4.0 gate reddened on `CIRISCache/save@v1` after every substantive step passed (build, strip/install_name, artifact upload all green). Same failure class CIRISPersist closed in v38.2.0/#762 on its darwin-aarch64 lane, same disposition — non-gating rather than deleted, so the attempt is still reported.

Feeds #521 (the build-once workflow refactor) and #502 (unbounded CI steps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FejjcCbAbRFpLkmcgCDLEY