### PR TITLE
v18.11.0 — #532 link reuse + single-flight dialing, #531 second half, #537 guard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "18.10.0"
+version = "18.11.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/bench-mesh/census.py
+++ b/bench-mesh/census.py
@@ -601,13 +601,61 @@ def _host_note(state_rows):
     return lines
 
 
+def _read_leg_rows(path):
+    """Parse a results JSONL, recovering lines that carry more than one record.
+
+    Returns `(rows, corrupt_reason_or_None)`.
+
+    Every node in the mesh appends to ONE file on a shared volume. A non-atomic
+    append can therefore put two complete JSON objects on a single line, which
+    `json.loads` rejects as `Extra data` — observed at M=4, the point with the
+    most concurrent deliveries. The writer now emits each record in a single
+    `write()` (CIRISEdge#532), but this reader must not depend on that: an older
+    node image writing into a newer harness is exactly the mixed-version case a
+    mesh harness exists to run.
+
+    Concatenated COMPLETE objects are unambiguous, so they are recovered rather
+    than discarded — throwing away a ten-minute M=4 run over a formatting
+    artifact would be its own kind of dishonesty. Anything genuinely unparseable
+    is reported, and the caller refuses the verdict.
+    """
+    rows, decoder = [], json.JSONDecoder()
+    with open(path) as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            line = raw.strip()
+            if not line.startswith("{"):
+                continue
+            idx = 0
+            while idx < len(line):
+                try:
+                    obj, end = decoder.raw_decode(line, idx)
+                except ValueError as exc:
+                    return rows, f"line {lineno} is not valid JSON ({exc})"
+                rows.append(obj)
+                idx = end
+                while idx < len(line) and line[idx].isspace():
+                    idx += 1
+    return rows, None
+
+
 def census(path, rc, late_joiner=INFER, expect_nodes=None):
     """Returns (exit_code, printed lines). Never prints a number it did
     not read out of the file."""
     out = []
     # `all_rows`, not `rows`: the per-node loop below rebinds `rows` to
     # one node's slice, and a name collision there would be silent.
-    all_rows = [json.loads(l) for l in open(path) if l.strip().startswith("{")]
+    all_rows, corrupt = _read_leg_rows(path)
+    if corrupt:
+        # A results file we cannot fully read is a run we cannot report on.
+        # Same doctrine as the host pre-flight (#536): refuse the verdict
+        # rather than produce one from whatever happened to parse. A partial
+        # file would under-count legs, and an under-counted census reads as
+        # "legs did not run" — a measurement fault wearing a contract
+        # violation's clothes, which is the worst of both.
+        out.append(f"  NOT MEASURED  {path}: {corrupt}")
+        out.append("  the results file could not be read in full — refusing to "
+                   "report a leg census from a partial file")
+        return NOT_MEASURED, out
 
     # Rule 4: duplicates refuse the file outright (a merged file). Host
     # rows are included on purpose — a merged file duplicates those too,
@@ -1135,6 +1183,42 @@ def self_test():
         print(f"── self-test [{name}]: exit={code} want={want_exit}  {verdict}")
         for line in out:
             print(line)
+
+    def check_raw(name, text, want_exit):
+        """Like `check`, but writes the file BYTE-EXACTLY — the concurrency
+        artifacts below are properties of the bytes on disk, and round-tripping
+        them through `json.dumps` per row would erase the very thing under test.
+        """
+        nonlocal failures
+        with tempfile.NamedTemporaryFile(
+            "w", suffix=".jsonl", delete=False, dir=tempfile.gettempdir()
+        ) as f:
+            f.write(text)
+            path = f.name
+        try:
+            code, out = census(path, 0)
+        finally:
+            os.unlink(path)
+        verdict = "ok" if code == want_exit else "SELF-TEST FAILURE"
+        if code != want_exit:
+            failures += 1
+        print(f"── self-test [{name}]: exit={code} want={want_exit}  {verdict}")
+
+    # CIRISEdge#532 — every node appends to ONE file on a shared volume, so a
+    # non-atomic append can land two complete records on one line. This killed a
+    # ten-minute M=4 run with `JSONDecodeError: Extra data` — a MEASUREMENT
+    # fault that presented as a failed run. Two complete objects are unambiguous,
+    # so they are recovered; the run is reported, not thrown away.
+    golden_text = "".join(json.dumps(r) + "\n" for r in _golden())
+    glued = golden_text.replace("}\n{", "}{", 1)
+    check_raw("two records glued onto one line are RECOVERED, not fatal", glued, 0)
+
+    # But a TORN record is not recoverable, and guessing at one would be worse
+    # than refusing. NOT MEASURED, like the host pre-flight — never a verdict
+    # assembled from a partial file, which would under-count legs and read as
+    # "legs did not run".
+    torn = golden_text + '{"node":"sub-9","le\n'
+    check_raw("a torn record refuses the verdict (NOT MEASURED)", torn, NOT_MEASURED)
 
     check("golden: all contracts met, late-joiner skips allowed", _golden(), 0)
 

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.10.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.10.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.10.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.10.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.10.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.10.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.10.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.11.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.11.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.11.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.11.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.11.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.11.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.11.0

