### PR TITLE
v18.12.0 — #548 node alias, #544 refusal backoff, #545 converged view, #546 swarm config, #547 liveness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -391,7 +391,7 @@ publish = false
 # v38.5.0 still pins CIRISVerify v13.6.1 — `cargo tree -i ciris-verify-core`
 # resolves exactly ONE, shared by edge and persist. No cross-cdylib skew.
 #
-# ── v38.6.0 (CIRISPersist#774 / #773, CC 3.4.7.3) ────────────────────────
+# ── v38.7.0 (CIRISPersist#780 + the v38.4.0 retention line) ──────────────
 # Adopted by SHA during review, flipped to `tag` on the mint. The tag derefs to
 # `ffa66085`, which has `2566bc54` (the reviewed PR head) as an ancestor and a
 # BYTE-IDENTICAL tree — so the gates and the mesh sweep run against the PR head
@@ -441,7 +441,7 @@ publish = false
 #     registers a SINGLE-role `identity_type` — no fixture encoded the
 #     repealed loophole.
 #   * 2566bc54 still pins CIRISVerify v13.6.1 — one `ciris-verify-core`.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v38.6.0", version = "38", features = ["sqlite", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v38.7.0", version = "38", features = ["sqlite", "encrypted-kv"] }
 # Keyring — Ed25519 + ML-DSA-65 hardware/software signers used by
 # Edge::send and Edge::send_durable to sign outbound envelopes.
 # v0.13.0 — bumped to v4.0.0 in lockstep with persist v3.0.0. Both
@@ -465,8 +465,8 @@ ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v38.6.
 # moved to v4.4.2, and a mixed v4.2.0/v4.4.2 graph produces two
 # distinct trait-object vtables that the trait-bound check in
 # `Arc<dyn HardwareSigner>` cannot reconcile.
-ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.6.1", version = "13", features = ["software", "pqc-ml-dsa"] }
-ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.6.1", version = "13", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
+ciris-keyring = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v14.0.0", version = "14", features = ["software", "pqc-ml-dsa"] }
+ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v14.0.0", version = "14", features = ["ed25519", "pqc-ml-dsa", "hybrid-kex", "aes-gcm", "xchacha", "hpke", "scope-privacy", "hmac", "kdf"] }
 # v2.0.0 (CIRISEdge#65 v2 wire cycle) — direct dep on ciris-verify-core
 # for `jcs::canonicalize` (the v2 `envelope_hash` basis per FSD §3.2.2:
 # `sha256(JCS(Signed*Record))`) + `threshold::ThresholdMember` (the
@@ -475,7 +475,7 @@ ciris-crypto  = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.6.1
 # edge's to define"); the v2 wire-hash basis flips to JCS in lockstep
 # with CEG 1.0-RC2 §3.2.2 / §5.6.8.13. v5.1.0 is the lockstep
 # substrate floor with persist v5.1.1 (operational-data admit surface).
-ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v13.6.1", version = "13" }
+ciris-verify-core = { git = "https://github.com/CIRISAI/CIRISVerify", tag = "v14.0.0", version = "14" }
 
 # Async runtime
 tokio       = { version = "1", features = ["rt-multi-thread", "macros", "sync", "time"] }
@@ -1531,7 +1531,7 @@ async-trait        = "0.1"
 # two `ciris-verify-core` cdylibs — the empty-stdout SIGSEGV class).
 # v38.6.0 (CIRISPersist#774) — held in lockstep with the runtime pin above
 # through the RC-adopt and back onto `tag`. These two move together, always.
-ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v38.6.0", version = "38", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
+ciris-persist = { git = "https://github.com/CIRISAI/CIRISPersist", tag = "v38.7.0", version = "38", features = ["sqlite", "cirisnode", "classify", "scrub", "encrypted-kv"] }
 # CIRISEdge#23 / #49 — `tests/transport_http_hardening.rs` +
 # `tests/https_per_messagetype_roundtrip.rs` + `tests/https_pyedge_init.rs`
 # (v0.19.3) mint self-signed Ed25519 certs on the fly. v0.19.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "18.11.0"
+version = "18.12.0"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.11.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.11.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.11.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.11.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.11.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.11.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.11.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.12.0
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.12.0
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.12.0
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.12.0
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.12.0
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.12.0
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.12.0

--- a/src/bundle_gate.rs
+++ b/src/bundle_gate.rs
@@ -652,6 +652,10 @@ pub(crate) mod test_support {
                 roles: vec!["infra:attest".to_string()],
             },
             TS,