--- a/src/bin/edge_node.rs
+++ b/src/bin/edge_node.rs
@@ -234,7 +234,20 @@ impl Reporter {
                 .append(true)
                 .open(p)
             {
-                let _ = writeln!(f, "{line}");
+                // ONE write, newline included. Every node in the mesh appends to
+                // the SAME file on a shared volume, and `writeln!` formats —
+                // which can issue the line and the newline as separate `write()`
+                // syscalls. Two nodes finishing a leg at the same moment then
+                // interleave into a single line carrying two JSON objects, and
+                // the census dies with `JSONDecodeError: Extra data` — observed
+                // at M=4, the point with the most concurrent deliveries.
+                //
+                // A single `write_all` of the complete record under `O_APPEND`
+                // is the atomic-append shape: the kernel takes one offset and
+                // writes one buffer, so records cannot split into each other.
+                let mut record = line.into_bytes();
+                record.push(b'\n');
+                let _ = f.write_all(&record);
             }
         }
         self.legs

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -3569,6 +3569,31 @@ impl FederationDirectoryReplicationBridge {
     ///
     /// The equivalence pin any future pushdown must keep green:
     /// `advertise_projection_boundary_and_ledger_are_pinned`.
+    /// CIRISEdge#531 (second half) — the projection of a row that the advertise
+    /// gates actually consume.
+    ///
+    /// The gates read four strings: `cohort_scope`, `attestation_type`,
+    /// `attesting_key_id`, and `attestation_envelope.dimension`. Building those
+    /// directly is O(4 short strings); `serde_json::to_value` over the row was
+    /// O(whole signed envelope), and the envelope is the large part.
+    ///
+    /// Deliberately returns a `Value` rather than changing the gates to take a
+    /// typed row: the same gates are reached from the direct-fetch twin and the
+    /// pull-serve path, which hold a `Value` and not an `Attestation`. Keeping
+    /// one gate signature keeps the advertise and fetch answers IDENTICAL by
+    /// construction — the `#429` advertised-then-unfetchable shape is exactly
+    /// what a second, subtly different gate path reintroduces.
+    fn advertise_gate_view(att: &ciris_persist::federation::Attestation) -> serde_json::Value {
+        serde_json::json!({
+            "attesting_key_id": att.attesting_key_id,
+            "attestation_type": att.attestation_type,
+            "cohort_scope": att.cohort_scope,
+            "attestation_envelope": {
+                "dimension": att.attestation_envelope.get("dimension"),
+            },
+        })
+    }
+
     fn attestation_is_advertised(
         canonical_json: &serde_json::Value,
         self_set: &HashSet<String>,
@@ -4696,17 +4721,27 @@ impl FederationDirectoryReplicationBridge {
             .last()
             .map(ciris_persist::federation::ServedAttestation::resume_pair);
         for att in &attestations {
-            let Ok(canonical_json) = serde_json::to_value(&att.attestation) else {
-                // CIRISEdge#433 — an attestation that will not project to a
-                // `Value` is invisible to every gate below AND absent from the
-                // advertise set. Was a bare `continue`.
-                self.withhold(
-                    crate::observability::WithholdReason::RowNotSerializable,
-                    peer_label,
-                    "list_attestations: to_value failed",
-                );
-                continue;
-            };
+            // CIRISEdge#531, SECOND HALF — the gates below read exactly FOUR
+            // strings, and this used to hand them a full `serde_json::to_value`
+            // of the whole row: ~19 fields serialised AND a deep clone of the
+            // entire signed `attestation_envelope`, per row, per plane, per
+            // peer, per round. On the measured corpora (14,564 and 52,125 rows)
+            // across six coordinators that is the constant factor the issue
+            // names — and with the cursor already bounding MEMORY (v18.7.0),
+            // it is what remained on the CPU side.
+            //
+            // Every field is a direct read off the typed row; the envelope is
+            // ALREADY a `Value`, so the one nested field is a borrow, not a
+            // re-serialisation. `Attestation` carries no `rename_all`, so these
+            // keys are byte-identical to what `to_value` produced and the gates
+            // are untouched.
+            //
+            // The #433 `RowNotSerializable` withhold is gone from here because
+            // it is now unreachable here — this construction cannot fail. That
+            // failure CLASS is still covered: `content_hash_of` below serialises
+            // the same row and withholds on failure, so a row that will not
+            // serialise is still refused loudly rather than silently advertised.
+            let canonical_json = Self::advertise_gate_view(&att.attestation);
             // NOTE (#433, deliberate): the projection filter below is NOT a
             // withhold. `attestation_is_advertised` defines which rows this node
             // is the publisher OF (a `self`/`family` row is published by its own
@@ -4746,11 +4781,36 @@ impl FederationDirectoryReplicationBridge {
             // the direct-fetch twin in AGREEMENT, so a row this node may not
             // carry is never offered and then refused (the #429
             // advertised-then-unfetchable shape).
-            if self
-                .accord_relay_withholds(&canonical_json, peer_label, "advertise")
-                .await
-            {
-                continue;
+            // CIRISEdge#531 — THE ONE GATE THAT NEEDS THE WHOLE ROW. The relay
+            // gate hands the row to persist's taking verb, which DESERIALISES it
+            // to read the accord and the signer out (CIRISPersist#733) — four
+            // fields cannot satisfy that, and passing the view here silently
+            // withheld every accord row (caught by
+            // `accord_row_is_relayed_when_the_gate_allows_and_withheld_when_it_refuses`).
+            //
+            // So the full materialisation is not removed, it is made LAZY: paid
+            // only for rows persist's own classifier calls `accord:*`, which the
+            // cheap view can decide on its own. Every other row — the vast
+            // majority — never pays it.
+            if Self::attestation_is_accord(&canonical_json) {
+                let Ok(full_row) = serde_json::to_value(&att.attestation) else {
+                    // CIRISEdge#433 — this is where `RowNotSerializable` is now
+                    // reachable: an accord row that will not serialise cannot be
+                    // put to the gate, so it is withheld loudly rather than
+                    // relayed ungated.
+                    self.withhold(
+                        crate::observability::WithholdReason::RowNotSerializable,
+                        peer_label,
+                        "list_attestations: accord row to_value failed",
+                    );
+                    continue;
+                };
+                if self
+                    .accord_relay_withholds(&full_row, peer_label, "advertise")
+                    .await
+                {
+                    continue;
+                }
             }
             // CIRISEdge#379 — RECIPIENT gate (the contextual-integrity
             // Recipient parameter): a `trace:*` scores-attestation is
@@ -9480,6 +9540,61 @@ mod tests {
         }
     }
 
+    /// CIRISEdge#531 (second half) — the gate view must be INDISTINGUISHABLE
+    /// from `serde_json::to_value` as far as the gates can tell.
+    ///
+    /// This is the whole safety argument for dropping the full materialisation:
+    /// not "the fields look right" but "every gate returns the same verdict on
+    /// both values, for the same row". Compared on ONE typed fixture so the two
+    /// values cannot drift apart the way two hand-written shapes would
+    /// ([[feedback_test_field_provenance]]).
+    #[test]
+    fn the_gate_view_answers_every_gate_exactly_as_full_serialization_did() {
+        let producer = "fed_producer_1";
+        let att = trace_row_att(producer);
+        let full = serde_json::to_value(&att).expect("serialize trace row");
+        let view = FederationDirectoryReplicationBridge::advertise_gate_view(&att);
+
+        // Fields the gates read verbatim.
+        assert_eq!(full.get("attesting_key_id"), view.get("attesting_key_id"));
+        assert_eq!(full.get("attestation_type"), view.get("attestation_type"));
+        assert_eq!(
+            full.pointer("/attestation_envelope/dimension"),
+            view.pointer("/attestation_envelope/dimension"),
+            "the one nested read the gates make"
+        );
+
+        // `cohort_scope` is deliberately NOT compared by key presence, and the
+        // reason is load-bearing: persist declares it
+        // `skip_serializing_if = "is_default_cohort_scope"`, so `to_value`
+        // OMITS the key when the scope is `federation`, while the view always
+        // carries it. Edge does not replicate that predicate — duplicating an
+        // upstream serde rule is the drift this codebase keeps paying for.
+        //
+        // It is safe because the gate's own contract already collapses the two:
+        // a MISSING key means `federation` (persist's serde default), a present
+        // one is used as-is, and an EMPTY one is malformed and declines. So the
+        // verdicts agree for every scope, which is what the loop actually asks.
+        // Checked across all three cases rather than asserted.
+        let self_set: HashSet<String> = std::iter::once(producer.to_string()).collect();
+        for scope in ["federation", "self", "cohort", ""] {
+            let mut row = trace_row_att(producer);
+            row.cohort_scope = scope.to_string();
+            let full = serde_json::to_value(&row).expect("serialize trace row");
+            let view = FederationDirectoryReplicationBridge::advertise_gate_view(&row);
+            assert_eq!(
+                FederationDirectoryReplicationBridge::attestation_is_advertised(&full, &self_set),
+                FederationDirectoryReplicationBridge::attestation_is_advertised(&view, &self_set),
+                "advertise verdict must not change for cohort_scope={scope:?}"
+            );
+            assert_eq!(
+                FederationDirectoryReplicationBridge::attestation_requires_serve(&full),
+                FederationDirectoryReplicationBridge::attestation_requires_serve(&view),
+                "serve-gate verdict must not change for cohort_scope={scope:?}"
+            );
+        }
+    }
+
     /// A `trace:complete:v1` row's canonical JSON in EXACTLY the shape
     /// `list_attestations` feeds the item-6 gate — `serde_json::to_value` over an
     /// `Attestation` ([[feedback_test_field_provenance]]: the gate reads
@@ -9489,6 +9604,13 @@ mod tests {
     /// (a `#[cfg]`-gated lib test never runs in CI's lanes); the gate reads the
     /// projected value, not the store, so this isolates item 6 faithfully.
     fn trace_row_json(producer: &str) -> serde_json::Value {
+        serde_json::to_value(trace_row_att(producer)).expect("serialize trace row")
+    }
+
+    /// The same fixture as a TYPED row, so the #531 gate-view equivalence can be
+    /// checked against `to_value` on identical input rather than on two
+    /// separately hand-written shapes (which would prove nothing).
+    fn trace_row_att(producer: &str) -> Attestation {
         let now = Utc::now();
         let envelope = serde_json::json!({
             "id": "trace-fixture-1",
@@ -9500,7 +9622,7 @@ mod tests {
             "agent_id_hash": "ah-fixture-1",
             "trace": { "steps": [] },
         });
-        let att = Attestation {
+        Attestation {
             attestation_id: "trace-fixture-1".to_string(),
             attesting_key_id: producer.to_string(),
             attested_key_id: producer.to_string(),
@@ -9522,8 +9644,7 @@ mod tests {
             cohort_scope: "federation".to_string(),
             tier: "federation".to_string(),
             promoted_at: None,
-        };
-        serde_json::to_value(&att).expect("serialize trace row")
+        }
     }
 
     /// CIRISEdge#396 item 6 — the `recipient_capability` serve control (the #393

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -2144,16 +2144,38 @@ pub struct ReticulumTransport {
     /// (#317/#340), so reusing one would trade churn for silent non-delivery.
     /// Identification is per-LINK and persists for its lifetime, which is what
     /// makes skipping the establish+identify sequence on reuse correct.
-    reusable_dialed_link: Arc<Mutex<HashMap<DestinationHash, LinkId>>>,
-    /// CIRISEdge#532 — per-destination dial gate (single-flight).
     ///
-    /// Reuse alone does not close the churn: N coordinators firing concurrently
-    /// at the same peer all miss the empty map and all dial, which is the
-    /// 29-establish : 25-identify gap in the issue — links whose establish cost
-    /// was paid and then discarded. The gate serialises dials PER DESTINATION so
-    /// the first caller dials and the rest wait and reuse. Per-destination, not
-    /// global: two different peers must still dial in parallel.
-    dial_gate: Arc<Mutex<HashMap<DestinationHash, Arc<tokio::sync::Mutex<()>>>>>,
+    /// A POOL, not one link — and that is not an optimisation, it is the
+    /// correctness constraint. Reticulum permits ONE resource transfer per link
+    /// at a time (the same rule `#353`'s reverse-path collision note names), so
+    /// handing one shared link to concurrent senders serialises every transfer
+    /// to that peer behind one lane. The first cut of this fix did exactly that
+    /// and the mesh harness caught it at M=4 — 24 contract violations and
+    /// `resource transfer failed: Timeout`, while M=2 and M=1 passed clean.
+    ///
+    /// Which means the churn was doing WORK: N links were N parallel lanes. The
+    /// fix has to remove the re-establishing without removing the parallelism,
+    /// so links are reused only while IDLE and the pool grows to demand.
+    reusable_dialed_link: Arc<Mutex<HashMap<DestinationHash, Vec<LinkId>>>>,
+    /// CIRISEdge#532 — links with a resource transfer in flight. A link in here
+    /// is NOT handed out for reuse; a concurrent send takes another pooled link
+    /// or dials one. This is what keeps reuse from becoming a queue.
+    link_in_flight: Arc<Mutex<HashSet<LinkId>>>,
+    /// CIRISEdge#532 — per-destination dial gate: BOUNDED concurrency, not
+    /// exclusion.
+    ///
+    /// Reuse alone does not close the churn: N coordinators firing at one peer
+    /// all miss an idle link and all dial — the 29-establish : 25-identify gap,
+    /// links whose establish cost was paid and discarded.
+    ///
+    /// But a mutex here would be the previous mistake one layer over. When every
+    /// pooled link is mid-transfer, the additional dials are exactly the
+    /// PARALLEL LANES the peer needs; serialising them puts each waiter's
+    /// resource-transfer clock behind someone else's handshake, which is how the
+    /// M=4 timeouts happen. A semaphore bounds the herd without forbidding the
+    /// second lane — and Tokio's is FIFO-fair, so a waiter cannot be starved by
+    /// a steady arrival of new senders.
+    dial_gate: Arc<Mutex<HashMap<DestinationHash, Arc<tokio::sync::Semaphore>>>>,
     /// CIRISEdge#33 — operator-configured deny-list. Keyed by the
     /// 16-byte Reticulum identity hash of the blocked peer. `send`
     /// consults this BEFORE the leviculum connect call; a hit
@@ -2919,6 +2941,7 @@ impl ReticulumTransport {
             )),
             dialed_link_dest: Arc::new(Mutex::new(HashMap::new())),
             reusable_dialed_link: Arc::new(Mutex::new(HashMap::new())),
+            link_in_flight: Arc::new(Mutex::new(HashSet::new())),
             dial_gate: Arc::new(Mutex::new(HashMap::new())),
             blackhole: blackhole_rules,
             blackhole_cache: std::sync::Mutex::new((0, None)),
@@ -3946,10 +3969,14 @@ impl ReticulumTransport {
         // identity guard: only retract THIS link, never a newer one to the peer.
         if let Some(dest) = self.dialed_link_dest.lock().await.remove(&link_id) {
             let mut reusable = self.reusable_dialed_link.lock().await;
-            if reusable.get(&dest) == Some(&link_id) {
-                reusable.remove(&dest);
+            if let Some(pool) = reusable.get_mut(&dest) {
+                pool.retain(|id| *id != link_id);
+                if pool.is_empty() {
+                    reusable.remove(&dest);
+                }
             }
         }
+        self.link_in_flight.lock().await.remove(&link_id);
         Ok(())
     }
 
@@ -4855,7 +4882,9 @@ impl ReticulumTransport {
         self.reusable_dialed_link
             .lock()
             .await
-            .insert(peer.dest_hash, link_id);
+            .entry(peer.dest_hash)
+            .or_default()
+            .push(link_id);
 
         Ok(link_id)
     }
@@ -4869,13 +4898,33 @@ impl ReticulumTransport {
     /// registry, and leviculum is the authority.
     async fn reusable_link_to(&self, dest: &DestinationHash) -> Option<LinkId> {
         let mut map = self.reusable_dialed_link.lock().await;
-        let id = *map.get(dest)?;
-        if self.node.link_is_established(&id) {
-            Some(id)
-        } else {
+        let pool = map.get_mut(dest)?;
+        // Drop links leviculum no longer holds, so a dead entry cannot occupy a
+        // pool slot forever. The map is a cache over the link registry and the
+        // registry is the authority.
+        pool.retain(|id| self.node.link_is_established(id));
+        if pool.is_empty() {
             map.remove(dest);
-            None
+            return None;
         }
+        let in_flight = self.link_in_flight.lock().await;
+        // IDLE only. A link mid-transfer is not available: Reticulum runs one
+        // resource per link, so handing it out serialises the caller behind the
+        // transfer already on it — which is the regression the M=4 sweep caught.
+        pool.iter().find(|id| !in_flight.contains(*id)).copied()
+    }
+
+    /// CIRISEdge#532 — claim a link for a transfer, or report it already busy.
+    ///
+    /// Returned as a bool the caller must honour rather than a guard type
+    /// because the release has to happen on EVERY exit path from the ship,
+    /// including the error paths the durable dispatcher retries through.
+    async fn claim_link_for_transfer(&self, link_id: LinkId) -> bool {
+        self.link_in_flight.lock().await.insert(link_id)
+    }
+
+    async fn release_link_after_transfer(&self, link_id: LinkId) {
+        self.link_in_flight.lock().await.remove(&link_id);
     }
 
     /// CIRISEdge#532 — the per-destination dial gate handle (single-flight).
@@ -4884,14 +4933,10 @@ impl ReticulumTransport {
     /// map lock; a dial takes an establish timeout, and holding the map would
     /// serialise dials to DIFFERENT peers behind it — trading link churn for a
     /// convoy, which is not an improvement.
-    async fn dial_gate_for(&self, dest: DestinationHash) -> Arc<tokio::sync::Mutex<()>> {
-        Arc::clone(
-            self.dial_gate
-                .lock()
-                .await
-                .entry(dest)
-                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
-        )
+    async fn dial_gate_for(&self, dest: DestinationHash) -> Arc<tokio::sync::Semaphore> {
+        Arc::clone(self.dial_gate.lock().await.entry(dest).or_insert_with(|| {
+            Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_DIALS_PER_DEST))
+        }))
     }
 
     async fn live_attributed_link_to(&self, destination_key_id: &str) -> Option<LinkId> {
@@ -5481,7 +5526,10 @@ impl Transport for ReticulumTransport {
             // gap in #532, where the cost of a link is paid and then discarded.
             // The gate is per-destination so other peers still dial in parallel.
             let gate = self.dial_gate_for(peer.dest_hash).await;
-            let _dial_permit = gate.lock().await;
+            let _dial_permit = gate
+                .acquire()
+                .await
+                .map_err(|e| TransportError::Io(format!("dial gate closed: {e}")))?;
             // Double-check: a concurrent dial we queued behind may have just
             // published a reusable link. Checking only before the gate would
             // make the gate a queue of redundant dials rather than a filter.
@@ -5499,19 +5547,32 @@ impl Transport for ReticulumTransport {
             }
         };
 
-        // The outbound-dial path we just established this link; a `Busy`
-        // collision here is not the reverse-path retry case, so both variants
-        // surface as the send's transport error (the durable dispatcher retries).
-        // Freshly-dialed link we control: lenient no-progress window, full
-        // [`RESOURCE_TRANSFER_TIMEOUT`] hard cap (v13.6.1 progress-aware wait).
-        self.ship_resource_on_link(
-            &link_id,
-            envelope_bytes,
-            DIAL_NO_PROGRESS_WINDOW,
-            RESOURCE_TRANSFER_TIMEOUT,
-        )
-        .await
-        .map_err(ShipError::into_transport)?;
+        // CIRISEdge#532 — hold the link for the duration of the transfer, so a
+        // concurrent send to this peer takes another pooled link or dials one
+        // rather than queueing behind this resource. Reticulum runs ONE resource
+        // per link; without this the pool would hand the same link to everyone
+        // and reuse would become serialisation.
+        //
+        // Released on EVERY exit path, including the error paths the durable
+        // dispatcher retries through — a leaked marker would retire the link
+        // from the pool permanently while it sat there perfectly usable.
+        let claimed = self.claim_link_for_transfer(link_id).await;
+        // A `Busy` collision here is not the reverse-path retry case, so both
+        // variants surface as the send's transport error (the durable dispatcher
+        // retries). Lenient no-progress window, full [`RESOURCE_TRANSFER_TIMEOUT`]
+        // hard cap (v13.6.1 progress-aware wait).
+        let shipped = self
+            .ship_resource_on_link(
+                &link_id,
+                envelope_bytes,
+                DIAL_NO_PROGRESS_WINDOW,
+                RESOURCE_TRANSFER_TIMEOUT,
+            )
+            .await;
+        if claimed {
+            self.release_link_after_transfer(link_id).await;
+        }
+        shipped.map_err(ShipError::into_transport)?;
 
         Ok(TransportSendOutcome::Delivered)
     }
@@ -5663,6 +5724,7 @@ impl Transport for ReticulumTransport {
                         event_bus: self.event_bus.as_deref(),
                         link_established_at: &self.link_established_at,
                         reusable_dialed_link: &self.reusable_dialed_link,
+                        link_in_flight: &self.link_in_flight,
                         link_to_peer_key_id: &self.link_to_peer_key_id,
                         link_last_inbound_at: &self.link_last_inbound_at,
                         inbound_reasm: &self.inbound_reasm,
@@ -5776,7 +5838,9 @@ struct EventCtx<'a> {
     /// `LinkStale`.
     link_established_at: &'a Mutex<HashMap<LinkId, u64>>,
     /// CIRISEdge#532 — so a closed link stops being offered for reuse.
-    reusable_dialed_link: &'a Mutex<HashMap<DestinationHash, LinkId>>,
+    reusable_dialed_link: &'a Mutex<HashMap<DestinationHash, Vec<LinkId>>>,
+    /// CIRISEdge#532 — so a closed link does not leak an in-flight marker.
+    link_in_flight: &'a Mutex<HashSet<LinkId>>,
     /// v3.5.1 (CIRISEdge#119 + #120) — per-link rooted-peer
     /// attribution. Populated on `NodeEvent::LinkIdentified` after
     /// matching the link's remote identity to a rooted peer; consumed
@@ -6720,10 +6784,16 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             // one's close event.
             if let Some(dest) = closed_dest {
                 let mut reusable = ctx.reusable_dialed_link.lock().await;
-                if reusable.get(&dest) == Some(&link_id) {
-                    reusable.remove(&dest);
+                if let Some(pool) = reusable.get_mut(&dest) {
+                    pool.retain(|id| *id != link_id);
+                    if pool.is_empty() {
+                        reusable.remove(&dest);
+                    }
                 }
             }
+            // CIRISEdge#532 — a closed link cannot still be "transferring"; leaving
+            // it marked would leak a pool slot that is never handed out again.
+            ctx.link_in_flight.lock().await.remove(&link_id);
             tracing::debug!(link = ?link_id, reason = ?reason, "link closed");
             // CIRISEdge#34 link half (v0.14.0) — emit `link_closed`
             // event. Severity reflects whether the close was graceful.
@@ -11496,6 +11566,30 @@ impl crate::scope_lifecycle::ScopedDestinationSink for ReticulumTransport {
     }
 }
 
+/// CIRISEdge#532 — how many dials to one peer may be in flight at once.
+///
+/// Not 1: when every pooled link is mid-transfer the extra dials ARE the peer's
+/// additional resource lanes, and Reticulum allows one transfer per link. Not
+/// unbounded: unbounded is the 29-establishes-per-minute state this fixes. Four
+/// is the working set a coordinator fan-out actually needs — the mesh runs six
+/// coordinators per peer, but they do not all ship simultaneously, and a link
+/// returns to the pool the moment its transfer ends.
+const MAX_CONCURRENT_DIALS_PER_DEST: usize = 4;
+// A cap of 1 is a mutex, and a mutex here is the M=4 regression one layer up:
+// each waiter's resource-transfer clock would sit behind someone else's
+// handshake. Guarded at COMPILE time because the value is a constant and a
+// runtime test of a constant proves nothing about the build that ships.
+const _: () = assert!(
+    MAX_CONCURRENT_DIALS_PER_DEST > 1,
+    "CIRISEdge#532: a per-destination dial cap of 1 serialises the peer's \
+     parallel resource lanes — that is the M=4 timeout regression, not a fix"
+);
+const _: () = assert!(
+    MAX_CONCURRENT_DIALS_PER_DEST < 29,
+    "CIRISEdge#532: the cap must stay far below the 29 establishes/minute this \
+     bounds, or it stops bounding anything"
+);
+
 // ── CIRISEdge#537: edge's body cap must fit what the transport will DELIVER ──
 //
 // The production symptom was 765 decode failures all at column 1048570 — a body
@@ -11578,9 +11672,38 @@ mod link_reuse_tests {
         assert!(!should_retract(None, link(1)));
     }
 
-    /// The gate is keyed PER DESTINATION. A global dial lock would serialise
-    /// dials to different peers behind one slow handshake — trading link churn
-    /// for a convoy, which is not an improvement on a 2-core box.
+    /// The regression the M=4 sweep caught, as an invariant.
+    ///
+    /// Reticulum runs ONE resource transfer per link, so a link mid-transfer
+    /// must not be handed to a concurrent sender — the first cut of this fix did
+    /// exactly that and turned N parallel lanes into one queue: 24 contract
+    /// violations and `resource transfer failed: Timeout` at M=4, while M=2 and
+    /// M=1 (less concurrency) passed clean. Reuse is IDLE-only for that reason,
+    /// and it is the reason, not a tidy-up.
+    #[test]
+    fn a_link_mid_transfer_is_not_offered_for_reuse() {
+        let pool = [link(1), link(2)];
+        let in_flight: std::collections::HashSet<LinkId> = std::iter::once(link(1)).collect();
+        let picked = pool.iter().find(|id| !in_flight.contains(*id)).copied();
+        assert_eq!(
+            picked,
+            Some(link(2)),
+            "the busy link must be skipped in favour of an idle one"
+        );
+
+        // Every pooled link busy ⇒ no reuse ⇒ the caller dials another lane,
+        // rather than queueing behind a transfer already in progress.
+        let all_busy: std::collections::HashSet<LinkId> = pool.iter().copied().collect();
+        assert_eq!(
+            pool.iter().find(|id| !all_busy.contains(*id)).copied(),
+            None,
+            "with every lane busy the answer is dial, not wait"
+        );
+    }
+
+    /// The gate is keyed PER DESTINATION. A global gate would bound dials to
+    /// different peers against each other — trading link churn for a convoy,
+    /// which is not an improvement on a 2-core box.
     #[test]
     fn the_dial_gate_is_per_destination_not_global() {
         let mut gates: HashMap<DestinationHash, u32> = HashMap::new();

--- a/src/transport/reticulum.rs
+++ b/src/transport/reticulum.rs
@@ -2130,6 +2130,30 @@ pub struct ReticulumTransport {
     /// of "I dialed link L to dest D", consulted when `link_destination` is `None`.
     /// Removed on `LinkClosed`.
     dialed_link_dest: Arc<Mutex<HashMap<LinkId, DestinationHash>>>,
+    /// CIRISEdge#532 — the peer's REUSABLE outbound link, keyed by the dest we
+    /// dialed. This is the fix for 29 establishes/minute across 20 links on a
+    /// 3-peer mesh: `connect_awaited` creates a NEW link on EVERY call (it is
+    /// `inner.connect()`, with no dedupe), and edge's only reuse selector
+    /// (`live_attributed_link_to`) is consulted on the REVERSE path alone. So
+    /// every send that could not ride an inbound link dialed — and with a
+    /// coordinator per plane per peer per round, the establish rate scaled with
+    /// PLANES (issue #532 question 3, answered: yes, effectively per-plane).
+    ///
+    /// Populated ONLY after `identify_link` succeeds. An unidentified link is
+    /// not reusable: the responder drops frames on it as `SkippedNoSourceKeyId`
+    /// (#317/#340), so reusing one would trade churn for silent non-delivery.
+    /// Identification is per-LINK and persists for its lifetime, which is what
+    /// makes skipping the establish+identify sequence on reuse correct.
+    reusable_dialed_link: Arc<Mutex<HashMap<DestinationHash, LinkId>>>,
+    /// CIRISEdge#532 — per-destination dial gate (single-flight).
+    ///
+    /// Reuse alone does not close the churn: N coordinators firing concurrently
+    /// at the same peer all miss the empty map and all dial, which is the
+    /// 29-establish : 25-identify gap in the issue — links whose establish cost
+    /// was paid and then discarded. The gate serialises dials PER DESTINATION so
+    /// the first caller dials and the rest wait and reuse. Per-destination, not
+    /// global: two different peers must still dial in parallel.
+    dial_gate: Arc<Mutex<HashMap<DestinationHash, Arc<tokio::sync::Mutex<()>>>>>,
     /// CIRISEdge#33 — operator-configured deny-list. Keyed by the
     /// 16-byte Reticulum identity hash of the blocked peer. `send`
     /// consults this BEFORE the leviculum connect call; a hit
@@ -2894,6 +2918,8 @@ impl ReticulumTransport {
                 crate::transport::frame_fragment::Reassembler::new(),
             )),
             dialed_link_dest: Arc::new(Mutex::new(HashMap::new())),
+            reusable_dialed_link: Arc::new(Mutex::new(HashMap::new())),
+            dial_gate: Arc::new(Mutex::new(HashMap::new())),
             blackhole: blackhole_rules,
             blackhole_cache: std::sync::Mutex::new((0, None)),
             binding_cache: std::sync::Mutex::new(HashMap::new()),
@@ -3915,6 +3941,15 @@ impl ReticulumTransport {
         // Eagerly remove so a second teardown is the no-op above.
         self.established_links.lock().await.remove(&link_id);
         self.link_established_at.lock().await.remove(&link_id);
+        // CIRISEdge#532 — an explicitly torn-down link must stop being offered
+        // for reuse here too, not only via the event loop's LinkClosed. Same
+        // identity guard: only retract THIS link, never a newer one to the peer.
+        if let Some(dest) = self.dialed_link_dest.lock().await.remove(&link_id) {
+            let mut reusable = self.reusable_dialed_link.lock().await;
+            if reusable.get(&dest) == Some(&link_id) {
+                reusable.remove(&dest);
+            }
+        }
         Ok(())
     }
 
@@ -4713,6 +4748,152 @@ impl ReticulumTransport {
     /// links leviculum still holds `Active` (`link_is_established` resolves
     /// the #66 re-key alias, so a re-keyed inbound link still matches).
     /// Newest-established wins when a peer holds several.
+    /// CIRISEdge#532 — dial a peer and bring the link all the way to USABLE:
+    /// established, identified, and bundle-served. Extracted from `send` so the
+    /// reuse and single-flight decisions above read as one choice instead of
+    /// being threaded through a linear sequence.
+    ///
+    /// On success the link is published to `reusable_dialed_link`, which is what
+    /// lets the next send — and every other coordinator's send to this peer —
+    /// skip all of this.
+    async fn dial_and_identify(
+        &self,
+        destination_key_id: &str,
+        peer: &ResolvedPeer,
+        has_path: bool,
+        establish_timeout: Duration,
+    ) -> Result<LinkId, TransportError> {
+        // CIRISEdge#484 — leviculum v0.16 `connect_awaited` returns the handle
+        // immediately AND a completion future for `LinkEstablished`, registered
+        // BEFORE dispatch (edge no longer needs to observe the event loop `listen`
+        // owns). The future keys on the ORIGINAL dial id — the #342/#66 alias the old
+        // `link_is_established` poll resolved — takes NO node lock, and resolves
+        // `Err(LinkClosed)` on link death. Caller owns the wall-clock bound.
+        let (link, established) = self
+            .node
+            .connect_awaited(&peer.dest_hash, &peer.signing_key)
+            .await
+            .map_err(|e| TransportError::Io(format!("reticulum connect: {e}")))?;
+        let link_id = *link.link_id();
+        // CIRISEdge#424 — record the dest we dialed for THIS link so an inbound
+        // reply arriving over it (the initiator-side reverse path a NAT'd peer's
+        // responder uses) attributes to this peer even though leviculum's
+        // `link_destination` returns `None` for our own dialed links.
+        self.dialed_link_dest
+            .lock()
+            .await
+            .insert(link_id, peer.dest_hash);
+
+        // Await `LinkEstablished` on BOTH ends — the peer must have accepted the
+        // LINK_REQUEST or a resource transfer cannot start. `established` resolves
+        // `Ok(())` on establishment, `Err(LinkClosed)` if the peer refused / the link
+        // died first; a timeout means no route or a stalled dial.
+        let established_ok = matches!(
+            with_timeout(establish_timeout, established).await,
+            Some(Ok(()))
+        );
+        if !established_ok {
+            // CIRISEdge#336 — a no-path target that never established is
+            // un-routable, not slow: fail fast with the self-diagnosing error
+            // (naming target dest, key_id, and the paths we DO hold — the
+            // routable named dest for this peer usually appears there, making
+            // the explicit-vs-named mismatch obvious). A had-a-path target that
+            // stalled is a genuine slow/dead link → the opaque timeout stands.
+            if !has_path {
+                let target_dest = hex::encode(peer.dest_hash.into_bytes());
+                let paths = self.path_table_snapshot();
+                tracing::error!(
+                    key_id = %destination_key_id,
+                    target_dest = %target_dest,
+                    has_path,
+                    known_paths = %paths,
+                    "link_request target has no route — un-routable dest (CIRISEdge#336). \
+                     A no-path dest is broadcast-only and no directly-attached neighbor \
+                     answered; if the peer is relay-reachable it must be addressed on its \
+                     announced (named) dest, which appears in known_paths."
+                );
+                return Err(TransportError::NoRouteToPeer {
+                    key_id: destination_key_id.to_string(),
+                    target_dest,
+                    has_path,
+                    paths,
+                });
+            }
+            log_nat_topology_diagnosis(destination_key_id, establish_timeout);
+            return Err(TransportError::Timeout(establish_timeout));
+        }
+
+        // CIRISEdge#340 — IDENTIFY the link before sending. A Reticulum link is
+        // anonymous by default; only the initiator may identify it, and the
+        // responder emits `LinkIdentified` (→ populates its `link_to_peer_key_id`
+        // via the #314 identity-hash match → attributes our inbound frame) ONLY
+        // if we do. Without this, every replication frame we send lands on the
+        // responder as `source_key_id=None` and is dropped `SkippedNoSourceKeyId`
+        // (#317) — the field-confirmed reason attribution never fired and
+        // CIRISServer#235 was never verified end-to-end. Ordered before
+        // `send_resource` on the same link so the LINKIDENTIFY is processed
+        // first. A failure here means the responder cannot attribute the frame,
+        // so fail the send (the durable dispatcher retries) rather than ship an
+        // unattributable resource that will be silently dropped.
+        self.node
+            .identify_link(&link_id, &self.local_identity)
+            .await
+            .map_err(|e| TransportError::Io(format!("reticulum identify_link: {e}")))?;
+
+        // CIRISEdge#436 — initiator-side bundle serve, ordered AFTER the
+        // LINKIDENTIFY (so the responder attributes it) and BEFORE the
+        // resource ship (the fragments ride the link Channel, which never
+        // contends with the resource lane — leviculum#27).
+        if let Some(own) = self.own_bundle.as_ref() {
+            push_own_bundle_frames(&self.node, own, &link_id).await;
+        }
+
+        // PUBLISH LAST. Only now is the link established AND identified AND
+        // bundle-served — the three things a reusing sender skips. Publishing
+        // any earlier would hand another coordinator a link the responder will
+        // drop frames on (`SkippedNoSourceKeyId`, #317/#340).
+        self.reusable_dialed_link
+            .lock()
+            .await
+            .insert(peer.dest_hash, link_id);
+
+        Ok(link_id)
+    }
+
+    /// CIRISEdge#532 — the live, identified link we already hold to this dest,
+    /// if any. `None` means a dial is required.
+    ///
+    /// Liveness uses the same `link_is_established` gate the reverse-path
+    /// selector does. A stale entry is EVICTED on the way out rather than left
+    /// to fail the next send too — the map is a cache over leviculum's link
+    /// registry, and leviculum is the authority.
+    async fn reusable_link_to(&self, dest: &DestinationHash) -> Option<LinkId> {
+        let mut map = self.reusable_dialed_link.lock().await;
+        let id = *map.get(dest)?;
+        if self.node.link_is_established(&id) {
+            Some(id)
+        } else {
+            map.remove(dest);
+            None
+        }
+    }
+
+    /// CIRISEdge#532 — the per-destination dial gate handle (single-flight).
+    ///
+    /// Cloned out under a short lock so the dial itself is NOT held under the
+    /// map lock; a dial takes an establish timeout, and holding the map would
+    /// serialise dials to DIFFERENT peers behind it — trading link churn for a
+    /// convoy, which is not an improvement.
+    async fn dial_gate_for(&self, dest: DestinationHash) -> Arc<tokio::sync::Mutex<()>> {
+        Arc::clone(
+            self.dial_gate
+                .lock()
+                .await
+                .entry(dest)
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(()))),
+        )
+    }
+
     async fn live_attributed_link_to(&self, destination_key_id: &str) -> Option<LinkId> {
         let candidates: Vec<LinkId> = self
             .link_to_peer_key_id
@@ -5274,90 +5455,49 @@ impl Transport for ReticulumTransport {
             NO_PATH_ESTABLISH_TIMEOUT
         };
 
-        // CIRISEdge#484 — leviculum v0.16 `connect_awaited` returns the handle
-        // immediately AND a completion future for `LinkEstablished`, registered
-        // BEFORE dispatch (edge no longer needs to observe the event loop `listen`
-        // owns). The future keys on the ORIGINAL dial id — the #342/#66 alias the old
-        // `link_is_established` poll resolved — takes NO node lock, and resolves
-        // `Err(LinkClosed)` on link death. Caller owns the wall-clock bound.
-        let (link, established) = self
-            .node
-            .connect_awaited(&peer.dest_hash, &peer.signing_key)
-            .await
-            .map_err(|e| TransportError::Io(format!("reticulum connect: {e}")))?;
-        let link_id = *link.link_id();
-        // CIRISEdge#424 — record the dest we dialed for THIS link so an inbound
-        // reply arriving over it (the initiator-side reverse path a NAT'd peer's
-        // responder uses) attributes to this peer even though leviculum's
-        // `link_destination` returns `None` for our own dialed links.
-        self.dialed_link_dest
-            .lock()
-            .await
-            .insert(link_id, peer.dest_hash);
-
-        // Await `LinkEstablished` on BOTH ends — the peer must have accepted the
-        // LINK_REQUEST or a resource transfer cannot start. `established` resolves
-        // `Ok(())` on establishment, `Err(LinkClosed)` if the peer refused / the link
-        // died first; a timeout means no route or a stalled dial.
-        let established_ok = matches!(
-            with_timeout(establish_timeout, established).await,
-            Some(Ok(()))
-        );
-        if !established_ok {
-            // CIRISEdge#336 — a no-path target that never established is
-            // un-routable, not slow: fail fast with the self-diagnosing error
-            // (naming target dest, key_id, and the paths we DO hold — the
-            // routable named dest for this peer usually appears there, making
-            // the explicit-vs-named mismatch obvious). A had-a-path target that
-            // stalled is a genuine slow/dead link → the opaque timeout stands.
-            if !has_path {
-                let target_dest = hex::encode(peer.dest_hash.into_bytes());
-                let paths = self.path_table_snapshot();
-                tracing::error!(
+        // ── CIRISEdge#532: REUSE BEFORE DIALING ──────────────────────────────
+        // A live, identified link to this dest is a finished handshake. Sending
+        // on it is the whole point of having established it; dialing a second
+        // one pays the establish cost again and abandons the first. This is the
+        // 29-establishes-per-minute loop, and the reason it scaled with planes:
+        // every coordinator's send took the dial path independently.
+        //
+        // Everything the dial path does after `connect_awaited` — recording the
+        // dialed dest (#424), awaiting establishment, `identify_link` (#340),
+        // and the initiator-side bundle serve (#436) — is per-LINK setup that
+        // already happened for a reused link. Skipping it is not an omission;
+        // repeating it per send was the waste.
+        let reused = self.reusable_link_to(&peer.dest_hash).await;
+        let link_id = if let Some(existing) = reused {
+            tracing::trace!(
+                key_id = %destination_key_id,
+                link = ?existing,
+                "reusing the live identified link to this peer (CIRISEdge#532)"
+            );
+            existing
+        } else {
+            // SINGLE-FLIGHT. Without this, N coordinators firing at the same
+            // peer all observe "no link" and all dial — the establish:identify
+            // gap in #532, where the cost of a link is paid and then discarded.
+            // The gate is per-destination so other peers still dial in parallel.
+            let gate = self.dial_gate_for(peer.dest_hash).await;
+            let _dial_permit = gate.lock().await;
+            // Double-check: a concurrent dial we queued behind may have just
+            // published a reusable link. Checking only before the gate would
+            // make the gate a queue of redundant dials rather than a filter.
+            if let Some(existing) = self.reusable_link_to(&peer.dest_hash).await {
+                tracing::trace!(
                     key_id = %destination_key_id,
-                    target_dest = %target_dest,
-                    has_path,
-                    known_paths = %paths,
-                    "link_request target has no route — un-routable dest (CIRISEdge#336). \
-                     A no-path dest is broadcast-only and no directly-attached neighbor \
-                     answered; if the peer is relay-reachable it must be addressed on its \
-                     announced (named) dest, which appears in known_paths."
+                    link = ?existing,
+                    "another send established this peer's link while we waited on \
+                     the dial gate — reusing it (CIRISEdge#532)"
                 );
-                return Err(TransportError::NoRouteToPeer {
-                    key_id: destination_key_id.to_string(),
-                    target_dest,
-                    has_path,
-                    paths,
-                });
+                existing
+            } else {
+                self.dial_and_identify(destination_key_id, &peer, has_path, establish_timeout)
+                    .await?
             }
-            log_nat_topology_diagnosis(destination_key_id, establish_timeout);
-            return Err(TransportError::Timeout(establish_timeout));
-        }
-
-        // CIRISEdge#340 — IDENTIFY the link before sending. A Reticulum link is
-        // anonymous by default; only the initiator may identify it, and the
-        // responder emits `LinkIdentified` (→ populates its `link_to_peer_key_id`
-        // via the #314 identity-hash match → attributes our inbound frame) ONLY
-        // if we do. Without this, every replication frame we send lands on the
-        // responder as `source_key_id=None` and is dropped `SkippedNoSourceKeyId`
-        // (#317) — the field-confirmed reason attribution never fired and
-        // CIRISServer#235 was never verified end-to-end. Ordered before
-        // `send_resource` on the same link so the LINKIDENTIFY is processed
-        // first. A failure here means the responder cannot attribute the frame,
-        // so fail the send (the durable dispatcher retries) rather than ship an
-        // unattributable resource that will be silently dropped.
-        self.node
-            .identify_link(&link_id, &self.local_identity)
-            .await
-            .map_err(|e| TransportError::Io(format!("reticulum identify_link: {e}")))?;
-
-        // CIRISEdge#436 — initiator-side bundle serve, ordered AFTER the
-        // LINKIDENTIFY (so the responder attributes it) and BEFORE the
-        // resource ship (the fragments ride the link Channel, which never
-        // contends with the resource lane — leviculum#27).
-        if let Some(own) = self.own_bundle.as_ref() {
-            push_own_bundle_frames(&self.node, own, &link_id).await;
-        }
+        };
 
         // The outbound-dial path we just established this link; a `Busy`
         // collision here is not the reverse-path retry case, so both variants
@@ -5522,6 +5662,7 @@ impl Transport for ReticulumTransport {
                         own_bundle: self.own_bundle.as_ref(),
                         event_bus: self.event_bus.as_deref(),
                         link_established_at: &self.link_established_at,
+                        reusable_dialed_link: &self.reusable_dialed_link,
                         link_to_peer_key_id: &self.link_to_peer_key_id,
                         link_last_inbound_at: &self.link_last_inbound_at,
                         inbound_reasm: &self.inbound_reasm,
@@ -5634,6 +5775,8 @@ struct EventCtx<'a> {
     /// populated on `LinkEstablished` / cleared on `LinkClosed` /
     /// `LinkStale`.
     link_established_at: &'a Mutex<HashMap<LinkId, u64>>,
+    /// CIRISEdge#532 — so a closed link stops being offered for reuse.
+    reusable_dialed_link: &'a Mutex<HashMap<DestinationHash, LinkId>>,
     /// v3.5.1 (CIRISEdge#119 + #120) — per-link rooted-peer
     /// attribution. Populated on `NodeEvent::LinkIdentified` after
     /// matching the link's remote identity to a rooted peer; consumed
@@ -6569,7 +6712,18 @@ async fn handle_event(event: NodeEvent, ctx: &EventCtx<'_>) {
             // closed link can never win the reverse-path selector.
             ctx.link_last_inbound_at.lock().await.remove(&link_id);
             // CIRISEdge#424 — drop the dialed-dest record for the closed link.
-            ctx.dialed_link_dest.lock().await.remove(&link_id);
+            let closed_dest = ctx.dialed_link_dest.lock().await.remove(&link_id);
+            // CIRISEdge#532 — and drop it as this dest's REUSABLE link, so the
+            // next send dials instead of handing a dead link to every
+            // coordinator. Keyed by dest, so remove only if THIS link is the one
+            // published: a newer link to the same peer must survive an older
+            // one's close event.
+            if let Some(dest) = closed_dest {
+                let mut reusable = ctx.reusable_dialed_link.lock().await;
+                if reusable.get(&dest) == Some(&link_id) {
+                    reusable.remove(&dest);
+                }
+            }
             tracing::debug!(link = ?link_id, reason = ?reason, "link closed");
             // CIRISEdge#34 link half (v0.14.0) — emit `link_closed`
             // event. Severity reflects whether the close was graceful.
@@ -11339,5 +11493,101 @@ impl crate::scope_lifecycle::ScopedDestinationSink for ReticulumTransport {
     ) -> Result<(), String> {
         self.retire_scoped_destination(address, scope)
             .map_err(|e| e.to_string())
+    }
+}
+
+// ── CIRISEdge#537: edge's body cap must fit what the transport will DELIVER ──
+//
+// The production symptom was 765 decode failures all at column 1048570 — a body
+// cut at `RESOURCE_MAX_EFFICIENT_SIZE` minus the metadata block, attributed to
+// the SENDER as a decode error several layers above the truncation. v18.8.0
+// fixed the cause (`resource_delivery_is_whole` replaced an arm that routed
+// segment 1 as if it were the whole transfer), but nothing compared the two
+// limits, so the relationship could invert again from either side.
+//
+// The constant to compare against is NOT `RESOURCE_MAX_EFFICIENT_SIZE`
+// (1_048_575). That is the SEGMENTATION THRESHOLD — when leviculum splits a
+// transfer — not a delivery ceiling, and asserting `8 MiB <= 1 MiB` would both
+// fail to build and forbid the entirely legitimate multi-segment path.
+//
+// What governs deliverability is the per-transfer ASSEMBLY ceiling. Edge never
+// calls `ReticulumNodeBuilder::max_assembled_resource_size`, so the driver
+// default IS the effective ceiling: an 8 MiB envelope is ~9 segments and
+// assembles comfortably under 64 MiB.
+//
+// This assert is what keeps the degraded-transfer hole UNREACHABLE. Past the
+// assembly ceiling leviculum declines to assemble and falls back to per-segment
+// delivery, whose FINAL slice is indistinguishable from an assembled whole at
+// edge's seam (both are `segment_index == total_segments`) — it would be routed
+// and fail verification downstream. Holding the body cap under the ceiling means
+// edge never submits a body that can reach that state.
+const _: () = assert!(
+    MAX_BODY_BYTES <= leviculum_std::driver::DEFAULT_MAX_ASSEMBLED_RESOURCE_SIZE,
+    "CIRISEdge#537: edge admits a body larger than the transport will assemble — \
+     bodies between the two limits degrade to per-segment delivery, whose final \
+     slice routes as if whole and fails verification at the receiver"
+);
+
+// ── CIRISEdge#532: link reuse + single-flight dialing ───────────────────────
+#[cfg(test)]
+mod link_reuse_tests {
+    //! The churn #532 measured — 29 establishes/minute across 20 links on a
+    //! 3-peer mesh — came from `connect_awaited` creating a NEW link on every
+    //! call while edge's only reuse selector was consulted on the reverse path
+    //! alone. These pin the two decisions that close it, as pure functions over
+    //! the state the field produces.
+    use super::{DestinationHash, LinkId};
+    use std::collections::HashMap;
+
+    /// The eviction identity guard, extracted as the predicate it is: a close
+    /// event retracts the peer's reusable link ONLY if the closing link is the
+    /// one currently published.
+    fn should_retract(published: Option<LinkId>, closing: LinkId) -> bool {
+        published == Some(closing)
+    }
+
+    fn link(n: u8) -> LinkId {
+        LinkId::from([n; 16])
+    }
+
+    fn dest(n: u8) -> DestinationHash {
+        DestinationHash::new([n; 16])
+    }
+
+    /// A link closing retracts its own reuse entry.
+    #[test]
+    fn a_closing_link_retracts_its_own_reuse_entry() {
+        assert!(should_retract(Some(link(1)), link(1)));
+    }
+
+    /// The subtle one. A peer can hold a NEWER link while an OLDER one's close
+    /// event is still in flight — the reverse-path work (#353) exists precisely
+    /// because peers hold several links over a lifetime. Retracting on identity
+    /// rather than on destination keeps the old close from evicting the live
+    /// link, which would send the next round back to dialing and quietly
+    /// reintroduce the churn this fix removes.
+    #[test]
+    fn an_older_links_close_does_not_evict_the_peers_newer_link() {
+        assert!(!should_retract(Some(link(2)), link(1)));
+    }
+
+    /// Nothing published, nothing to retract — a close for a link that was
+    /// never reusable (dial failed before identify) is a no-op, not a panic.
+    #[test]
+    fn closing_an_unpublished_link_is_a_no_op() {
+        assert!(!should_retract(None, link(1)));
+    }
+
+    /// The gate is keyed PER DESTINATION. A global dial lock would serialise
+    /// dials to different peers behind one slow handshake — trading link churn
+    /// for a convoy, which is not an improvement on a 2-core box.
+    #[test]
+    fn the_dial_gate_is_per_destination_not_global() {
+        let mut gates: HashMap<DestinationHash, u32> = HashMap::new();
+        *gates.entry(dest(1)).or_default() += 1;
+        *gates.entry(dest(2)).or_default() += 1;
+        *gates.entry(dest(1)).or_default() += 1;
+        assert_eq!(gates.len(), 2, "two peers must get two independent gates");
+        assert_eq!(gates[&dest(1)], 2, "same peer shares one gate");
     }
 }


### PR DESCRIPTION
Closes #532. Closes #537. Addresses the second half of #531.

Against a production box whose binding constraint has **moved from memory to CPU**: `majflt=0`, 5.8 GB swap free, reads ~0 — but 0% idle, load 4.17 on 2 cores, with a link-flap loop burning ~80% of one.

## #532 — the churn, and the answer to question 3

`connect_awaited` is `inner.connect()` with no dedupe: it creates a **new link on every call**. Edge's only reuse selector, `live_attributed_link_to`, is consulted on the **reverse path alone**. So every send that couldn't ride an inbound link dialed.

That answers the issue's third question — the one you most wanted ruled out — and the answer is the bad one: **yes, the round loop effectively dials per plane.** The establish rate scaled with coordinators (4 → 6 in server 0.5.186), so the mesh got worse as it grew.

**Reuse alone doesn't close it.** N coordinators firing at the same peer all miss an empty map and all dial — that's the 29-establish : 25-identify gap, links whose establish cost was paid and then discarded. So there are two parts: `reusable_dialed_link` (the peer's live identified link, keyed by dialed dest) and a `dial_gate` that single-flights **per destination**. Per-destination, not global — a global dial lock would trade link churn for a convoy, which is not an improvement on a 2-core box.

Two invariants worth review attention:

- **Publish last.** Only after establish + identify + bundle-serve. An unidentified link makes the responder drop frames `SkippedNoSourceKeyId` (#317/#340), so publishing early would trade churn for silent non-delivery.
- **Evict on link identity, never on destination.** A peer holds several links over its lifetime (the whole premise of #353). An older link's close must not evict the peer's newer link, or the next round goes back to dialing and quietly reintroduces the churn.

## #531 — the second half

The cursor (v18.7.0) bounded *memory*; this is what remained on the *CPU* side, which is now the constraint that matters.

The gates read exactly four strings. The loop was handing them ~19 serialised fields plus a deep clone of the entire signed envelope — per row, per plane, per peer, per round, over corpora of **14,564** and **52,125** rows. Now built straight off the typed row, where the envelope is *already* a `Value`, so the one nested read is a borrow rather than a re-serialisation.

**Not a blanket removal.** The accord relay gate hands the row to persist's taking verb, which *deserialises* it (CIRISPersist#733). Passing the four-field view there silently withheld **every accord row** — caught by an existing test, not by inspection. So the full materialisation is **lazy**, not gone: paid only for rows persist's own classifier calls `accord:*`. `RowNotSerializable` becomes reachable exactly there, which is now the only place it can fire.

**Equivalence is pinned by verdict, not field shape**, and the reason is load-bearing: `cohort_scope` carries `skip_serializing_if`, so `to_value` **omits** it at its default while the view carries it. Edge does not replicate that predicate — duplicating an upstream serde rule is precisely the drift this codebase keeps paying for — and the gate's contract already collapses missing-means-`federation`. Asserted across all four scope cases including empty.

## #537 — the guard, aimed correctly

Not `RESOURCE_MAX_EFFICIENT_SIZE`: that's the *segmentation threshold*, the assert would read `8 MiB <= 1 MiB`, and it would neither build nor mean anything. The constant that governs deliverability is the per-transfer **assembly ceiling** edge never overrides.

**Mutation-tested** — raising `MAX_BODY_BYTES` to 128 MiB fails the build with the message. The guard is load-bearing, not decorative.

## Evidence

- `cargo clippy --all-features --all-targets` under `RUSTFLAGS=-D warnings` — clean
- **1317** lib tests pass, 0 failed; test-anchor e2e passes
- Mesh sweep will run against the final tree before tagging — this changes the dial path, so prior evidence does not carry

## What this does not claim

The flap rate is a *field* measurement; the fix is validated by construction and by unit tests, not yet by a production before/after. The mesh harness exercises the dial path under real relays, which is the closest pre-deploy signal — but the number that settles #532 is the next 60-second window on the canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R48n3YVunN6kqsDzxxqJEs