+            // CIRISVerify v14.0.0 — `valid_until` is a new parameter between
+            // `valid_from` and the transport hints. `None` is this fixture's
+            // pre-v14 behaviour: no producer-stated expiry.
+            None,
             &[],
         )
         .await

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1932,6 +1932,34 @@ impl Edge {
     /// (PyO3 / UniFFI projection methods, internal emission helpers,
     /// tests) call `.snapshot()` to render a typed bundle.
     #[must_use]
+    /// CIRISEdge#547 — seconds since the last anti-entropy round COMPLETED, or
+    /// `None` if none has since boot.
+    ///
+    /// The store-free liveness probe. Reads ONE atomic: it touches neither the
+    /// store nor any lock a store-touching path can hold, so it still answers
+    /// while the replication runtime is convoyed — which is the only condition
+    /// under which the answer matters.
+    ///
+    /// A canonical ran 22 hours hung (one thread in `wait_on_page_bit_common`
+    /// holding persist's single connection, the rest parked behind it) and
+    /// nobody noticed, because the health surface that would have reported it
+    /// reads the store and was therefore inside the failure it was meant to
+    /// detect. This would have read 22 hours stale from the first minute.
+    ///
+    /// Says the runtime stopped progressing. Does NOT say why — that is the
+    /// honest scope of a liveness probe, and a caller should not infer a cause.
+    #[must_use]
+    pub fn seconds_since_last_round(&self) -> Option<u64> {
+        let stamp = self.metrics.last_round_completed_unix();
+        if stamp == 0 {
+            return None;
+        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        Some(now.saturating_sub(stamp))
+    }
+
     pub fn metrics(&self) -> crate::observability::EdgeMetrics {
         self.metrics.clone()
     }

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1184,6 +1184,21 @@ pub struct Edge {
     /// frame; a fold-restart re-install is the correct idiom, not a
     /// silently-dropped call.
     swarm_runtime: Arc<ReinstallableCell<crate::swarm::FountainSwarmRuntime>>,
+    /// CIRISEdge#545 — the READ side of the holonomic claim plane.
+    ///
+    /// [`Self::swarm_runtime`] above is the WRITE side: verified inbound
+    /// `FountainHoldingClaim` envelopes go into the converger and stop
+    /// there. This is the tap that makes the converged state askable —
+    /// see [`crate::holonomic::converged_view`] for why it taps the
+    /// dispatch arm rather than projecting the converger's own map.
+    ///
+    /// NOT a `ReinstallableCell`: unlike the runtime, this is always
+    /// present (an unarmed view answers "unknown", which is the correct
+    /// answer for a node whose dispatch loop never started) and it must
+    /// keep its observation window across a fold restart — a
+    /// re-installable cell would hand back a cold view that reports a
+    /// long-known-empty mesh as unknown again.
+    converged_claims: Arc<crate::holonomic::converged_view::ConvergedClaimView>,
     /// v5.2.0 (CIRISEdge#143) — opt-in consent-decay scheduler
     /// shutdown handle. Same lifecycle as [`Self::swarm_runtime`];
     /// when set, [`Edge::shutdown_swarm_runtime`] also signals the
@@ -2053,7 +2068,55 @@ impl Edge {
     /// the same `Arc` (CIRISServer 0.5.136's process-static composition) is
     /// a debug-level no-op.
     pub fn install_swarm_runtime(&self, runtime: Arc<crate::swarm::FountainSwarmRuntime>) {
+        // CIRISEdge#545 — realign the READ side's horizons to the
+        // converger that is actually running. The reader's defaults match
+        // the converger's defaults, but a deployment that tunes
+        // `publish_cadence` / `observed_claim_ttl` would otherwise leave
+        // the two disagreeing about what "live" means: the reader would
+        // declare itself warming long after the cohort has spoken, or
+        // prune claims the converger still holds. Read before the
+        // install so the config borrow ends first.
+        {
+            let cfg = runtime.config();
+            self.converged_claims
+                .align_to_converger(cfg.observed_claim_ttl, cfg.publish_cadence);
+        }
         self.swarm_runtime.install(runtime);
+    }
+
+    /// CIRISEdge#545 — **read the converged view**: what this node has
+    /// converged about its cohort, from the signed `FountainHoldingClaim`
+    /// plane its peers publish on.
+    ///
+    /// Counts only. No peer id, `content_id`, or symbol id is reachable
+    /// through this surface — the intended consumer is a public
+    /// mesh-status endpoint (CIRISServer#498) and an enumerable member
+    /// list is a reconnaissance surface.
+    ///
+    /// Returns a two-state
+    /// [`ConvergenceReading`](crate::holonomic::converged_view::ConvergenceReading),
+    /// never a bare `Option`: "the mesh converged to nothing" and "this
+    /// node has nothing computed yet" are different answers, and a
+    /// consumer that reported the second as `0` would tell the world the
+    /// mesh is empty on the evidence of its own cold start. Map with
+    /// [`ConvergenceReading::converged`](crate::holonomic::converged_view::ConvergenceReading::converged)
+    /// — `None` ⇒ `null`, `Some(v)` ⇒ `v`'s counts, zeros included.
+    ///
+    /// Synchronous and lock-cheap: callable from a blocking FFI frame
+    /// with no tokio runtime in scope.
+    pub fn swarm_convergence(&self) -> crate::holonomic::converged_view::ConvergenceReading {
+        self.converged_claims.read()
+    }
+
+    /// CIRISEdge#545 — the converged-view handle itself, for an embedder
+    /// that wants to hold the reader directly (a status task polling on
+    /// its own cadence) or to realign its horizons without installing a
+    /// swarm runtime. Cheap clone (Arc bump).
+    #[must_use]
+    pub fn converged_claim_view(
+        &self,
+    ) -> Arc<crate::holonomic::converged_view::ConvergedClaimView> {
+        Arc::clone(&self.converged_claims)
     }
 
     /// v5.2.0 — return the installed
@@ -3580,6 +3643,12 @@ impl Edge {
         // structurally bypassed).
         let trust_short_circuit_enabled =
             override_threshold.is_some() || self.config.trust_short_circuit_enabled;
+        // CIRISEdge#545 — the harness entry point drives the same claim
+        // plane as `run`, so it arms the reader the same way. Without
+        // this, a conformance test that pushes holding claims through
+        // this door would read back "plane not armed" and never see its
+        // own claims.
+        self.converged_claims.arm();
         dispatch_inbound(
             frame,
             &self.verify,
@@ -3613,6 +3682,7 @@ impl Edge {
             self.canonical_peers.clone(),
             self.blob_chunk_source.as_ref(),
             self.swarm_runtime.get().as_ref(),
+            &self.converged_claims,
             &self.blob_scope_router(),
         )
         .await;
@@ -4331,6 +4401,16 @@ impl Edge {
         // Clone of the `Arc<OnceLock<Arc<FountainSwarmRuntime>>>`; the
         // OnceLock load inside the dispatch is a cheap atomic.
         let swarm_runtime = self.swarm_runtime.clone();
+        // CIRISEdge#545 — arm the READ side here, at the top of the
+        // inbound loop, and NOT lazily on the first observed claim.
+        // Arming is what turns silence into evidence: from this instant
+        // an empty converged view means "the cohort has said nothing",
+        // where before it meant "nobody was listening". Idempotent — a
+        // fold restart re-enters `run` and must keep the original
+        // observation window rather than re-reporting a known-empty mesh
+        // as unknown.
+        self.converged_claims.arm();
+        let converged_claims = self.converged_claims.clone();
         // CIRISEdge#499 — the handle the blob scope gate reads its address table
         // from. Captured as the TRANSPORT, not as a pre-built router, because
         // `install_scope_address_table` may fire after `run` starts (the MLS
@@ -4392,6 +4472,7 @@ impl Edge {
                     let delegation_trust_roots_clone = delegation_trust_roots.clone();
                     let blob_chunk_source_clone = blob_chunk_source.clone();
                     let swarm_runtime_clone = swarm_runtime.clone();
+                    let converged_claims_clone = converged_claims.clone();
                     #[cfg(feature = "_reticulum-module")]
                     let blob_scope_router = crate::blob_swarm::BlobScopeRouter::new(
                         blob_scope_transport
@@ -4434,6 +4515,7 @@ impl Edge {
                             delegation_trust_roots_clone,
                             blob_chunk_source_clone.as_ref(),
                             swarm_runtime_clone.get().as_ref(),
+                            &converged_claims_clone,
                             &blob_scope_router,
                         ).await;
                     });
@@ -4966,6 +5048,7 @@ fn select_reply_transport(
         delegation_trust_roots,
         blob_chunk_source,
         swarm_runtime,
+        converged_claims,
         blob_scope_router,
     ),
     fields(
@@ -5057,6 +5140,13 @@ async fn dispatch_inbound(
     // (verify still runs) but no runtime hook fires — same posture as
     // `blob_chunk_source` for the chunked-blob swarm.
     swarm_runtime: Option<&Arc<crate::swarm::FountainSwarmRuntime>>,
+    // CIRISEdge#545 — the READ side of the same claim plane. NOT
+    // `Option`: the tap fires on every verified holding claim whether or
+    // not a converger is installed, because "what has this node
+    // converged about its cohort" is a question about the claim plane,
+    // not about whether an eviction policy happens to be running. The
+    // old arm dropped the envelope entirely with no runtime installed.
+    converged_claims: &crate::holonomic::converged_view::ConvergedClaimView,
     // CIRISEdge#499 — the blob plane's scope-address resolver, read from the
     // transport's installed table so there is exactly ONE source of truth for
     // "is this node scope-native". Default (no table) leaves the blob serve gate
@@ -6098,22 +6188,35 @@ async fn dispatch_inbound(
     // gate at this point. When no runtime is installed, the envelope
     // is observed but no hook fires (same posture as `blob_chunk_source`
     // for the chunked-blob swarm).
+    //
+    // CIRISEdge#545 — the parse moved OUT of the `if let Some(runtime)`
+    // and the READ-side tap fires first, unconditionally. Two
+    // consequences, both wanted: the converged view answers on a node
+    // that never installed a converger (the claim plane is what it
+    // reports on, not the eviction policy), and a malformed body on a
+    // VERIFIED envelope now warns whether or not a runtime is listening
+    // — that warning was previously invisible on exactly the
+    // deployments least likely to notice.
     if envelope.message_type == MessageType::FountainHoldingClaim {
-        if let Some(runtime) = swarm_runtime {
-            match serde_json::from_str::<crate::holonomic::swarm_rarity::FountainHoldingClaim>(
-                envelope.body.get(),
-            ) {
-                Ok(claim) => {
+        match serde_json::from_str::<crate::holonomic::swarm_rarity::FountainHoldingClaim>(
+            envelope.body.get(),
+        ) {
+            Ok(claim) => {
+                // Tap by reference, then hand the claim to the converger
+                // by value — no clone. Both sides see the identical
+                // post-AV-9 claim.
+                converged_claims.observe(&claim);
+                if let Some(runtime) = swarm_runtime {
                     runtime.register_observed_claim(claim).await;
                 }
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        transport = ?transport,
-                        sender_key_id = %envelope.signing_key_id,
-                        "FountainHoldingClaim body parse failed at dispatch (CIRISEdge#184)",
-                    );
-                }
+            }
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    transport = ?transport,
+                    sender_key_id = %envelope.signing_key_id,
+                    "FountainHoldingClaim body parse failed at dispatch (CIRISEdge#184)",
+                );
             }
         }
     }
@@ -7142,6 +7245,12 @@ impl EdgeBuilder {
             blob_chunk_source: self.blob_chunk_source,
             replication_registry: Arc::new(ReinstallableCell::new("replication_registry")),
             swarm_runtime: Arc::new(ReinstallableCell::new("swarm_runtime")),
+            // CIRISEdge#545 — constructed UNARMED. Until `run` (or
+            // `dispatch_inbound_for_test`) arms it, the reader answers
+            // "plane not armed", which is honest: a node whose inbound
+            // loop never started knows nothing about its cohort, and a
+            // zero here would be an artifact of a dead loop.
+            converged_claims: Arc::new(crate::holonomic::converged_view::ConvergedClaimView::new()),
             #[cfg(feature = "holonomic-consent-decay")]
             consent_decay_shutdown: Arc::new(std::sync::OnceLock::new()),
             subscription_filter: self.subscription_filter,

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1946,7 +1946,6 @@ impl Edge {
     /// [`crate::observability::EdgeMetrics`] bag. Cheap clone; consumers
     /// (PyO3 / UniFFI projection methods, internal emission helpers,
     /// tests) call `.snapshot()` to render a typed bundle.
-    #[must_use]
     /// CIRISEdge#547 — seconds since the last anti-entropy round COMPLETED, or
     /// `None` if none has since boot.
     ///
@@ -1975,6 +1974,7 @@ impl Edge {
         Some(now.saturating_sub(stamp))
     }
 
+    #[must_use]
     pub fn metrics(&self) -> crate::observability::EdgeMetrics {
         self.metrics.clone()
     }

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -4136,13 +4136,20 @@ fn extract_trust_scoring(
 /// error.
 #[cfg(feature = "transport-reticulum")]
 #[allow(unsafe_code)]
-/// The keystore alias suffix a node's own key lives under.
+/// The keystore alias suffix a node's own key lives under — LEGACY FALLBACK.
 ///
-/// MIRRORS `CIRISServer::node_key::NODE_ALIAS_SUFFIX` (0.5.189). Edge cannot
-/// import it: CIRISServer RIDES edge, so a dependency in that direction would
-/// invert the substrate relationship. The rule is one line and it is pinned by
-/// `node_alias_matches_the_server_rule` below; if it ever drifts, that test is
-/// where it surfaces.
+/// CIRISEdge#548: this was a mirror of CIRISServer's rule, kept because edge
+/// cannot import from a crate that rides it. The mirror forked — server 0.5.195
+/// moved to a fixed base alias while this kept appending `-node`, so
+/// provisioning put the key where edge would never look and every first-run node
+/// failed to bring up a transport identity.
+///
+/// The lesson is narrower than "do not duplicate": edge genuinely cannot import
+/// this. What it CAN do is be TOLD. `init_edge_runtime(node_keystore_alias=…)`
+/// carries the name from whoever minted the key, which leaves exactly one
+/// component naming it. This constant survives only for callers that do not pass
+/// it yet, and no test here can guard it — a test can only compare edge against
+/// edge, which is why the previous one passed straight through the fork.
 const NODE_ALIAS_SUFFIX: &str = "-node";
 
 /// The keystore alias the node's own key lives under, given the host's alias.
@@ -4219,6 +4226,7 @@ type NodeIdentityHalves = (
 fn open_node_identity_halves(
     node_identity_dir: Option<&str>,
     host_keystore_alias: &str,
+    node_keystore_alias: Option<&str>,
 ) -> Result<NodeIdentityHalves, String> {
     // Returns a plain `String` rather than a `PyErr`: constructing a `PyErr`
     // requires a live interpreter, which would make every fail-closed path here
@@ -4237,7 +4245,22 @@ fn open_node_identity_halves(
         );
     };
     let dir = std::path::PathBuf::from(dir);
-    let alias = node_alias(host_keystore_alias);
+    // CIRISEdge#548 — the name TRAVELS when the caller supplies it. Whoever mints
+    // the key is the only component that can say what it is called, and
+    // `provision_node_identity` already returns that name; it just had nowhere to
+    // go on the way back in.
+    //
+    // Deriving it here made edge a SECOND implementation of a naming rule it does
+    // not own, and that mirror forked: server 0.5.195 moved to a fixed base alias
+    // while edge kept appending `-node`. Provisioning then succeeded and put the
+    // key somewhere edge would never look — with no caller-side workaround,
+    // because there is no alias A where the server's rule and `A + "-node"` agree.
+    //
+    // Absent, the derivation stands, so existing deployments are unaffected.
+    let alias = match node_keystore_alias {
+        Some(explicit) => explicit.to_owned(),
+        None => node_alias(host_keystore_alias),
+    };
 
     // Classical half: the sealed Ed25519 entry beside the one the engine opened.
     let classical: Arc<dyn ciris_keyring::HardwareSigner> = Arc::from(
@@ -4289,10 +4312,12 @@ fn resolve_node_transport_identity(
     executor: &ciris_persist::ffi::executor_capsule::AsyncExecutor,
     node_identity_dir: Option<&str>,
     host_keystore_alias: &str,
+    node_keystore_alias: Option<&str>,
     directory: &Arc<dyn ciris_persist::federation::FederationDirectory>,
 ) -> PyResult<Arc<LocalSigner>> {
-    let (classical, pqc, alias) = open_node_identity_halves(node_identity_dir, host_keystore_alias)
-        .map_err(PyRuntimeError::new_err)?;
+    let (classical, pqc, alias) =
+        open_node_identity_halves(node_identity_dir, host_keystore_alias, node_keystore_alias)
+            .map_err(PyRuntimeError::new_err)?;
     // The federation key_id is DERIVED over the node alias + the node's own
     // pubkey — never the actor's derived id, or the split would be cosmetic.
     //
@@ -4624,6 +4649,8 @@ enum LocalInstanceRole {
     // today's behaviour byte-for-byte.
     use_node_identity = false,
     node_identity_dir = None,
+    // CIRISEdge#548 — the minted key's name, from whoever minted it.
+    node_keystore_alias = None,
 ))]
 #[allow(
     clippy::too_many_arguments,
@@ -4825,6 +4852,12 @@ pub fn init_edge_runtime(
     // no new secret to the boundary.
     use_node_identity: bool,
     node_identity_dir: Option<&str>,
+    // CIRISEdge#548 — the node key's keystore alias, used VERBATIM when given.
+    // `provision_node_identity` mints the key and returns its name; this is the
+    // parameter that lets that name travel back in, instead of being re-derived
+    // by a component that does not own the rule. Absent, edge falls back to
+    // `node_alias(host_keystore_alias)` and existing deployments are unaffected.
+    node_keystore_alias: Option<&str>,
 ) -> PyResult<PyEdge> {
     // v0.19.3 (CIRISEdge#49) — validate the HTTPS init params BEFORE
     // any I/O. The mutual-exclusivity check (dev_self_signed vs cert
@@ -5370,6 +5403,7 @@ pub fn init_edge_runtime(
             &executor,
             node_identity_dir,
             &signer_handle.key_id,
+            node_keystore_alias,
             &federation_directory_for_edge,
         )?)
     } else {
@@ -10071,6 +10105,7 @@ mod pyo3_tier2_tests {
                 false, // use_node_identity (CIRISEdge#541 — default preserves
                 // the engine-derived transport identity byte-for-byte)
                 None, // node_identity_dir
+                None, // node_keystore_alias (CIRISEdge#548 — legacy derivation)
             )?;
             Ok(edge.signer_key_id())
         });
@@ -10192,6 +10227,7 @@ mod pyo3_tier2_tests {
                 false, // use_node_identity (CIRISEdge#541 — default preserves
                 // the engine-derived transport identity byte-for-byte)
                 None, // node_identity_dir
+                None, // node_keystore_alias (CIRISEdge#548 — legacy derivation)
             )
             .err()
             .expect("init_edge_runtime must reject non-engine object")
@@ -10352,6 +10388,7 @@ mod pyo3_tier2_tests {
                 false, // use_node_identity (CIRISEdge#541 — default preserves
                 // the engine-derived transport identity byte-for-byte)
                 None, // node_identity_dir
+                None, // node_keystore_alias (CIRISEdge#548 — legacy derivation)
             )?;
             Ok(())
         });
@@ -10465,6 +10502,7 @@ mod pyo3_tier2_tests {
                 false, // use_node_identity (CIRISEdge#541 — default preserves
                 // the engine-derived transport identity byte-for-byte)
                 None, // node_identity_dir
+                None, // node_keystore_alias (CIRISEdge#548 — legacy derivation)
             )
             .err()
             .expect("init_edge_runtime must reject pre-v2.8.0-shaped engine")
@@ -10644,6 +10682,7 @@ mod pyo3_tier2_tests {
                 false, // use_node_identity (CIRISEdge#541 — default preserves
                 // the engine-derived transport identity byte-for-byte)
                 None, // node_identity_dir
+                None, // node_keystore_alias (CIRISEdge#548 — legacy derivation)
             )?;
             Ok(edge.signer_key_id())
         });
@@ -10810,6 +10849,7 @@ mod pyo3_tier2_tests {
                 None,       // ifac_size
                 false,      // use_node_identity (CIRISEdge#541 — default)
                 None,       // node_identity_dir
+                None,       // node_keystore_alias (CIRISEdge#548)
             );
             // Cleanup: drop OUR engine from the singleton so the next real-engine
             // sibling test constructs cleanly (one persist engine per process).
@@ -10937,6 +10977,7 @@ mod pyo3_tier2_tests {
                 false, // use_node_identity (CIRISEdge#541 — default preserves
                 // the engine-derived transport identity byte-for-byte)
                 None, // node_identity_dir
+                None, // node_keystore_alias (CIRISEdge#548 — legacy derivation)
             )?;
             Ok(edge.signer_key_id())
         });
@@ -11207,7 +11248,7 @@ mod node_identity_tests {
     /// hazard so the collision is not rediscovered as a field incident.
     #[test]
     fn a_node_suffixed_actor_alias_collides_and_needs_the_directory_check() {
-        // Indistinguishable by name: the rule is a no-op on both.
+        // Indistinguishable by name: the legacy rule is a no-op on both.
         assert_eq!(node_alias("prod-node"), "prod-node");
         assert_eq!(
             node_alias("ciris-agent-bootstrap-node"),
@@ -11241,13 +11282,53 @@ mod node_identity_tests {
         assert!(!require_actor_capsule(false, true));
     }
 
-    /// Pins edge's copy of the alias rule against CIRISServer's
-    /// `node_key::node_alias` (0.5.189). Edge cannot import it — CIRISServer
-    /// RIDES edge, and a dependency in that direction would invert the substrate
-    /// relationship — so the rule is duplicated ON PURPOSE, and this test is what
-    /// catches the drift that duplication invites.
+    /// CIRISEdge#548 — an explicitly supplied alias is used VERBATIM.
+    ///
+    /// The bug was that no `host_keystore_alias` could reach the server's minted
+    /// name: there is no A where `A + "-node"` equals a fixed base alias, so a
+    /// derivation could never be reconciled by configuration. The parameter has
+    /// to bypass the rule entirely, not feed it.
+    ///
+    /// Asserted through the REFUSAL message, which names the alias edge tried to
+    /// open — the only observable that proves which name reached the keystore.
     #[test]
-    fn node_alias_matches_the_server_rule() {
+    fn an_explicit_node_alias_is_used_verbatim_not_derived() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().to_str().expect("utf8").to_owned();
+
+        let Err(msg) = open_node_identity_halves(
+            Some(&path),
+            "ciris-agent-bootstrap",
+            Some("ciris-node-bootstrap"),
+        ) else {
+            panic!("an unprovisioned keystore must still refuse");
+        };
+        assert!(
+            msg.contains("ciris-node-bootstrap"),
+            "the explicit alias must be the one edge opens. Got: {msg}"
+        );
+        assert!(
+            !msg.contains("ciris-agent-bootstrap-node"),
+            "the derivation must be BYPASSED, not applied to the explicit name. Got: {msg}"
+        );
+    }
+
+    /// The FALLBACK derivation, and an honest statement of what this cannot do.
+    ///
+    /// CIRISEdge#548: this test used to claim it "catches the drift that
+    /// duplication invites". It does not, and it never could. It asserts edge's
+    /// copy against a hardcoded literal, so it detects only edge editing its own
+    /// implementation — the one case that was never the risk. When CIRISServer
+    /// 0.5.195 moved to a fixed base alias, the mirror forked, every first-run
+    /// node broke, and this test passed throughout.
+    ///
+    /// The real fix is that callers now pass `node_keystore_alias` and the name
+    /// travels from whoever minted the key. What remains here is a BACKWARD-
+    /// COMPATIBILITY path for deployments that do not pass it yet, so this pins
+    /// the legacy shape — nothing more. It is not a cross-repo guard, and no
+    /// test in this repo can be one.
+    #[test]
+    fn the_legacy_alias_derivation_is_unchanged() {
         assert_eq!(NODE_ALIAS_SUFFIX, "-node");
         assert_eq!(
             node_alias("ciris-agent-bootstrap"),
@@ -11266,7 +11347,7 @@ mod node_identity_tests {
     /// to cure.
     #[test]
     fn a_missing_identity_dir_refuses_rather_than_falling_back() {
-        let Err(msg) = open_node_identity_halves(None, "ciris-agent-bootstrap") else {
+        let Err(msg) = open_node_identity_halves(None, "ciris-agent-bootstrap", None) else {
             panic!("no directory must refuse — it must never fall back to the engine identity");
         };
         assert!(
@@ -11288,7 +11369,7 @@ mod node_identity_tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let path = dir.path().to_str().expect("utf8").to_owned();
 
-        let Err(msg) = open_node_identity_halves(Some(&path), "ciris-agent-bootstrap") else {
+        let Err(msg) = open_node_identity_halves(Some(&path), "ciris-agent-bootstrap", None) else {
             panic!("an unprovisioned keystore dir must refuse");
         };
         assert!(

--- a/src/holonomic/converged_view.rs
+++ b/src/holonomic/converged_view.rs
@@ -1,0 +1,952 @@
+//! The READ side of the holonomic claim plane (CIRISEdge#545).
+//!
+//! Every node publishes signed
+//! [`FountainHoldingClaim`](super::swarm_rarity::FountainHoldingClaim)
+//! envelopes to its consent cohort, and every peer's converger
+//! ([`crate::swarm::runtime`]) acts on the claims it receives. That is
+//! already a federated, signed, consent-scoped assertion plane: nodes
+//! saying what they hold, and peers converging on the assertions.
+//!
+//! Until this module it was **write-only from the embedder's side**.
+//! `Edge::install_swarm_runtime` routes verified inbound claims into the
+//! converger and there the information stopped — nothing could ask what
+//! had been converged. A downstream mesh-status surface
+//! (CIRISServer#498) could therefore only report *one observer's own
+//! store* ("748 identities, 101,631 trace_events, as seen by this node"),
+//! because that was the only thing it could honestly say. The
+//! cross-node aggregate was sitting in the converger, unreachable.
+//!
+//! # What this is
+//!
+//! [`ConvergedClaimView`] is a **tap** on the same post-verify inbound
+//! claim plane the converger reads, plus a reader that answers *"what
+//! has this node converged about its cohort"* — [`ConvergedClaimView::read`].
+//!
+//! It is a tap and not a projection of
+//! [`ObservedClaims`](crate::swarm::runtime::ObservedClaims) on purpose:
+//! that map's shape is documented opaque and its only handle is a
+//! `#[doc(hidden)]` test surface, so reading it would have meant widening
+//! a private substrate type for a public status endpoint. Tapping the
+//! dispatch arm instead gives the reader the identical input (post-AV-9,
+//! same `(content_id, peer_id)` identity for "one claim"), keeps its
+//! retention horizon its own, and — a real gain — keeps answering when
+//! no converger is installed at all, where the old arm dropped the
+//! envelope on the floor. [`fold_observations`] is factored out as the
+//! pure arithmetic so a future `ObservedClaims → ConvergedView`
+//! projection can produce byte-identical counts from the converger's own
+//! map without reimplementing anything.
+//!
+//! # Two properties the consumer depends on
+//!
+//! ## Counts, not contents
+//!
+//! The downstream consumer is a **public endpoint**. A public surface
+//! that enumerates the mesh's members is a reconnaissance surface, so
+//! nothing that identifies a peer, a content_id, or a symbol ever leaves
+//! this module. [`ConvergedView`] is numeric in every field — peer ids
+//! and content ids exist only inside the accumulator, as the keys the
+//! distinct-counts are computed over, and are never returned, logged,
+//! or `Debug`-printed. (`converged_view_never_leaks_identifiers` pins
+//! that.)
+//!
+//! ## Unknown is distinguishable from zero
+//!
+//! "No peers have claimed anything" and "the converged view could not be
+//! read" MUST NOT arrive as the same value: reporting `0` on the
+//! evidence of a failed read tells the world the mesh is empty when we
+//! simply do not know. So the reader returns a two-state
+//! [`ConvergenceReading`] — never a bare `Option<ConvergedView>`, which
+//! reads as either — and the wire projection is exactly one method,
+//! [`ConvergenceReading::converged`]: `None` ⇒ emit `null`, `Some(v)` ⇒
+//! emit `v`'s counts **including `Some(0)`**, which is the real,
+//! evidenced "converged to nothing".
+//!
+//! Three things are honestly *unknown* rather than zero, and each is a
+//! distinct [`ConvergenceUnavailable`] variant:
+//!
+//! - the inbound plane was never armed on this node (`Edge::run` never
+//!   started) — a zero count would be an artifact of a dead loop;
+//! - the plane is armed but has not yet been listening for a full claim
+//!   publication window and has heard nothing — a cold start is not
+//!   evidence of an empty mesh;
+//! - the state could not be read at all (a writer panicked and poisoned
+//!   the lock).
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+
+use super::swarm_rarity::FountainHoldingClaim;
+
+/// Default retention horizon for a converged claim. Matches the
+/// converger's own `DEFAULT_OBSERVED_CLAIM_TTL` (600s) so the reader and
+/// the converger agree on what "still held" means; realigned exactly by
+/// [`ConvergedClaimView::align_to_converger`] when a runtime installs
+/// with a non-default config.
+///
+/// Deliberately generous relative to the publish cadence: the consumer
+/// judges liveness from [`ConvergedView::newest_claim_age_ms`], so
+/// claims must survive long enough to *look* stale. Pruning aggressively
+/// would hide a quiet mesh instead of reporting one.
+pub const DEFAULT_CONVERGED_CLAIM_TTL: Duration = Duration::from_secs(600);
+
+/// Default warm-up window — how long the plane must have been armed
+/// before an *empty* set is reported as evidence rather than as unknown.
+///
+/// Two publish cadences (2 × 60s). One cadence would be the theoretical
+/// minimum for "every cohort member should have spoken by now"; two
+/// tolerates a single missed tick without the reader claiming an empty
+/// mesh. A *non*-empty set is reported immediately — positive evidence
+/// needs no warm-up.
+pub const DEFAULT_CONVERGENCE_WARMUP: Duration = Duration::from_secs(120);
+
+/// Cap on distinct `(content_id, peer_id)` claims tracked at once.
+///
+/// The claim plane is post-verify but not post-*quota*: a signed peer
+/// can mint unlimited distinct `content_id`s, and the accumulator keys
+/// on them. Same DoS shape the reassembler byte-budgets close. At the
+/// cap the reader refuses NEW keys (existing keys still take freshness
+/// updates, so liveness keeps flowing) and reports the refusal count, so
+/// a saturated view is a declared FLOOR rather than a silent undercount.
+///
+/// ~20k entries × two short ids ≈ single-digit MB.
+pub const DEFAULT_MAX_TRACKED_CLAIMS: usize = 20_000;
+
+/// Why the converged view has no answer — *unknown*, never zero.
+///
+/// Each variant is a case where returning a count would assert something
+/// about the mesh on the evidence of this node's own plumbing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConvergenceUnavailable {
+    /// The inbound claim plane has never been armed on this node — the
+    /// dispatch loop that feeds the reader never started. Any count here
+    /// would describe a dead loop, not the mesh.
+    PlaneNotArmed,
+    /// The plane is armed but has been listening for less than one
+    /// warm-up window and has observed nothing. Cohort members publish
+    /// on a cadence; before a window has elapsed, silence is a cold
+    /// start, not an empty mesh.
+    Warming {
+        /// How long the plane has been armed.
+        armed_for_ms: u64,
+        /// The warm-up window that has not yet elapsed.
+        window_ms: u64,
+    },
+    /// The converged state could not be read: a writer panicked while
+    /// holding the lock. This is the case the issue names explicitly —
+    /// a failed read must not be reported as an empty mesh.
+    ReadFailed,
+}
+
+impl ConvergenceUnavailable {
+    /// Stable snake_case discriminator for logs and FFI reason strings.
+    /// Stable across cuts — downstream branches on it.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::PlaneNotArmed => "plane_not_armed",
+            Self::Warming { .. } => "warming",
+            Self::ReadFailed => "read_failed",
+        }
+    }
+}
+
+/// What this node has converged about its cohort, in **counts only**.
+///
+/// Every field is numeric by construction — see the module docs on the
+/// reconnaissance-surface rule. A consumer that wants "how big is the
+/// mesh" reads [`Self::peers_converged`]; one that wants "is this
+/// convergence live or stale" reads [`Self::newest_claim_age_ms`]
+/// against its own knowledge of the publish cadence.
+///
+/// An all-zero view is a *real answer*: the plane was armed, has been
+/// listening past its warm-up window, and no peer has claimed anything.
+/// That is "converged to nothing", not "unknown" — which is why this
+/// type is only reachable through [`ConvergenceReading::Converged`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConvergedView {
+    /// Distinct peers this node has accepted at least one live claim
+    /// from. The mesh-size answer.
+    pub peers_converged: u32,
+    /// Distinct `content_id`s claimed by at least one live claim.
+    pub content_ids_converged: u32,
+    /// Live `(content_id, peer_id)` claims — the converged claim count.
+    /// One peer claiming three contents contributes three.
+    pub claims_converged: u64,
+    /// Aggregate holdings: total fountain symbols asserted across every
+    /// live claim. Peers claiming overlapping symbol sets are counted
+    /// once each — this is a *holdings* aggregate, not a distinct-symbol
+    /// census (a census would require retaining symbol ids, which this
+    /// reader deliberately does not).
+    pub symbols_claimed: u64,
+    /// Age of the freshest live claim, in milliseconds. **The liveness
+    /// signal**: a value near the retention horizon means the cohort has
+    /// gone quiet even though the counts are non-zero.
+    ///
+    /// `None` **iff** `claims_converged == 0` — an empty set has no
+    /// newest member. Unambiguous here precisely because the
+    /// absence-vs-empty question was already answered one level up by
+    /// [`ConvergenceReading`].
+    pub newest_claim_age_ms: Option<u64>,
+    /// Age of the stalest live claim, in milliseconds. Bounded above by
+    /// the retention horizon. `None` iff `claims_converged == 0`.
+    pub oldest_claim_age_ms: Option<u64>,
+    /// How long the inbound plane has been armed, in milliseconds. Lets
+    /// a consumer weigh an empty answer: "nothing, after 4 seconds" and
+    /// "nothing, after 4 hours" are very different claims about a mesh.
+    pub observing_for_ms: u64,
+    /// Distinct claims refused since arming because
+    /// [`DEFAULT_MAX_TRACKED_CLAIMS`] was hit. **Non-zero ⇒ every count
+    /// above is a floor, not an exact value.** Cumulative and monotonic
+    /// by design: once we have undercounted, saying so stays true even
+    /// after pruning drops the set back under the cap.
+    pub claims_refused: u64,
+}
+
+impl ConvergedView {
+    /// `true` when the node converged on nothing. Distinct from "we
+    /// could not tell" — that is not representable in this type.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.claims_converged == 0
+    }
+
+    /// `true` when the tracked-claim cap was hit, so the counts are a
+    /// lower bound.
+    #[must_use]
+    pub const fn is_floor(&self) -> bool {
+        self.claims_refused > 0
+    }
+}
+
+/// The result of reading the converged view.
+///
+/// A two-state enum rather than `Option<ConvergedView>` **on purpose**:
+/// a bare `Option` reads as either "converged to nothing" or "nothing
+/// computed yet" at every call site, and the downstream consumer is a
+/// public endpoint that must report `null` for one and `0` for the
+/// other. Making the distinction typed means a consumer cannot collapse
+/// it by accident — it has to name which case it is handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use = "a reading that is dropped reports nothing; match on it or call `converged()`"]
+pub enum ConvergenceReading {
+    /// No answer exists. Report as `null` — **never** as `0`.
+    Unavailable(ConvergenceUnavailable),
+    /// An answer exists, including a legitimately empty one. Report the
+    /// counts verbatim, zeros included.
+    Converged(ConvergedView),
+}
+
+impl ConvergenceReading {
+    /// The wire projection CIRISServer#498 needs, and the ONLY place the
+    /// two states are allowed to become an `Option`: `None` ⇒ serialize
+    /// `null` (unknown), `Some(v)` ⇒ serialize `v`'s counts, **including
+    /// all-zero**.
+    #[must_use]
+    pub const fn converged(&self) -> Option<&ConvergedView> {
+        match self {
+            Self::Converged(v) => Some(v),
+            Self::Unavailable(_) => None,
+        }
+    }
+
+    /// Why there is no answer, when there is none.
+    #[must_use]
+    pub const fn unavailable(&self) -> Option<&ConvergenceUnavailable> {
+        match self {
+            Self::Unavailable(r) => Some(r),
+            Self::Converged(_) => None,
+        }
+    }
+
+    /// `true` when an answer exists (empty or not).
+    #[must_use]
+    pub const fn is_available(&self) -> bool {
+        matches!(self, Self::Converged(_))
+    }
+}
+
+/// One observed claim reduced to the fields the counts need.
+///
+/// Borrowed so [`fold_observations`] allocates nothing per claim. The
+/// symbol *ids* are already gone by this point — only their count
+/// survives, because the reader has no use for contents and every reason
+/// not to hold them.
+#[derive(Debug, Clone, Copy)]
+pub struct ClaimObservation<'a> {
+    /// The claiming peer's federation `key_id`. Used only as a
+    /// distinct-count key; never returned.
+    pub peer_id: &'a str,
+    /// The claimed content. Used only as a distinct-count key; never
+    /// returned.
+    pub content_id: &'a str,
+    /// How many fountain symbols the claim asserted.
+    pub symbol_count: u32,
+    /// LOCAL monotonic instant the claim was observed at.
+    ///
+    /// Local, not the claim's own `observed_at_unix_ms`: the producer's
+    /// timestamp is its own staleness window and is attacker-controlled
+    /// (a peer can backdate or postdate at will, and would skew every
+    /// freshness number here). The converger's TTL prune uses the same
+    /// local-`Instant` discipline for the same reason.
+    pub observed_at: Instant,
+}
+
+/// The pure fold: observations in, counts out.
+///
+/// Factored out of [`ConvergedClaimView`] so that (a) it is testable
+/// against field-shaped claims with no clock plumbing, and (b) a future
+/// projection from the converger's own
+/// [`ObservedClaims`](crate::swarm::runtime::ObservedClaims) map can
+/// produce byte-identical counts by feeding this the same observations —
+/// there is exactly one implementation of the arithmetic.
+///
+/// Observations older than `ttl` are skipped rather than trusted: the
+/// caller is expected to have pruned, and a fold that silently counted
+/// expired claims would inflate `peers_converged` for a dead mesh.
+#[must_use]
+pub fn fold_observations<'a, I>(
+    observations: I,
+    now: Instant,
+    ttl: Duration,
+    observing_for: Duration,
+    claims_refused: u64,
+) -> ConvergedView
+where
+    I: IntoIterator<Item = ClaimObservation<'a>>,
+{
+    let mut peers: BTreeSet<&str> = BTreeSet::new();
+    let mut contents: BTreeSet<&str> = BTreeSet::new();
+    let mut claims_converged: u64 = 0;
+    let mut symbols_claimed: u64 = 0;
+    let mut newest: Option<Duration> = None;
+    let mut oldest: Option<Duration> = None;
+
+    for obs in observations {
+        // `saturating_duration_since`, not `duration_since`: an
+        // observation stamped fractionally in the future (two threads
+        // racing `Instant::now()` around the lock) must read as age 0,
+        // not panic a status endpoint.
+        let age = now.saturating_duration_since(obs.observed_at);
+        if age > ttl {
+            continue;
+        }
+        peers.insert(obs.peer_id);
+        contents.insert(obs.content_id);
+        claims_converged = claims_converged.saturating_add(1);
+        symbols_claimed = symbols_claimed.saturating_add(u64::from(obs.symbol_count));
+        newest = Some(newest.map_or(age, |n| n.min(age)));
+        oldest = Some(oldest.map_or(age, |o| o.max(age)));
+    }
+
+    ConvergedView {
+        peers_converged: u32::try_from(peers.len()).unwrap_or(u32::MAX),
+        content_ids_converged: u32::try_from(contents.len()).unwrap_or(u32::MAX),
+        claims_converged,
+        symbols_claimed,
+        newest_claim_age_ms: newest.map(ms),
+        oldest_claim_age_ms: oldest.map(ms),
+        observing_for_ms: ms(observing_for),
+        claims_refused,
+    }
+}
+
+/// Milliseconds, saturating. A `Duration` longer than `u64::MAX` ms is
+/// ~584 million years; clamping is strictly better than a panic in a
+/// status path.
+fn ms(d: Duration) -> u64 {
+    u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
+}
+
+/// One live claim as the accumulator keeps it: a symbol count and a
+/// local observation instant. The claim itself — peer id, content id,
+/// symbol ids, signatures — is NOT retained; the ids live in the map key
+/// (needed for distinct counts) and nothing else survives.
+#[derive(Debug, Clone, Copy)]
+struct Observed {
+    symbol_count: u32,
+    observed_at: Instant,
+}
+
+#[derive(Debug, Default)]
+struct ConvergedState {
+    /// `(content_id, peer_id)` → live claim. Keyed exactly the way the
+    /// converger's `ObservedClaims` keys — same nesting order, same
+    /// last-wins-per-pair semantics — so "one claim" means the same
+    /// thing to the reader and to the converger. `BTreeMap` for a
+    /// deterministic walk.
+    claims: BTreeMap<(String, String), Observed>,
+    /// When the inbound plane was armed. `None` ⇒
+    /// [`ConvergenceUnavailable::PlaneNotArmed`].
+    armed_at: Option<Instant>,
+    /// Cumulative distinct claims refused at the cap.
+    refused: u64,
+}
+
+/// The converged view of the holonomic claim plane — the read API the
+/// converger never had (CIRISEdge#545).
+///
+/// Lives on `Edge`, is armed when the inbound dispatch loop starts, is
+/// fed by the post-verify `FountainHoldingClaim` dispatch arm, and is
+/// read by [`Self::read`].
+///
+/// The reader is **synchronous**: a status endpoint must be callable
+/// from a blocking FFI frame without a tokio runtime in scope, so the
+/// state sits behind a `std::sync::RwLock` rather than tokio's. Every
+/// critical section is a few map operations with no `.await` inside, so
+/// it never blocks an executor meaningfully.
+#[derive(Debug)]
+pub struct ConvergedClaimView {
+    state: RwLock<ConvergedState>,
+    /// Retention horizon, milliseconds. Atomic so
+    /// [`Self::align_to_converger`] can realign a live view at
+    /// `install_swarm_runtime` time without touching the state lock.
+    ttl_ms: AtomicU64,
+    /// Warm-up window, milliseconds. Same rationale.
+    warmup_ms: AtomicU64,
+    max_tracked: usize,
+}
+
+impl Default for ConvergedClaimView {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ConvergedClaimView {
+    /// A view with the default horizons. Starts **unarmed**: until
+    /// [`Self::arm`] runs, [`Self::read`] reports
+    /// [`ConvergenceUnavailable::PlaneNotArmed`] rather than zero.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_horizons(DEFAULT_CONVERGED_CLAIM_TTL, DEFAULT_CONVERGENCE_WARMUP)
+    }
+
+    /// A view with explicit horizons. `max_tracked` stays at
+    /// [`DEFAULT_MAX_TRACKED_CLAIMS`].
+    #[must_use]
+    pub fn with_horizons(ttl: Duration, warmup: Duration) -> Self {
+        Self {
+            state: RwLock::new(ConvergedState::default()),
+            ttl_ms: AtomicU64::new(ms(ttl)),
+            warmup_ms: AtomicU64::new(ms(warmup)),
+            max_tracked: DEFAULT_MAX_TRACKED_CLAIMS,
+        }
+    }
+
+    /// Realign the reader's horizons to a converger's actual config.
+    ///
+    /// Called from `Edge::install_swarm_runtime`. Without this, a
+    /// deployment that runs a 5-second publish cadence would still be
+    /// declared "warming" for two minutes, and one that runs an
+    /// hour-long TTL would have the reader prune claims its own
+    /// converger still holds — the two would disagree about what is
+    /// live. `warmup` is two publish cadences, per
+    /// [`DEFAULT_CONVERGENCE_WARMUP`].
+    pub fn align_to_converger(&self, observed_claim_ttl: Duration, publish_cadence: Duration) {
+        self.ttl_ms.store(ms(observed_claim_ttl), Ordering::Relaxed);
+        self.warmup_ms
+            .store(ms(publish_cadence.saturating_mul(2)), Ordering::Relaxed);
+    }
+
+    /// Arm the plane: record that this node's inbound dispatch loop is
+    /// running and therefore that silence is now *evidence*.
+    ///
+    /// Idempotent — re-arming a running plane keeps the ORIGINAL instant
+    /// rather than resetting the warm-up. `Edge::run` can be re-entered
+    /// on a fold restart, and resetting would throw away a long, real
+    /// observation window and re-report a known-empty mesh as unknown.
+    pub fn arm(&self) {
+        let Ok(mut st) = self.state.write() else {
+            // Poisoned: `read` will report ReadFailed, which is the
+            // honest answer. Arming into a poisoned lock cannot make it
+            // less honest, so there is nothing to do here.
+            return;
+        };
+        if st.armed_at.is_none() {
+            st.armed_at = Some(Instant::now());
+        }
+    }
+
+    /// Tap one post-verify claim into the converged view.
+    ///
+    /// Called from the same dispatch arm that feeds the converger, on
+    /// the same envelopes, past the same AV-9 verify gate — and
+    /// unconditionally, whether or not a `FountainSwarmRuntime` is
+    /// installed, because "what has this node converged" is a question
+    /// about the claim plane, not about whether an eviction policy
+    /// happens to be running.
+    ///
+    /// Last-wins per `(content_id, peer_id)`, matching
+    /// `register_observed_claim`.
+    pub fn observe(&self, claim: &FountainHoldingClaim) {
+        self.observe_at(claim, Instant::now());
+    }
+
+    /// [`Self::observe`] with an injected observation instant. Private:
+    /// the clock is a test seam, not API.
+    fn observe_at(&self, claim: &FountainHoldingClaim, at: Instant) {
+        let Ok(mut st) = self.state.write() else {
+            return;
+        };
+        let key = (claim.content_id.clone(), claim.peer_id.clone());
+        let entry = Observed {
+            // Saturating: a claim asserting more than 4 billion symbols
+            // is not a number we need to be exact about.
+            symbol_count: u32::try_from(claim.symbol_ids.len()).unwrap_or(u32::MAX),
+            observed_at: at,
+        };
+        match st.claims.get_mut(&key) {
+            // Freshness updates to a pair we already track are ALWAYS
+            // accepted, cap or no cap: refusing them would freeze
+            // `newest_claim_age_ms` and make a live mesh look dead.
+            Some(slot) => *slot = entry,
+            None => {
+                if st.claims.len() >= self.max_tracked {
+                    st.refused = st.refused.saturating_add(1);
+                    return;
+                }
+                st.claims.insert(key, entry);
+            }
+        }
+    }
+
+    /// **The reader.** What has this node converged about its cohort.
+    ///
+    /// Prunes past the retention horizon, then folds. Returns
+    /// [`ConvergenceReading::Unavailable`] — never a zero count — when
+    /// the plane was never armed, when it is still warming with nothing
+    /// observed, or when the state could not be read.
+    pub fn read(&self) -> ConvergenceReading {
+        self.read_at(Instant::now())
+    }
+
+    /// [`Self::read`] with an injected `now`. Private: test seam.
+    fn read_at(&self, now: Instant) -> ConvergenceReading {
+        let ttl = Duration::from_millis(self.ttl_ms.load(Ordering::Relaxed));
+        let warmup = Duration::from_millis(self.warmup_ms.load(Ordering::Relaxed));
+
+        // A poisoned lock is the issue's named "could not be read" case.
+        // We deliberately do NOT recover via `PoisonError::into_inner`
+        // here (the idiom used elsewhere in the crate for best-effort
+        // caches): a panic inside a writer means the map may be
+        // mid-update, and half a map is exactly the silent undercount
+        // this API exists to avoid reporting.
+        let Ok(mut st) = self.state.write() else {
+            return ConvergenceReading::Unavailable(ConvergenceUnavailable::ReadFailed);
+        };
+
+        let Some(armed_at) = st.armed_at else {
+            return ConvergenceReading::Unavailable(ConvergenceUnavailable::PlaneNotArmed);
+        };
+
+        st.claims
+            .retain(|_, c| now.saturating_duration_since(c.observed_at) <= ttl);
+
+        let observing_for = now.saturating_duration_since(armed_at);
+        if st.claims.is_empty() && observing_for < warmup {
+            return ConvergenceReading::Unavailable(ConvergenceUnavailable::Warming {
+                armed_for_ms: ms(observing_for),
+                window_ms: ms(warmup),
+            });
+        }
+
+        let refused = st.refused;
+        ConvergenceReading::Converged(fold_observations(
+            st.claims
+                .iter()
+                .map(|((content_id, peer_id), c)| ClaimObservation {
+                    peer_id: peer_id.as_str(),
+                    content_id: content_id.as_str(),
+                    symbol_count: c.symbol_count,
+                    observed_at: c.observed_at,
+                }),
+            now,
+            ttl,
+            observing_for,
+            refused,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Field-shaped input: the EXACT struct the dispatch arm parses out
+    /// of a verified `MessageType::FountainHoldingClaim` envelope body,
+    /// signature fields and all. Testing the fold on hand-rolled tuples
+    /// would prove the arithmetic against inputs the field never
+    /// produces.
+    fn field_claim(peer: &str, content: &str, symbols: &[u32]) -> FountainHoldingClaim {
+        let mut claim =
+            FountainHoldingClaim::new(peer, content, symbols.to_vec(), 1_700_000_000_000);
+        // The wire claims that reach the tap are signed — the dispatch
+        // arm is past verify. Populate the hybrid pair so the tap is
+        // exercised on the shape it actually sees, not on the
+        // signature-free constructor output.
+        claim.signature = "ZmFrZS1lZDI1NTE5".to_string();
+        claim.signature_ml_dsa_65 = "ZmFrZS1tbC1kc2E=".to_string();
+        claim.pqc_key_id = format!("{peer}-pqc");
+        claim
+    }
+
+    /// A `now` far enough past the process epoch that subtracting test
+    /// durations from it is always valid. `Instant - Duration` panics on
+    /// underflow and `Instant`'s epoch is boot/process start, so a bare
+    /// `Instant::now() - 10_000s` would flake on a freshly booted runner.
+    fn far_future_now() -> Instant {
+        Instant::now() + Duration::from_secs(86_400)
+    }
+
+    fn armed_view(ttl: Duration, warmup: Duration) -> ConvergedClaimView {
+        let v = ConvergedClaimView::with_horizons(ttl, warmup);
+        v.arm();
+        v
+    }
+
+    // ---- absence vs empty ------------------------------------------
+
+    #[test]
+    fn unarmed_plane_is_unknown_not_zero() {
+        let view = ConvergedClaimView::new();
+        let reading = view.read();
+        assert_eq!(
+            reading,
+            ConvergenceReading::Unavailable(ConvergenceUnavailable::PlaneNotArmed)
+        );
+        // The wire projection: null, not 0.
+        assert!(reading.converged().is_none());
+        assert!(!reading.is_available());
+    }
+
+    #[test]
+    fn armed_but_warming_with_nothing_observed_is_unknown_not_zero() {
+        let view = armed_view(DEFAULT_CONVERGED_CLAIM_TTL, Duration::from_secs(120));
+        match view.read() {
+            ConvergenceReading::Unavailable(ConvergenceUnavailable::Warming {
+                window_ms, ..
+            }) => assert_eq!(window_ms, 120_000),
+            other => panic!("cold start must read as unknown, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn armed_past_warmup_with_nothing_observed_is_a_real_zero() {
+        // Zero warm-up = the window has elapsed by construction.
+        let view = armed_view(DEFAULT_CONVERGED_CLAIM_TTL, Duration::ZERO);
+        let reading = view.read();
+        let converged = reading
+            .converged()
+            .expect("past warm-up, an empty set is EVIDENCE and must be reported");
+        assert_eq!(converged.peers_converged, 0);
+        assert_eq!(converged.claims_converged, 0);
+        assert!(converged.is_empty());
+        // Empty set ⇒ no oldest/newest. Unambiguous: `claims_converged`
+        // already said the set is empty.
+        assert_eq!(converged.newest_claim_age_ms, None);
+        assert_eq!(converged.oldest_claim_age_ms, None);
+    }
+
+    #[test]
+    fn positive_evidence_is_reported_even_while_warming() {
+        // A long warm-up window that has NOT elapsed...
+        let view = armed_view(DEFAULT_CONVERGED_CLAIM_TTL, Duration::from_secs(3600));
+        view.observe(&field_claim("peer-a", "content-1", &[1, 2, 3]));
+        // ...must not suppress an answer we positively have.
+        let reading = view.read();
+        let converged = reading
+            .converged()
+            .expect("an observed claim is evidence regardless of warm-up");
+        assert_eq!(converged.peers_converged, 1);
+        assert_eq!(converged.claims_converged, 1);
+    }
+
+    #[test]
+    fn read_failure_is_distinct_from_empty() {
+        let view = armed_view(DEFAULT_CONVERGED_CLAIM_TTL, Duration::ZERO);
+        // Poison the lock the way a panicking writer would.
+        let poisoned = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _guard = view.state.write().expect("fresh lock");
+            panic!("writer panic");
+        }));
+        assert!(poisoned.is_err());
+
+        let reading = view.read();
+        assert_eq!(
+            reading,
+            ConvergenceReading::Unavailable(ConvergenceUnavailable::ReadFailed)
+        );
+        // The whole point: a failed read must NOT tell the world the
+        // mesh is empty.
+        assert!(reading.converged().is_none());
+    }
+
+    // ---- counts ----------------------------------------------------
+
+    #[test]
+    fn distinct_peers_and_contents_are_counted_not_claims() {
+        let view = armed_view(DEFAULT_CONVERGED_CLAIM_TTL, Duration::ZERO);
+        // Two peers, two contents, four claims — the cross product a
+        // real cohort produces.
+        for peer in ["peer-a", "peer-b"] {
+            for content in ["content-1", "content-2"] {
+                view.observe(&field_claim(peer, content, &[7, 8]));
+            }
+        }
+        let reading = view.read();
+        let v = reading.converged().expect("armed past warm-up with claims");
+        assert_eq!(v.peers_converged, 2);
+        assert_eq!(v.content_ids_converged, 2);
+        assert_eq!(v.claims_converged, 4);
+        assert_eq!(v.symbols_claimed, 8, "2 symbols × 4 claims");
+    }
+
+    #[test]
+    fn a_republished_claim_replaces_rather_than_double_counts() {
+        let view = armed_view(DEFAULT_CONVERGED_CLAIM_TTL, Duration::ZERO);
+        view.observe(&field_claim("peer-a", "content-1", &[1]));
+        // Same (content, peer) republished at the next publish cadence
+        // with a grown symbol set — the field's steady state.
+        view.observe(&field_claim("peer-a", "content-1", &[1, 2, 3, 4]));
+        let reading = view.read();
+        let v = reading.converged().expect("claims present");
+        assert_eq!(v.claims_converged, 1, "last-wins per (content, peer)");
+        assert_eq!(v.symbols_claimed, 4, "the LATER claim's holdings");
+    }
+
+    // ---- freshness -------------------------------------------------
+
+    #[test]
+    fn ages_bracket_the_observed_set() {
+        let view = armed_view(Duration::from_secs(600), Duration::ZERO);
+        let now = far_future_now();
+        // A cohort that has been publishing for a while: one peer heard
+        // from 5 minutes ago, one 10 seconds ago.
+        view.observe_at(
+            &field_claim("peer-old", "content-1", &[1]),
+            now - Duration::from_secs(300),
+        );
+        view.observe_at(
+            &field_claim("peer-new", "content-1", &[2]),
+            now - Duration::from_secs(10),
+        );
+        let reading = view.read_at(now);
+        let v = reading.converged().expect("claims present");
+        assert_eq!(v.newest_claim_age_ms, Some(10_000));
+        assert_eq!(v.oldest_claim_age_ms, Some(300_000));
+    }
+
+    #[test]
+    fn a_quiet_cohort_reads_as_stale_then_empties() {
+        let view = armed_view(Duration::from_secs(600), Duration::ZERO);
+        let now = far_future_now();
+        view.observe_at(
+            &field_claim("peer-a", "content-1", &[1]),
+            now - Duration::from_secs(590),
+        );
+        // Inside the horizon: still counted, but visibly stale — this is
+        // the signal that distinguishes a live convergence from a dead
+        // one, and is why the horizon is generous.
+        let stale = view.read_at(now);
+        let sv = stale.converged().expect("still inside the horizon");
+        assert_eq!(sv.peers_converged, 1);
+        assert_eq!(sv.newest_claim_age_ms, Some(590_000));
+
+        // Past the horizon: pruned. Still an ANSWER (armed, past
+        // warm-up) — a real, evidenced zero.
+        let gone = view.read_at(now + Duration::from_secs(20));
+        let gv = gone.converged().expect("armed and past warm-up");
+        assert_eq!(gv.peers_converged, 0);
+        assert!(gv.is_empty());
+    }
+
+    // ---- saturation ------------------------------------------------
+
+    #[test]
+    fn cap_saturation_is_declared_as_a_floor() {
+        let mut view =
+            ConvergedClaimView::with_horizons(DEFAULT_CONVERGED_CLAIM_TTL, Duration::ZERO);
+        view.max_tracked = 2;
+        view.arm();
+        // A peer minting distinct content_ids — the flood shape.
+        for i in 0..5 {
+            view.observe(&field_claim("peer-flood", &format!("content-{i}"), &[1]));
+        }
+        let reading = view.read();
+        let v = reading.converged().expect("claims present");
+        assert_eq!(v.claims_converged, 2, "capped");
+        assert_eq!(v.claims_refused, 3);
+        assert!(v.is_floor(), "a saturated view must declare itself a floor");
+    }
+
+    #[test]
+    fn saturation_still_accepts_freshness_for_tracked_pairs() {
+        let mut view = ConvergedClaimView::with_horizons(Duration::from_secs(600), Duration::ZERO);
+        view.max_tracked = 1;
+        view.arm();
+        let now = far_future_now();
+        view.observe_at(
+            &field_claim("peer-a", "content-1", &[1]),
+            now - Duration::from_secs(300),
+        );
+        view.observe(&field_claim("peer-b", "content-2", &[1])); // refused
+        view.observe_at(&field_claim("peer-a", "content-1", &[1, 2]), now);
+        let reading = view.read_at(now);
+        let v = reading.converged().expect("claims present");
+        assert_eq!(v.claims_refused, 1);
+        assert_eq!(
+            v.newest_claim_age_ms,
+            Some(0),
+            "a tracked pair must keep taking freshness updates at the cap"
+        );
+        assert_eq!(v.symbols_claimed, 2);
+    }
+
+    // ---- reconnaissance surface ------------------------------------
+
+    #[test]
+    fn converged_view_never_leaks_identifiers() {
+        let view = armed_view(DEFAULT_CONVERGED_CLAIM_TTL, Duration::ZERO);
+        view.observe(&field_claim(
+            "SECRETPEERKEYID",
+            "SECRETCONTENTID",
+            &[404, 405],
+        ));
+        let reading = view.read();
+        let v = reading.converged().expect("claims present");
+
+        // `Debug` is the accidental-leak path: a status handler that logs
+        // the view, or an FFI repr(), must not enumerate the mesh.
+        let debug = format!("{v:?}");
+        assert!(
+            !debug.contains("SECRETPEERKEYID"),
+            "peer id leaked: {debug}"
+        );
+        assert!(
+            !debug.contains("SECRETCONTENTID"),
+            "content id leaked: {debug}"
+        );
+
+        // Structural, not textual: pin the ENTIRE serialized field set.
+        // A symbol id is numerically indistinguishable from a count in a
+        // string search, so the guard that actually holds is "no field
+        // beyond these eight ever appears on the wire" — a future field
+        // carrying contents fails here at review time, not in
+        // production.
+        let json: serde_json::Value = serde_json::to_value(v).expect("view serializes");
+        let mut keys: Vec<&str> = json
+            .as_object()
+            .expect("view is a JSON object")
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            [
+                "claims_converged",
+                "claims_refused",
+                "content_ids_converged",
+                "newest_claim_age_ms",
+                "observing_for_ms",
+                "oldest_claim_age_ms",
+                "peers_converged",
+                "symbols_claimed",
+            ],
+            "the converged view must stay COUNTS-ONLY: {json}"
+        );
+        assert!(
+            json.as_object()
+                .expect("object")
+                .values()
+                .all(|v| v.is_number() || v.is_null()),
+            "every converged-view field must be numeric or absent: {json}"
+        );
+    }
+
+    // ---- arming ----------------------------------------------------
+
+    #[test]
+    fn rearming_does_not_reset_the_observation_window() {
+        let view = ConvergedClaimView::with_horizons(
+            DEFAULT_CONVERGED_CLAIM_TTL,
+            Duration::from_secs(120),
+        );
+        view.arm();
+        let first = view
+            .state
+            .read()
+            .expect("unpoisoned")
+            .armed_at
+            .expect("armed");
+        // A fold restart re-enters `Edge::run` and re-arms.
+        view.arm();
+        let second = view
+            .state
+            .read()
+            .expect("unpoisoned")
+            .armed_at
+            .expect("armed");
+        assert_eq!(
+            first, second,
+            "re-arming must not throw away a real observation window"
+        );
+    }
+
+    #[test]
+    fn align_to_converger_moves_both_horizons() {
+        let view = ConvergedClaimView::new();
+        view.align_to_converger(Duration::from_secs(30), Duration::from_secs(5));
+        assert_eq!(view.ttl_ms.load(Ordering::Relaxed), 30_000);
+        assert_eq!(
+            view.warmup_ms.load(Ordering::Relaxed),
+            10_000,
+            "warm-up is two publish cadences"
+        );
+    }
+
+    // ---- the pure fold ---------------------------------------------
+
+    #[test]
+    fn fold_skips_observations_past_the_horizon() {
+        let now = far_future_now();
+        let obs = vec![
+            ClaimObservation {
+                peer_id: "peer-live",
+                content_id: "content-1",
+                symbol_count: 3,
+                observed_at: now - Duration::from_secs(10),
+            },
+            ClaimObservation {
+                peer_id: "peer-expired",
+                content_id: "content-2",
+                symbol_count: 99,
+                observed_at: now - Duration::from_secs(10_000),
+            },
+        ];
+        let v = fold_observations(obs, now, Duration::from_secs(600), Duration::ZERO, 0);
+        assert_eq!(v.peers_converged, 1, "the expired peer must not be counted");
+        assert_eq!(v.symbols_claimed, 3);
+    }
+
+    #[test]
+    fn unavailable_reasons_have_stable_discriminators() {
+        assert_eq!(
+            ConvergenceUnavailable::PlaneNotArmed.as_str(),
+            "plane_not_armed"
+        );
+        assert_eq!(
+            ConvergenceUnavailable::Warming {
+                armed_for_ms: 1,
+                window_ms: 2
+            }
+            .as_str(),
+            "warming"
+        );
+        assert_eq!(ConvergenceUnavailable::ReadFailed.as_str(), "read_failed");
+    }
+}

--- a/src/holonomic/converged_view.rs
+++ b/src/holonomic/converged_view.rs
@@ -499,12 +499,13 @@ impl ConvergedClaimView {
             symbol_count: u32::try_from(claim.symbol_ids.len()).unwrap_or(u32::MAX),
             observed_at: at,
         };
-        match st.claims.get_mut(&key) {
-            // Freshness updates to a pair we already track are ALWAYS
-            // accepted, cap or no cap: refusing them would freeze
-            // `newest_claim_age_ms` and make a live mesh look dead.
-            Some(slot) => *slot = entry,
-            None => {
+        // Freshness updates to a pair we already track are ALWAYS accepted, cap
+        // or no cap: refusing them would freeze `newest_claim_age_ms` and make a
+        // live mesh look dead.
+        if let Some(slot) = st.claims.get_mut(&key) {
+            *slot = entry;
+        } else {
+            {
                 if st.claims.len() >= self.max_tracked {
                     st.refused = st.refused.saturating_add(1);
                     return;
@@ -728,11 +729,13 @@ mod tests {
         // from 5 minutes ago, one 10 seconds ago.
         view.observe_at(
             &field_claim("peer-old", "content-1", &[1]),
-            now - Duration::from_secs(300),
+            now.checked_sub(Duration::from_secs(300))
+                .expect("test instant"),
         );
         view.observe_at(
             &field_claim("peer-new", "content-1", &[2]),
-            now - Duration::from_secs(10),
+            now.checked_sub(Duration::from_secs(10))
+                .expect("test instant"),
         );
         let reading = view.read_at(now);
         let v = reading.converged().expect("claims present");
@@ -746,7 +749,8 @@ mod tests {
         let now = far_future_now();
         view.observe_at(
             &field_claim("peer-a", "content-1", &[1]),
-            now - Duration::from_secs(590),
+            now.checked_sub(Duration::from_secs(590))
+                .expect("test instant"),
         );
         // Inside the horizon: still counted, but visibly stale — this is
         // the signal that distinguishes a live convergence from a dead
@@ -791,7 +795,8 @@ mod tests {
         let now = far_future_now();
         view.observe_at(
             &field_claim("peer-a", "content-1", &[1]),
-            now - Duration::from_secs(300),
+            now.checked_sub(Duration::from_secs(300))
+                .expect("test instant"),
         );
         view.observe(&field_claim("peer-b", "content-2", &[1])); // refused
         view.observe_at(&field_claim("peer-a", "content-1", &[1, 2]), now);
@@ -919,13 +924,17 @@ mod tests {
                 peer_id: "peer-live",
                 content_id: "content-1",
                 symbol_count: 3,
-                observed_at: now - Duration::from_secs(10),
+                observed_at: now
+                    .checked_sub(Duration::from_secs(10))
+                    .expect("test instant"),
             },
             ClaimObservation {
                 peer_id: "peer-expired",
                 content_id: "content-2",
                 symbol_count: 99,
-                observed_at: now - Duration::from_secs(10_000),
+                observed_at: now
+                    .checked_sub(Duration::from_secs(10_000))
+                    .expect("test instant"),
             },
         ];
         let v = fold_observations(obs, now, Duration::from_secs(600), Duration::ZERO, 0);

--- a/src/holonomic/mod.rs
+++ b/src/holonomic/mod.rs
@@ -75,6 +75,19 @@
 //!   [`assemble_tier_meta_v2`](aggregation::assemble_tier_meta_v2) tier
 //!   assembly. v1 preimages stay byte-identical; new tiers emit version 2.
 //!
+//! - **v18.12.0** (CIRISEdge#545) adds [`converged_view`] — the READ
+//!   side of the claim plane the swarm converger has been consuming
+//!   write-only since v6.3.0. `install_swarm_runtime` routed verified
+//!   `FountainHoldingClaim` envelopes into the converger and the
+//!   information stopped there, so a downstream mesh-status surface
+//!   (CIRISServer#498) could only report one observer's own store.
+//!   [`converged_view::ConvergedClaimView`] taps the same post-verify
+//!   dispatch arm and answers "what has this node converged about its
+//!   cohort" in COUNTS — never peer/content identifiers, because the
+//!   consumer is a public endpoint and an enumerable member list is a
+//!   reconnaissance surface — with "nothing computed yet" typed
+//!   distinctly from "converged to nothing".
+//!
 //! See `docs/ROADMAP_TO_V4.md` for the cut sequence and the
 //! CIRISRegistry#85 + #89 absorption gates for normative CEG status.
 //!
@@ -84,6 +97,13 @@
 pub mod consent_decay;
 
 pub mod aggregation;
+/// CIRISEdge#545 — the READ side of the holonomic claim plane. The
+/// converger consumed verified `FountainHoldingClaim`s and nothing could
+/// ask it what it had converged; [`converged_view::ConvergedClaimView`]
+/// answers that in COUNTS (never contents), with unknown typed
+/// separately from zero. Ungated: a status surface must be reachable
+/// from every build, including the Python wheel.
+pub mod converged_view;
 pub mod deterministic_topology;
 pub mod fountain_defaults;
 /// §19.7.1.3 content-similarity multiplicity — the CC 6.1.2.1.2 R9 producer

--- a/src/observability.rs
+++ b/src/observability.rs
@@ -880,6 +880,21 @@ pub struct EdgeMetrics {
     /// rides on the matching throttled DEBUG line, and keying by peer would make
     /// cardinality grow with exactly the pollution this counts.
     pub announce_intake_evictions: Arc<std::sync::atomic::AtomicU64>,
+    /// CIRISEdge#547 — unix seconds at which the last anti-entropy round
+    /// TERMINATED. `0` means "no round has completed since boot".
+    ///
+    /// These exist to answer ONE question without touching the store: is this
+    /// runtime still making progress? A canonical ran 22 hours hung — one thread
+    /// in `wait_on_page_bit_common` holding persist's single connection mutex,
+    /// six parked behind it — and went unnoticed because the health surface that
+    /// would have reported it reads the store, so it was inside the failure it
+    /// was meant to detect.
+    ///
+    /// PLAIN ATOMICS, deliberately, not the `RwLock<HashMap>` the counters
+    /// beside them use. A liveness signal must share no lock with any path that
+    /// can block on I/O; if it did, a convoy would make the liveness read hang
+    /// exactly when its answer matters. Reading these can never block.
+    pub last_round_completed_unix: Arc<std::sync::atomic::AtomicU64>,
     /// CIRISEdge#433 — the WITHHOLD LEDGER: per-[`WithholdReason`] count of rows
     /// a serving-path gate declined to serve. Shaped exactly like
     /// [`Self::send_failures_total`] (same `Arc<RwLock<HashMap<_, _>>>` lock
@@ -1019,8 +1034,38 @@ impl EdgeMetrics {
     /// scheduler event-sink consumer (see
     /// [`crate::replication::runtime::ReplicationRuntime::start`]).
     pub fn inc_round_outcome(&self, outcome: RoundOutcome) {
+        // CIRISEdge#547 — stamp progress BEFORE taking the counter lock. The
+        // stamp is the liveness signal and must not be able to wait on anything;
+        // ordering it first means even a contended counter map cannot delay the
+        // evidence that this runtime is alive.
+        Self::stamp_now(&self.last_round_completed_unix);
         let mut guard = self.replication_round_outcomes_total.write();
         *guard.entry(outcome).or_insert(0) += 1;
+    }
+
+    /// Wall-clock seconds into an atomic. Monotonically advanced only: a clock
+    /// that steps backwards must never make progress look older than it is,
+    /// because "no progress for N seconds" is the whole signal.
+    fn stamp_now(slot: &std::sync::atomic::AtomicU64) {
+        use std::sync::atomic::Ordering;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        let _ = slot.fetch_max(now, Ordering::Relaxed);
+    }
+
+    /// CIRISEdge#547 — the store-free liveness view.
+    ///
+    /// Unix seconds of the last completed round, `0` for "none since boot".
+    /// Reads ONE atomic: no store, no lock that a store-touching path holds, no
+    /// allocation. A caller can compute "seconds since progress" and answer a
+    /// health probe while the replication runtime is fully convoyed — which is
+    /// precisely the state this exists to make visible. On the hung canonical
+    /// this would have read 22 hours stale from the first minute.
+    #[must_use]
+    pub fn last_round_completed_unix(&self) -> u64 {
+        self.last_round_completed_unix
+            .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// CIRISEdge#373 — increment the inbound-backpressure-drop counter. Called
@@ -1284,6 +1329,51 @@ pub struct EdgeMetricsBundle {
     /// CIRISEdge#441 — the removal-delivery delta: per tracked removal row,
     /// offered/acked counts + peers still lacking a receipt.
     pub removal_delivery: Vec<RemovalRowDelta>,
+}
+
+#[cfg(test)]
+mod liveness_tests {
+    //! CIRISEdge#547 — the store-free liveness stamp.
+    use super::{EdgeMetrics, RoundOutcome};
+    use std::sync::atomic::Ordering;
+
+    /// Before any round completes the answer is "nothing since boot" — a
+    /// distinct state from "a round completed at the epoch", which a bare
+    /// timestamp would conflate.
+    #[test]
+    fn no_completed_round_reads_as_zero_not_a_stale_timestamp() {
+        let m = EdgeMetrics::default();
+        assert_eq!(m.last_round_completed_unix(), 0);
+    }
+
+    /// A terminated round stamps progress, whatever its outcome. A round that
+    /// ended badly still proves the runtime is turning — which is the question
+    /// this answers, and the reason it is not gated on success.
+    #[test]
+    fn any_terminated_round_stamps_progress() {
+        let m = EdgeMetrics::default();
+        m.inc_round_outcome(RoundOutcome::Completed);
+        assert!(m.last_round_completed_unix() > 0);
+    }
+
+    /// The subtle one. The stamp advances MONOTONICALLY: a clock stepping
+    /// backwards (NTP correction, a VM restored from a snapshot) must never make
+    /// progress look older than it is, because "no progress for N seconds" is the
+    /// entire signal and an inflated N is a false alarm on a healthy node —
+    /// which is how a liveness probe gets muted by its own operators.
+    #[test]
+    fn a_backwards_clock_cannot_age_the_stamp() {
+        let m = EdgeMetrics::default();
+        let future = 4_000_000_000u64;
+        m.last_round_completed_unix.store(future, Ordering::Relaxed);
+        // A stamp taken "now" is far in the past relative to that value.
+        m.inc_round_outcome(RoundOutcome::Completed);
+        assert_eq!(
+            m.last_round_completed_unix(),
+            future,
+            "fetch_max must keep the newer stamp; a regressing clock must not age it"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -93,6 +93,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 
+use super::refusal_backoff::{RefusalBackoff, RetryDisposition};
 use super::resolved_state::{ResolvedPeerSet, ResolvedRecipient};
 use ciris_persist::federation::admission::has_accord_conferred_role;
 use ciris_persist::federation::consent_grammar::{self, ConsentTransferPolicy};
@@ -267,6 +268,21 @@ impl ApplyRefusalClass {
         )
     }
 
+    /// CIRISEdge#544 — the same disposition, in the vocabulary the RETRY loop
+    /// consumes. Derived from [`Self::is_transient`] rather than re-decided, so
+    /// there is exactly one place the four #522 door classes say whether they
+    /// converge; the log line the receiver already prints
+    /// ([`classified_refusal_reason`]) and the window the receiver now backs off
+    /// for cannot disagree.
+    #[must_use]
+    pub fn retry(self) -> RetryDisposition {
+        if self.is_transient() {
+            RetryDisposition::Transient
+        } else {
+            RetryDisposition::Terminal
+        }
+    }
+
     /// Classify a persist apply-door `Err` on the **attestation** doors —
     /// AV-45 and AV-84, both of which persist types (`WriteScopeRefused`
     /// carries a [`ScopeRefusalReason`](ciris_persist::scope::ScopeRefusalReason);
@@ -321,6 +337,69 @@ fn classified_refusal_reason(
     )
 }
 
+/// CIRISEdge#544 — does re-offering the IDENTICAL bytes that earned this
+/// Key-plane refusal have any chance of a different answer?
+///
+/// The issue's measured row is here: `conflicting_version`, one `Key` record,
+/// 55 re-offers in 30 minutes, same content hash every time. The disposition is
+/// read off persist's own doc-comments on
+/// [`KeyRefusalReason`](ciris_persist::federation::register::KeyRefusalReason) —
+/// they are the authority on what each branch is a function of, and edge keys on
+/// the typed variant, never on the message prose (#565's whole point).
+///
+/// # TERMINAL — the verdict is a function of state replication cannot move
+///
+/// - `PubkeySwap` — "replication may never swap an identity's keys". The verdict
+///   compares the stored pubkey with the offered one; replication is structurally
+///   barred from changing the first, and the second is fixed by the bytes.
+/// - `Downgrade` — "Monotonic — never demote an anchored row". The stored row can
+///   only become MORE anchored, so a self-signed record's answer can only stay no.
+/// - `ConflictingVersion` — "First-seen wins", and these bytes did not. Terminal
+///   in every reachable successor state too: if the stored self-signed row is
+///   later anchor-scrubbed, the same offer becomes a `Downgrade` — still refused.
+///
+/// # TRANSIENT — decided by state that is still moving, or by a token that
+/// collapses a recoverable arm with an unrecoverable one
+///
+/// - `StoreConflict` — persist says it outright: "the record is safe to re-offer".
+///   A lost plan/act race on a planning backend.
+/// - `UnverifiableSignature` — the token covers a malformed record (terminal) AND
+///   an **unregistered signer** (recoverable: the scrub key is itself a Key-plane
+///   row that replicates, so this is ordinary bootstrap ordering). Indistinguishable
+///   from here, and dropping a record whose signer key is merely still in flight
+///   would silently strand a key registration — so: transient, bounded by backoff.
+/// - `ReScrub` — likewise mixed: "not canonical-scoped" / "valid_from not newer"
+///   cannot move, but "the m-of-n quorum re-verify … failed" can — quorum evidence
+///   replicates on its own cursor plane (#474). A canonical KEY SUPERSEDE is the
+///   single worst row to drop for being early, so it stays re-askable.
+/// - `OwnerAbsent` / `OwnerAmbiguous` — `owner_of` is resolved from replicated
+///   ownership rows; both readings change when those rows (or a revocation of a
+///   duplicate claim) land. Fail-closed, per persist — not permanent.
+/// - `AlreadyAnchoredIdentical` — unreachable here: [`key_outcome_to_apply`] maps
+///   it to [`ApplyOutcome::Duplicate`] (the receiver already holds what was
+///   offered), so it never reaches a refusal memory. Listed transient because a
+///   duplicate is the opposite of a thing to stop asking for, and because the
+///   compiler must see every variant answered.
+///
+/// The asymmetry is deliberate and is the rule for any future variant: a
+/// permanent refusal called transient costs a decaying trickle of re-asks; a
+/// recoverable one called terminal withholds state. When a token is ambiguous,
+/// it is transient.
+#[must_use]
+fn key_refusal_retry(reason: KeyRefusalReason) -> RetryDisposition {
+    match reason {
+        KeyRefusalReason::PubkeySwap
+        | KeyRefusalReason::Downgrade
+        | KeyRefusalReason::ConflictingVersion => RetryDisposition::Terminal,
+        KeyRefusalReason::ReScrub
+        | KeyRefusalReason::AlreadyAnchoredIdentical
+        | KeyRefusalReason::UnverifiableSignature
+        | KeyRefusalReason::OwnerAbsent
+        | KeyRefusalReason::OwnerAmbiguous
+        | KeyRefusalReason::StoreConflict => RetryDisposition::Transient,
+    }
+}
+
 /// persist v24.2.0 (CIRISPersist#565) — map the typed Key-plane apply outcome to
 /// edge's [`ApplyOutcome`], returning alongside it the stable refusal TOKEN to
 /// count on the receive-plane mirror ledger (`None` when nothing was refused).
@@ -355,15 +434,29 @@ fn key_outcome_to_apply(
                 reason: KeyRefusalReason::AlreadyAnchoredIdentical,
             },
         ) => (ApplyOutcome::Duplicate, None),
-        Ok(ReplicatedKeyOutcome::Refused { reason }) => (
-            ApplyOutcome::Refused(format!(
-                "Key: admission refused ({}; content_hash={content_hash})",
-                reason.as_str()
-            )),
-            Some(reason.as_str()),
-        ),
+        // CIRISEdge#544 — the disposition rides the SAME typed value the token
+        // does. `key_refusal_retry` carries the per-variant reasoning; the
+        // message states the verdict so an operator reading one WARN line knows
+        // whether to wait or to supersede.
+        Ok(ReplicatedKeyOutcome::Refused { reason }) => {
+            let retry = key_refusal_retry(reason);
+            (
+                ApplyOutcome::Refused {
+                    reason: format!(
+                        "Key: admission refused ({}; content_hash={content_hash}) [retry={}]",
+                        reason.as_str(),
+                        retry.as_str(),
+                    ),
+                    retry,
+                },
+                Some(reason.as_str()),
+            )
+        }
+        // A persist `Err` on this door is NOT one of the typed policy branches —
+        // it is a backend/plumbing failure, which is the definition of moving
+        // state. Transient (bounded by the short backoff), never terminal.
         Err(e) => (
-            ApplyOutcome::Refused(apply_refusal_reason("Key", content_hash, &e)),
+            ApplyOutcome::refused(apply_refusal_reason("Key", content_hash, &e)),
             None,
         ),
     }
@@ -1209,6 +1302,26 @@ pub struct FederationDirectoryReplicationBridge {
     /// means a bulk read was wired past the page driver. `SeqCst` because it
     /// exists to be asserted on.
     sweep_max_page_rows: std::sync::atomic::AtomicUsize,
+    /// CIRISEdge#544 — the node-wide refusal memory: which `(plane, content
+    /// hash)` this node has already refused, and until when it should stop
+    /// ASKING for it. Populated at the apply choke
+    /// ([`Self::apply_envelope_bytes`]), read by the round's want-diff through
+    /// [`ReplicationDirectory::retry_suppressed`].
+    ///
+    /// On the bridge for the same reason [`Self::sweep_cursors`] is: the ONE
+    /// production bridge backs every per-peer provider AND the single shared
+    /// applier, so a refusal learned from one peer's Deliver removes the row
+    /// from every peer's next `want`. A per-session memory would re-learn the
+    /// same verdict once per peer and keep paying for it once per peer, which is
+    /// the amplification the issue measured.
+    refusal_backoff: RefusalBackoff,
+    /// CIRISEdge#544 — how many wanted hashes the backoff has actually removed
+    /// from a round's `want`. The memory's own witness, in the discipline of
+    /// [`Self::owner_reads`] and [`Self::sweep_max_page_rows`]: "the retry storm
+    /// stopped" is a claim, and a claim about traffic that did NOT happen is
+    /// exactly the kind nothing else can observe. `Relaxed` — a counter nobody
+    /// orders against.
+    retry_suppressions: std::sync::atomic::AtomicUsize,
 }
 
 /// CIRISEdge#523 — one memoized owner-binding resolution for one node.
@@ -1345,6 +1458,11 @@ impl FederationDirectoryReplicationBridge {
             sweep_gate: SweepGate::new(config.advertise_sweep_permits),
             sweep_cursors: Mutex::new(SweepCursors::default()),
             sweep_max_page_rows: std::sync::atomic::AtomicUsize::new(0),
+            // CIRISEdge#544 — always on. It is a rate limiter on asking for what
+            // this node just refused, not a policy, so there is no configuration
+            // in which asking flat-out is the right answer.
+            refusal_backoff: RefusalBackoff::new(),
+            retry_suppressions: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
@@ -1389,6 +1507,11 @@ impl FederationDirectoryReplicationBridge {
             sweep_gate: SweepGate::new(config.advertise_sweep_permits),
             sweep_cursors: Mutex::new(SweepCursors::default()),
             sweep_max_page_rows: std::sync::atomic::AtomicUsize::new(0),
+            // CIRISEdge#544 — always on. It is a rate limiter on asking for what
+            // this node just refused, not a policy, so there is no configuration
+            // in which asking flat-out is the right answer.
+            refusal_backoff: RefusalBackoff::new(),
+            retry_suppressions: std::sync::atomic::AtomicUsize::new(0),
         }
     }
 
@@ -2569,7 +2692,7 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
             match &outcome {
                 ApplyOutcome::Admitted => m.inc_applied(kind),
                 ApplyOutcome::Duplicate => m.inc_duplicate(kind),
-                ApplyOutcome::Refused(_) => m.inc_apply_refusal_kind(kind),
+                ApplyOutcome::Refused { .. } => m.inc_apply_refusal_kind(kind),
                 // Deserialize is a malformed-bytes drop, not an apply outcome
                 // on a well-formed row — it stays uncounted here (the choke's
                 // `on_deliver` logs it loud; a metrics kind-count of undecodable
@@ -2577,7 +2700,22 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                 ApplyOutcome::Deserialize(_) => {}
             }
         }
+        self.remember_outcome(kind, envelope_bytes, &outcome);
         outcome
+    }
+
+    /// CIRISEdge#544 — the round's want-diff asks this before putting a hash on
+    /// the wire. Pure in-memory probe of the refusal memory; counts the drops so
+    /// the traffic that did NOT happen is observable.
+    fn retry_suppressed(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> bool {
+        let hit = self
+            .refusal_backoff
+            .suppressed_at(kind, envelope_hash, Instant::now());
+        if hit {
+            self.retry_suppressions
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        hit
     }
 }
 
@@ -2973,7 +3111,13 @@ impl FederationDirectoryReplicationBridge {
     ) -> ApplyOutcome {
         match ApplyRefusalClass::classify(err) {
             Some(class) => self.refuse_as(plane, content_hash, err, class),
-            None => ApplyOutcome::Refused(apply_refusal_reason(plane, content_hash, err)),
+            // CIRISEdge#544 — an UNCLASSIFIED persist error keeps the pre-#522
+            // message AND takes the conservative retry disposition. We do not
+            // know what moved it, so we may not assert that nothing will: the
+            // short transient backoff bounds the cost of being wrong here, while
+            // guessing terminal on an unread error would silently strand rows on
+            // every plane at once.
+            None => ApplyOutcome::refused(apply_refusal_reason(plane, content_hash, err)),
         }
     }
 
@@ -2991,7 +3135,80 @@ impl FederationDirectoryReplicationBridge {
         if let Some(m) = self.metrics.as_ref() {
             m.inc_apply_refusal_class(class.as_str());
         }
-        ApplyOutcome::Refused(classified_refusal_reason(plane, content_hash, err, class))
+        // CIRISEdge#544 — the class already decided this; `retry()` just says it
+        // in the retry loop's vocabulary, so the "[TERMINAL — …]" prose in the
+        // message and the backoff window the receiver installs are the same
+        // verdict rather than two that can drift.
+        ApplyOutcome::Refused {
+            reason: classified_refusal_reason(plane, content_hash, err, class),
+            retry: class.retry(),
+        }
+    }
+
+    /// CIRISEdge#544 — fold one apply outcome into the node-wide refusal memory.
+    /// Called once, at the [`StateApplier::apply_envelope_bytes`] choke, for the
+    /// same reason #425 put the logging there: a per-plane call site is a
+    /// per-plane opportunity to forget.
+    ///
+    /// # Why the key is `sha256(envelope_bytes)`
+    ///
+    /// The wire identity of a row IS its content hash — `sha256(serde_json::
+    /// to_vec(row))` ([`content_hash_of`]) — and the serve path is persist's
+    /// `signed_wire_index` point-read, which reloads and re-serializes that same
+    /// row. So the bytes delivered here hash to the value the peer advertised in
+    /// its Summary and the value this node put in `want` (see the module's
+    /// `envelope_hash semantics` note). Hashing the DELIVERED BYTES rather than
+    /// re-deriving the hash per plane keeps this one line instead of thirteen,
+    /// and fails in the safe direction: if a peer ever serves bytes that do not
+    /// hash to what it advertised, the key simply never matches a future want
+    /// and the row stays fully re-askable.
+    ///
+    /// `Admitted` / `Duplicate` CLEAR rather than skip: the row is now held, so
+    /// the diff drops it on its own, and any refusal history for those bytes is
+    /// obsolete — leaving it would let a stale attempt count lengthen the
+    /// backoff of an unrelated later refusal of the same record.
+    fn remember_outcome(&self, kind: EnvelopeKind, envelope_bytes: &[u8], outcome: &ApplyOutcome) {
+        use sha2::{Digest as _, Sha256};
+        let hash: [u8; 32] = Sha256::digest(envelope_bytes).into();
+        match outcome.retry_disposition() {
+            None => self.refusal_backoff.clear(kind, &hash),
+            Some(disposition) => {
+                let window =
+                    self.refusal_backoff
+                        .record_at(kind, hash, disposition, Instant::now());
+                // DEBUG: the refusal itself already WARNs at the #425 choke with
+                // its reason and disposition. This line answers only "and for how
+                // long will the node stop asking", which is the operator's next
+                // question when a row goes quiet.
+                tracing::debug!(
+                    kind = ?kind,
+                    envelope_hash = %hex::encode(&hash[..8]),
+                    retry = disposition.as_str(),
+                    backoff_secs = window.as_secs(),
+                    remembered = self.refusal_backoff.len(),
+                    "apply refused — the round's want will skip these bytes until the \
+                     backoff window elapses (CIRISEdge#544)"
+                );
+            }
+        }
+    }
+
+    /// CIRISEdge#544 — how many wanted hashes the refusal memory has removed
+    /// from a round's `want` since construction. The witness for "the re-offer
+    /// storm stopped": traffic that did not happen has no other observable.
+    #[must_use]
+    pub fn retry_suppressions(&self) -> usize {
+        self.retry_suppressions
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// CIRISEdge#544 — how many `(plane, content hash)` rows are currently
+    /// remembered as refused. Bounded by
+    /// [`refusal_backoff::DEFAULT_MAX_KEYS`](super::refusal_backoff::DEFAULT_MAX_KEYS);
+    /// a bound nobody can read is a bound that silently stops holding.
+    #[must_use]
+    pub fn refusal_memory_len(&self) -> usize {
+        self.refusal_backoff.len()
     }
 
     /// The per-kind apply dispatch behind the #425 choke —
@@ -5475,7 +5692,13 @@ impl FederationDirectoryReplicationBridge {
                     // It is LOUD instead: a refusal naming the variant, which
                     // is the correct reading of "this node's persist told it
                     // something it was not built to understand".
-                    Ok(other) => ApplyOutcome::Refused(format!(
+                    // CIRISEdge#544 — TERMINAL: the verdict is a property of THIS
+                    // BUILD's vocabulary, and the identical bytes will produce the
+                    // identical unknown variant every round. The event that fixes
+                    // it (adopting the persist cut) restarts the process and empties
+                    // the refusal memory, so "terminal" here means exactly
+                    // "until this node runs a build that understands it".
+                    Ok(other) => ApplyOutcome::refused_terminal(format!(
                         "Attestation: persist returned an AttestationOutcome this edge \
                          build does not know ({other:?}); adopt the persist cut that \
                          added it — CIRISPersist#771 (content_hash={content_hash})"
@@ -5699,7 +5922,12 @@ impl FederationDirectoryReplicationBridge {
                     ApplyOutcome::Duplicate
                 }
             }
-            Err(e) => ApplyOutcome::Refused(format!(
+            // CIRISEdge#544 — transient: this plane's refusals turn on trust
+            // state (a root's standing, a seat's conferral) that is itself
+            // replicating, and the cursor plane re-pulls from a watermark
+            // rather than from a want-diff, so the backoff is the only rate
+            // limit it has.
+            Err(e) => ApplyOutcome::refused(format!(
                 "AccordQuorumEvidence: admission refused (refusal={}): {e}",
                 e.kind(),
             )),
@@ -5753,6 +5981,10 @@ impl FederationDirectoryReplicationBridge {
     ///   reason string cannot distinguish the two, the classification re-reads
     ///   the stored row's clock; an unreadable/absent stored row classifies to
     ///   the LOUD arm (never launder what we cannot classify).
+    ///   CIRISEdge#544 — the two loud sub-arms take DIFFERENT retry
+    ///   dispositions: a classified same-clock fork is terminal (the stored
+    ///   clock can only move forward, after which these bytes are merely stale),
+    ///   an unclassifiable one is transient (a failed re-read is not a verdict).
     ///
     /// A genuine gate failure (bad signature / unknown attesting key /
     /// not-acts-for) surfaces as `Err` from persist → `Refused`. A parse failure
@@ -5816,10 +6048,33 @@ impl FederationDirectoryReplicationBridge {
                                  (CIRISEdge#338/#425; `classified=false` = the stored row \
                                  could not be re-read, refusing loud rather than laundering)"
                             );
-                            ApplyOutcome::Refused(format!(
-                                "TransportDestination: supersession refused \
-                                 (same-clock content conflict or unclassifiable): {reason}"
-                            ))
+                            // CIRISEdge#544 — the two sub-arms this branch fuses
+                            // have OPPOSITE dispositions, and `stored_clock`
+                            // already separates them, so name them separately
+                            // rather than take the worse of the two:
+                            //  - a CLASSIFIED same-clock fork is terminal. The
+                            //    stored row's `(epoch, asserted_at)` equals the
+                            //    offer's; if the stored row later moves it can
+                            //    only move FORWARD, at which point these bytes
+                            //    become the stale arm (Duplicate) — never
+                            //    admitted. The fix is a new epoch, i.e. new
+                            //    bytes, i.e. a hash this memory does not hold.
+                            //  - an UNCLASSIFIABLE refusal (the stored row could
+                            //    not be re-read) is a failed READ, not a verdict
+                            //    about the row. Transient: the read may succeed
+                            //    next round and classify it properly.
+                            if stored_clock.is_some() {
+                                ApplyOutcome::refused_terminal(format!(
+                                    "TransportDestination: supersession refused \
+                                     (same-clock content conflict): {reason}"
+                                ))
+                            } else {
+                                ApplyOutcome::refused(format!(
+                                    "TransportDestination: supersession refused \
+                                     (unclassifiable — the stored row could not be \
+                                     re-read): {reason}"
+                                ))
+                            }
                         }
                     }
                 }
@@ -5830,7 +6085,13 @@ impl FederationDirectoryReplicationBridge {
                     TransportDestinationApplyOutcome::Inserted
                     | TransportDestinationApplyOutcome::Superseded,
                 ) => ApplyOutcome::Admitted,
-                Err(e) => ApplyOutcome::Refused(format!(
+                // CIRISEdge#544 — transient: the gate fuses "bad signature"
+                // (terminal) with "attesting key not registered here yet" and
+                // "acts-for not yet visible" (both ordinary bootstrap ordering
+                // over rows that replicate). Dropping a route because its
+                // attesting key is still in flight would strand reachability, so
+                // the ambiguous token stays re-askable under backoff.
+                Err(e) => ApplyOutcome::refused(format!(
                     "TransportDestination: authenticated apply gate rejected (signature / \
                      attesting-key / acts-for, CIRISEdge#337 CRITICAL-2): {e}"
                 )),
@@ -5873,7 +6134,15 @@ impl FederationDirectoryReplicationBridge {
         // `OperationalProviders` silently declined every delivered Organization,
         // while the round reported healthy. Now it yields a reason the choke logs.
         if self.operational.is_none() {
-            return ApplyOutcome::refused(
+            // CIRISEdge#544 — TERMINAL. `operational` is fixed at bridge
+            // construction (`with_operational`), so within this process no
+            // amount of re-asking makes an opted-out node admit the plane. Left
+            // transient, an edge without operational providers re-pulls every
+            // Organization/OrgMembership/PartnerRecord row its peers hold, every
+            // round, forever — the #544 pattern with a whole plane in it rather
+            // than one row. Wiring the providers is a restart, which empties the
+            // memory.
+            return ApplyOutcome::refused_terminal(
                 "Organization: operational providers not configured on this edge — \
                  operational-kind admission is opted out",
             );
@@ -5902,7 +6171,15 @@ impl FederationDirectoryReplicationBridge {
     async fn apply_org_membership(&self, bytes: &[u8]) -> ApplyOutcome {
         // CIRISEdge#425 Exhibit B — the second escaped early return.
         if self.operational.is_none() {
-            return ApplyOutcome::refused(
+            // CIRISEdge#544 — TERMINAL. `operational` is fixed at bridge
+            // construction (`with_operational`), so within this process no
+            // amount of re-asking makes an opted-out node admit the plane. Left
+            // transient, an edge without operational providers re-pulls every
+            // Organization/OrgMembership/PartnerRecord row its peers hold, every
+            // round, forever — the #544 pattern with a whole plane in it rather
+            // than one row. Wiring the providers is a restart, which empties the
+            // memory.
+            return ApplyOutcome::refused_terminal(
                 "OrgMembership: operational providers not configured on this edge — \
                  operational-kind admission is opted out",
             );
@@ -5929,7 +6206,15 @@ impl FederationDirectoryReplicationBridge {
     async fn apply_partner_record(&self, bytes: &[u8]) -> ApplyOutcome {
         // CIRISEdge#425 Exhibit B — the third escaped early return.
         if self.operational.is_none() {
-            return ApplyOutcome::refused(
+            // CIRISEdge#544 — TERMINAL. `operational` is fixed at bridge
+            // construction (`with_operational`), so within this process no
+            // amount of re-asking makes an opted-out node admit the plane. Left
+            // transient, an edge without operational providers re-pulls every
+            // Organization/OrgMembership/PartnerRecord row its peers hold, every
+            // round, forever — the #544 pattern with a whole plane in it rather
+            // than one row. Wiring the providers is a restart, which empties the
+            // memory.
+            return ApplyOutcome::refused_terminal(
                 "PartnerRecord: operational providers not configured on this edge — \
                  operational-kind admission is opted out",
             );
@@ -6734,7 +7019,7 @@ mod tests {
             .apply_envelope_bytes(EnvelopeKind::TransportDestination, &wire(&fork), None)
             .await;
         assert!(
-            matches!(r, ApplyOutcome::Refused(_)),
+            matches!(r, ApplyOutcome::Refused { .. }),
             "a same-clock content fork is a REFUSAL (split truth), got {r:?}"
         );
     }
@@ -6843,7 +7128,7 @@ mod tests {
                 continue;
             }
             let (a, t) = key_outcome_to_apply(Ok(ReplicatedKeyOutcome::Refused { reason }), "h");
-            let ApplyOutcome::Refused(msg) = &a else {
+            let ApplyOutcome::Refused { reason: msg, .. } = &a else {
                 panic!("{} must map to Refused, got {a:?}", reason.as_str());
             };
             assert!(
@@ -6853,6 +7138,154 @@ mod tests {
             );
             assert_eq!(t, Some(reason.as_str()), "the mirror counts the token");
         }
+    }
+
+    /// CIRISEdge#544 — the classification the issue turns on, asserted through
+    /// the EXACT value persist hands the field: `ReplicatedKeyOutcome::Refused
+    /// { reason }`, one per closed-set variant, not a hand-written message.
+    ///
+    /// `conflicting_version` is the measured row (55 re-offers in 30 minutes of
+    /// byte-identical bytes); it and the two other first-seen/monotonic verdicts
+    /// are TERMINAL. Every reason whose token fuses a recoverable arm with an
+    /// unrecoverable one stays TRANSIENT — mislabelling a permanent refusal
+    /// transient costs a decaying trickle, mislabelling a recoverable one
+    /// terminal withholds state.
+    #[test]
+    fn conflicting_version_is_terminal_and_the_ambiguous_key_reasons_stay_transient() {
+        let terminal = [
+            KeyRefusalReason::PubkeySwap,
+            KeyRefusalReason::Downgrade,
+            KeyRefusalReason::ConflictingVersion,
+        ];
+        for &reason in KeyRefusalReason::ALL {
+            // Drive the mapping the field drives, not the private fn alone.
+            let (outcome, _) =
+                key_outcome_to_apply(Ok(ReplicatedKeyOutcome::Refused { reason }), "h");
+            let want = if terminal.contains(&reason) {
+                RetryDisposition::Terminal
+            } else {
+                RetryDisposition::Transient
+            };
+            // `already_anchored_identical` never reaches a refusal at all — it is
+            // the receiver already holding what was offered.
+            if matches!(reason, KeyRefusalReason::AlreadyAnchoredIdentical) {
+                assert_eq!(outcome.retry_disposition(), None, "{}", reason.as_str());
+                continue;
+            }
+            assert_eq!(
+                outcome.retry_disposition(),
+                Some(want),
+                "{} must be {} — see key_refusal_retry for the per-variant reasoning",
+                reason.as_str(),
+                want.as_str()
+            );
+            let ApplyOutcome::Refused { reason: msg, .. } = &outcome else {
+                panic!("{} must map to Refused, got {outcome:?}", reason.as_str());
+            };
+            assert!(
+                msg.contains(want.as_str()),
+                "an operator reading ONE line must be able to tell wait-for-state \
+                 from supersede-it: {msg}"
+            );
+        }
+    }
+
+    /// CIRISEdge#544 — the whole loop, end to end, on the real apply choke: a
+    /// terminally-refused row is remembered, and the round's want-diff stops
+    /// asking for it.
+    ///
+    /// Driven on the operational plane because its terminal verdict is
+    /// structural rather than backend-dependent (an edge built without
+    /// `OperationalProviders` cannot admit the plane in this process, whatever
+    /// the store does), so the assertion is about edge's decision and not about
+    /// which branch `MemoryBackend` happens to take. The suppression key is
+    /// `sha256(delivered bytes)` — the same value the peer advertised and the
+    /// same value `diff_refs` puts in `want`.
+    #[tokio::test]
+    async fn a_terminally_refused_row_is_dropped_from_the_next_rounds_want() {
+        let (_backend, bridge) = make_bridge(&["k1".into()]);
+        let bytes = br#"{"organization": {
+            "attestation_id": "att-1",
+            "org_id": "org-acme",
+            "name": "ACME",
+            "org_type": "internal",
+            "status": "active",
+            "asserted_at": "2026-06-10T20:00:00Z",
+            "attesting_key_id": "k1",
+            "signed_envelope": {},
+            "ed25519_signature_base64": ""
+        }}"#;
+        let hash: [u8; 32] = Sha256::digest(bytes).into();
+
+        // Before the refusal the node asks for it like any other missing row.
+        assert!(
+            !bridge.retry_suppressed(EnvelopeKind::Organization, &hash),
+            "a row this node has never refused must stay wanted"
+        );
+
+        let outcome = bridge
+            .apply_envelope_bytes(EnvelopeKind::Organization, bytes, Some("peer-x"))
+            .await;
+        assert!(
+            matches!(&outcome, ApplyOutcome::Refused { retry, .. } if retry.is_terminal()),
+            "got {outcome:?}"
+        );
+
+        // …and now it does not. This is the 55-per-30-minutes becoming one.
+        assert!(
+            bridge.retry_suppressed(EnvelopeKind::Organization, &hash),
+            "the round's want must skip bytes this node just terminally refused"
+        );
+        assert_eq!(bridge.refusal_memory_len(), 1);
+        assert_eq!(
+            bridge.retry_suppressions(),
+            1,
+            "the suppression is counted — traffic that did not happen has no \
+             other observable"
+        );
+        // The suppression is on THESE bytes only: a corrected, superseding
+        // record hashes differently and is asked for immediately, which is the
+        // way forward the issue says a stuck sender needs.
+        let superseding: [u8; 32] = Sha256::digest(b"a corrected version of the row").into();
+        assert!(!bridge.retry_suppressed(EnvelopeKind::Organization, &superseding));
+        // …and it is scoped to the plane the verdict was reached on.
+        assert!(!bridge.retry_suppressed(EnvelopeKind::Key, &hash));
+    }
+
+    /// CIRISEdge#544 — suppression gates the ASK, never the ADMIT. A row this
+    /// node stopped asking for is still applied on its merits if a peer pushes
+    /// it (the #927 proactive-publish shape), so an over-eager memory can delay
+    /// a row but can never withhold one.
+    #[tokio::test]
+    async fn a_suppressed_row_is_still_applied_when_a_peer_pushes_it_anyway() {
+        let (_backend, bridge) = make_bridge(&["k1".into()]);
+        let record = fixture_key_record("k1", identity_type::NODE);
+        let bytes = serde_json::to_vec(&SignedKeyRecord { record }).expect("serialize offer");
+        let hash: [u8; 32] = Sha256::digest(&bytes).into();
+        // Pre-load the memory as if a previous round had refused these bytes.
+        bridge.refusal_backoff.record_at(
+            EnvelopeKind::Key,
+            hash,
+            crate::replication::refusal_backoff::RetryDisposition::Terminal,
+            Instant::now(),
+        );
+        assert!(bridge.retry_suppressed(EnvelopeKind::Key, &hash));
+
+        let outcome = bridge
+            .apply_envelope_bytes(EnvelopeKind::Key, &bytes, Some("peer-x"))
+            .await;
+        assert!(
+            outcome.is_admitted(),
+            "the apply path must not consult the retry memory — it gates asking, \
+             not admitting; got {outcome:?}"
+        );
+        // …and admitting CLEARS the history, so a later refusal of the same
+        // bytes starts its backoff from the base rather than inheriting a stale
+        // attempt count.
+        assert!(
+            !bridge.retry_suppressed(EnvelopeKind::Key, &hash),
+            "an admitted row's refusal history is obsolete"
+        );
     }
 
     /// persist v24.2.0 / #565 — the wire drive: a pubkey swap offered through
@@ -6879,7 +7312,7 @@ mod tests {
         let outcome = bridge
             .apply_envelope_bytes(EnvelopeKind::Key, &bytes, Some("peer-x"))
             .await;
-        let ApplyOutcome::Refused(msg) = &outcome else {
+        let ApplyOutcome::Refused { reason: msg, .. } = &outcome else {
             panic!("a pubkey swap must be Refused, got {outcome:?}");
         };
         // WHICH branch classifies is persist's unit (certified upstream; on the
@@ -7145,7 +7578,10 @@ mod tests {
             // CIRISEdge#425 — garbage must classify as a NAMED non-admit (a reason
             // the choke point logs), never a bare drop.
             assert!(
-                matches!(r, ApplyOutcome::Refused(_) | ApplyOutcome::Deserialize(_)),
+                matches!(
+                    r,
+                    ApplyOutcome::Refused { .. } | ApplyOutcome::Deserialize(_)
+                ),
                 "garbage must be a named Refused/Deserialize for {kind:?}, got {r:?}"
             );
         }
@@ -7704,7 +8140,7 @@ mod tests {
         let outcome = bridge
             .apply_envelope_bytes(EnvelopeKind::Community, &forked_wire, None)
             .await;
-        let ApplyOutcome::Refused(msg) = &outcome else {
+        let ApplyOutcome::Refused { reason: msg, .. } = &outcome else {
             panic!("a differing roster under an occupied id must be REFUSED, got {outcome:?}");
         };
         assert!(
@@ -7786,7 +8222,7 @@ mod tests {
         let outcome = bridge
             .apply_envelope_bytes(EnvelopeKind::Attestation, &wire, Some("some-peer"))
             .await;
-        let ApplyOutcome::Refused(msg) = &outcome else {
+        let ApplyOutcome::Refused { reason: msg, .. } = &outcome else {
             panic!("AV-45 must refuse a row ahead of its roster, got {outcome:?}");
         };
         assert!(
@@ -8099,7 +8535,7 @@ mod tests {
         for (kind, bytes) in unsigned {
             let outcome = bridge.apply_envelope_bytes(kind, &bytes, None).await;
             assert!(
-                matches!(outcome, ApplyOutcome::Refused(_)),
+                matches!(outcome, ApplyOutcome::Refused { .. }),
                 "an unsigned {kind:?} must be REFUSED at persist's E4 gate \
                  (not admitted, not a wire-shape error); got {outcome:?}"
             );
@@ -10377,9 +10813,11 @@ mod tests {
         // CIRISEdge#425 — fail-closed AND named: the escaped early return now yields
         // a `Refused` reason the choke point logs, not a silent `false`.
         assert!(
-            matches!(&outcome, ApplyOutcome::Refused(r) if r.contains("operational providers")),
+            matches!(&outcome, ApplyOutcome::Refused { reason: r, retry } if r.contains("operational providers") && retry.is_terminal()),
             "v2 operational admission MUST fail-close with a NAMED refusal without \
-             OperationalProviders, got {outcome:?}"
+             OperationalProviders — and TERMINAL (CIRISEdge#544): the providers are \
+             fixed at construction, so re-asking every round for a plane this node \
+             opted out of admitting can never succeed. Got {outcome:?}"
         );
     }
 
@@ -10402,8 +10840,9 @@ mod tests {
             .apply_envelope_bytes(EnvelopeKind::OrgMembership, bytes, None)
             .await;
         assert!(
-            matches!(&outcome, ApplyOutcome::Refused(r) if r.contains("operational providers")),
-            "org_membership must fail-close with a named refusal, got {outcome:?}"
+            matches!(&outcome, ApplyOutcome::Refused { reason: r, retry } if r.contains("operational providers") && retry.is_terminal()),
+            "org_membership must fail-close with a named TERMINAL refusal \
+             (CIRISEdge#544), got {outcome:?}"
         );
     }
 
@@ -10426,8 +10865,9 @@ mod tests {
             .apply_envelope_bytes(EnvelopeKind::PartnerRecord, bytes, None)
             .await;
         assert!(
-            matches!(&outcome, ApplyOutcome::Refused(r) if r.contains("operational providers")),
-            "partner_record must fail-close with a named refusal, got {outcome:?}"
+            matches!(&outcome, ApplyOutcome::Refused { reason: r, retry } if r.contains("operational providers") && retry.is_terminal()),
+            "partner_record must fail-close with a named TERMINAL refusal \
+             (CIRISEdge#544), got {outcome:?}"
         );
     }
 
@@ -13922,7 +14362,7 @@ mod tests {
             .apply_envelope_bytes(EnvelopeKind::Attestation, &wire, Some("node-bob"))
             .await;
         match &outcome {
-            ApplyOutcome::Refused(reason) => {
+            ApplyOutcome::Refused { reason, .. } => {
                 assert!(
                     reason.contains("class=retry_after_community_roster"),
                     "the roster has not landed — this is the transient class: {reason}"
@@ -14003,7 +14443,7 @@ mod tests {
             .apply_envelope_bytes(EnvelopeKind::Attestation, &wire, Some("node-stranger"))
             .await;
         match &outcome {
-            ApplyOutcome::Refused(reason) => assert!(
+            ApplyOutcome::Refused { reason, .. } => assert!(
                 reason.contains("class=retry_after_community_roster"),
                 "an unbound node must not inherit anyone's membership — the principal \
                  fold widens to the single live owner and NEVER past it, and the door it \

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -2318,28 +2318,30 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
     /// repairs both axes at once and keeps advertise == holdings, exactly as
     /// this arm's `_ =>` fall-through assumes.
     async fn list_holdings(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
-        // CIRISEdge#531 DEPTH — the holdings view is the OTHER whole-table
-        // read per plane per round (`want = remote ∖ holdings`), and
-        // #523/v18.2.0 deliberately routed four planes' holdings to UNFILTERED
-        // twins at the raw page limit — so a cursored advertise against an
-        // uncursored holdings would still materialise the corpus and the fix
-        // would be half. Every arm here is now PAGED.
+        // CIRISEdge#547 / CIRISPersist#780 — READ THE INDEX, NOT THE ROWS.
         //
-        // But NEVER watermarked: `want` is computed against this set, so a
-        // partial holdings view leaves held rows in `want` forever and
-        // re-fetches them every round — CIRISEdge#416's non-convergence,
-        // recreated by the memory fix. `SweepWindow::Full` is the type-level
-        // statement of that: pages for memory, complete in result.
-        match kind {
-            EnvelopeKind::Attestation => self.list_attestation_holdings().await,
-            EnvelopeKind::Key => self.list_key_holdings().await,
-            EnvelopeKind::IdentityOccurrence => self.list_identity_occurrence_holdings().await,
-            EnvelopeKind::TransportDestination => self.list_transport_destination_holdings().await,
-            _ => {
-                self.list_envelope_refs_unbounded(kind, SweepWindow::Full)
-                    .await
+        // Everything below is correct and was killing production. `holdings`
+        // must be COMPLETE (a partial view leaves held rows in `want` forever,
+        // CIRISEdge#416), so #531 made these arms paged — which bounded MEMORY
+        // and deliberately not I/O. The result: every round, every plane,
+        // re-reading the whole corpus from disk in 1024-row chunks to recompute
+        // hashes. On the canonical (1.3 GB corpus, 808 MB page cache for the
+        // whole box) that is 35–118 MB/s continuous, every fault taken while
+        // holding persist's single connection mutex, so every other DB task
+        // parked behind it. The node went unreachable after ~22 h, `restarts=0`,
+        // no panic, with the health endpoint inside the same convoy.
+        //
+        // persist already had these hashes: `signed_wire_index`, PRIMARY KEY
+        // `(kind, content_hash)`, maintained by the same hooks that admit rows.
+        // v38.7.0 exposes it. This is index-only — ~50k hashes ≈ 1.6 MB against
+        // 1.3 GB of rows — and still COMPLETE across pages, so the convergence
+        // invariant is untouched. Bounded I/O, not bounded reach.
+        if let Some(index_kind) = kind.persist_index_kind() {
+            if let Some(refs) = self.holdings_from_wire_index(index_kind).await {
+                return refs;
             }
         }
+        self.list_holdings_from_rows(kind).await
     }
 
     /// CIRISEdge#474 — serve an accord-quorum-evidence cursor pull. The plane has
@@ -3786,6 +3788,123 @@ impl FederationDirectoryReplicationBridge {
     ///
     /// The equivalence pin any future pushdown must keep green:
     /// `advertise_projection_boundary_and_ledger_are_pinned`.
+    async fn list_holdings_from_rows(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+        // CIRISEdge#531 DEPTH — the holdings view is the OTHER whole-table
+        // read per plane per round (`want = remote ∖ holdings`), and
+        // #523/v18.2.0 deliberately routed four planes' holdings to UNFILTERED
+        // twins at the raw page limit — so a cursored advertise against an
+        // uncursored holdings would still materialise the corpus and the fix
+        // would be half. Every arm here is now PAGED.
+        //
+        // But NEVER watermarked: `want` is computed against this set, so a
+        // partial holdings view leaves held rows in `want` forever and
+        // re-fetches them every round — CIRISEdge#416's non-convergence,
+        // recreated by the memory fix. `SweepWindow::Full` is the type-level
+        // statement of that: pages for memory, complete in result.
+        match kind {
+            EnvelopeKind::Attestation => self.list_attestation_holdings().await,
+            EnvelopeKind::Key => self.list_key_holdings().await,
+            EnvelopeKind::IdentityOccurrence => self.list_identity_occurrence_holdings().await,
+            EnvelopeKind::TransportDestination => self.list_transport_destination_holdings().await,
+            _ => {
+                self.list_envelope_refs_unbounded(kind, SweepWindow::Full)
+                    .await
+            }
+        }
+    }
+
+    /// CIRISEdge#547 / CIRISPersist#780 — the holdings set read from persist's
+    /// content-hash index instead of re-derived from every row.
+    ///
+    /// `None` means "could not read it" and the caller MUST fall back to the row
+    /// path. That distinction is the whole safety of this function: `want` is
+    /// `remote ∖ holdings`, so an error mistaken for an empty holdings set makes
+    /// `want` mean EVERYTHING — a full re-fetch storm against every peer, from a
+    /// read that merely failed. persist made the same call on its side: its
+    /// default refuses rather than returning an empty vec, precisely so a
+    /// set-difference consumer cannot confuse the two. `Ok(vec![])` is a real
+    /// answer (the plane is genuinely empty); an `Err` never is.
+    ///
+    /// Pages on the CONTENT HASH, not a timestamp: the index has no time column,
+    /// and its PRIMARY KEY `(kind, content_hash)` makes the hash the keyset —
+    /// ordered, unique within a kind, and covered. Completeness comes from
+    /// draining to a short page, exactly as the row path does.
+    async fn holdings_from_wire_index(&self, index_kind: &str) -> Option<Vec<EnvelopeRef>> {
+        let budget = self.sweep_page_budget().await;
+        let mut refs: Vec<EnvelopeRef> = Vec::new();
+        let mut after: Option<String> = None;
+        for _page in 0..MAX_FULL_DRAIN_PAGES {
+            // CIRISEdge#531 WIDTH — one permit per PAGE, released between pages,
+            // exactly as the row drain takes it. The index read is far cheaper
+            // per page but it is still a database read, and the gate bounds
+            // CONCURRENT pressure, not bytes: without it every coordinator's
+            // holdings read hits the store unbounded, which is the convoy
+            // #547 is about arriving by a cheaper route. Caught by
+            // `a_multi_page_drain_takes_one_permit_per_page`, which saw this
+            // path return correct data while taking ZERO permits.
+            let read = {
+                let _permit = self.sweep_gate.enter().await;
+                self.directory
+                    .list_wire_hashes_since(index_kind, after.as_deref(), budget)
+                    .await
+            };
+            let page = match read {
+                Ok(p) => p,
+                Err(e) => {
+                    // Throttled, and at WARN: falling back is CORRECT but it is
+                    // also the expensive path this exists to retire, so a
+                    // deployment silently paying it should be able to see that.
+                    tracing::warn!(
+                        kind = index_kind,
+                        error = %e,
+                        "wire-hash holdings read failed — falling back to the ROW \
+                         scan (correct, but this is the O(corpus) read CIRISEdge#547 \
+                         is about). A backend predating CIRISPersist#780 reports \
+                         Unsupported here."
+                    );
+                    return None;
+                }
+            };
+            let served = page.len();
+            for hex_hash in &page {
+                let Some(h) = Self::decode_hash(hex_hash) else {
+                    // A hash the index holds but edge cannot decode would silently
+                    // shrink `holdings` and put a held row back in `want` forever
+                    // — the #416 shape. Refuse the whole read instead.
+                    tracing::warn!(
+                        kind = index_kind,
+                        hash = %hex_hash,
+                        "wire-hash index returned an undecodable content hash — \
+                         refusing the index read rather than returning a SHORT \
+                         holdings set (CIRISEdge#547)"
+                    );
+                    return None;
+                };
+                // `seq` is unread on the holdings side: `diff_refs` builds its
+                // local set from `envelope_hash` alone. Zero is not a lie here,
+                // it is the absence of a field this axis never consults.
+                refs.push(EnvelopeRef {
+                    envelope_hash: h,
+                    seq: 0,
+                });
+            }
+            if served < budget as usize {
+                return Some(refs);
+            }
+            after = page.last().cloned();
+        }
+        // Drained to the page cap without a short page. The row path has the same
+        // guard for the same reason; a truncated holdings set is worse than a slow
+        // one, so this refuses rather than returning what it has.
+        tracing::warn!(
+            kind = index_kind,
+            pages = MAX_FULL_DRAIN_PAGES,
+            "wire-hash holdings drain hit the page cap — refusing rather than \
+             returning a truncated holdings set (CIRISEdge#547)"
+        );
+        None
+    }
+
     /// CIRISEdge#531 (second half) — the projection of a row that the advertise
     /// gates actually consume.
     ///
@@ -9974,6 +10093,63 @@ mod tests {
                 "the re-derived bytes are the advertised revocation"
             );
         }
+    }
+
+    /// CIRISEdge#547 — an index read that FAILS must never look like empty
+    /// holdings.
+    ///
+    /// This is the one way the fix could be worse than the bug. `want` is
+    /// `remote ∖ holdings`; an empty holdings set means "I hold nothing", so a
+    /// failed read mistaken for an empty answer turns one bad query into a full
+    /// re-fetch of every plane from every peer — an outage caused by the code
+    /// meant to prevent one. `holdings_from_wire_index` returns `Option`
+    /// precisely so the two cannot be spelled the same way, and persist's own
+    /// default refuses rather than returning an empty vec for the same reason.
+    ///
+    /// Pinned as the type-level property, since the failure is unreachable in a
+    /// test that can only exercise the happy path against a real backend.
+    #[test]
+    fn a_failed_index_read_is_not_an_empty_holdings_set() {
+        // The contract: None ⇒ fall back to rows. Some(vec![]) ⇒ genuinely empty.
+        let failed: Option<Vec<EnvelopeRef>> = None;
+        let genuinely_empty: Option<Vec<EnvelopeRef>> = Some(Vec::new());
+        assert!(
+            failed.is_none(),
+            "a read failure must be distinguishable from an empty plane"
+        );
+        assert_ne!(
+            failed.as_ref().map(Vec::len),
+            genuinely_empty.as_ref().map(Vec::len),
+            "an error and an empty plane must not collapse to the same reading — \
+             `want = remote ∖ holdings` turns the confusion into a re-fetch storm"
+        );
+    }
+
+    /// The holdings axis reads only `envelope_hash`, so `seq: 0` on an
+    /// index-sourced ref is the absence of a field this axis never consults —
+    /// not a wrong value. If `diff_refs` ever starts reading local `seq`, this
+    /// fails and the index path needs the row path's seq back.
+    #[test]
+    fn the_holdings_diff_reads_only_the_hash() {
+        let h = [7u8; 32];
+        let from_index = EnvelopeRef {
+            envelope_hash: h,
+            seq: 0,
+        };
+        let from_rows = EnvelopeRef {
+            envelope_hash: h,
+            seq: 99,
+        };
+        let remote = vec![EnvelopeRef {
+            envelope_hash: h,
+            seq: 42,
+        }];
+        assert_eq!(
+            crate::replication::summary::diff_refs(&[from_index], &remote),
+            crate::replication::summary::diff_refs(&[from_rows], &remote),
+            "an index-sourced holdings set must produce the SAME want as a \
+             row-sourced one; if it does not, `seq` became load-bearing here"
+        );
     }
 
     /// CIRISEdge#531 (second half) — the gate view must be INDISTINGUISHABLE

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -174,6 +174,22 @@ pub trait ReplicationDirectory: Send + Sync {
         self.fetch_envelope_bytes(kind, envelope_hash).await
     }
 
+    /// CIRISEdge#544 — has this node already refused `(kind, envelope_hash)`
+    /// recently enough that the round should NOT ask for it again?
+    ///
+    /// Deliberately **synchronous**: it is an in-memory probe of the
+    /// implementation's own refusal memory, consulted once per wanted hash per
+    /// round, and routing it through the adapter's `block_on` would put a
+    /// runtime hop on the hot path of a pure map lookup. It must never do I/O.
+    ///
+    /// Defaults to `false` (ask for everything, the pre-#544 behaviour) so the
+    /// mock and any host impl need no change; the bridge overrides it with the
+    /// [`RefusalBackoff`](super::refusal_backoff::RefusalBackoff) its apply path
+    /// populates.
+    fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
+        false
+    }
+
     /// Apply one envelope to local state. The implementation verifies the signed
     /// envelope's signature + canonical-bytes hash before admitting; the merge
     /// layer in persist is the canonical anti-rollback authority. Returns an
@@ -264,6 +280,16 @@ impl StateProvider for DirectoryStateAdapter {
             tokio::runtime::Handle::current()
                 .block_on(async move { inner.list_holdings(kind).await })
         })
+    }
+
+    /// CIRISEdge#544 — forward the want-suppression question to the directory,
+    /// which is the ONE shared bridge every per-peer provider sits on. No
+    /// `block_on`: the trait method is sync precisely so this stays a map probe.
+    /// Node-wide by construction — peer A's refusal removes the row from peer
+    /// B's `want` too, which is the point (the verdict is about this node's
+    /// state, not about who carried the bytes).
+    fn retry_suppressed(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> bool {
+        self.inner.retry_suppressed(kind, envelope_hash)
     }
 
     fn fetch_envelope(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> Option<Vec<u8>> {

--- a/src/replication/mesh_config.rs
+++ b/src/replication/mesh_config.rs
@@ -12,15 +12,27 @@
 //! - **most-restrictive-across-roots** (CC 4.2.1 rule 2): where roots
 //!   disagree, the tightest value binds.
 //!
-//! Edge consumes exactly four of the registered keys (their `consumer` fields
+//! Edge consumes eight of the registered keys (their `consumer` fields
 //! in persist's closed registry name edge-side loops):
 //!
-//! | wire key                    | edge consumer                                  |
-//! |-----------------------------|------------------------------------------------|
-//! | `antientropy.round_secs`    | scheduler cadence (next round)                 |
-//! | `antientropy.page_limit`    | the bridge's since-page limit                  |
-//! | `feature.trace_replication` | pause the `trace:*` advertise/serve plane      |
-//! | `feature.av_streams`        | ALM admission toggle (`plan_parent_gated`)     |
+//! | wire key                         | edge consumer                             |
+//! |----------------------------------|-------------------------------------------|
+//! | `antientropy.round_secs`         | scheduler cadence (next round)            |
+//! | `antientropy.page_limit`         | the bridge's since-page limit             |
+//! | `feature.trace_replication`      | pause the `trace:*` advertise/serve plane |
+//! | `feature.av_streams`             | ALM admission toggle (`plan_parent_gated`)|
+//! | `redundancy.k_repair_symbols`    | `FountainPolicy::k_repair`                |
+//! | `redundancy.min_viable_symbols`  | `FountainPolicy::min_viable_symbols`      |
+//! | `redundancy.target_holders`      | swarm converger `target_holders` (`H`)    |
+//! | `redundancy.min_viable_holders`  | swarm converger `min_viable`              |
+//!
+//! The last four land on the swarm converger (CIRISEdge#546); persist v30.0.0
+//! (CIRISPersist#602) split the fused redundancy pair onto the SYMBOL and
+//! HOLDER axes precisely so each key names one edge field. Their consumer is
+//! [`crate::swarm::runtime::SwarmRuntimeConfig::with_mesh_relief`], applied on
+//! the converger tick — the swarm runtime had no setter at all before #546, so
+//! these four were `consumed: false` in CIRISServer#365's map for want of a
+//! place to put the answer, not for want of a mapping.
 //!
 //! ## Relief, not a gate — absence is EXACTLY today's behavior
 //!
@@ -82,6 +94,21 @@ pub struct MeshConfigRelief {
     /// `feature.av_streams` relieved to `0`: ALM admission
     /// (`plan_parent_gated`) refuses with a named error.
     pub av_streams_paused: bool,
+    /// CIRISEdge#546 — `redundancy.k_repair_symbols` iff relieved. The swarm
+    /// runtime takes `min(configured, relieved)` into
+    /// [`crate::holonomic::fountain_defaults::FountainPolicy::k_repair`].
+    pub k_repair_symbols: Option<u32>,
+    /// CIRISEdge#546 — `redundancy.min_viable_symbols` iff relieved →
+    /// [`crate::holonomic::fountain_defaults::FountainPolicy::min_viable_symbols`]
+    /// (the BLINKING_DOT floor), `min`'d against the configured value.
+    pub min_viable_symbols: Option<u32>,
+    /// CIRISEdge#546 — `redundancy.target_holders` iff relieved → the swarm
+    /// converger's `H`. Distinct axis from [`Self::k_repair_symbols`]: peers,
+    /// not symbols (CIRISPersist#602 split the fused pair for exactly this).
+    pub target_holders: Option<u32>,
+    /// CIRISEdge#546 — `redundancy.min_viable_holders` iff relieved → the
+    /// holder floor below which the converger emits `RepairNeeded`.
+    pub min_viable_holders: Option<u32>,
 }
 
 impl MeshConfigRelief {
@@ -91,6 +118,10 @@ impl MeshConfigRelief {
         page_limit: None,
         trace_replication_paused: false,
         av_streams_paused: false,
+        k_repair_symbols: None,
+        min_viable_symbols: None,
+        target_holders: None,
+        min_viable_holders: None,
     };
 
     /// Derive the relief snapshot from a resolved fold. Pure; the
@@ -103,14 +134,27 @@ impl MeshConfigRelief {
                 .map(|s| s.effective)
         };
         let paused = |key: MeshConfigKey| relieved(key).is_some_and(|v| v == 0);
+        // Every count-shaped key lands in a `u32` edge field; persist's domains
+        // cap at 4096, so the saturating conversion is a belt on an i64 that
+        // cannot be negative in-domain, never a live path.
+        let count =
+            |key: MeshConfigKey| relieved(key).map(|v| u32::try_from(v).unwrap_or(u32::MAX));
         Self {
             round_cadence: relieved(MeshConfigKey::AntientropyRoundSecs)
                 .and_then(|v| u64::try_from(v).ok())
                 .map(Duration::from_secs),
-            page_limit: relieved(MeshConfigKey::AntientropyPageLimit)
-                .map(|v| u32::try_from(v).unwrap_or(u32::MAX)),
+            page_limit: count(MeshConfigKey::AntientropyPageLimit),
             trace_replication_paused: paused(MeshConfigKey::FeatureTraceReplication),
             av_streams_paused: paused(MeshConfigKey::FeatureAvStreams),
+            // CIRISEdge#546 — the swarm converger's four. Read here and only
+            // here; the `min(configured, relieved)` bound that keeps a root
+            // from raising them past the operator's own ceiling lives at the
+            // consumer (`SwarmRuntimeConfig::with_mesh_relief`), mirroring
+            // `bridge::effective_page_limit`.
+            k_repair_symbols: count(MeshConfigKey::RedundancyKRepairSymbols),
+            min_viable_symbols: count(MeshConfigKey::RedundancyMinViableSymbols),
+            target_holders: count(MeshConfigKey::RedundancyTargetHolders),
+            min_viable_holders: count(MeshConfigKey::RedundancyMinViableHolders),
         }
     }
 }
@@ -247,6 +291,14 @@ impl MeshConfigReader {
                     page_limit = resolved.page_limit,
                     trace_replication_paused = resolved.trace_replication_paused,
                     av_streams_paused = resolved.av_streams_paused,
+                    // CIRISEdge#546 — the swarm four. Named here because the
+                    // change detection above is over the WHOLE snapshot: a line
+                    // that fires while showing only the #440 fields reads as a
+                    // spurious log rather than as the redundancy row it was.
+                    k_repair_symbols = resolved.k_repair_symbols,
+                    min_viable_symbols = resolved.min_viable_symbols,
+                    target_holders = resolved.target_holders,
+                    min_viable_holders = resolved.min_viable_holders,
                     "mesh-config relief snapshot changed (CIRISEdge#440)"
                 );
             }
@@ -520,6 +572,50 @@ mod tests {
         assert_eq!(relief.page_limit, Some(100));
         assert!(!relief.trace_replication_paused);
         assert!(!relief.av_streams_paused);
+    }
+
+    /// FIELD PROVENANCE, CIRISEdge#546 — the swarm converger's four keys,
+    /// admitted through persist's REAL door, each landing on its OWN relief
+    /// field. Every value is deliberately distinct so a fold that fused the
+    /// symbol and holder axes back together (the pre-CIRISPersist#602 shape)
+    /// shows up as a crossed assertion rather than as a passing test.
+    #[tokio::test]
+    async fn admitted_redundancy_rows_populate_each_swarm_field_separately() {
+        let backend = Arc::new(MemoryBackend::new());
+        seed_key(&backend, "node-local").await;
+        seed_key(&backend, "root-1").await;
+        seed_subscription(&backend, "node-local", "root-1").await;
+
+        // All four are `HigherMeansMoreFlow` against persist's `owner_default`
+        // ceilings (k_repair 20, min_viable_symbols 20, both holder keys 64),
+        // so every value below is a RELIEF and none is clamped away.
+        for (key, value) in [
+            (MeshConfigKey::RedundancyKRepairSymbols, 4),
+            (MeshConfigKey::RedundancyMinViableSymbols, 3),
+            (MeshConfigKey::RedundancyTargetHolders, 12),
+            (MeshConfigKey::RedundancyMinViableHolders, 2),
+        ] {
+            let row = mesh_row("root-1", key, value, MeshConfigForm::Emergency);
+            let outcome =
+                record_mesh_config_row(&*backend, "node-local", &baseline(), &row, Utc::now())
+                    .await
+                    .expect("admission door reachable");
+            assert!(
+                matches!(outcome, MeshConfigOutcome::Admitted),
+                "the REAL admission door must admit the fixture row (fixture rot \
+                 otherwise invalidates every downstream assertion): {outcome:?}"
+            );
+        }
+
+        let relief = reader_over(&backend).await.relief().await;
+        assert_eq!(relief.k_repair_symbols, Some(4));
+        assert_eq!(relief.min_viable_symbols, Some(3));
+        assert_eq!(relief.target_holders, Some(12));
+        assert_eq!(relief.min_viable_holders, Some(2));
+        assert_eq!(
+            relief.round_cadence, None,
+            "the #440 keys stay un-relieved — a redundancy row must not move them"
+        );
     }
 
     /// FIELD PROVENANCE, replication plane — feature pause rows arriving the

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -122,6 +122,7 @@ pub mod coordinator;
 pub mod directory;
 pub mod mesh_config;
 pub mod protocol;
+pub mod refusal_backoff;
 pub mod registry;
 pub mod resolved_state;
 pub mod runtime;
@@ -154,6 +155,9 @@ pub use protocol::{
     DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage, ReplicationMessage,
     SummaryMessage,
 };
+
+#[doc(inline)]
+pub use refusal_backoff::{RefusalBackoff, RetryDisposition};
 
 pub use registry::{RegistryError, ReplicationRegistry, RouteOutcome};
 #[doc(inline)]

--- a/src/replication/refusal_backoff.rs
+++ b/src/replication/refusal_backoff.rs
@@ -1,0 +1,463 @@
+//! CIRISEdge#544 — the retry DISPOSITION of an apply refusal, and the bounded
+//! per-row memory that acts on it.
+//!
+//! # The loop this closes
+//!
+//! Anti-entropy's re-offer is RECEIVER-PULLED, not sender-pushed: the round's
+//! `want` is `remote.refs ∖ local_holdings` ([`super::session::Session`]'s
+//! `on_summary`). A refused row is never stored, so it never enters
+//! `local_holdings`, so it is in `want` again next round — and the peer, doing
+//! exactly what it was asked, delivers the same bytes again. Every round.
+//! At the same transport cost as a healthy delivery.
+//!
+//! For a refusal that CAN clear on its own that IS the convergence mechanism and
+//! it is correct — [`super::bridge::ApplyRefusalClass::is_transient`] documents
+//! it as "convergence by construction, not by a retry queue". For one that
+//! cannot, it is a permanent uniform-rate burn. #544 measured it on the CIRIS
+//! canonical: ONE `Key` row refused `conflicting_version`, re-offered **55× in
+//! 30 minutes**, the same content hash every time — so byte-identical, so
+//! refused on attempt 56 for the reason it was refused on attempt 1.
+//!
+//! # What this module does, and what it deliberately does NOT do
+//!
+//! It suppresses the **ask**, never the **admit**. A suppressed hash is dropped
+//! from `want`; an unsolicited Deliver carrying it (the #927 proactive push) is
+//! still applied on its merits. Nothing here can withhold a row from local
+//! state — the failure mode of an over-eager suppression is a re-offer that
+//! arrives a few minutes later, never a row silently dropped.
+//!
+//! It is keyed on the **content hash**, which is what makes the issue's "the
+//! sender needs some way forward other than retrying" work by construction: a
+//! corrected, SUPERSEDING record is different bytes, so a different hash, so it
+//! is never suppressed. Only the exact bytes that lost are throttled.
+//!
+//! It is never permanent. A terminal entry decays to a long window, not to
+//! silence: the node re-asks on a schedule that shrinks the 55/30min to ~1/30min
+//! and then to a handful a day, so a verdict that DOES move (an operator prunes
+//! the conflicting row; a code upgrade fixes a wire skew — the latter restarts
+//! the process and empties this map anyway) still converges without an operator
+//! knowing this memory exists.
+//!
+//! # Bounded, because the key is peer-influenced
+//!
+//! The map key contains a content hash a peer chooses by choosing what to offer.
+//! An unbounded map would relocate the exhaustion vector into the mitigation —
+//! the [`crate::log_throttle`] lesson. Same cure: a front-drop cap
+//! ([`DEFAULT_MAX_KEYS`]). Evicting an entry only costs one re-ask.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use super::protocol::EnvelopeKind;
+
+/// A refusal's answer to the only question the retry loop actually has:
+/// **should this node ask for THESE EXACT BYTES again?**
+///
+/// Orthogonal to *why* the row was refused — persist's
+/// [`kind()`](ciris_persist::federation::Error::kind), the Key plane's
+/// [`KeyRefusalReason`](ciris_persist::federation::register::KeyRefusalReason)
+/// token, and edge's [`ApplyRefusalClass`](super::bridge::ApplyRefusalClass)
+/// all answer *which gate*. This answers *what the transport does next*, and
+/// the two axes do not collapse: `federation_write_scope_refused` is one
+/// `kind()` with both dispositions in it depending on whether the roster has
+/// landed yet, which is exactly why #522 introduced a second axis rather than
+/// re-reading the first.
+///
+/// # Getting it wrong, in both directions
+///
+/// A **permanent** refusal labelled `Transient` asserts a convergence that never
+/// arrives: it keeps the row in `want` forever and spins the #531 advertise
+/// re-sweep against bytes that can never land. That is the #544 bug.
+///
+/// A **recoverable** refusal labelled `Terminal` silently drops work that would
+/// have converged. That one is worse — the first burns transport visibly, the
+/// second withholds state invisibly — so where a persist token collapses a
+/// recoverable arm and an unrecoverable one into the SAME value (`re_scrub`,
+/// `unverifiable_signature`), the call is `Transient`, and the backoff is what
+/// makes that safe to say.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RetryDisposition {
+    /// The verdict was decided by state that is still MOVING — a roster that
+    /// has not landed, a signer key that has not replicated, a lost write race.
+    /// Re-asking is the convergence mechanism; it only needs a rate.
+    Transient,
+    /// The verdict is a function of state replication cannot move. Re-asking
+    /// yields the identical answer, so the only outcomes are "succeeds
+    /// eventually" (impossible) and "burns transport forever".
+    Terminal,
+}
+
+impl RetryDisposition {
+    /// The stable, low-cardinality token for logs and any future ledger key.
+    /// Consumers key on THIS, never on message prose (the #433/#565 rule this
+    /// crate already enforces on the two refusal-reason axes).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Transient => "transient",
+            Self::Terminal => "terminal",
+        }
+    }
+
+    /// `true` iff re-offering the identical bytes cannot change the verdict.
+    #[must_use]
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Terminal)
+    }
+
+    /// The suppression window to install after `attempts` consecutive refusals
+    /// of the same bytes: the disposition's base, doubled per attempt, clamped
+    /// to its cap. `attempts` is 1-based (the window after the FIRST refusal is
+    /// the base).
+    ///
+    /// Doubling rather than a flat window because the two failure shapes want
+    /// opposite things from the first few minutes: a roster-ordering refusal
+    /// usually clears in the first round or two and should not pay a long
+    /// penalty for it, while a row that has been refused eleven times has
+    /// earned the cap.
+    #[must_use]
+    pub fn window(self, attempts: u32) -> Duration {
+        let (base, cap) = match self {
+            Self::Transient => (TRANSIENT_BASE, TRANSIENT_CAP),
+            Self::Terminal => (TERMINAL_BASE, TERMINAL_CAP),
+        };
+        // Shift capped well below 64 so the `<<` cannot overflow; the `min(cap)`
+        // below makes anything past a handful of doublings equivalent anyway.
+        let shift = attempts.saturating_sub(1).min(16);
+        let secs = base.as_secs().saturating_mul(1u64 << shift);
+        Duration::from_secs(secs).min(cap)
+    }
+}
+
+/// First transient window — two anti-entropy rounds at the 30 s default cadence
+/// (`antientropy.round_secs`, `mesh_config`). A roster-ordering refusal that
+/// clears immediately therefore costs at most one skipped round, which is the
+/// price of not asking 120 times an hour for something the node already knows
+/// it cannot admit yet.
+pub const TRANSIENT_BASE: Duration = Duration::from_secs(60);
+/// Transient ceiling. Deliberately SHORT: the transient classes converge on
+/// state that is actively replicating, and worst-case added convergence latency
+/// is this value. 5 minutes turns the flat-out 120 asks/hour into at most 12
+/// while keeping a stalled cohort roster's recovery inside a coffee break.
+pub const TRANSIENT_CAP: Duration = Duration::from_secs(300);
+/// First terminal window. On the #544 measurement this alone is the fix: 55
+/// re-offers in 30 minutes becomes 1.
+pub const TERMINAL_BASE: Duration = Duration::from_secs(1800);
+/// Terminal ceiling — the "never permanently dark" bound. A row whose verdict
+/// genuinely moves (the conflicting local row is pruned) is re-asked within 6
+/// hours with no operator action and no knowledge that this memory exists.
+pub const TERMINAL_CAP: Duration = Duration::from_secs(21_600);
+/// Front-drop cap on the memory. Sized like [`crate::log_throttle`]'s key cap
+/// and leviculum's live-link ring: large enough that a real mesh's genuinely
+/// stuck rows all fit, small enough that a peer cycling junk hashes cannot
+/// grow it without bound. Eviction costs exactly one re-ask.
+pub const DEFAULT_MAX_KEYS: usize = 4096;
+
+/// `(plane, content hash)` — the same identity the wire uses. `EnvelopeKind` is
+/// part of the key because the hash spaces are per-plane and a refusal is a
+/// verdict about a row on a plane, never about 32 bytes in the abstract.
+type RowKey = (EnvelopeKind, [u8; 32]);
+
+struct Entry {
+    /// Consecutive refusals of these bytes. Drives the doubling; reset only by
+    /// [`RefusalBackoff::clear`] (an admit) or eviction.
+    attempts: u32,
+    /// The MOST RECENT verdict. A row can change disposition — a signer key
+    /// lands and `unverifiable_signature` becomes `conflicting_version` — and
+    /// the latest reading is the one that should govern the next window.
+    disposition: RetryDisposition,
+    /// When this node may ask for these bytes again.
+    retry_at: Instant,
+}
+
+struct State {
+    entries: HashMap<RowKey, Entry>,
+    /// Eviction order; front is oldest. Capped at `max_keys`.
+    order: VecDeque<RowKey>,
+}
+
+/// The node-wide refusal memory.
+///
+/// **Node-wide, not per-peer, on purpose.** A refusal is a verdict about THIS
+/// NODE'S state versus a row; which peer happened to carry the bytes is not part
+/// of it. A per-session memory would learn the same verdict once per peer and
+/// re-burn the round for every peer that offers the row — precisely the
+/// amplification #544 is about. One instance lives on the shared
+/// [`FederationDirectoryReplicationBridge`](super::bridge::FederationDirectoryReplicationBridge),
+/// which every per-peer provider and the one shared applier already sit on top
+/// of, so the first refusal teaches every peer's next round.
+///
+/// In-memory and process-lifetime by design: a restart is the one event that
+/// can change a verdict this module calls terminal without any row moving (a
+/// new build parses bytes the old one could not; an operator wires the
+/// operational providers that were absent), so forgetting on restart is correct
+/// rather than a limitation.
+pub struct RefusalBackoff {
+    state: Mutex<State>,
+    max_keys: usize,
+}
+
+impl Default for RefusalBackoff {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RefusalBackoff {
+    /// A memory capped at [`DEFAULT_MAX_KEYS`].
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_MAX_KEYS)
+    }
+
+    /// A memory capped at `max_keys` front-drop entries (tests; a host with an
+    /// unusually wide stuck set).
+    #[must_use]
+    pub fn with_capacity(max_keys: usize) -> Self {
+        Self {
+            state: Mutex::new(State {
+                entries: HashMap::new(),
+                order: VecDeque::new(),
+            }),
+            max_keys: max_keys.max(1),
+        }
+    }
+
+    /// Book one refusal of `(kind, envelope_hash)` and install the resulting
+    /// suppression window. Returns the window, so the caller can say how long
+    /// it will be quiet in the same line that says what was refused.
+    ///
+    /// `now` is passed in rather than read here so the whole schedule is
+    /// testable without sleeping.
+    pub fn record_at(
+        &self,
+        kind: EnvelopeKind,
+        envelope_hash: [u8; 32],
+        disposition: RetryDisposition,
+        now: Instant,
+    ) -> Duration {
+        let key = (kind, envelope_hash);
+        let mut st = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+        if let Some(e) = st.entries.get_mut(&key) {
+            e.attempts = e.attempts.saturating_add(1);
+            e.disposition = disposition;
+            let window = disposition.window(e.attempts);
+            e.retry_at = now + window;
+            return window;
+        }
+
+        // New key — evict oldest first if at capacity (front-drop, matching
+        // `LogThrottle`), so a peer cycling hashes cannot grow this unbounded.
+        if st.order.len() >= self.max_keys {
+            if let Some(evict) = st.order.pop_front() {
+                st.entries.remove(&evict);
+            }
+        }
+        let window = disposition.window(1);
+        st.entries.insert(
+            key,
+            Entry {
+                attempts: 1,
+                disposition,
+                retry_at: now + window,
+            },
+        );
+        st.order.push_back(key);
+        window
+    }
+
+    /// Should the round's `want` DROP `(kind, envelope_hash)` at `now`?
+    ///
+    /// Fail-open in every uncertain direction: an unknown row, an expired
+    /// window, or an evicted entry all answer `false` (ask for it). The only
+    /// `true` is "this node refused these exact bytes and the window it earned
+    /// has not elapsed".
+    #[must_use]
+    pub fn suppressed_at(
+        &self,
+        kind: EnvelopeKind,
+        envelope_hash: &[u8; 32],
+        now: Instant,
+    ) -> bool {
+        let st = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        st.entries
+            .get(&(kind, *envelope_hash))
+            .is_some_and(|e| now < e.retry_at)
+    }
+
+    /// Forget `(kind, envelope_hash)` — the row landed (or was already held), so
+    /// the refusal history that produced the backoff is obsolete. Called on
+    /// every non-refusing apply outcome so a row that recovers does not carry a
+    /// stale attempt count into a future refusal of the same bytes.
+    pub fn clear(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) {
+        let key = (kind, *envelope_hash);
+        let mut st = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if st.entries.remove(&key).is_some() {
+            st.order.retain(|k| *k != key);
+        }
+    }
+
+    /// How many rows are currently remembered. The memory's own witness — a
+    /// bound nobody can observe is the kind that silently stops holding.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .entries
+            .len()
+    }
+
+    /// `true` iff nothing is remembered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(seed: u8) -> [u8; 32] {
+        let mut h = [0u8; 32];
+        h[0] = seed;
+        h
+    }
+
+    /// The #544 measurement, in miniature: the FIRST terminal refusal already
+    /// takes the row out of `want` for half an hour, so the 55-per-30-minutes
+    /// re-offer becomes one.
+    #[test]
+    fn a_terminal_refusal_suppresses_the_row_for_the_whole_first_window() {
+        let b = RefusalBackoff::new();
+        let t0 = Instant::now();
+        let window = b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Terminal, t0);
+        assert_eq!(window, TERMINAL_BASE);
+        // Every 30 s round inside the window is a round that does not ask.
+        for round in 1..=55 {
+            let t = t0 + Duration::from_secs(30 * round);
+            if t < t0 + TERMINAL_BASE {
+                assert!(
+                    b.suppressed_at(EnvelopeKind::Key, &hash(1), t),
+                    "round {round} must not re-ask for a terminally refused row"
+                );
+            }
+        }
+    }
+
+    /// Never permanently dark: the window expires and the node asks again.
+    #[test]
+    fn a_terminal_suppression_expires_so_a_verdict_that_moves_still_converges() {
+        let b = RefusalBackoff::new();
+        let t0 = Instant::now();
+        b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Terminal, t0);
+        assert!(!b.suppressed_at(EnvelopeKind::Key, &hash(1), t0 + TERMINAL_BASE));
+    }
+
+    /// The suppression is per-(plane, content hash): the SUPERSEDING record the
+    /// issue says a stuck sender needs is different bytes, so a different hash,
+    /// so it is never held back by its predecessor's verdict.
+    #[test]
+    fn a_different_content_hash_is_never_suppressed_by_its_predecessors_refusal() {
+        let b = RefusalBackoff::new();
+        let t0 = Instant::now();
+        b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Terminal, t0);
+        assert!(!b.suppressed_at(EnvelopeKind::Key, &hash(2), t0));
+        // …and the same hash on a DIFFERENT plane is a different row.
+        assert!(!b.suppressed_at(EnvelopeKind::Attestation, &hash(1), t0));
+    }
+
+    #[test]
+    fn the_window_doubles_per_consecutive_refusal_and_stops_at_the_cap() {
+        let b = RefusalBackoff::new();
+        let mut t = Instant::now();
+        let mut windows = Vec::new();
+        for _ in 0..8 {
+            let w = b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Transient, t);
+            windows.push(w);
+            t += w;
+        }
+        assert_eq!(
+            &windows[..3],
+            &[TRANSIENT_BASE, TRANSIENT_BASE * 2, TRANSIENT_BASE * 4][..],
+            "consecutive refusals double the window: {windows:?}"
+        );
+        assert!(
+            windows.iter().all(|w| *w <= TRANSIENT_CAP),
+            "no window may exceed the cap: {windows:?}"
+        );
+        assert_eq!(
+            *windows.last().expect("8 windows"),
+            TRANSIENT_CAP,
+            "the schedule settles AT the cap, it does not keep growing"
+        );
+    }
+
+    /// A transient refusal costs at most one skipped round before its first
+    /// re-ask, and never more than the (short) transient cap — the property
+    /// that makes it safe to classify an ambiguous persist token transient.
+    #[test]
+    fn the_transient_schedule_stays_inside_the_short_cap() {
+        assert_eq!(RetryDisposition::Transient.window(1), TRANSIENT_BASE);
+        assert_eq!(RetryDisposition::Transient.window(99), TRANSIENT_CAP);
+        assert!(
+            TRANSIENT_CAP < TERMINAL_BASE,
+            "a transient row is re-asked long before a terminal one"
+        );
+    }
+
+    #[test]
+    fn an_admitted_row_forgets_its_refusal_history() {
+        let b = RefusalBackoff::new();
+        let t0 = Instant::now();
+        b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Transient, t0);
+        b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Transient, t0);
+        b.clear(EnvelopeKind::Key, &hash(1));
+        assert!(b.is_empty(), "clear drops the entry, not just the deadline");
+        assert!(!b.suppressed_at(EnvelopeKind::Key, &hash(1), t0));
+        // …and the attempt count went with it: the next refusal starts at base.
+        assert_eq!(
+            b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Transient, t0),
+            TRANSIENT_BASE
+        );
+    }
+
+    /// The key contains a peer-chosen content hash, so the map must not be a
+    /// memory-exhaustion vector of its own.
+    #[test]
+    fn the_memory_is_capacity_bounded_and_front_drops_the_oldest_row() {
+        let b = RefusalBackoff::with_capacity(4);
+        let t0 = Instant::now();
+        for i in 0..64u8 {
+            b.record_at(EnvelopeKind::Key, hash(i), RetryDisposition::Terminal, t0);
+        }
+        assert_eq!(b.len(), 4, "the cap holds under hash churn");
+        // The oldest was evicted — which costs exactly one re-ask, never a
+        // wrong answer.
+        assert!(!b.suppressed_at(EnvelopeKind::Key, &hash(0), t0));
+        assert!(b.suppressed_at(EnvelopeKind::Key, &hash(63), t0));
+    }
+
+    /// A row whose verdict changes class carries its attempt count but adopts
+    /// the NEW disposition's schedule.
+    #[test]
+    fn a_re_classified_row_adopts_the_latest_verdicts_schedule() {
+        let b = RefusalBackoff::new();
+        let t0 = Instant::now();
+        b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Transient, t0);
+        let w = b.record_at(EnvelopeKind::Key, hash(1), RetryDisposition::Terminal, t0);
+        assert_eq!(w, RetryDisposition::Terminal.window(2));
+    }
+}

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -149,6 +149,15 @@ pub struct Session {
     /// The long-lived session preserves this across the Diff →
     /// Deliver phase boundary, so [`Self::on_deliver`] computes
     /// `BoundedBy { missing }` / `InSync` instead of `Unknown`.
+    ///
+    /// CIRISEdge#544 — this counts what we ASKED FOR, which is now the wanted
+    /// set MINUS the hashes this node has already refused. That is deliberate,
+    /// and it makes the signal more honest rather than less: a terminally
+    /// refused row is not an envelope still in flight, it is one this node
+    /// declined, and counting it kept a single junk row reporting
+    /// `BoundedBy { missing: 1 }` forever — permanently degrading every consumer
+    /// that conditions τ_partial on this signal, over a row that was never going
+    /// to arrive. The refusal itself stays loud at the apply choke.
     diff_want_count: Option<usize>,
     /// Whether the round has completed from this side's view.
     completed: bool,
@@ -480,7 +489,32 @@ impl Session {
         // so `want` became "everything" or the round went dark. `local_holdings`
         // is the node's peer-blind own-state; the offer + delivery stay send-gated.
         let local = provider.local_holdings(self.kind);
-        let want = diff_refs(&local, &remote.refs);
+        let mut want = diff_refs(&local, &remote.refs);
+        // CIRISEdge#544 — the re-offer loop is RECEIVER-PULLED, and this is where
+        // the pull is decided. `want` is memoryless: a refused row is never
+        // stored, so it is absent from `local_holdings`, so it comes straight
+        // back into `want` next round and the peer — doing exactly what we asked
+        // — delivers the identical bytes again. Measured on the canonical: one
+        // `conflicting_version` Key row, 55 re-offers in 30 minutes, same content
+        // hash every time. Dropping the hashes the applier has already refused,
+        // for the window its disposition earned, is the whole fix; the sender
+        // needs to be told nothing, because it was never the one choosing.
+        let before = want.len();
+        want.retain(|h| !provider.retry_suppressed(self.kind, h));
+        let suppressed = before - want.len();
+        if suppressed > 0 {
+            // DEBUG, not WARN: the suppression is the CURE, and the refusal that
+            // caused it already logged loud at the apply choke with its reason
+            // and disposition. A WARN here would re-flood the log this exists to
+            // quiet down.
+            tracing::debug!(
+                kind = ?self.kind,
+                suppressed,
+                still_wanted = want.len(),
+                "want: dropped hashes this node already refused — backing off \
+                 instead of re-asking every round (CIRISEdge#544)"
+            );
+        }
         let mut outbound = Vec::new();
         // Responder ALSO needs to send its Summary so the
         // initiator's side of the round can progress. We include it
@@ -692,11 +726,16 @@ impl Session {
                     );
                 }
                 // A gate REFUSED a well-formed envelope — the darkens-carriage class.
-                ApplyOutcome::Refused(reason) => {
+                // CIRISEdge#544 — the line now carries the RETRY disposition, so a
+                // reader can tell "this converges once more state lands" from "this
+                // will be refused identically forever" without knowing which persist
+                // token maps to which. It is a stable token, never prose.
+                ApplyOutcome::Refused { reason, retry } => {
                     refused += 1;
                     tracing::warn!(
                         kind = ?self.kind,
                         reason = %reason,
+                        retry = retry.as_str(),
                         "delivered envelope REFUSED — not applied (CIRISEdge#425 apply choke point)"
                     );
                 }
@@ -705,6 +744,11 @@ impl Session {
                     tracing::warn!(
                         kind = ?self.kind,
                         error = %err,
+                        // Terminal by nature: the wire identity is the content hash,
+                        // so re-fetching it returns bytes that fail to parse the same
+                        // way (CIRISEdge#544).
+                        retry = crate::replication::refusal_backoff::RetryDisposition::Terminal
+                            .as_str(),
                         "delivered envelope failed to DESERIALIZE — dropped, not applied \
                          (CIRISEdge#425 apply choke point)"
                     );
@@ -1669,6 +1713,88 @@ mod tests {
                 assert_eq!(refused, 3, "every refused envelope is counted, not dropped");
             }
             o => panic!("expected Applied, got {o:?}"),
+        }
+    }
+
+    /// CIRISEdge#544 — the re-offer loop is RECEIVER-PULLED, and this is the
+    /// pull. A peer advertises two rows the node lacks; the node has already
+    /// refused one of them, so its Diff asks for the OTHER one only. Nothing is
+    /// sent to the peer to make this happen — the sender was never the one
+    /// choosing, which is why the fix needs no wire change.
+    #[test]
+    fn the_rounds_want_omits_hashes_this_node_has_already_refused() {
+        /// A provider holding nothing, that has refused exactly `refused`.
+        struct SuppressingProvider {
+            refused: [u8; 32],
+        }
+        impl StateProvider for SuppressingProvider {
+            fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+            fn retry_suppressed(&self, _kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> bool {
+                *envelope_hash == self.refused
+            }
+        }
+
+        let provider = SuppressingProvider { refused: h(1) };
+        let mut session = Session::new(SessionRole::Responder, EnvelopeKind::Key);
+        // The peer advertises BOTH rows — including the one we cannot admit. It
+        // has no way to know, and does not need one.
+        let remote = SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![
+                EnvelopeRef {
+                    envelope_hash: h(1),
+                    seq: 1,
+                },
+                EnvelopeRef {
+                    envelope_hash: h(2),
+                    seq: 2,
+                },
+            ],
+        };
+        let ReplicationOutcome::Send(msgs) = session.on_message(
+            ReplicationMessage::Summary(remote),
+            &provider,
+            &NoApply,
+            None,
+        ) else {
+            panic!("a Summary must produce Summary+Diff");
+        };
+        let diff = msgs
+            .iter()
+            .find_map(|m| match m {
+                ReplicationMessage::Diff(d) => Some(d),
+                _ => None,
+            })
+            .expect("the responder answers with a Diff");
+        assert_eq!(
+            diff.want,
+            vec![h(2)],
+            "the refused hash must not be re-requested; without this the row is \
+             in `want` every round forever (55 re-offers in 30 min, CIRISEdge#544)"
+        );
+        assert_eq!(
+            session.diff_want_count,
+            Some(1),
+            "staleness must be computed from what we ACTUALLY asked for, or a \
+             suppressed row reads as permanently-missing progress"
+        );
+    }
+
+    /// An applier for want-side tests, which never see a Deliver.
+    struct NoApply;
+    impl StateApplier for NoApply {
+        fn apply_envelope(
+            &self,
+            _k: EnvelopeKind,
+            _b: &[u8],
+            _source_peer: Option<&str>,
+        ) -> ApplyOutcome {
+            ApplyOutcome::refused("no envelope should reach this applier")
         }
     }
 

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -17,6 +17,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use super::protocol::{EnvelopeKind, EnvelopeRef};
+use super::refusal_backoff::RetryDisposition;
 
 /// Snapshot of the envelopes a peer holds locally per
 /// [`EnvelopeKind`]. The state machine consumes this to build
@@ -104,6 +105,30 @@ pub trait StateProvider: Send + Sync {
         self.local_refs(kind)
     }
 
+    /// CIRISEdge#544 — should the round's `want` DROP this hash?
+    ///
+    /// The receive axis' third question, after "what do I offer" and "what do I
+    /// hold": *what have I already refused?* `want = remote ∖ holdings` is
+    /// otherwise memoryless, so a row a gate will never admit is re-requested
+    /// every round at the same cost as a healthy one — the #544 measurement was
+    /// 55 re-offers of one `conflicting_version` `Key` row in 30 minutes.
+    ///
+    /// This gates the ASK ONLY. A peer that pushes the row unsolicited is still
+    /// applied on its merits ([`StateApplier::apply_envelope`] never consults
+    /// this), so an over-eager `true` can delay a row but can never withhold
+    /// one. Implementations MUST decay: a permanently-`true` answer is a plane
+    /// going quietly dark, which is the failure this crate spends #423/#425/#433
+    /// refusing to allow.
+    ///
+    /// Defaults to `false` — every provider without a refusal memory (the test
+    /// providers, the DST store) keeps the pre-#544 ask-every-round behaviour.
+    /// The production `DirectoryStateAdapter` forwards to the ONE shared bridge,
+    /// so the verdict is node-wide: the first peer's refusal teaches every
+    /// peer's next round.
+    fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
+        false
+    }
+
     /// Return the byte-exact signed envelope for the given content
     /// hash, or `None` if the envelope isn't in local state. Called
     /// during the Deliver-message construction step.
@@ -184,7 +209,21 @@ pub enum ApplyOutcome {
     /// `Error::kind()`, a missing operational provider, a downgrade/ambiguous-owner
     /// rejection, … This is the class that DARKENS carriage: `on_deliver` logs it
     /// at WARN with `reason` (a short, stable, low-cardinality label). NEVER silent.
-    Refused(String),
+    ///
+    /// CIRISEdge#544 — `retry` is a SECOND required field, for the same structural
+    /// reason `reason` is one: #425 made "why" unforgettable by making it
+    /// impossible to construct a refusal without it, and "does re-asking help?"
+    /// was the next thing every apply branch was silently answering `yes` to.
+    /// The receiver's `want` is `remote ∖ holdings` and a refused row is never
+    /// stored, so EVERY refusal re-pulled its own bytes next round, forever —
+    /// one `conflicting_version` row measured at 55 re-offers in 30 minutes.
+    /// A new apply branch must now state the disposition; it cannot default into
+    /// the spin. [`RetryDisposition`] documents both directions of getting it
+    /// wrong.
+    Refused {
+        reason: String,
+        retry: RetryDisposition,
+    },
     /// The delivered bytes failed to deserialize into the plane's record type — a
     /// producer/consumer wire-shape skew, not absence of work. WARN with the error.
     Deserialize(String),
@@ -198,9 +237,51 @@ impl ApplyOutcome {
         matches!(self, ApplyOutcome::Admitted)
     }
 
-    /// A `Refused` with a borrowed-then-owned reason — ergonomic constructor.
+    /// A `Refused` whose verdict is decided by state still in motion — the
+    /// CONSERVATIVE constructor, and the right default for any refusal whose
+    /// underlying token collapses a recoverable arm together with an
+    /// unrecoverable one. Re-asking is bounded by
+    /// [`RetryDisposition::Transient`]'s short backoff, so calling a genuinely
+    /// terminal refusal transient costs a trickle; calling a recoverable one
+    /// terminal would withhold state. Reach for
+    /// [`Self::refused_terminal`] only when re-offering the IDENTICAL bytes
+    /// cannot change the answer.
     pub fn refused(reason: impl Into<String>) -> Self {
-        ApplyOutcome::Refused(reason.into())
+        ApplyOutcome::Refused {
+            reason: reason.into(),
+            retry: RetryDisposition::Transient,
+        }
+    }
+
+    /// CIRISEdge#544 — a `Refused` that re-offering the identical bytes cannot
+    /// move: a first-seen-wins conflict, a row this build cannot understand, a
+    /// plane this node opted out of admitting. The receiver stops ASKING for
+    /// these bytes for a long (never infinite) window; it never stops accepting
+    /// them if a peer pushes them anyway, and a corrected SUPERSEDING record is
+    /// different bytes — a different content hash — so it is unaffected.
+    pub fn refused_terminal(reason: impl Into<String>) -> Self {
+        ApplyOutcome::Refused {
+            reason: reason.into(),
+            retry: RetryDisposition::Terminal,
+        }
+    }
+
+    /// CIRISEdge#544 — what this outcome says about ASKING for the same bytes
+    /// again, or `None` when the question does not arise (the row is now held,
+    /// so it leaves `want` on its own).
+    ///
+    /// `Deserialize` is [`RetryDisposition::Terminal`] by nature and not by a
+    /// stored field: the wire identity IS the content hash, so re-fetching that
+    /// hash returns the same bytes and the same parse failure. The one event
+    /// that changes the answer — a build that understands the shape — restarts
+    /// the process, which empties the memory anyway.
+    #[must_use]
+    pub fn retry_disposition(&self) -> Option<RetryDisposition> {
+        match self {
+            ApplyOutcome::Admitted | ApplyOutcome::Duplicate => None,
+            ApplyOutcome::Refused { retry, .. } => Some(*retry),
+            ApplyOutcome::Deserialize(_) => Some(RetryDisposition::Terminal),
+        }
     }
 }
 

--- a/src/swarm/runtime.rs
+++ b/src/swarm/runtime.rs
@@ -222,11 +222,12 @@ impl Default for SwarmRuntimeConfig {
 /// node actually runs. A row moving 64 → 40 is a relief up there and an
 /// expansion down here; the `min` is what makes it a no-op instead.
 const fn shrink_to(configured: u32, relieved: Option<u32>) -> u32 {
+    // `Ord::min` is not const; the branch is. `None` and a relief that does not
+    // shrink are the same answer — the operator's value stands — so they share
+    // one arm rather than two identical ones.
     match relieved {
-        None => configured,
-        // `Ord::min` is not const; the branch is.
         Some(r) if r < configured => r,
-        Some(_) => configured,
+        _ => configured,
     }
 }
 

--- a/src/swarm/runtime.rs
+++ b/src/swarm/runtime.rs
@@ -53,6 +53,44 @@
 //! per-peer mutation surface to expose. Hot-changing the cohort
 //! membership is the replication runtime's job; the swarm runtime
 //! follows.
+//!
+//! ## CIRISEdge#546 — the config plane governs a RUNNING swarm
+//!
+//! Until #546 the *configuration* was equally frozen, and for no such
+//! reason: [`FountainSwarmRuntime::start`] took [`SwarmRuntimeConfig`] by
+//! value and copied each field into the spawned tasks, so the only moment
+//! a value could ever be applied was composition. That is what kept
+//! CIRISServer#365's four redundancy keys at `consumed: false` — a
+//! boot-only consumer is strictly WORSE than none on a TTL-evaluated
+//! plane, because a relief whose TTL expires keeps applying until a
+//! restart nobody performs (the eternal 72-hour emergency).
+//!
+//! Two seams close it, and they meet in one place on purpose:
+//!
+//! 1. **The operator's ceiling** is a [`watch`] channel.
+//!    [`FountainSwarmRuntime::set_config`] replaces it; publisher and
+//!    converger re-read it every tick, so an operator change is live
+//!    without a restart.
+//! 2. **The mesh-config plane's relief** is
+//!    [`crate::replication::mesh_config::MeshConfigReader`], resolved on
+//!    the converger tick (a cached read inside the reader's TTL) and
+//!    folded onto the ceiling by
+//!    [`SwarmRuntimeConfig::with_mesh_relief`].
+//!
+//! Because the relief is re-resolved every tick rather than latched,
+//! *"the emergency expired"* and *"the operator changed it"* are the SAME
+//! code path — the fold simply stops reporting the key and `min` walks
+//! the value back to the ceiling. Which is what the issue asked for in
+//! its option 2, expressed in the seam edge already uses everywhere else
+//! (`relief()` at the round/tick boundary) rather than a second one.
+//!
+//! **Relief can only SHRINK.** Every knob is `min(configured, relieved)`,
+//! the discipline [`crate::replication::bridge`]'s `effective_page_limit`
+//! sets: persist's fold already enforces relieve-never-expand against ITS
+//! baseline, but that baseline is persist's `owner_default` ceiling (64
+//! holders), not this node's configured 30 — so a row relieving 64 → 40
+//! is a genuine relief upstream and would still be an EXPANSION here. The
+//! `min` at the consumer is what makes that impossible.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -75,6 +113,7 @@ use crate::holonomic::swarm_rarity::{
 };
 use crate::identity::{build_envelope, sign_envelope, LocalSigner};
 use crate::messages::MessageType;
+use crate::replication::mesh_config::{MeshConfigReader, MeshConfigRelief};
 use crate::transport::Transport;
 
 /// `target_holders` default — the recommended `H` from §R-policy
@@ -126,7 +165,15 @@ pub struct ObservedClaim {
 
 /// Configuration for the swarm orchestration runtime. All fields are
 /// tunable per deployment; defaults match the v3.10.0 §R-policy.
-#[derive(Debug, Clone)]
+///
+/// CIRISEdge#546 — this is the OPERATOR'S CEILING, not necessarily what a
+/// tick runs: [`FountainSwarmRuntime::set_config`] replaces it live, and
+/// [`Self::with_mesh_relief`] narrows it (never widens it) by whatever the
+/// mesh-config plane is currently asking for. `PartialEq` is derived
+/// because the converger compares consecutive *effective* configs to decide
+/// whether a change is worth an INFO line — the comparison must cover every
+/// field, so deriving it is safer than hand-listing the ones we remembered.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SwarmRuntimeConfig {
     /// How often the publisher walks the operator's held content
     /// and broadcasts a [`FountainHoldingClaim`] per content.
@@ -161,6 +208,74 @@ impl Default for SwarmRuntimeConfig {
             observed_claim_ttl: DEFAULT_OBSERVED_CLAIM_TTL,
             policy: recommended_policy(),
         }
+    }
+}
+
+/// CIRISEdge#546 — the one arithmetic the whole relief seam rests on:
+/// **a relief may shrink a bound and may never raise it.**
+///
+/// `None` (no root spoke, or the row's TTL expired since the last read) is
+/// the configured value untouched — absence is not a value. A `Some` is
+/// `min`'d against the configured value rather than replacing it, because
+/// persist's relieve-never-expand holds against persist's OWN baseline
+/// (`owner_default`, e.g. 64 holders), which is a ceiling above what this
+/// node actually runs. A row moving 64 → 40 is a relief up there and an
+/// expansion down here; the `min` is what makes it a no-op instead.
+const fn shrink_to(configured: u32, relieved: Option<u32>) -> u32 {
+    match relieved {
+        None => configured,
+        // `Ord::min` is not const; the branch is.
+        Some(r) if r < configured => r,
+        Some(_) => configured,
+    }
+}
+
+impl SwarmRuntimeConfig {
+    /// CIRISEdge#546 — this configuration narrowed by one mesh-config relief
+    /// snapshot: the config a converger tick actually runs under.
+    ///
+    /// Pure and total, so it is unit-testable against the exact
+    /// [`MeshConfigRelief`] the reader produces rather than against a
+    /// convenient stand-in. [`MeshConfigRelief::NONE`] — what an empty
+    /// plane, an unresolvable plane, and an EXPIRED emergency row all
+    /// resolve to — returns `self` field-for-field, which is why expiry
+    /// needs no code path of its own.
+    ///
+    /// Only the four `redundancy.*` keys land here. `publish_cadence` /
+    /// `observe_cadence` / `observed_claim_ttl` / `eviction_grace_pct` have
+    /// no registered key (`antientropy.round_secs` is the REPLICATION
+    /// scheduler's cadence, a different loop — routing it here would be a
+    /// second consumer for one key), so they move only by
+    /// [`FountainSwarmRuntime::set_config`].
+    ///
+    /// A relief may take `policy` outside the §R-policy relations the
+    /// `const _: () = assert!(…)` block in
+    /// [`crate::holonomic::fountain_defaults`] locks. That is deliberate and
+    /// not a violation: those asserts bind the recommended DEFAULTS at
+    /// compile time, while a root relieving `k_repair` to 2 is asking this
+    /// node to hold less — the whole point of a restrict-only plane. The
+    /// survival floor degrades exactly as the root asked it to.
+    #[must_use]
+    pub fn with_mesh_relief(&self, relief: &MeshConfigRelief) -> Self {
+        let mut out = self.clone();
+        out.target_holders = shrink_to(self.target_holders, relief.target_holders);
+        out.min_viable = shrink_to(self.min_viable, relief.min_viable_holders);
+        // `policy.target_holders` — NOT a duplicate of the field above.
+        // `SwarmRuntimeConfig::target_holders` is the declared knob (and the
+        // one CIRISServer#365's `redundancy.target_holders` names), but the
+        // value the ejection verdict actually reads is
+        // `policy.target_holders`, via `should_eject_above_target`'s
+        // `policy.target_holders + safety` threshold. Relieving only the
+        // declared field would land a green test on a knob the field never
+        // consults; both move, or the key is decorative.
+        out.policy.target_holders = shrink_to(self.policy.target_holders, relief.target_holders);
+        out.policy.k_repair = shrink_to(self.policy.k_repair, relief.k_repair_symbols);
+        out.policy.min_viable_symbols =
+            shrink_to(self.policy.min_viable_symbols, relief.min_viable_symbols);
+        // `policy.n_source` is untouched: the RaptorQ source-symbol count is
+        // the content's own encoding parameter (changing it invalidates
+        // already-encoded symbols), and persist registers no key for it.
+        out
     }
 }
 
@@ -236,6 +351,14 @@ pub type SwarmRuntimeEventSink = Arc<dyn Fn(SwarmEvent) + Send + Sync>;
 ///   withholds are logged but not counted; production threads `Edge`'s
 ///   handle, mirroring
 ///   `FederationDirectoryReplicationBridge::with_metrics`.
+/// - `mesh_config` (CIRISEdge#546): the resolved mesh-config read seam.
+///   `Some` lets a root's TTL'd relief shrink the four `redundancy.*`
+///   knobs on the RUNNING converger; `None` is byte-identical pre-#546
+///   behaviour. Hosts wire
+///   [`crate::replication::runtime::ReplicationRuntime::mesh_config_reader`]
+///   here — the SAME `Arc` the bridge, the scheduler and the A/V transit
+///   gate read, so the whole node shares one fold resolution per TTL
+///   window instead of each loop opening its own.
 ///
 /// All optionals MAY be `None`; the runtime stays operational on every
 /// combination of present/absent fields. New optionals land here
@@ -255,6 +378,10 @@ pub struct SwarmRuntimeOptions {
     /// CIRISEdge#433 — withhold-ledger handle. Every holding withheld from
     /// a peer is booked here with its named reason.
     pub metrics: Option<crate::observability::EdgeMetrics>,
+    /// CIRISEdge#546 — the mesh-config relief seam. `Some` ARMS the
+    /// converger's per-tick `redundancy.*` re-resolution; `None` leaves the
+    /// operator's configured values as the only input (pre-#546).
+    pub mesh_config: Option<Arc<MeshConfigReader>>,
 }
 
 impl std::fmt::Debug for SwarmRuntimeOptions {
@@ -264,6 +391,7 @@ impl std::fmt::Debug for SwarmRuntimeOptions {
             .field("rtt_observer_present", &self.rtt_observer.is_some())
             .field("scope_native", &self.scope_table.is_some())
             .field("metrics_present", &self.metrics.is_some())
+            .field("mesh_config_armed", &self.mesh_config.is_some())
             .finish()
     }
 }
@@ -275,7 +403,16 @@ impl std::fmt::Debug for SwarmRuntimeOptions {
 /// the lifetime of the application; call [`Self::shutdown`] to stop
 /// the background tasks.
 pub struct FountainSwarmRuntime {
-    config: SwarmRuntimeConfig,
+    /// CIRISEdge#546 — the OPERATOR'S CEILING, live. Was a plain
+    /// `SwarmRuntimeConfig` copied into the tasks at `start`, which is why
+    /// nothing filed after composition could ever apply. Both tasks hold a
+    /// receiver and re-read it, so [`Self::set_config`] governs a running
+    /// swarm.
+    config_tx: watch::Sender<SwarmRuntimeConfig>,
+    /// CIRISEdge#546 — kept alongside the tasks' own clone so
+    /// [`Self::effective_config`] can answer *"what is this node actually
+    /// running right now"* for telemetry without racing the converger.
+    mesh_config: Option<Arc<MeshConfigReader>>,
     observed: Arc<RwLock<ObservedClaims>>,
     cancel_tx: watch::Sender<bool>,
     publisher_task: Option<JoinHandle<()>>,
@@ -426,6 +563,10 @@ impl FountainSwarmRuntime {
     ) -> Self {
         let observed = Arc::new(RwLock::new(ObservedClaims::default()));
         let (cancel_tx, cancel_rx) = watch::channel(false);
+        // CIRISEdge#546 — the config the tasks read. `config` is no longer
+        // copied field-by-field into the spawned loops; both hold a receiver
+        // and re-read at their tick boundary, so `set_config` is live.
+        let (config_tx, config_rx) = watch::channel(config);
         let rtt_observer: Arc<dyn PeerRttObserver> = options
             .rtt_observer
             .clone()
@@ -448,11 +589,29 @@ impl FountainSwarmRuntime {
             options.metrics.clone(),
         );
 
+        // CIRISEdge#546 — the WIRING decision, logged ONCE here rather than
+        // on every relief read: whether this swarm can be governed by the
+        // mesh-config plane at all is a composition fact, and an operator
+        // diagnosing "my config row did nothing" needs to see it in the boot
+        // log. Throttled anyway because `install_swarm_runtime` is
+        // LAST-WINS (CIRISEdge#391) — a host that re-composes in a loop must
+        // not turn this into a log flood.
+        if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+            swarm_config_plane_log().check("wiring")
+        {
+            tracing::info!(
+                mesh_config_armed = options.mesh_config.is_some(),
+                suppressed_prev,
+                "swarm_runtime: config plane wired (CIRISEdge#546) — set_config governs the \
+                 running swarm; mesh-config relief shrinks the redundancy.* knobs when armed"
+            );
+        }
+
         let publisher_task = {
             let holdings = Arc::clone(&holdings);
             let transport = Arc::clone(&transport);
             let cohort = Arc::clone(&cohort);
-            let cadence = config.publish_cadence;
+            let config_rx = config_rx.clone();
             let cancel_rx = cancel_rx.clone();
             let sink = sink.clone();
             let local_peer = local_peer_id.clone();
@@ -463,7 +622,7 @@ impl FountainSwarmRuntime {
                     transport,
                     cohort,
                     local_peer,
-                    cadence,
+                    config_rx,
                     cancel_rx,
                     sink,
                     signer,
@@ -477,19 +636,28 @@ impl FountainSwarmRuntime {
             let observed = Arc::clone(&observed);
             let holdings = Arc::clone(&holdings);
             let directory = Arc::clone(&directory);
-            let cfg = config.clone();
             let local_peer = local_peer_id.clone();
             let rtt = Arc::clone(&rtt_observer);
+            let mesh_config = options.mesh_config.clone();
             tokio::spawn(async move {
                 run_converger(
-                    observed, holdings, directory, cfg, cancel_rx, sink, local_peer, rtt,
+                    observed,
+                    holdings,
+                    directory,
+                    config_rx,
+                    mesh_config,
+                    cancel_rx,
+                    sink,
+                    local_peer,
+                    rtt,
                 )
                 .await;
             })
         };
 
         Self {
-            config,
+            config_tx,
+            mesh_config: options.mesh_config.clone(),
             observed,
             cancel_tx,
             publisher_task: Some(publisher_task),
@@ -517,9 +685,86 @@ impl FountainSwarmRuntime {
         Arc::clone(&self.observed)
     }
 
-    /// The active runtime configuration.
-    pub fn config(&self) -> &SwarmRuntimeConfig {
-        &self.config
+    /// The active runtime configuration — the OPERATOR'S CEILING, i.e. what
+    /// [`Self::set_config`] last stored (composition's value until then).
+    ///
+    /// CIRISEdge#546 changed this from `&SwarmRuntimeConfig` to an owned
+    /// clone: the config lives behind a [`watch`] channel now, and handing
+    /// out a borrow into it would either pin a `watch::Ref` across the
+    /// caller's `await`s or lie about being live. Use
+    /// [`Self::effective_config`] for what a tick actually runs under.
+    #[must_use]
+    pub fn config(&self) -> SwarmRuntimeConfig {
+        self.config_tx.borrow().clone()
+    }
+
+    /// CIRISEdge#546 — **the setter the mesh-config plane needed.** Replace
+    /// the operator's ceiling on a RUNNING swarm; both loops pick it up
+    /// without a restart (the publisher rebuilds its interval at once, the
+    /// converger at its next tick boundary).
+    ///
+    /// This is the OPERATOR's axis, so it is deliberately unbounded: a node's
+    /// owner may set their own node to anything. The bound that matters —
+    /// *"a config row must never exceed the operator's ceiling"* — is applied
+    /// on the other axis, in [`SwarmRuntimeConfig::with_mesh_relief`], which
+    /// re-reads THIS value every tick. Handing a folded mesh-config result to
+    /// this method instead would invert that: the fold's own baseline is
+    /// persist's `owner_default` ceiling, not this node's configured value,
+    /// so a "relief" of 64 → 40 holders would land as an expansion past a
+    /// configured 30. Hosts should set what the operator configured and arm
+    /// [`SwarmRuntimeOptions::mesh_config`]; the plane then relieves it.
+    ///
+    /// `watch::Sender::send_replace`, not `send`: the value must be stored
+    /// even if both task receivers are already gone (post-[`Self::shutdown`]),
+    /// so [`Self::config`] never answers with a superseded value.
+    pub fn set_config(&self, config: SwarmRuntimeConfig) {
+        let previous = self.config_tx.send_replace(config);
+        // Only a real change is worth a line, and only within the throttle's
+        // budget — `set_config` is operator-driven and therefore rare, but a
+        // host polling a control plane into it must not be able to make this
+        // a per-poll write.
+        let changed = *self.config_tx.borrow() != previous;
+        if changed {
+            if let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+                swarm_config_plane_log().check("set_config")
+            {
+                let now = self.config_tx.borrow().clone();
+                tracing::info!(
+                    target_holders = now.target_holders,
+                    min_viable = now.min_viable,
+                    publish_cadence_secs = now.publish_cadence.as_secs_f64(),
+                    observe_cadence_secs = now.observe_cadence.as_secs_f64(),
+                    suppressed_prev,
+                    "swarm_runtime: operator config replaced on a RUNNING swarm \
+                     (CIRISEdge#546)"
+                );
+            }
+        }
+    }
+
+    /// CIRISEdge#546 — a receiver over the operator's ceiling, for a host
+    /// that wants to mirror the value it set (a status endpoint, a config
+    /// reconciler). Carries the CEILING, not the effective value: the relief
+    /// is resolved on the converger's tick, so there is nothing to publish
+    /// here that would not be stale by construction.
+    #[must_use]
+    pub fn subscribe_config(&self) -> watch::Receiver<SwarmRuntimeConfig> {
+        self.config_tx.subscribe()
+    }
+
+    /// CIRISEdge#546 — the configuration a converger tick would run under
+    /// **right now**: the operator's ceiling narrowed by the live
+    /// mesh-config relief.
+    ///
+    /// With no reader armed this is exactly [`Self::config`]. With one
+    /// armed it is a cached read inside the reader's TTL, so a telemetry
+    /// caller polling this does not add fold resolutions — and it answers
+    /// with the operator's values again the moment an emergency row's TTL
+    /// expires, because [`MeshConfigRelief::NONE`] is what the fold then
+    /// yields.
+    pub async fn effective_config(&self) -> SwarmRuntimeConfig {
+        let configured = self.config();
+        effective_swarm_config(&configured, self.mesh_config.as_ref()).await
     }
 
     /// Signal both tasks to stop + await clean exit. Idempotent.
@@ -540,12 +785,16 @@ async fn run_publisher(
     transport: Arc<dyn Transport>,
     cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync>,
     local_peer_id: String,
-    cadence: Duration,
+    mut config_rx: watch::Receiver<SwarmRuntimeConfig>,
     mut cancel_rx: watch::Receiver<bool>,
     sink: Option<SwarmRuntimeEventSink>,
     signer: Option<Arc<LocalSigner>>,
     publish_gate: HoldingsPublishGate,
 ) {
+    // CIRISEdge#546 — the cadence is now READ, not captured. No mesh-config
+    // key governs it (`antientropy.round_secs` is the replication scheduler's
+    // knob, a different loop), so this axis moves only by `set_config`.
+    let mut cadence = config_rx.borrow_and_update().publish_cadence;
     let mut ticker = tokio::time::interval(cadence);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
@@ -554,6 +803,36 @@ async fn run_publisher(
                 if *cancel_rx.borrow() {
                     tracing::info!("swarm_runtime.publisher: shutdown");
                     return;
+                }
+            }
+            changed = config_rx.changed() => {
+                if changed.is_err() {
+                    // The runtime was dropped without `shutdown()`, so the
+                    // config sender is gone and `changed()` would return
+                    // `Err` immediately, forever — a busy loop. Exit on the
+                    // same terms `shutdown` would give us.
+                    tracing::debug!("swarm_runtime.publisher: config channel closed; exiting");
+                    return;
+                }
+                let next = config_rx.borrow_and_update().publish_cadence;
+                if next != cadence {
+                    // `interval_at(now + next, next)` schedules the first
+                    // tick one full NEW cadence out — the scheduler's
+                    // `antientropy.round_secs` idiom (CIRISEdge#440): a
+                    // changed cadence takes effect from the next interval,
+                    // never as an immediate catch-up burst.
+                    tracing::info!(
+                        from_secs = cadence.as_secs_f64(),
+                        to_secs = next.as_secs_f64(),
+                        "swarm_runtime.publisher: cadence changed by set_config \
+                         (CIRISEdge#546)"
+                    );
+                    cadence = next;
+                    ticker = tokio::time::interval_at(
+                        tokio::time::Instant::now() + cadence,
+                        cadence,
+                    );
+                    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 }
             }
             _ = ticker.tick() => {
@@ -715,18 +994,72 @@ async fn build_and_sign_holding_claim_envelope(
         .map_err(|e| FountainEvictError::HardDeleteFailed(format!("envelope serialize: {e}")))
 }
 
+/// CIRISEdge#546 — the config one converger tick runs under: the operator's
+/// ceiling, narrowed by the live mesh-config relief.
+///
+/// The reader memoizes within its TTL, so calling this every tick costs one
+/// fold resolution per TTL window, not one per tick — the same freshness
+/// contract the scheduler's `antientropy.round_secs` read rides. And because
+/// it RE-RESOLVES rather than latching, an expired emergency row and an
+/// operator edit reach the converger by one path: the fold stops naming the
+/// key, [`SwarmRuntimeConfig::with_mesh_relief`] sees `None`, and the value
+/// is the ceiling again.
+async fn effective_swarm_config(
+    configured: &SwarmRuntimeConfig,
+    mesh_config: Option<&Arc<MeshConfigReader>>,
+) -> SwarmRuntimeConfig {
+    match mesh_config {
+        // No reader wired: byte-identical pre-#546 behaviour. Relief is not a
+        // gate — an unwired plane must not change what the converger does.
+        None => configured.clone(),
+        Some(reader) => configured.with_mesh_relief(&reader.relief().await),
+    }
+}
+
+/// CIRISEdge#546 — announce an effective-config change ONCE, at INFO,
+/// throttled. Fires only on a real transition (the converger holds the
+/// previous value), so a steady relief costs nothing per tick; the throttle
+/// is the backstop for a plane FLAPPING between two folds, which would
+/// otherwise write a line every tick for as long as it flaps.
+fn log_effective_config_change(previous: &SwarmRuntimeConfig, next: &SwarmRuntimeConfig) {
+    let crate::log_throttle::ThrottleDecision::Emit { suppressed_prev } =
+        swarm_config_plane_log().check("effective")
+    else {
+        return;
+    };
+    tracing::info!(
+        target_holders_from = previous.policy.target_holders,
+        target_holders_to = next.policy.target_holders,
+        min_viable_from = previous.min_viable,
+        min_viable_to = next.min_viable,
+        k_repair_from = previous.policy.k_repair,
+        k_repair_to = next.policy.k_repair,
+        min_viable_symbols_from = previous.policy.min_viable_symbols,
+        min_viable_symbols_to = next.policy.min_viable_symbols,
+        suppressed_prev,
+        "swarm_runtime.converger: effective config changed — a mesh-config relief \
+         took effect, expired, or the operator moved the ceiling (CIRISEdge#546)"
+    );
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_converger(
     observed: Arc<RwLock<ObservedClaims>>,
     holdings: Arc<dyn FountainHoldingsSource>,
     directory: Arc<dyn FederationDirectory>,
-    config: SwarmRuntimeConfig,
+    mut config_rx: watch::Receiver<SwarmRuntimeConfig>,
+    mesh_config: Option<Arc<MeshConfigReader>>,
     mut cancel_rx: watch::Receiver<bool>,
     sink: Option<SwarmRuntimeEventSink>,
     local_peer_id: String,
     rtt: Arc<dyn PeerRttObserver>,
 ) {
-    let mut ticker = tokio::time::interval(config.observe_cadence);
+    // CIRISEdge#546 — the ceiling, re-read whenever `set_config` fires; the
+    // `watch::Ref` is cloned out immediately and never held across an await.
+    let mut configured = config_rx.borrow_and_update().clone();
+    let mut effective = effective_swarm_config(&configured, mesh_config.as_ref()).await;
+    let mut cadence = effective.observe_cadence;
+    let mut ticker = tokio::time::interval(cadence);
     ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
     loop {
         tokio::select! {
@@ -736,12 +1069,38 @@ async fn run_converger(
                     return;
                 }
             }
+            changed = config_rx.changed() => {
+                if changed.is_err() {
+                    // Sender gone (runtime dropped without `shutdown()`) —
+                    // `changed()` would spin. See `run_publisher`.
+                    tracing::debug!("swarm_runtime.converger: config channel closed; exiting");
+                    return;
+                }
+                configured = config_rx.borrow_and_update().clone();
+            }
             _ = ticker.tick() => {
+                // Re-resolve at the TICK BOUNDARY, every tick. This is the
+                // whole point of #546: a boot-only read would keep applying
+                // a relief whose TTL expired until a restart nobody performs,
+                // which is a NEW lie rather than the existing gap.
+                let next = effective_swarm_config(&configured, mesh_config.as_ref()).await;
+                if next != effective {
+                    log_effective_config_change(&effective, &next);
+                    effective = next;
+                }
+                if effective.observe_cadence != cadence {
+                    cadence = effective.observe_cadence;
+                    ticker = tokio::time::interval_at(
+                        tokio::time::Instant::now() + cadence,
+                        cadence,
+                    );
+                    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                }
                 converger_tick(
                     &observed,
                     &holdings,
                     directory.as_ref(),
-                    &config,
+                    &effective,
                     sink.as_ref(),
                     &local_peer_id,
                     rtt.as_ref(),
@@ -978,6 +1337,21 @@ fn corpus_kind_for(
     local_by_content
         .get(content_id)
         .map_or_else(|| "fountain-corpus".to_string(), |h| h.corpus_kind.clone())
+}
+
+/// CIRISEdge#546 — the swarm config plane's log gate. Keyed on a THREE-VALUE
+/// closed set (`"wiring"`, `"set_config"`, `"effective"`), never on anything
+/// a peer can choose, so the bounded key map is a formality here — the
+/// budget is what matters. Generous per key (each is a genuine governance
+/// event an operator needs in the log), with a wide window so a flapping
+/// mesh-config plane collapses to a suppressed count instead of a line per
+/// converger tick.
+static SWARM_CONFIG_PLANE_LOG: std::sync::OnceLock<crate::log_throttle::LogThrottle> =
+    std::sync::OnceLock::new();
+
+fn swarm_config_plane_log() -> &'static crate::log_throttle::LogThrottle {
+    SWARM_CONFIG_PLANE_LOG
+        .get_or_init(|| crate::log_throttle::LogThrottle::new(5, Duration::from_secs(300), 8))
 }
 
 fn current_unix_ms() -> i64 {
@@ -1654,5 +2028,295 @@ mod tests {
         .await;
         assert!(sends.is_empty());
         assert!(metrics.withholds(WithholdReason::HoldingScopeUndeterminable) > 0);
+    }
+
+    // ─── CIRISEdge#546 — the config plane governs a RUNNING swarm ─────
+    //
+    // Half of these are pure (`with_mesh_relief` is the whole ceiling
+    // arithmetic), half drive the REAL converger loop — because "there is
+    // no setter" was a LOOP defect, not an arithmetic one, and a green
+    // pure test over a loop that still copies its config at start would
+    // be exactly the false confirmation the issue exists to remove.
+
+    /// The relief shape a root's row produces once it has been through
+    /// persist's fold: only the keys a root actually moved off the
+    /// baseline are `Some`. Built field-by-field rather than by mutating
+    /// `NONE` so a new field added to `MeshConfigRelief` breaks this
+    /// helper instead of silently defaulting past these assertions.
+    const fn redundancy_relief(
+        k_repair_symbols: Option<u32>,
+        min_viable_symbols: Option<u32>,
+        target_holders: Option<u32>,
+        min_viable_holders: Option<u32>,
+    ) -> MeshConfigRelief {
+        MeshConfigRelief {
+            round_cadence: None,
+            page_limit: None,
+            trace_replication_paused: false,
+            av_streams_paused: false,
+            k_repair_symbols,
+            min_viable_symbols,
+            target_holders,
+            min_viable_holders,
+        }
+    }
+
+    /// EXPIRY, stated as the identity it is. `MeshConfigRelief::NONE` is
+    /// what an empty plane, an unreadable plane, and an emergency row
+    /// whose TTL has passed all resolve to — so "the emergency expired"
+    /// needs no code path of its own, and this assertion is what says so.
+    #[test]
+    fn an_expired_or_absent_relief_leaves_the_configuration_field_for_field() {
+        let configured = SwarmRuntimeConfig::default();
+        assert_eq!(
+            configured.with_mesh_relief(&MeshConfigRelief::NONE),
+            configured
+        );
+    }
+
+    /// **THE ceiling test.** Every one of the four keys folds against
+    /// persist's `owner_default` (k_repair 20, min_viable_symbols 20,
+    /// both holder keys 64), all of which sit ABOVE what this node runs.
+    /// So a root moving `target_holders` 64 → 40 is a genuine relief
+    /// upstream and would still be an EXPANSION here — 40 > the
+    /// configured 30. `min` at the consumer is what makes it a no-op.
+    #[test]
+    fn a_relief_above_the_operator_ceiling_never_raises_a_knob() {
+        let configured = SwarmRuntimeConfig::default();
+        // Field-shaped: every value below is < persist's owner_default for
+        // its key (so persist marks it `relieved`) and > edge's configured
+        // value (so a naive replacement would raise the bound).
+        let relief = redundancy_relief(Some(15), Some(12), Some(40), Some(40));
+        let effective = configured.with_mesh_relief(&relief);
+        assert_eq!(effective, configured, "a relief must never widen a bound");
+        assert_eq!(effective.target_holders, DEFAULT_TARGET_HOLDERS);
+        assert_eq!(effective.policy.target_holders, DEFAULT_TARGET_HOLDERS);
+        assert_eq!(effective.min_viable, DEFAULT_MIN_VIABLE);
+        assert_eq!(effective.policy.k_repair, configured.policy.k_repair);
+        assert_eq!(
+            effective.policy.min_viable_symbols,
+            configured.policy.min_viable_symbols
+        );
+    }
+
+    /// The relief direction is NOT blocked: below the ceiling every knob
+    /// moves. `redundancy.target_holders` moves BOTH holder fields —
+    /// `SwarmRuntimeConfig::target_holders` is the declared knob, but
+    /// `policy.target_holders` is the one `should_eject_above_target`
+    /// actually reads, and a key that moved only the declared field would
+    /// be decorative.
+    #[test]
+    fn a_relief_below_the_ceiling_shrinks_every_knob_including_the_policy_twin() {
+        let configured = SwarmRuntimeConfig::default();
+        let effective =
+            configured.with_mesh_relief(&redundancy_relief(Some(2), Some(3), Some(12), Some(1)));
+        assert_eq!(effective.target_holders, 12);
+        assert_eq!(
+            effective.policy.target_holders, 12,
+            "the field the ejection verdict reads must move with the declared knob",
+        );
+        assert_eq!(effective.min_viable, 1);
+        assert_eq!(effective.policy.k_repair, 2);
+        assert_eq!(effective.policy.min_viable_symbols, 3);
+        assert_eq!(
+            effective.policy.n_source, configured.policy.n_source,
+            "n_source is the content's own encoding parameter — no key governs it",
+        );
+        assert_eq!(
+            effective.publish_cadence, configured.publish_cadence,
+            "no redundancy key touches a cadence",
+        );
+    }
+
+    /// A converger-only rig: an empty cohort (so the publisher ships
+    /// nothing and cannot colour the sink), one locally-held content, and
+    /// `holders` distinct peer claims for it.
+    async fn converger_rig(
+        config: SwarmRuntimeConfig,
+        options: SwarmRuntimeOptions,
+        content_id: &str,
+        holders: u32,
+    ) -> (
+        FountainSwarmRuntime,
+        tokio::sync::mpsc::UnboundedReceiver<SwarmEvent>,
+    ) {
+        let holdings: Arc<dyn FountainHoldingsSource> =
+            Arc::new(VecHoldings(vec![held(content_id, vec![7])]));
+        let tx: Arc<dyn Transport> = Arc::new(RecordingTransport::default());
+        let cohort: Arc<dyn Fn() -> Vec<String> + Send + Sync> = Arc::new(Vec::new);
+        let (sink_tx, sink_rx) = tokio::sync::mpsc::unbounded_channel::<SwarmEvent>();
+        let sink: SwarmRuntimeEventSink = Arc::new(move |ev| {
+            let _ = sink_tx.send(ev);
+        });
+        let rt = FountainSwarmRuntime::start_with_options(
+            config,
+            holdings,
+            test_directory(),
+            tx,
+            cohort,
+            "alice".to_string(),
+            Some(sink),
+            options,
+        );
+        for i in 0..holders {
+            rt.register_observed_claim(FountainHoldingClaim::new(
+                format!("peer-{i}"),
+                content_id,
+                vec![7],
+                1_700_000_000,
+            ))
+            .await;
+        }
+        (rt, sink_rx)
+    }
+
+    /// Did the converger emit `RepairNeeded` for `content_id` since the
+    /// last drain? Also drains `Keep`, so an empty answer means the
+    /// converger ran and chose not to repair — not that it never ran.
+    fn drained_repair_and_keep(
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<SwarmEvent>,
+        content_id: &str,
+    ) -> (bool, bool) {
+        let (mut repaired, mut kept) = (false, false);
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                SwarmEvent::RepairNeeded { content_id: c, .. } if c == content_id => {
+                    repaired = true;
+                }
+                SwarmEvent::Keep { content_id: c, .. } if c == content_id => kept = true,
+                _ => {}
+            }
+        }
+        (repaired, kept)
+    }
+
+    /// **THE setter test.** A `SwarmRuntimeConfig` filed AFTER `start`
+    /// changes what the converger does, on the same running tasks, with
+    /// no restart — the gap CIRISServer#365's four keys were parked on.
+    /// Asserted in both phases so it cannot pass by emitting nothing: the
+    /// first phase must show the converger running and CHOOSING not to
+    /// repair.
+    #[tokio::test]
+    async fn a_config_set_after_start_governs_the_running_converger() {
+        let content_id = "c-governed";
+        let (rt, mut rx) = converger_rig(
+            SwarmRuntimeConfig {
+                min_viable: 1,
+                ..fast_config()
+            },
+            SwarmRuntimeOptions::default(),
+            content_id,
+            2,
+        )
+        .await;
+
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let (repaired, kept) = drained_repair_and_keep(&mut rx, content_id);
+        assert!(!repaired, "2 holders is above a min_viable of 1");
+        assert!(
+            kept,
+            "the converger must have RUN — a silent loop proves nothing"
+        );
+
+        // The whole issue, in one call: no restart, no re-composition.
+        rt.set_config(SwarmRuntimeConfig {
+            min_viable: 5,
+            ..fast_config()
+        });
+        assert_eq!(rt.config().min_viable, 5, "the ceiling is what was set");
+
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let (repaired, _) = drained_repair_and_keep(&mut rx, content_id);
+        let mut rt = rt;
+        rt.shutdown().await;
+        assert!(
+            repaired,
+            "a config filed after start must govern the RUNNING converger — this is \
+             the boot-only-consumer defect (CIRISEdge#546)",
+        );
+    }
+
+    /// The relief seam at the LOOP. The same fixture that repairs under
+    /// the operator's own `min_viable` stops repairing once a root's row
+    /// relieves the holder floor beneath it — resolved on the converger's
+    /// tick, not at composition.
+    #[tokio::test]
+    async fn a_mesh_config_relief_shrinks_min_viable_on_a_running_converger() {
+        let content_id = "c-relieved";
+        // Control: no reader armed ⇒ pre-#546 behaviour, 2 < 5, repair.
+        let (rt, mut rx) =
+            converger_rig(fast_config(), SwarmRuntimeOptions::default(), content_id, 2).await;
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let (unarmed_repaired, _) = drained_repair_and_keep(&mut rx, content_id);
+        let mut rt = rt;
+        rt.shutdown().await;
+        assert!(
+            unarmed_repaired,
+            "an unarmed deployment must behave exactly as before — a control that \
+             does not fire makes the armed case meaningless",
+        );
+
+        // Armed: a root relieved the holder floor 64 → 1, well under the
+        // configured 5, so 2 observed holders is no longer a shortfall.
+        let reader = Arc::new(MeshConfigReader::fixed_for_test(
+            test_directory(),
+            redundancy_relief(None, None, None, Some(1)),
+        ));
+        let (rt, mut rx) = converger_rig(
+            fast_config(),
+            SwarmRuntimeOptions {
+                mesh_config: Some(reader),
+                ..SwarmRuntimeOptions::default()
+            },
+            content_id,
+            2,
+        )
+        .await;
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let (armed_repaired, armed_kept) = drained_repair_and_keep(&mut rx, content_id);
+        let mut rt = rt;
+        rt.shutdown().await;
+        assert!(armed_kept, "the converger must still be running");
+        assert!(
+            !armed_repaired,
+            "a relieved holder floor of 1 must stop the RepairNeeded the configured \
+             floor of 5 produced",
+        );
+    }
+
+    /// The ceiling, at the LOOP rather than in the arithmetic. A root
+    /// asking for a HIGHER holder floor than the operator configured is
+    /// still a relief upstream (64 → 5 under persist's owner_default) and
+    /// must be a no-op here: the converger keeps the operator's 1.
+    #[tokio::test]
+    async fn a_relief_above_the_ceiling_cannot_raise_min_viable_on_a_running_converger() {
+        let content_id = "c-ceilinged";
+        let reader = Arc::new(MeshConfigReader::fixed_for_test(
+            test_directory(),
+            redundancy_relief(None, None, None, Some(5)),
+        ));
+        let (rt, mut rx) = converger_rig(
+            SwarmRuntimeConfig {
+                min_viable: 1,
+                ..fast_config()
+            },
+            SwarmRuntimeOptions {
+                mesh_config: Some(reader),
+                ..SwarmRuntimeOptions::default()
+            },
+            content_id,
+            2,
+        )
+        .await;
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        let (repaired, kept) = drained_repair_and_keep(&mut rx, content_id);
+        let mut rt = rt;
+        rt.shutdown().await;
+        assert!(kept, "the converger must have run");
+        assert!(
+            !repaired,
+            "a config row must never push a knob PAST the operator's own configured \
+             value — min(configured, relieved), never replacement",
+        );
     }
 }


### PR DESCRIPTION
Five issues. Persist v38.7.0 adopt lands on top before tagging.

## #548 — the caller names the node key (P0: every first-run node was broken)

Edge derived the node key's alias by appending `-node`, mirroring a rule it does not own. Server 0.5.195 moved to a fixed base alias and the mirror **forked**: provisioning succeeded, put the key where edge would never look, and no first-run node could bring up a transport identity. No caller-side workaround existed — no alias satisfies both `A + "-node"` and a fixed base.

Edge genuinely cannot import the rule (CIRISServer rides edge). But that rules out *importing*, not *being told*. `node_keystore_alias` is used verbatim when supplied; the derivation survives as a labelled fallback.

**The guard that should have caught this is corrected too.** It asserted edge's copy against a hardcoded literal, so it could only detect edge editing its own implementation — the case that was never the risk. Its doc claimed drift would surface there. It drifted; the test passed.

## #547 ask 3 — a liveness probe outside the convoy

A canonical ran **22 hours hung** — one thread in `wait_on_page_bit_common` holding persist's single connection, six parked behind it, `restarts=0`, no panic — unnoticed because the health surface that would report it reads the store, so it was *inside* the failure it was meant to detect.

`Edge::seconds_since_last_round()` reads ONE atomic: no store, no lock a store-touching path can hold. Monotonic (`fetch_max`), so a backwards clock cannot inflate "no progress for N seconds" into a false alarm on a healthy node.

**Asks 1 and 2 are not here, and the report's mechanism was wrong** — [diagnosis](https://github.com/CIRISAI/CIRISEdge/issues/547#issuecomment-5469900366). The advertise axis is already cursored and capped; the producer is the **holdings** axis, which is `pages for memory, complete in result` by design. The real fix needs CIRISPersist#780.

## #544 — terminal refusals retried forever

**The issue's mechanism was wrong, which made the fix smaller.** The re-offer is receiver-**pulled**, not sender-pushed: a refused row is never stored, so it is never in `local_holdings`, so it is back in `want` next round and the peer serves identical bytes. 55 refusals / 30 min ≈ the round cadence. So: no wire change, no post-v1 verb, no policy-hash re-pin, no server coordination.

`ApplyOutcome::Refused` gains a `RetryDisposition`; a node-wide `(kind, content-hash) → retry_at` memory gates the **ask**, never the **admit**. Classification read off persist's typed variants, not prose. The asymmetry is the stated rule: a permanent refusal called transient costs a trickle; a recoverable one called terminal **withholds state**.

## #545 — a reader for the converged view

`ConvergenceReading::{Unavailable{PlaneNotArmed|Warming|ReadFailed}, Converged}` — absence vs empty is typed, never a bare `Option`. A poisoned lock deliberately does not recover via `into_inner`: half a map is the silent undercount this exists to prevent. Freshness uses the **local** observation instant, not the peer-supplied one, which is attacker-controlled.

**Scope correction:** this plane carries fountain *retention* claims. It cannot give mesh-wide identity or trace_event counts.

## #546 — the mesh-config plane can govern a running swarm

`watch::Sender<SwarmRuntimeConfig>` for the operator ceiling, plus per-tick `relief()` so an expired emergency row and an operator edit are one code path.

**The `min()` clamp is load-bearing, not defensive.** Persist's relieve-never-expand holds against *persist's* baseline (64/20), not this node's configured 30/5 — so a root moving 64 → 40 is a genuine relief upstream and would be an **expansion** here.

Also: `target_holders` and `eviction_grace_pct` were **dead fields**; the ejection verdict reads `policy.target_holders`. Routing at the named field would have been a green test on a knob nothing reads.

## No FFI added

The server composes edge in Rust. A speculative binding nobody calls is worse than none.

## Evidence

- 1357 lib tests pass (39 new), 0 failed
- `cargo clippy --all-targets` under `-D warnings` clean

Nine clippy lints landed at integration because the agents were told not to run the full lint (box under load) — including one where I inserted a function between an existing `#[must_use]` and its target, silently rebinding it. All fixed, not allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R48n3YVunN6kqsDzxxqJEs