### PR TITLE
RC: hash-first directory (#552/#553) + the contact ladder edge tier (#554)

### DIFF
--- a/.github/workflows/bench-mesh.yml
+++ b/.github/workflows/bench-mesh.yml
@@ -79,6 +79,26 @@ jobs:
           docker version
           docker compose version
 
+      - name: Set the committed baselines aside
+        # bench-mesh/results/ is gitignored, but each release's acceptance
+        # baselines are force-added into it as the record of that sweep. The
+        # census globs the SAME directory, so a partial run (one config) read
+        # the other configs' baselines out of the CHECKOUT and reported them
+        # as its own — a one-config job announced "legs=106 ran=102 passed=102"
+        # when 72 of those legs came from git and never executed. Worse, a leg
+        # that regressed to absent stayed green through the committed file.
+        # Emptying the directory first means everything the census finds was
+        # produced by THIS run, and a config that did not run is ABSENT rather
+        # than silently passing.
+        working-directory: bench-mesh
+        run: |
+          shopt -s nullglob
+          mkdir -p ../baselines-from-checkout
+          for f in results/*.jsonl; do
+            echo "  baseline set aside (from the checkout, NOT run here): $f"
+            mv "$f" ../baselines-from-checkout/
+          done
+
       - name: Run the mesh
         id: mesh
         working-directory: bench-mesh
@@ -106,6 +126,7 @@ jobs:
             echo "NO RESULTS FILES — the harness measured nothing." >&2
             exit 1
           fi
+          echo "  every file below was produced by this run; baselines were set aside"
           python3 - "${files[@]}" <<'PY'
           import json, sys
           total = ran = ok = 0

--- a/bench-mesh/census.py
+++ b/bench-mesh/census.py
@@ -69,6 +69,7 @@ EXPECTED = {
     "publisher": {
         "mesh.standup",
         "mesh.rooting",
+        "ladder.discover",
         "cohort.join",
         "scope.install",
         "perf.publish_fanout",
@@ -80,6 +81,7 @@ EXPECTED = {
     "subscriber": {
         "mesh.standup",
         "mesh.rooting",
+        "ladder.discover",
         "cohort.join",
         "scope.install",
         "perf.receive",
@@ -863,6 +865,10 @@ def _golden():
                        ("nonmember", "nonmember")]:
         rows.append(_row(node, role, "mesh.standup"))
         rows.append(_row(node, role, "mesh.rooting"))
+        # CIRISEdge#554 — every node that roots must also be able to ADDRESS its
+        # peers; the two are different claims and the ladder needs the second.
+        if role in ("publisher", "subscriber"):
+            rows.append(_row(node, role, "ladder.discover"))
     for leg in ["cohort.join", "scope.install", "perf.publish_fanout",
                 "perf.blob_fanout", "conformance.seal_retires",
                 "mesh.member_reports"]:

--- a/docs/FSD_SIGNER_RECOVERY.md
+++ b/docs/FSD_SIGNER_RECOVERY.md
@@ -1,0 +1,157 @@
+# FSD — Signer-Key Recovery under Hash-First Retention
+
+**Status:** design, for CIRISEdge#552
+**Supersedes:** three failed in-code attempts on PR #556 (see §3)
+
+## 1. The problem
+
+Under `Retention::HashFirst` a node converges the hash set for the directory
+planes and does not fetch their bodies. A delivered row on any plane is then
+refused **transiently** when its signer's `Key` body is absent, because persist's
+shared ingest gate resolves the signer's registered pubkeys via
+`lookup_public_key` before it verifies anything.
+
+Ordinary anti-entropy cannot repair this. Hash-first is precisely the decision
+*not* to fetch bodies, so the `Key` body never arrives on its own, the #544
+backoff re-offers the row forever, and a row whose signer is unknown is
+permanently unadmittable. When that row is a **revocation**, the result is a kill
+order that never lands.
+
+The node must therefore be able to ask a peer for one specific `Key` body,
+**by identifier**, and receive it.
+
+## 2. What is available
+
+`PullMessage { kind, subject_key_id }` is the only verb that names a record by
+identifier; every other read is content-hash-addressed, and a node cannot compute
+the hash of a record it does not hold.
+
+Its responder rule (`bridge::subject_holdings`) answers:
+
+* a requester authenticated **as** the subject — the data-subject access path; and
+* on the four unconditionally-`public` planes, a request for **the responding
+  node's own record**, which is exactly what the `self_own` advertise projection
+  already hands every peer.
+
+A **third-party** subject is refused, and that refusal is load-bearing:
+`subject_holdings_inner` performs an arbitrary lookup against the responder's
+whole local directory, so answering it would turn a body-holding server into an
+address-book oracle for records it never advertised.
+
+**Consequence for this design:** the only fetchable signer is *the peer that
+delivered the row*, asking for *its own* key. That is not a limitation of the
+recovery mechanism; it is the entitlement boundary, and the mechanism must not
+try to exceed it.
+
+## 3. Why three previous attempts failed
+
+All three failed on the same fact, stated here so a fourth does not repeat it:
+
+> **An Initiator reads inbound messages only inside the drive loop, and the drive
+> loop's first step (`drive_round_step(None)`) OPENS by sending a Summary.**
+
+| attempt | shape | failure |
+|---|---|---|
+| 1 | send Pull, then `run_one_round` | Two exchanges outstanding. Both answer with a Summary and there is no request correlation, so the **scheduled** Summary could be consumed as the Pull's reply — putting the peer's whole Key page into `pending_bodies` and fetching every body on a node that had just chosen not to. |
+| 2 | batch up to 32 Pulls per round | The on-demand exemption is a **round counter**, not a per-request ledger. The batch outran its own exemption and later replies were suppressed as ordinary hash-first traffic, after the names had already been dequeued. |
+| 3 | send Pull, then `continue` the tick | Defers *receiving* rather than driving. The next tick's `run_one_round` sends its Summary **first** and then dequeues the stale Pull reply — the same overlap, one tick later. |
+
+The lesson: the Pull's reply must be consumed by a loop that **did not also send a
+Summary**.
+
+## 4. Design
+
+### D1 — A recovery exchange is a ROUND TYPE, not a message inserted into a round
+
+`run_one_round` is exactly two things: an initiating step, then a
+send-and-wait loop. Recovery reuses the second and omits the first.
+
+```
+run_one_round          = drive_exchange_to_completion(initiating_step)
+run_one_recovery_round = send Pull; drive_exchange_to_completion(SendThenWait(∅))
+```
+
+`SendThenWait(∅)` sends nothing and waits, so the reply the loop consumes can only
+be the Pull's. No new wire verb, no request ID, no protocol version event.
+
+### D2 — Correlation by construction: one exchange outstanding per coordinator
+
+Each `(peer, kind)` coordinator has one sequential scheduler task. A recovery
+round **replaces** the ordinary round on its tick, so at no point are two
+exchanges outstanding on one coordinator. This is what makes the absence of
+request IDs safe, and it is the same property the rest of the protocol already
+relies on — the session is a sequential per-peer state machine.
+
+### D3 — A recovery round replaces its tick
+
+Cost: one cadence tick per recovered key, and only on a tick where a name is
+actually queued. Bounded by D4: at most one name per peer exists, so recovery
+can displace at most one ordinary round per peer before it is done.
+
+### D4 — Queue only what a Pull can satisfy: the delivering peer's own key
+
+From §2, a third-party signer is not fetchable by identifier. Queueing one would
+schedule a request guaranteed to return empty while consuming a recovery slot and
+a tick.
+
+This bounds the queue **at its root**, which matters for more than tidiness: a
+peer can enqueue exactly one name — its own — so an attacker delivering rows that
+name thousands of unique nonexistent signers has nothing to enqueue, and cannot
+crowd out another peer's revocation recovery. Policing the queue after the fact
+(caps, fair-share eviction) left that vector open; this closes it.
+
+### D5 — An expectation is REQUEST state, not ROUND state
+
+`pending_bodies` is the set of hashes this node explicitly asked for, and it is
+the only thing that lets those bytes past the hash-first gate. Today
+`Session::reset` clears the whole set once `pull_exempt_rounds` reaches zero, so:
+
+* a `start_fetch` expectation, which sets no exemption, is discarded by the very
+  next reset; and
+* an expectation whose body arrived and was refused **transiently** is discarded
+  even though the node still wants it.
+
+Each expectation therefore carries its **own** time-to-live in rounds, decremented
+on reset and dropped at zero. An expectation outlives the round that created it,
+and a transient refusal refreshes it rather than consuming it.
+
+### D6 — Failure is silent-safe, never silent-lossy
+
+A recovery round that times out, is refused, or returns an empty Summary leaves
+the row transiently refused and **visible**. The name is not re-queued by the
+recovery path itself: the row that named it re-notes it on its next offer, so the
+retry rides #544's existing backoff instead of a second, unbounded timer.
+
+## 5. Naming
+
+Every name states which of the two round types it belongs to.
+
+| name | meaning |
+|---|---|
+| `drive_exchange_to_completion` | the shared send-and-wait loop, given its first step |
+| `run_one_round` | anti-entropy: initiate, then drive |
+| `run_one_recovery_round` | recovery: send the Pull, then drive **without initiating** |
+| `ReplicationCoordinator::send_recovery_pull` | take this peer's queued name and Pull it; `None` when nothing is queued |
+| `StateProvider::take_missing_signer_for(peer)` | take the one name `peer` can answer for |
+| `Session::expect_body_for_rounds` | record an expectation with its own TTL |
+| `RoundEvent::RecoveryCompleted` | a recovery round finished, distinct on the instrument |
+
+## 6. Invariants (each has a test)
+
+1. **A recovery round sends no Summary.** Otherwise the reply is ambiguous again.
+2. **At most one exchange outstanding per coordinator.**
+3. **Only a peer's own key is ever queued** — a third-party signer is never enqueued.
+4. **An expectation survives a round reset** until its own TTL expires.
+5. **A transiently-refused requested body stays expected.**
+6. **A third-party subject Pull is refused by the responder** (the anti-oracle rule).
+7. **Recovery never runs under `Retention::Bodies`** — there the Key body replicates on its own.
+
+## 7. Out of scope
+
+* **Third-party signer resolution.** Needs a separately authorized, rate-limited
+  resolver; the entitlement question is not answered by this design.
+* **Contact resolution of an unheld third-party identifier.** Same reason;
+  `contact::request_key_body` returns `false` and says so rather than promising a
+  fetch that cannot happen.
+* **A production path from `KnownHashes` to `Fetch`.** The holder map is recorded
+  but no runtime consumer selects a holder and issues a point fetch yet.

--- a/src/bin/edge_node.rs
+++ b/src/bin/edge_node.rs
@@ -1538,6 +1538,46 @@ async fn run_publisher(occ: Occurrence) -> Result<(), String> {
         }),
     );
 
+    // ── Ladder: discovery over the REAL route table ──────────────────
+    //
+    // CIRISEdge#554. The ladder's resolution logic is unit-tested against a fake
+    // lens; what only a running mesh can prove is that a node can actually
+    // ADDRESS the peers it has rooted. `knows_peer` is the transport's own
+    // readback — the same question the send path asks before it dials — so this
+    // leg fails exactly when a send would, rather than when a fixture disagrees.
+    //
+    // Reachability here also carries the multi-hop claim: a peer is addressable
+    // through whatever path Reticulum found, and this node did no relaying to
+    // make that true.
+    {
+        use ciris_edge::contact::{ReticulumRoutes, RouteLens as _};
+        let routes = ReticulumRoutes::new(&occ.transport);
+        let mut reachable = Vec::new();
+        let mut unreachable = Vec::new();
+        for peer in &peers {
+            if routes.has_destination(peer).await {
+                reachable.push(peer.clone());
+            } else {
+                unreachable.push(peer.clone());
+            }
+        }
+        let all_reachable = unreachable.is_empty() && !reachable.is_empty();
+        rep.ran(
+            "ladder.discover",
+            all_reachable,
+            serde_json::json!({
+                "rooted_peers": peers.len(),
+                "reachable": reachable.len(),
+                "unreachable": unreachable,
+                "readback": "transport.knows_peer",
+                // Stated so a reader of the census knows what this leg does NOT
+                // cover: identifier resolution needs owner bindings the harness
+                // does not seed, and is unit-tested instead.
+                "covers": "route reachability only; identity resolution is unit-tested",
+            }),
+        );
+    }
+
     // ── Cohort: create, admit members over the real wire ─────────────
     let kv = Arc::new(open_sealed_kv(
         &cfg.state_dir,
@@ -2471,6 +2511,40 @@ async fn run_subscriber(occ: Occurrence) -> Result<(), String> {
     // admission lands mid-stream.
     if cfg.late_joiner.as_deref() == Some(cfg.node_id.as_str()) {
         tokio_sleep(env_secs("EDGE_LATE_JOIN_DELAY_SECS", 5)).await;
+    }
+
+    // ── Ladder: discovery over the REAL route table ──────────────────
+    //
+    // CIRISEdge#554, subscriber side. Discovery must work in BOTH directions:
+    // the publisher reaching a subscriber proves nothing about a subscriber
+    // reaching back, and a contact request travels the way the publisher does
+    // not. A one-directional check passes on a mesh where half the ladder is
+    // broken.
+    {
+        use ciris_edge::contact::{ReticulumRoutes, RouteLens as _};
+        let routes = ReticulumRoutes::new(&occ.transport);
+        let mut reachable = Vec::new();
+        let mut unreachable = Vec::new();
+        // The subscriber roots against the publisher, so that is the peer whose
+        // reachability the return direction depends on.
+        for peer in std::slice::from_ref(&publisher) {
+            if routes.has_destination(peer).await {
+                reachable.push(peer.clone());
+            } else {
+                unreachable.push(peer.clone());
+            }
+        }
+        rep.ran(
+            "ladder.discover",
+            unreachable.is_empty() && !reachable.is_empty(),
+            serde_json::json!({
+                "rooted_peers": 1,
+                "reachable": reachable.len(),
+                "unreachable": unreachable,
+                "readback": "transport.knows_peer",
+                "direction": "subscriber -> publisher",
+            }),
+        );
     }
 
     // ── Real cross-process MLS join ──────────────────────────────────

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -122,6 +122,23 @@ pub trait DirectoryLens: Send + Sync {
     async fn owner_of(&self, key_id: &str) -> Option<String>;
     /// Every node that person owns.
     async fn nodes_owned_by(&self, fed_id: &str) -> Vec<String>;
+
+    /// CIRISEdge#552 — ask for a key's BODY on demand, returning whether a
+    /// fetch was actually queued.
+    ///
+    /// A hash-first server holds this key's hash without its body, so
+    /// `identity_type_of` answers `None` for a key the node demonstrably knows
+    /// about. Reporting that as "wait for convergence" would be advice that
+    /// never comes true: bulk convergence is exactly what hash-first suppressed.
+    /// The fetch reuses the missing-signer queue — a resolution miss and a
+    /// stalled admission want the identical thing, a `Key` body — so it drains
+    /// through the same Key Pull on the next round.
+    ///
+    /// Defaults to `false`: a node holding bodies has nothing to request, and
+    /// its miss really is "not announced yet".
+    async fn request_key_body(&self, _key_id: &str) -> bool {
+        false
+    }
 }
 
 /// Resolve any identifier to the person and the nodes that reach them.
@@ -141,12 +158,20 @@ pub async fn resolve(lens: &dyn DirectoryLens, any_id: &str) -> Result<Subject, 
     let stall = || LadderStall::NotYetDiscovered {
         fed_id: any_id.to_owned(),
     };
-    let kind = IdentityKind::from_identity_type(
-        lens.identity_type_of(any_id)
-            .await
-            .ok_or_else(stall)?
-            .as_str(),
-    );
+    // CIRISEdge#552 — before calling a miss "not announced yet", ask whether
+    // this node is merely holding the hash. If a fetch is queued the remedy is
+    // different and the wait is bounded, so the stall must say so; a caller
+    // told to wait for an announce that already happened waits forever.
+    let Some(identity_type) = lens.identity_type_of(any_id).await else {
+        return Err(if lens.request_key_body(any_id).await {
+            LadderStall::BodyFetchQueued {
+                key_id: any_id.to_owned(),
+            }
+        } else {
+            stall()
+        });
+    };
+    let kind = IdentityKind::from_identity_type(identity_type.as_str());
 
     let fed_id = match &kind {
         IdentityKind::Person => any_id.to_owned(),
@@ -252,6 +277,11 @@ pub enum LadderStall {
     ConsentNotGranted { fed_id: String },
     /// The rung before this one has not completed.
     PriorRungIncomplete { rung: Rung, prior: Rung },
+    /// CIRISEdge#552 — this node knows the key as a HASH and has queued a fetch
+    /// for its body. Self-resolving, but for a different reason than
+    /// [`Self::NotYetDiscovered`]: nothing is waiting on the subject to
+    /// announce, only on this node's next Key round.
+    BodyFetchQueued { key_id: String },
     /// The key resolves, but not to anything a person can be contacted through
     /// — a steward, an accord holder, a partner record. TERMINAL: no amount of
     /// convergence turns one of these into a contactable person, so a caller
@@ -295,6 +325,13 @@ impl LadderStall {
                  instead, or check that the identifier is the one you meant — this \
                  will not resolve by waiting."
             ),
+            Self::BodyFetchQueued { key_id } => format!(
+                "{key_id} is known to this node as a hash, but its body was not \
+                 held — this node runs hash-first retention. A fetch is queued and \
+                 goes out on the next Key replication round; retry the lookup \
+                 after it. Waiting for the peer to announce would NOT help: it \
+                 already did."
+            ),
             Self::PriorRungIncomplete { rung, prior } => format!(
                 "{rung} cannot proceed because {prior} has not completed. Look at the \
                  {prior} rung on this node first — a ladder failure is nearly always \
@@ -311,7 +348,10 @@ impl LadderStall {
     #[must_use]
     pub const fn self_resolving(&self) -> bool {
         match self {
-            Self::NotYetDiscovered { .. } | Self::Unreachable { .. } => true,
+            Self::NotYetDiscovered { .. }
+            | Self::Unreachable { .. }
+            // The fetch is queued; the next Key round carries it.
+            | Self::BodyFetchQueued { .. } => true,
             Self::AwaitingConsent { .. }
             | Self::ConsentNotGranted { .. }
             | Self::PriorRungIncomplete { .. }
@@ -448,12 +488,32 @@ pub trait RouteLens: Send + Sync {
 /// which question.
 pub struct PersistLens<'a> {
     directory: &'a dyn ciris_persist::federation::FederationDirectory,
+    /// CIRISEdge#552 — where an on-demand body fetch is queued. `None` on a
+    /// node that holds bodies: there is nothing to fetch, and the lens must
+    /// then answer `request_key_body` with `false` so the stall stays the
+    /// honest "not announced yet".
+    replication: Option<std::sync::Arc<dyn crate::replication::directory::ReplicationDirectory>>,
 }
 
 impl<'a> PersistLens<'a> {
     #[must_use]
     pub fn new(directory: &'a dyn ciris_persist::federation::FederationDirectory) -> Self {
-        Self { directory }
+        Self {
+            directory,
+            replication: None,
+        }
+    }
+
+    /// Give the lens the replication directory, so a resolution miss on a
+    /// hash-first node can queue the body fetch instead of reporting a wait
+    /// that never ends.
+    #[must_use]
+    pub fn with_replication(
+        mut self,
+        replication: std::sync::Arc<dyn crate::replication::directory::ReplicationDirectory>,
+    ) -> Self {
+        self.replication = Some(replication);
+        self
     }
 }
 
@@ -483,6 +543,22 @@ impl DirectoryLens for PersistLens<'_> {
         ciris_persist::federation::admission::nodes_owned_by(self.directory, fed_id)
             .await
             .unwrap_or_default()
+    }
+
+    async fn request_key_body(&self, key_id: &str) -> bool {
+        let Some(replication) = self.replication.as_ref() else {
+            return false;
+        };
+        // The same gate the admission path uses: under `Bodies` the body
+        // replicates on its own, so queueing would ask for something already in
+        // flight and the stall's ordinary remedy is the right one.
+        if !crate::replication::retention::should_note_missing_signer(
+            replication.retention(crate::replication::protocol::EnvelopeKind::Key),
+        ) {
+            return false;
+        }
+        replication.note_missing_signer(crate::replication::protocol::EnvelopeKind::Key, key_id);
+        true
     }
 }
 
@@ -768,5 +844,90 @@ mod tests {
         sorted.dedup();
         assert_eq!(sorted.len(), names.len(), "rung names must be distinct");
         assert!(names.contains(&"request_contact"));
+    }
+
+    /// CIRISEdge#552 — a hash-first node that knows the key as a HASH must
+    /// queue the body fetch, and must say so.
+    ///
+    /// The bug this closes: `identity_type_of` answers `None` because the body
+    /// was never fetched, and the ladder reports `NotYetDiscovered`, whose
+    /// remedy is "wait for the peer to announce". The peer already announced.
+    /// Bulk convergence is exactly what hash-first suppressed, so that wait
+    /// never ends — the same shape as a kill order that cannot land.
+    #[tokio::test]
+    async fn a_resolution_miss_on_a_hash_first_node_queues_the_body_fetch() {
+        struct HashOnlyLens {
+            requested: std::sync::Mutex<Vec<String>>,
+        }
+        #[async_trait::async_trait]
+        impl super::DirectoryLens for HashOnlyLens {
+            async fn identity_type_of(&self, _key_id: &str) -> Option<String> {
+                None // the body is not held — only its hash
+            }
+            async fn owner_of(&self, _key_id: &str) -> Option<String> {
+                None
+            }
+            async fn nodes_owned_by(&self, _fed_id: &str) -> Vec<String> {
+                Vec::new()
+            }
+            async fn request_key_body(&self, key_id: &str) -> bool {
+                self.requested.lock().unwrap().push(key_id.to_owned());
+                true
+            }
+        }
+
+        let lens = HashOnlyLens {
+            requested: std::sync::Mutex::new(Vec::new()),
+        };
+        let err = super::resolve(&lens, "frank-abc123")
+            .await
+            .expect_err("the body is not held, so this cannot resolve yet");
+
+        assert_eq!(
+            lens.requested.lock().unwrap().as_slice(),
+            ["frank-abc123"],
+            "the miss must QUEUE the fetch — without it the lookup can never \
+             succeed on a hash-first node"
+        );
+        match &err {
+            LadderStall::BodyFetchQueued { key_id } => {
+                assert_eq!(key_id, "frank-abc123");
+            }
+            other => panic!("expected BodyFetchQueued, got {other:?}"),
+        }
+        assert!(err.self_resolving(), "the next Key round carries the fetch");
+        assert!(
+            err.remedy().contains("already did"),
+            "the remedy must NOT tell an operator to wait for an announce that \
+             already happened: {}",
+            err.remedy()
+        );
+    }
+
+    /// A node that holds bodies has nothing to fetch, so its miss really is
+    /// "not announced yet" — the default must not manufacture a fetch.
+    #[tokio::test]
+    async fn a_bodies_node_still_reports_not_yet_discovered() {
+        struct BodiesLens;
+        #[async_trait::async_trait]
+        impl super::DirectoryLens for BodiesLens {
+            async fn identity_type_of(&self, _key_id: &str) -> Option<String> {
+                None
+            }
+            async fn owner_of(&self, _key_id: &str) -> Option<String> {
+                None
+            }
+            async fn nodes_owned_by(&self, _fed_id: &str) -> Vec<String> {
+                Vec::new()
+            }
+        }
+        let err = super::resolve(&BodiesLens, "frank-abc123")
+            .await
+            .expect_err("unknown key");
+        assert!(
+            matches!(err, LadderStall::NotYetDiscovered { .. }),
+            "a bodies-retention node's miss is an ordinary not-yet-discovered, \
+             got {err:?}"
+        );
     }
 }

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -137,9 +137,16 @@ pub async fn resolve(lens: &dyn DirectoryLens, any_id: &str) -> Result<Subject, 
         IdentityKind::Node | IdentityKind::Agent => {
             lens.owner_of(any_id).await.ok_or_else(stall)?
         }
-        // A steward or accord holder is not a contactable person. Refusing here
-        // beats resolving to something that looks addressable and is not.
-        IdentityKind::Other(_) => return Err(stall()),
+        // A steward or accord holder is not a contactable person. TERMINAL, not
+        // `NotYetDiscovered`: the latter self-resolves, so a caller would retry
+        // forever against something that will never become contactable — and the
+        // remedy ("wait for convergence") would be advice that never comes true.
+        IdentityKind::Other(t) => {
+            return Err(LadderStall::NotContactable {
+                key_id: any_id.to_owned(),
+                identity_type: t.clone(),
+            })
+        }
     };
 
     let nodes = lens.nodes_owned_by(&fed_id).await;
@@ -227,6 +234,14 @@ pub enum LadderStall {
     ConsentNotGranted { fed_id: String },
     /// The rung before this one has not completed.
     PriorRungIncomplete { rung: Rung, prior: Rung },
+    /// The key resolves, but not to anything a person can be contacted through
+    /// — a steward, an accord holder, a partner record. TERMINAL: no amount of
+    /// convergence turns one of these into a contactable person, so a caller
+    /// that retries is retrying forever.
+    NotContactable {
+        key_id: String,
+        identity_type: String,
+    },
 }
 
 impl LadderStall {
@@ -253,6 +268,15 @@ impl LadderStall {
                 "this node has not granted replication consent to {fed_id}. Accept the \
                  contact request to make the conversation replicable in both directions."
             ),
+            Self::NotContactable {
+                key_id,
+                identity_type,
+            } => format!(
+                "{key_id} is registered as identity_type={identity_type}, which is \
+                 not a person and cannot hold a conversation. Contact its OWNER \
+                 instead, or check that the identifier is the one you meant — this \
+                 will not resolve by waiting."
+            ),
             Self::PriorRungIncomplete { rung, prior } => format!(
                 "{rung} cannot proceed because {prior} has not completed. Look at the \
                  {prior} rung on this node first — a ladder failure is nearly always \
@@ -272,7 +296,9 @@ impl LadderStall {
             Self::NotYetDiscovered { .. } | Self::Unreachable { .. } => true,
             Self::AwaitingConsent { .. }
             | Self::ConsentNotGranted { .. }
-            | Self::PriorRungIncomplete { .. } => false,
+            | Self::PriorRungIncomplete { .. }
+            // Terminal by nature: a steward does not become a person.
+            | Self::NotContactable { .. } => false,
         }
     }
 }
@@ -444,7 +470,15 @@ mod tests {
     #[tokio::test]
     async fn a_non_contactable_identity_type_stalls_rather_than_resolving() {
         let lens = frank();
-        assert!(super::resolve(&lens, "some-steward-ddd").await.is_err());
+        let Err(stall) = super::resolve(&lens, "some-steward-ddd").await else {
+            panic!("a steward is not a contactable person");
+        };
+        assert!(
+            !stall.self_resolving(),
+            "a steward never becomes contactable — a self-resolving stall would \
+             make the caller retry forever"
+        );
+        assert!(stall.remedy().contains("steward"), "{}", stall.remedy());
     }
 
     /// A key the directory has never seen is NOT an error the operator caused —

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -39,6 +39,122 @@
 
 use std::fmt;
 
+/// What a `key_id` names.
+///
+/// Three identifier types reach this surface — a fedID, a nodeID, an agentID —
+/// and a caller usually holds one without knowing which. `key_id` is
+/// `"<label>-<fingerprint>"` and the label is operator-chosen, so it is NOT a
+/// reliable discriminator: `frank-laptop-a3k…` could be anything. The directory
+/// is the authority, via `identity_type`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdentityKind {
+    /// A person. The party that CONSENTS.
+    Person,
+    /// A node. The party you actually reach over the wire.
+    Node,
+    /// An agent. Owned by a person, and cannot consent on their behalf.
+    Agent,
+    /// Something else in the directory — steward, accord holder, partner.
+    Other(String),
+}
+
+impl IdentityKind {
+    #[must_use]
+    pub fn from_identity_type(t: &str) -> Self {
+        match t {
+            "user" => Self::Person,
+            "node" => Self::Node,
+            "agent" => Self::Agent,
+            other => Self::Other(other.to_owned()),
+        }
+    }
+}
+
+/// Who you are talking to, and what you actually contact.
+///
+/// The two are DIFFERENT and the split is the footgun this type exists to
+/// remove. A person consents; a node is reachable. Collapsing them lets a caller
+/// send a consent request to a node (nobody is there to accept it) or try to
+/// open a link to a person (they have no transport key), and both fail in ways
+/// that look like the network.
+///
+/// Whatever identifier you started from — fedID, nodeID, agentID — you end up
+/// here, so the rest of the ladder is written once.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Subject {
+    /// The person. Who consents, and who a conversation is *with*.
+    pub fed_id: String,
+    /// Their nodes. What a contact request is actually delivered to, and where
+    /// Reticulum routes — across as many hops as separate you.
+    pub nodes: Vec<String>,
+    /// Which identifier the caller supplied, so a log line can say how it got
+    /// here. A stall on a nodeID and the same stall on its owner's fedID are
+    /// different situations to an operator.
+    pub resolved_from: IdentityKind,
+}
+
+/// The directory reads resolution needs. A trait so the ladder is testable
+/// without standing up persist — the resolution rules are the part that gets
+/// this wrong, not the SQL.
+#[async_trait::async_trait]
+pub trait DirectoryLens: Send + Sync {
+    /// `identity_type` for a key, or `None` if the directory has never seen it.
+    async fn identity_type_of(&self, key_id: &str) -> Option<String>;
+    /// The person who owns this node or agent.
+    async fn owner_of(&self, key_id: &str) -> Option<String>;
+    /// Every node that person owns.
+    async fn nodes_owned_by(&self, fed_id: &str) -> Vec<String>;
+}
+
+/// Resolve any identifier to the person and the nodes that reach them.
+///
+/// The rule is one sentence: **whatever you hand me, I find the person, then
+/// their nodes.** A nodeID and an agentID resolve through their owner; a fedID
+/// is already the person.
+///
+/// A stall here is nearly always `NotYetDiscovered`, which is the honest reading
+/// of "the directory has not converged on this key yet" — it is not an error and
+/// it fixes itself.
+///
+/// # Errors
+/// [`LadderStall::NotYetDiscovered`] when the directory does not yet know the
+/// key, its owner, or any node to reach.
+pub async fn resolve(lens: &dyn DirectoryLens, any_id: &str) -> Result<Subject, LadderStall> {
+    let stall = || LadderStall::NotYetDiscovered {
+        fed_id: any_id.to_owned(),
+    };
+    let kind = IdentityKind::from_identity_type(
+        lens.identity_type_of(any_id)
+            .await
+            .ok_or_else(stall)?
+            .as_str(),
+    );
+
+    let fed_id = match &kind {
+        IdentityKind::Person => any_id.to_owned(),
+        // A node or agent cannot consent; its OWNER does. Resolving through the
+        // owner is what makes "add frank-laptop as a contact" mean "add Frank".
+        IdentityKind::Node | IdentityKind::Agent => {
+            lens.owner_of(any_id).await.ok_or_else(stall)?
+        }
+        // A steward or accord holder is not a contactable person. Refusing here
+        // beats resolving to something that looks addressable and is not.
+        IdentityKind::Other(_) => return Err(stall()),
+    };
+
+    let nodes = lens.nodes_owned_by(&fed_id).await;
+    if nodes.is_empty() {
+        // Known person, nothing to reach. Distinct from "unknown key", and the
+        // remedy is the same: wait for their announce to replicate.
+        return Err(LadderStall::NotYetDiscovered { fed_id });
+    }
+    Ok(Subject {
+        fed_id,
+        nodes,
+        resolved_from: kind,
+    })
+}
+
 /// A rung of the ladder. Stable strings — an operator greps these, and a
 /// dashboard groups by them.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -192,9 +308,174 @@ pub fn log_rung(rung: Rung, fed_id: &str, stall: Option<&LadderStall>) {
     }
 }
 
+/// The [`DirectoryLens`] over a real persist directory.
+///
+/// Thin on purpose: every rule that can be got wrong lives in [`resolve`] and is
+/// tested without a database. This adapter only says which persist call answers
+/// which question.
+pub struct PersistLens<'a> {
+    directory: &'a dyn ciris_persist::federation::FederationDirectory,
+}
+
+impl<'a> PersistLens<'a> {
+    #[must_use]
+    pub fn new(directory: &'a dyn ciris_persist::federation::FederationDirectory) -> Self {
+        Self { directory }
+    }
+}
+
+#[async_trait::async_trait]
+impl DirectoryLens for PersistLens<'_> {
+    async fn identity_type_of(&self, key_id: &str) -> Option<String> {
+        // An error and an absence are the SAME answer here on purpose: both mean
+        // "this node cannot say what that key is yet", and the ladder's stall for
+        // that is `NotYetDiscovered`, which self-resolves. Distinguishing them
+        // would produce a second diagnostic with the same remedy.
+        self.directory
+            .lookup_public_key(key_id)
+            .await
+            .ok()
+            .flatten()
+            .map(|record| record.identity_type)
+    }
+
+    async fn owner_of(&self, key_id: &str) -> Option<String> {
+        ciris_persist::federation::admission::owner_of(self.directory, key_id)
+            .await
+            .ok()
+            .flatten()
+    }
+
+    async fn nodes_owned_by(&self, fed_id: &str) -> Vec<String> {
+        ciris_persist::federation::admission::nodes_owned_by(self.directory, fed_id)
+            .await
+            .unwrap_or_default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{LadderStall, Rung};
+
+    /// A fake directory. The resolution RULES are what get this wrong, not the
+    /// SQL, so the tests exercise the rules directly.
+    struct FakeLens {
+        types: std::collections::HashMap<String, String>,
+        owners: std::collections::HashMap<String, String>,
+        nodes: std::collections::HashMap<String, Vec<String>>,
+    }
+
+    #[async_trait::async_trait]
+    impl super::DirectoryLens for FakeLens {
+        async fn identity_type_of(&self, key_id: &str) -> Option<String> {
+            self.types.get(key_id).cloned()
+        }
+        async fn owner_of(&self, key_id: &str) -> Option<String> {
+            self.owners.get(key_id).cloned()
+        }
+        async fn nodes_owned_by(&self, fed_id: &str) -> Vec<String> {
+            self.nodes.get(fed_id).cloned().unwrap_or_default()
+        }
+    }
+
+    fn frank() -> FakeLens {
+        let mut types = std::collections::HashMap::new();
+        types.insert("frank-fed-aaa".into(), "user".into());
+        types.insert("frank-laptop-bbb".into(), "node".into());
+        types.insert("frank-agent-ccc".into(), "agent".into());
+        types.insert("some-steward-ddd".into(), "steward".into());
+        let mut owners = std::collections::HashMap::new();
+        owners.insert("frank-laptop-bbb".into(), "frank-fed-aaa".into());
+        owners.insert("frank-agent-ccc".into(), "frank-fed-aaa".into());
+        let mut nodes = std::collections::HashMap::new();
+        nodes.insert(
+            "frank-fed-aaa".into(),
+            vec!["frank-laptop-bbb".into(), "frank-phone-eee".into()],
+        );
+        FakeLens {
+            types,
+            owners,
+            nodes,
+        }
+    }
+
+    /// The headline DX property: all three identifier types land on the same
+    /// person and the same reachable nodes. A caller holding "a Frank
+    /// identifier" does not have to know which one it is.
+    #[tokio::test]
+    async fn any_identifier_resolves_to_the_same_person_and_nodes() {
+        let lens = frank();
+        for id in ["frank-fed-aaa", "frank-laptop-bbb", "frank-agent-ccc"] {
+            let s = super::resolve(&lens, id).await.expect("{id} must resolve");
+            assert_eq!(s.fed_id, "frank-fed-aaa", "{id} must resolve to the PERSON");
+            assert_eq!(
+                s.nodes.len(),
+                2,
+                "{id} must yield every node that reaches him"
+            );
+        }
+    }
+
+    /// And it records HOW it got there — a stall on a nodeID and the same stall
+    /// on its owner's fedID are different situations to whoever is debugging.
+    #[tokio::test]
+    async fn the_subject_remembers_which_identifier_it_came_from() {
+        let lens = frank();
+        let from_node = super::resolve(&lens, "frank-laptop-bbb").await.unwrap();
+        assert_eq!(from_node.resolved_from, super::IdentityKind::Node);
+        let from_person = super::resolve(&lens, "frank-fed-aaa").await.unwrap();
+        assert_eq!(from_person.resolved_from, super::IdentityKind::Person);
+    }
+
+    /// An agent cannot consent on its owner's behalf, so addressing one must
+    /// resolve to the PERSON. Returning the agent would send a consent request
+    /// to something that cannot accept it — and it would look like the peer
+    /// simply never answered.
+    #[tokio::test]
+    async fn an_agent_resolves_to_its_owner_not_itself() {
+        let lens = frank();
+        let s = super::resolve(&lens, "frank-agent-ccc").await.unwrap();
+        assert_eq!(s.fed_id, "frank-fed-aaa");
+        assert!(!s.nodes.contains(&"frank-agent-ccc".to_string()));
+    }
+
+    /// A steward or accord holder is not a contactable person. Refusing beats
+    /// resolving to something that looks addressable and is not.
+    #[tokio::test]
+    async fn a_non_contactable_identity_type_stalls_rather_than_resolving() {
+        let lens = frank();
+        assert!(super::resolve(&lens, "some-steward-ddd").await.is_err());
+    }
+
+    /// A key the directory has never seen is NOT an error the operator caused —
+    /// it is an unconverged directory, and it fixes itself.
+    #[tokio::test]
+    async fn an_unknown_key_stalls_as_not_yet_discovered_and_self_resolves() {
+        let lens = frank();
+        let Err(stall) = super::resolve(&lens, "stranger-zzz").await else {
+            panic!("an unknown key cannot resolve");
+        };
+        assert!(
+            stall.self_resolving(),
+            "an unconverged directory must not page anyone"
+        );
+    }
+
+    /// A known person with no reachable node is its own case: the remedy names
+    /// THEM, not the identifier the caller happened to type.
+    #[tokio::test]
+    async fn a_person_with_no_nodes_stalls_naming_the_person() {
+        let mut lens = frank();
+        lens.nodes.clear();
+        let Err(stall) = super::resolve(&lens, "frank-laptop-bbb").await else {
+            panic!("no reachable node means no contact");
+        };
+        assert!(
+            stall.remedy().contains("frank-fed-aaa"),
+            "the remedy must name the person we could not reach: {}",
+            stall.remedy()
+        );
+    }
 
     /// The ladder is ordered, and the order is the diagnostic. A failure is
     /// nearly always the previous rung, so every rung must be able to name it.

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -198,9 +198,23 @@ pub async fn resolve(lens: &dyn DirectoryLens, any_id: &str) -> Result<Subject, 
         IdentityKind::Person => any_id.to_owned(),
         // A node or agent cannot consent; its OWNER does. Resolving through the
         // owner is what makes "add frank-laptop as a contact" mean "add Frank".
-        IdentityKind::Node | IdentityKind::Agent => {
-            lens.owner_of(any_id).await.ok_or_else(stall)?
-        }
+        IdentityKind::Node | IdentityKind::Agent => match lens.owner_of(any_id).await {
+            Some(owner) => owner,
+            None => {
+                // The readability probe runs only when the KEY lookup misses. A
+                // key that resolves and an owner that does not can still be a
+                // local backend failure, and reporting that as
+                // `NotYetDiscovered` tells an operator to wait for replication
+                // to repair a disk.
+                return Err(if lens.directory_readable().await {
+                    stall()
+                } else {
+                    LadderStall::DirectoryUnreadable {
+                        key_id: any_id.to_owned(),
+                    }
+                });
+            }
+        },
         // A steward or accord holder is not a contactable person. TERMINAL, not
         // `NotYetDiscovered`: the latter self-resolves, so a caller would retry
         // forever against something that will never become contactable — and the
@@ -214,6 +228,9 @@ pub async fn resolve(lens: &dyn DirectoryLens, any_id: &str) -> Result<Subject, 
     };
 
     let nodes = lens.nodes_owned_by(&fed_id).await;
+    if nodes.is_empty() && !lens.directory_readable().await {
+        return Err(LadderStall::DirectoryUnreadable { key_id: fed_id });
+    }
     if nodes.is_empty() {
         // Known person, nothing to reach. Distinct from "unknown key", and the
         // remedy is the same: wait for their announce to replicate.

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -352,6 +352,35 @@ pub fn log_rung(rung: Rung, fed_id: &str, stall: Option<&LadderStall>) {
     }
 }
 
+/// [`RouteLens`] over the live Reticulum transport.
+///
+/// This is the half unit tests cannot reach. Resolution is pure logic and is
+/// tested against a fake lens; whether a real node can actually address a peer
+/// depends on announces having arrived and routes having been admitted, which is
+/// only true in a running mesh. `knows_peer` is the transport's own readback for
+/// "can this node address that key right now" — the same question the send path
+/// asks before it dials.
+#[cfg(feature = "transport-reticulum")]
+pub struct ReticulumRoutes<'a> {
+    transport: &'a crate::transport::reticulum::ReticulumTransport,
+}
+
+#[cfg(feature = "transport-reticulum")]
+impl<'a> ReticulumRoutes<'a> {
+    #[must_use]
+    pub fn new(transport: &'a crate::transport::reticulum::ReticulumTransport) -> Self {
+        Self { transport }
+    }
+}
+
+#[cfg(feature = "transport-reticulum")]
+#[async_trait::async_trait]
+impl RouteLens for ReticulumRoutes<'_> {
+    async fn has_destination(&self, node_key_id: &str) -> bool {
+        self.transport.knows_peer(node_key_id).await
+    }
+}
+
 /// A resolved subject that is actually CONTACTABLE.
 ///
 /// [`resolve`] proves someone owns nodes. This proves at least one of them can

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -1,0 +1,285 @@
+//! CIRISEdge#552/#554 — the contact ladder: **announce → discover → request →
+//! consent → chat**.
+//!
+//! # Why this module exists at all
+//!
+//! Every rung of this ladder already existed as a primitive, and none of it was
+//! reachable without knowing five subsystems. Discovery meant resolving a
+//! `TransportDestination` yourself; a contact meant hand-building a
+//! `consent:replication:v1` grant; a chat room meant knowing it is really a
+//! 2-member `Community`. That is not a DX problem in the cosmetic sense — it is
+//! why the ladder had never been walked end to end, and why nobody could say
+//! which rung was broken.
+//!
+//! So the surface here takes a **fedID and nothing else**. `discover(fed_id)`,
+//! `request_contact(fed_id)`, `accept_contact(fed_id)`, `open_chat(fed_id)`.
+//! Anything a caller must look up first is a rung they can get wrong.
+//!
+//! # Multi-hop is free, and that is load-bearing
+//!
+//! A node publishes its RNS transport key on the `TransportDestination` plane.
+//! Once discovery yields that, **Reticulum routes to it across however many hops
+//! separate the two nodes** — edge does not implement relaying, path discovery,
+//! or a DHT to make contact work at range.
+//!
+//! This is why the hash-first directory (#552) does not need multi-hop hash
+//! propagation to deliver contact: what has to travel is the *destination*, and
+//! the transport already carries it. A node one hop from a body-holder can
+//! discover anyone that holder knows, and then reach them directly at any
+//! distance.
+//!
+//! # Every rung logs, and says what to do
+//!
+//! The ladder is diagnosed from logs, because its failures are distributed: the
+//! rung that breaks is usually not on the node you are looking at. So each rung
+//! emits a structured event with the same shape — step, subject, outcome — and a
+//! failure names the ACTIONABLE cause, not the mechanical one. "no transport
+//! destination for X: it has not announced, or this node has not admitted its
+//! announce" beats "lookup returned None".
+
+use std::fmt;
+
+/// A rung of the ladder. Stable strings — an operator greps these, and a
+/// dashboard groups by them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rung {
+    /// This node published its own identity and transport key.
+    Announce,
+    /// Resolve a fedID to something reachable.
+    Discover,
+    /// Ask a peer to be a contact. Point-to-point; leaves no federation trace.
+    RequestContact,
+    /// Grant replication consent — the contact becomes real and replicable.
+    Consent,
+    /// Open or find the 2-member community that carries the conversation.
+    OpenChat,
+    /// Put a message in it.
+    SendMessage,
+}
+
+impl Rung {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Announce => "announce",
+            Self::Discover => "discover",
+            Self::RequestContact => "request_contact",
+            Self::Consent => "consent",
+            Self::OpenChat => "open_chat",
+            Self::SendMessage => "send_message",
+        }
+    }
+
+    /// The rung before this one. A failure is nearly always the previous rung
+    /// not having completed, so the diagnostic can say where to look.
+    #[must_use]
+    pub const fn previous(self) -> Option<Self> {
+        match self {
+            Self::Announce => None,
+            Self::Discover => Some(Self::Announce),
+            Self::RequestContact => Some(Self::Discover),
+            Self::Consent => Some(Self::RequestContact),
+            Self::OpenChat => Some(Self::Consent),
+            Self::SendMessage => Some(Self::OpenChat),
+        }
+    }
+}
+
+impl fmt::Display for Rung {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Why a rung did not complete — in terms of what an operator can do about it.
+///
+/// Deliberately NOT a wrapper over the underlying error types. A caller that
+/// needs the mechanical cause has the log; this is the axis a human acts on, and
+/// keeping it small is what makes it usable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LadderStall {
+    /// The subject has not announced, or this node has not admitted its
+    /// announce yet. Resolves itself as replication converges.
+    NotYetDiscovered { fed_id: String },
+    /// Discovered, but nothing answered. The peer may be offline; RNS will route
+    /// when it returns.
+    Unreachable { fed_id: String },
+    /// The peer has not consented. Not an error — the ladder is waiting on a
+    /// human, and no amount of retrying changes that.
+    AwaitingConsent { fed_id: String },
+    /// This node has not consented to the peer. The reciprocal of the above.
+    ConsentNotGranted { fed_id: String },
+    /// The rung before this one has not completed.
+    PriorRungIncomplete { rung: Rung, prior: Rung },
+}
+
+impl LadderStall {
+    /// What an operator should do. Every arm answers it — a stall with no
+    /// remedy is a bug report, not a diagnostic.
+    #[must_use]
+    pub fn remedy(&self) -> String {
+        match self {
+            Self::NotYetDiscovered { fed_id } => format!(
+                "no transport destination for {fed_id}: either it has not announced, \
+                 or this node has not admitted its announce yet. Check that the peer \
+                 is running and that a replication round with it has completed."
+            ),
+            Self::Unreachable { fed_id } => format!(
+                "{fed_id} is discoverable but did not answer. It is probably offline; \
+                 Reticulum will route to it across the mesh when it returns. No action \
+                 needed unless it stays unreachable while known to be up."
+            ),
+            Self::AwaitingConsent { fed_id } => format!(
+                "waiting for {fed_id} to accept the contact request. This is a person, \
+                 not a timeout — retrying does not help and re-sending is spam."
+            ),
+            Self::ConsentNotGranted { fed_id } => format!(
+                "this node has not granted replication consent to {fed_id}. Accept the \
+                 contact request to make the conversation replicable in both directions."
+            ),
+            Self::PriorRungIncomplete { rung, prior } => format!(
+                "{rung} cannot proceed because {prior} has not completed. Look at the \
+                 {prior} rung on this node first — a ladder failure is nearly always \
+                 the rung before it."
+            ),
+        }
+    }
+
+    /// Is this a stall the ladder resolves on its own?
+    ///
+    /// The distinction that matters operationally: a `false` here means the
+    /// ladder is waiting on a HUMAN, and an operator watching a dashboard should
+    /// not treat it as a fault to escalate.
+    #[must_use]
+    pub const fn self_resolving(&self) -> bool {
+        match self {
+            Self::NotYetDiscovered { .. } | Self::Unreachable { .. } => true,
+            Self::AwaitingConsent { .. }
+            | Self::ConsentNotGranted { .. }
+            | Self::PriorRungIncomplete { .. } => false,
+        }
+    }
+}
+
+/// Emit the one structured line a rung produces.
+///
+/// One shape for every rung, so `step=` is greppable and a dashboard can group
+/// without parsing prose. Success is INFO because walking the ladder is a rare,
+/// meaningful event — not a hot path — and the first question after "it did not
+/// work" is always which rungs DID.
+pub fn log_rung(rung: Rung, fed_id: &str, stall: Option<&LadderStall>) {
+    match stall {
+        None => tracing::info!(
+            step = rung.as_str(),
+            fed_id,
+            outcome = "ok",
+            "contact ladder: {rung} completed for {fed_id}"
+        ),
+        Some(s) if s.self_resolving() => tracing::info!(
+            step = rung.as_str(),
+            fed_id,
+            outcome = "waiting",
+            remedy = %s.remedy(),
+            "contact ladder: {rung} is waiting — this resolves itself"
+        ),
+        Some(s) => tracing::warn!(
+            step = rung.as_str(),
+            fed_id,
+            outcome = "stalled",
+            remedy = %s.remedy(),
+            "contact ladder: {rung} stalled and needs someone to act"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LadderStall, Rung};
+
+    /// The ladder is ordered, and the order is the diagnostic. A failure is
+    /// nearly always the previous rung, so every rung must be able to name it.
+    #[test]
+    fn every_rung_but_the_first_names_its_predecessor() {
+        assert_eq!(Rung::Announce.previous(), None, "announce is the base");
+        for rung in [
+            Rung::Discover,
+            Rung::RequestContact,
+            Rung::Consent,
+            Rung::OpenChat,
+            Rung::SendMessage,
+        ] {
+            assert!(
+                rung.previous().is_some(),
+                "{rung} must name the rung to look at first"
+            );
+        }
+    }
+
+    /// Waiting on a PERSON is not a fault. An operator dashboard that escalates
+    /// "awaiting consent" trains people to ignore it, and then they ignore the
+    /// real ones too.
+    #[test]
+    fn waiting_on_a_human_is_not_self_resolving() {
+        let awaiting = LadderStall::AwaitingConsent {
+            fed_id: "fed_abc".into(),
+        };
+        assert!(!awaiting.self_resolving());
+
+        let converging = LadderStall::NotYetDiscovered {
+            fed_id: "fed_abc".into(),
+        };
+        assert!(
+            converging.self_resolving(),
+            "an unconverged directory fixes itself and must not page anyone"
+        );
+    }
+
+    /// Every stall answers "what do I do". A diagnostic that names a condition
+    /// and no action is a bug report addressed to the wrong person.
+    #[test]
+    fn every_stall_states_a_remedy_naming_its_subject() {
+        let id = "fed_7f3a9c21e4b8";
+        let stalls = [
+            LadderStall::NotYetDiscovered { fed_id: id.into() },
+            LadderStall::Unreachable { fed_id: id.into() },
+            LadderStall::AwaitingConsent { fed_id: id.into() },
+            LadderStall::ConsentNotGranted { fed_id: id.into() },
+        ];
+        for s in stalls {
+            let r = s.remedy();
+            assert!(r.len() > 40, "a remedy must actually say something: {r}");
+            assert!(
+                r.contains(id),
+                "a remedy must name its subject so a log line is actionable alone: {r}"
+            );
+        }
+        // The structural one names rungs rather than a fedID.
+        let prior = LadderStall::PriorRungIncomplete {
+            rung: Rung::OpenChat,
+            prior: Rung::Consent,
+        };
+        let r = prior.remedy();
+        assert!(r.contains("open_chat") && r.contains("consent"), "{r}");
+    }
+
+    /// The rung strings are an operator interface: they are grepped and grouped.
+    #[test]
+    fn rung_names_are_stable_and_distinct() {
+        let names: Vec<&str> = [
+            Rung::Announce,
+            Rung::Discover,
+            Rung::RequestContact,
+            Rung::Consent,
+            Rung::OpenChat,
+            Rung::SendMessage,
+        ]
+        .iter()
+        .map(|r| r.as_str())
+        .collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), names.len(), "rung names must be distinct");
+        assert!(names.contains(&"request_contact"));
+    }
+}

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -11,9 +11,27 @@
 //! why the ladder had never been walked end to end, and why nobody could say
 //! which rung was broken.
 //!
-//! So the surface here takes a **fedID and nothing else**. `discover(fed_id)`,
-//! `request_contact(fed_id)`, `accept_contact(fed_id)`, `open_chat(fed_id)`.
-//! Anything a caller must look up first is a rung they can get wrong.
+//! So the surface here takes a **fedID and nothing else**. Anything a caller
+//! must look up first is a rung they can get wrong.
+//!
+//! # What lives here, and what deliberately does not
+//!
+//! Edge owns the rungs that are about REACHING someone:
+//!
+//! * [`resolve`] — any identifier (fedID, nodeID, agentID) to the person and the
+//!   nodes that reach them;
+//! * [`discover`] — that, plus a transport destination, so "discovered" means
+//!   contactable rather than merely known.
+//!
+//! **Consent and chat are CIRISServer's**, and are not reimplemented here.
+//! `POST /v1/contacts` already ensures a `consent:replication:v1` grant covers
+//! `chat:`; `POST /v1/chat` already writes a 2-member `Community`;
+//! `POST /v1/chat/{id}/messages` already writes a `chat:message:v1` attestation.
+//! A second implementation of any of those in edge would be two components
+//! owning one rule — which is the failure this codebase keeps paying for, and
+//! the reason [`Rung`] names those rungs without implementing them: the ladder
+//! is a shared vocabulary for diagnosis, not a claim about who executes each
+//! step.
 //!
 //! # Multi-hop is free, and that is load-bearing
 //!
@@ -334,6 +352,66 @@ pub fn log_rung(rung: Rung, fed_id: &str, stall: Option<&LadderStall>) {
     }
 }
 
+/// A resolved subject that is actually CONTACTABLE.
+///
+/// [`resolve`] proves someone owns nodes. This proves at least one of them can
+/// be reached — which is a different claim, and the one a caller acts on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Discovered {
+    pub subject: Subject,
+    /// The nodes with a transport destination this node can dial. Never empty.
+    pub reachable: Vec<String>,
+}
+
+/// Resolve an identifier AND confirm somewhere to send.
+///
+/// `nodes_owned_by` proves ownership, not reachability: a person can own nodes
+/// this node has no route to, and reporting that as discovered hands the caller
+/// a `Subject` whose every send fails. The distinction matters because the two
+/// have different remedies — an unknown key waits for the directory, an
+/// unreachable node waits for the peer.
+///
+/// Once a destination IS known, distance stops mattering: a node publishes its
+/// RNS transport key, and Reticulum routes to it across however many hops
+/// separate the two. Edge implements no relaying to make that work.
+///
+/// # Errors
+/// [`LadderStall::NotYetDiscovered`] if the identifier does not resolve;
+/// [`LadderStall::Unreachable`] if it resolves to a person whose nodes have no
+/// route yet.
+pub async fn discover(
+    lens: &dyn DirectoryLens,
+    routes: &dyn RouteLens,
+    any_id: &str,
+) -> Result<Discovered, LadderStall> {
+    let subject = resolve(lens, any_id).await?;
+    let mut reachable = Vec::new();
+    for node in &subject.nodes {
+        if routes.has_destination(node).await {
+            reachable.push(node.clone());
+        }
+    }
+    if reachable.is_empty() {
+        let stall = LadderStall::Unreachable {
+            fed_id: subject.fed_id.clone(),
+        };
+        log_rung(Rung::Discover, &subject.fed_id, Some(&stall));
+        return Err(stall);
+    }
+    log_rung(Rung::Discover, &subject.fed_id, None);
+    Ok(Discovered { subject, reachable })
+}
+
+/// Whether this node has a transport destination for a peer.
+///
+/// Separate from [`DirectoryLens`] because it is a TRANSPORT question, not a
+/// directory one: the answer changes as announces arrive, and conflating them
+/// would make discovery look like a directory failure when it is a routing one.
+#[async_trait::async_trait]
+pub trait RouteLens: Send + Sync {
+    async fn has_destination(&self, node_key_id: &str) -> bool;
+}
+
 /// The [`DirectoryLens`] over a real persist directory.
 ///
 /// Thin on purpose: every rule that can be got wrong lives in [`resolve`] and is
@@ -509,6 +587,71 @@ mod tests {
             "the remedy must name the person we could not reach: {}",
             stall.remedy()
         );
+    }
+
+    struct AllRouted;
+    #[async_trait::async_trait]
+    impl super::RouteLens for AllRouted {
+        async fn has_destination(&self, _node: &str) -> bool {
+            true
+        }
+    }
+    struct NoRoutes;
+    #[async_trait::async_trait]
+    impl super::RouteLens for NoRoutes {
+        async fn has_destination(&self, _node: &str) -> bool {
+            false
+        }
+    }
+    struct OnlyPhone;
+    #[async_trait::async_trait]
+    impl super::RouteLens for OnlyPhone {
+        async fn has_destination(&self, node: &str) -> bool {
+            node == "frank-phone-eee"
+        }
+    }
+
+    /// Discovery means CONTACTABLE, not merely known. Owning nodes this node has
+    /// no route to is not discovery — reporting it as such hands the caller a
+    /// subject whose every send fails, with no clue why.
+    #[tokio::test]
+    async fn owning_nodes_with_no_route_is_not_discovery() {
+        let Err(stall) = super::discover(&frank(), &NoRoutes, "frank-fed-aaa").await else {
+            panic!("no route means not contactable");
+        };
+        assert!(
+            matches!(stall, super::LadderStall::Unreachable { .. }),
+            "an unreachable peer and an unknown key have DIFFERENT remedies — one \
+             waits for the peer, the other for the directory"
+        );
+        assert!(stall.self_resolving(), "the peer may simply be offline");
+    }
+
+    /// Only the nodes with a route are offered. Handing back an unroutable node
+    /// alongside a routable one invites the caller to pick the wrong one.
+    #[tokio::test]
+    async fn discovery_returns_only_the_reachable_nodes() {
+        let d = super::discover(&frank(), &OnlyPhone, "frank-laptop-bbb")
+            .await
+            .expect("one routable node is enough");
+        assert_eq!(d.reachable, vec!["frank-phone-eee".to_string()]);
+        assert_eq!(
+            d.subject.nodes.len(),
+            2,
+            "the subject still knows about both — only REACHABLE is filtered"
+        );
+    }
+
+    /// And any identifier still gets there.
+    #[tokio::test]
+    async fn discovery_works_from_any_identifier() {
+        for id in ["frank-fed-aaa", "frank-laptop-bbb", "frank-agent-ccc"] {
+            let d = super::discover(&frank(), &AllRouted, id)
+                .await
+                .expect("resolves");
+            assert_eq!(d.subject.fed_id, "frank-fed-aaa");
+            assert_eq!(d.reachable.len(), 2);
+        }
     }
 
     /// The ladder is ordered, and the order is the diagnostic. A failure is

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -453,7 +453,19 @@ pub async fn discover(
     routes: &dyn RouteLens,
     any_id: &str,
 ) -> Result<Discovered, LadderStall> {
-    let subject = resolve(lens, any_id).await?;
+    // Log the RESOLUTION stall here rather than `?`-ing past it. The stalls
+    // that reach this line — an unknown key, a queued body fetch, a missing
+    // owner, a non-contactable identity — are the ordinary ones in a
+    // distributed directory, and returning silently left `step=discover` in the
+    // diagnostic stream only for route failures and successes. The rung that
+    // fails most is then the one an operator cannot see.
+    let subject = match resolve(lens, any_id).await {
+        Ok(subject) => subject,
+        Err(stall) => {
+            log_rung(Rung::Discover, any_id, Some(&stall));
+            return Err(stall);
+        }
+    };
     let mut reachable = Vec::new();
     for node in &subject.nodes {
         if routes.has_destination(node).await {

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -614,27 +614,23 @@ impl DirectoryLens for PersistLens<'_> {
             .unwrap_or_default()
     }
 
-    async fn request_key_body(&self, key_id: &str) -> bool {
-        let Some(replication) = self.replication.as_ref() else {
-            return false;
-        };
-        // The same gate the admission path uses: under `Bodies` the body
-        // replicates on its own, so queueing would ask for something already in
-        // flight and the stall's ordinary remedy is the right one.
-        if !crate::replication::retention::should_note_missing_signer(
-            replication.retention(crate::replication::protocol::EnvelopeKind::Key),
-        ) {
-            return false;
-        }
-        // No delivering peer: a contact lookup is not repairing a row someone
-        // sent us, so there is no holder candidate. Recorded unrouted, which
-        // makes successive rounds try it against successive peers.
-        replication.note_missing_signer(
-            crate::replication::protocol::EnvelopeKind::Key,
-            key_id,
-            None,
-        );
-        true
+    async fn request_key_body(&self, _key_id: &str) -> bool {
+        // Deliberately always false, and the reason is a real limitation rather
+        // than an omission.
+        //
+        // A responder answers an identifier Pull on a public plane only for its
+        // OWN record; a third-party probe is refused, because
+        // `subject_holdings_inner` would otherwise turn a body-holding server
+        // into an address-book oracle for subjects it never advertised. A
+        // contact lookup is exactly a third-party request and has no delivering
+        // peer to route to, so there is no request this node can emit that any
+        // peer will answer.
+        //
+        // Reporting `BodyFetchQueued` here would promise a fetch that never
+        // happens. Resolving an unheld third-party identifier on a hash-first
+        // node needs a separately authorized, rate-limited resolver, which does
+        // not exist yet.
+        false
     }
 }
 

--- a/src/contact.rs
+++ b/src/contact.rs
@@ -139,6 +139,19 @@ pub trait DirectoryLens: Send + Sync {
     async fn request_key_body(&self, _key_id: &str) -> bool {
         false
     }
+
+    /// CIRISEdge#552 — can this node read its directory at all?
+    ///
+    /// Separates "the key is absent" from "the local read failed", which
+    /// `identity_type_of` reports identically as `None`. Only the first is
+    /// repairable by a peer; treating the second as absence emits a Pull no
+    /// reply can satisfy while telling an operator to wait for a round that
+    /// will not help.
+    ///
+    /// Defaults to `true` — a lens with no backend to fail.
+    async fn directory_readable(&self) -> bool {
+        true
+    }
 }
 
 /// Resolve any identifier to the person and the nodes that reach them.
@@ -163,6 +176,14 @@ pub async fn resolve(lens: &dyn DirectoryLens, any_id: &str) -> Result<Subject, 
     // different and the wait is bounded, so the stall must say so; a caller
     // told to wait for an announce that already happened waits forever.
     let Some(identity_type) = lens.identity_type_of(any_id).await else {
+        // A local read failure is not an absence. Check before queueing: a Pull
+        // cannot repair a backend this node cannot read, and reporting
+        // `BodyFetchQueued` would promise a remedy that never arrives.
+        if !lens.directory_readable().await {
+            return Err(LadderStall::DirectoryUnreadable {
+                key_id: any_id.to_owned(),
+            });
+        }
         return Err(if lens.request_key_body(any_id).await {
             LadderStall::BodyFetchQueued {
                 key_id: any_id.to_owned(),
@@ -277,6 +298,10 @@ pub enum LadderStall {
     ConsentNotGranted { fed_id: String },
     /// The rung before this one has not completed.
     PriorRungIncomplete { rung: Rung, prior: Rung },
+    /// CIRISEdge#552 — the local directory could not be read. NOT
+    /// self-resolving: no peer reply repairs a local backend failure, so
+    /// retrying is the one thing that cannot help.
+    DirectoryUnreadable { key_id: String },
     /// CIRISEdge#552 — this node knows the key as a HASH and has queued a fetch
     /// for its body. Self-resolving, but for a different reason than
     /// [`Self::NotYetDiscovered`]: nothing is waiting on the subject to
@@ -325,6 +350,12 @@ impl LadderStall {
                  instead, or check that the identifier is the one you meant — this \
                  will not resolve by waiting."
             ),
+            Self::DirectoryUnreadable { key_id } => format!(
+                "the local federation directory could not be read while resolving \
+                 {key_id}. This is a LOCAL fault — no peer reply repairs it and \
+                 retrying will not help. Check the node's persist backend \
+                 (disk, permissions, migration state) before looking at the mesh."
+            ),
             Self::BodyFetchQueued { key_id } => format!(
                 "{key_id} is known to this node as a hash, but its body was not \
                  held — this node runs hash-first retention. A fetch is queued and \
@@ -356,7 +387,9 @@ impl LadderStall {
             | Self::ConsentNotGranted { .. }
             | Self::PriorRungIncomplete { .. }
             // Terminal by nature: a steward does not become a person.
-            | Self::NotContactable { .. } => false,
+            | Self::NotContactable { .. }
+            // A local backend fault: the one stall retrying cannot fix.
+            | Self::DirectoryUnreadable { .. } => false,
         }
     }
 }
@@ -532,16 +565,23 @@ impl<'a> PersistLens<'a> {
 #[async_trait::async_trait]
 impl DirectoryLens for PersistLens<'_> {
     async fn identity_type_of(&self, key_id: &str) -> Option<String> {
-        // An error and an absence are the SAME answer here on purpose: both mean
-        // "this node cannot say what that key is yet", and the ladder's stall for
-        // that is `NotYetDiscovered`, which self-resolves. Distinguishing them
-        // would produce a second diagnostic with the same remedy.
         self.directory
             .lookup_public_key(key_id)
             .await
             .ok()
             .flatten()
             .map(|record| record.identity_type)
+    }
+
+    async fn directory_readable(&self) -> bool {
+        // CIRISEdge#552 — an error and an absence were folded together here on
+        // the reasoning that both mean "cannot say yet" and share a remedy. They
+        // no longer do. An ABSENCE on a hash-first node queues a body fetch and
+        // reports `BodyFetchQueued`, whose remedy is "the next Key round carries
+        // it". A local backend failure cannot be repaired by any peer, so that
+        // remedy is false and the Pull is pointless traffic emitted on every
+        // retry. Probing the same read is enough to separate them.
+        self.directory.lookup_public_key("").await.is_ok()
     }
 
     async fn owner_of(&self, key_id: &str) -> Option<String> {
@@ -569,7 +609,14 @@ impl DirectoryLens for PersistLens<'_> {
         ) {
             return false;
         }
-        replication.note_missing_signer(crate::replication::protocol::EnvelopeKind::Key, key_id);
+        // No delivering peer: a contact lookup is not repairing a row someone
+        // sent us, so there is no holder candidate. Recorded unrouted, which
+        // makes successive rounds try it against successive peers.
+        replication.note_missing_signer(
+            crate::replication::protocol::EnvelopeKind::Key,
+            key_id,
+            None,
+        );
         true
     }
 }
@@ -912,6 +959,65 @@ mod tests {
             err.remedy().contains("already did"),
             "the remedy must NOT tell an operator to wait for an announce that \
              already happened: {}",
+            err.remedy()
+        );
+    }
+
+    /// CIRISEdge#552 — a local backend failure must NOT be reported as a
+    /// queued fetch.
+    ///
+    /// `identity_type_of` answers `None` for both "absent" and "the read
+    /// failed". Only the first is repairable by a peer. Conflating them emits a
+    /// Pull no reply can satisfy — on every retry — while telling an operator
+    /// the next Key round will resolve it, which is a remedy that never comes.
+    #[tokio::test]
+    async fn a_backend_failure_is_not_reported_as_a_queued_fetch() {
+        struct BrokenBackendLens {
+            requested: std::sync::Mutex<Vec<String>>,
+        }
+        #[async_trait::async_trait]
+        impl super::DirectoryLens for BrokenBackendLens {
+            async fn identity_type_of(&self, _key_id: &str) -> Option<String> {
+                None // indistinguishable from absence, by construction
+            }
+            async fn owner_of(&self, _key_id: &str) -> Option<String> {
+                None
+            }
+            async fn nodes_owned_by(&self, _fed_id: &str) -> Vec<String> {
+                Vec::new()
+            }
+            async fn directory_readable(&self) -> bool {
+                false
+            }
+            async fn request_key_body(&self, key_id: &str) -> bool {
+                self.requested.lock().unwrap().push(key_id.to_owned());
+                true
+            }
+        }
+
+        let lens = BrokenBackendLens {
+            requested: std::sync::Mutex::new(Vec::new()),
+        };
+        let err = super::resolve(&lens, "frank-abc123")
+            .await
+            .expect_err("a node that cannot read its directory resolves nothing");
+
+        assert!(
+            lens.requested.lock().unwrap().is_empty(),
+            "no Pull may be emitted for a LOCAL read failure — no peer reply can \
+             repair it, so the traffic is pointless on every retry"
+        );
+        assert!(
+            matches!(err, LadderStall::DirectoryUnreadable { .. }),
+            "expected DirectoryUnreadable, got {err:?}"
+        );
+        assert!(
+            !err.self_resolving(),
+            "retrying is the one thing that cannot fix a local backend fault"
+        );
+        assert!(
+            err.remedy().contains("LOCAL"),
+            "the remedy must send an operator to the node, not the mesh: {}",
             err.remedy()
         );
     }

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -1600,6 +1600,17 @@ pub fn baked_canonical_ip_dials() -> Vec<(String, std::net::SocketAddr)> {
 }
 
 impl Edge {
+    /// CIRISEdge#552 — the mode this Edge was initialized with.
+    ///
+    /// Exposed because the replication runtime needs it: `BridgeConfig::mode`
+    /// selects retention, and without this the host path built the bridge from
+    /// `Default` and an Edge started with `agent_mode="server"` still ran the
+    /// `Proxy` default — a documented flag with no effect.
+    #[must_use]
+    pub fn agent_mode(&self) -> crate::AgentMode {
+        self.config.agent_mode
+    }
+
     #[must_use]
     pub fn builder() -> EdgeBuilder {
         EdgeBuilder {

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2503,6 +2503,13 @@ impl PyEdge {
         // path. The mode belongs to the Edge, so it is read from the Edge rather
         // than re-parsed or passed again by the caller.
         config.bridge.mode = self.inner.agent_mode();
+        // CIRISEdge#552 — and its own key_id, for the same reason: the Pull
+        // responder answers an identifier request for THIS NODE'S OWN record,
+        // which it cannot recognise without knowing which key_id that is. Left
+        // `None` by `Default`, the arm can never match and the recovery path is
+        // inert through the shipped host path — the same silent-default failure
+        // as the mode above, in the same function.
+        config.local_key_id = Some(self.inner.signer_key_id().to_string());
         // CIRISEdge#370 — hand the live metrics bag to the runtime so its
         // scheduler event-sink consumer folds each round's outcome into the
         // round-outcome counter surfaced by `metrics_snapshot`. Cheap clone;
@@ -11414,6 +11421,12 @@ mod node_identity_tests {
             .find("    fn start_replication(")
             .expect("start_replication exists");
         let body = &src[start..start + 8000];
+        assert!(
+            body.contains("config.local_key_id = Some(self.inner.signer_key_id().to_string());"),
+            "start_replication must set config.local_key_id from the Edge's own \
+             signer — without it the Pull responder cannot recognise a request \
+             for its own record and missing-signer recovery is inert"
+        );
         assert!(
             body.contains("config.bridge.mode = self.inner.agent_mode();"),
             "start_replication must set config.bridge.mode from the Edge's own \

--- a/src/ffi/pyo3.rs
+++ b/src/ffi/pyo3.rs
@@ -2495,6 +2495,14 @@ impl PyEdge {
         if let Some(secs) = cadence_seconds {
             config.scheduler.cadence = std::time::Duration::from_secs(secs);
         }
+        // CIRISEdge#552 — carry the Edge's OWN agent_mode into the bridge.
+        // `BridgeConfig::mode` selects retention, and this entry point built the
+        // config from `Default`, so an Edge initialized with agent_mode="server"
+        // still constructed a `Proxy` bridge: every production round chose
+        // `Bodies` and the mode flag did nothing at all through the shipped host
+        // path. The mode belongs to the Edge, so it is read from the Edge rather
+        // than re-parsed or passed again by the caller.
+        config.bridge.mode = self.inner.agent_mode();
         // CIRISEdge#370 — hand the live metrics bag to the runtime so its
         // scheduler event-sink consumer folds each round's outcome into the
         // round-outcome counter surfaced by `metrics_snapshot`. Cheap clone;
@@ -11387,6 +11395,30 @@ mod node_identity_tests {
         assert!(
             leftovers.is_empty(),
             "edge must OPEN the node identity, never MINT it — but it created: {leftovers:?}"
+        );
+    }
+
+    /// CIRISEdge#552 — `start_replication` must carry the Edge's agent_mode
+    /// into the bridge config.
+    ///
+    /// A SOURCE assertion, like the `is_bootstrap` wiring pin, because no Rust
+    /// test can observe this: the effect only appears through the Python host
+    /// path, and the failure is silent — the bridge takes its `Proxy` default
+    /// and every round selects `Bodies`, so a server-mode Edge behaves exactly
+    /// like a correctly-configured proxy. That is what shipped: the mode flag
+    /// was documented, parsed, validated, and then dropped on the floor here.
+    #[test]
+    fn start_replication_propagates_the_agent_mode_into_the_bridge() {
+        let src = include_str!("pyo3.rs");
+        let start = src
+            .find("    fn start_replication(")
+            .expect("start_replication exists");
+        let body = &src[start..start + 8000];
+        assert!(
+            body.contains("config.bridge.mode = self.inner.agent_mode();"),
+            "start_replication must set config.bridge.mode from the Edge's own \
+             agent_mode — without it BridgeConfig takes its Proxy default and \
+             hash-first retention is unreachable through the shipped host path"
         );
     }
 }

--- a/src/invite_gate.rs
+++ b/src/invite_gate.rs
@@ -72,6 +72,11 @@ pub enum RefuseReason {
     AlreadyPending,
     /// This sender has spent its budget and has not been accepted before.
     BudgetSpent,
+    /// CIRISEdge#554 — the receiver is already tracking as many strangers as it
+    /// will hold, and none could be released. A GLOBAL bound, not a per-sender
+    /// one: identity rotation defeats a per-sender budget by never reusing a
+    /// sender, so without a ceiling the map is the attack surface.
+    ReceiverAtCapacity,
 }
 
 /// Per-(sender, receiver) invite budget. One instance per receiving node.
@@ -111,9 +116,61 @@ impl InviteGate {
         Self::default()
     }
 
+    /// How many senders one receiver tracks. Past it, strangers whose budget
+    /// has fully refilled are released; if none can be, a new stranger is
+    /// refused outright rather than growing the map.
+    const SENDER_CAP: usize = 65_536;
+
+    /// Drop strangers whose budget has fully refilled.
+    ///
+    /// This is free, not a tradeoff: a stranger past `REFILL_SECS` has `spent`
+    /// reset on its next `admit`, so its retained state is
+    /// INDISTINGUISHABLE from that of a sender never seen before. Forgetting it
+    /// changes no verdict.
+    ///
+    /// `ever_accepted` senders are never released — that bit is the whole point
+    /// of the gate (an established contact must not be throttled like a
+    /// stranger), and it cannot be reconstructed from an invite.
+    fn release_refilled_strangers(&mut self, now: Ts) {
+        let before = self.senders.len();
+        self.senders.retain(|_, st| {
+            st.ever_accepted || now.saturating_sub(st.last_attempt) < Self::REFILL_SECS
+        });
+        let released = before - self.senders.len();
+        if released > 0 {
+            tracing::debug!(
+                released,
+                remaining = self.senders.len(),
+                "invite gate released refilled strangers (CIRISEdge#554)"
+            );
+        }
+    }
+
+    /// How many senders this receiver is currently tracking.
+    #[must_use]
+    pub fn tracked_senders(&self) -> usize {
+        self.senders.len()
+    }
+
     /// Decide whether an invite from `sender` reaches the person.
     #[must_use]
     pub fn admit(&mut self, sender: &str, now: Ts) -> InviteVerdict {
+        // CIRISEdge#554 — bound the map BEFORE inserting a new stranger.
+        //
+        // A per-sender budget assumes the sender is a fixed thing to charge.
+        // Rotating identities breaks that assumption completely: every first
+        // invite is a fresh sender, allowed by its fresh budget, and it costs
+        // the receiver another permanent entry. The per-sender rule was
+        // therefore both bypassed and the memory-growth vector, which is the
+        // opposite of what it was for.
+        if !self.senders.contains_key(sender) && self.senders.len() >= Self::SENDER_CAP {
+            self.release_refilled_strangers(now);
+            if self.senders.len() >= Self::SENDER_CAP {
+                return InviteVerdict::Refuse {
+                    reason: RefuseReason::ReceiverAtCapacity,
+                };
+            }
+        }
         let state = self
             .senders
             .entry(sender.to_owned())
@@ -279,6 +336,69 @@ mod tests {
             g.admit("real-person", T0 + 100),
             InviteVerdict::Allow,
             "a flood from one sender must not silence everyone else"
+        );
+    }
+
+    /// CIRISEdge#554 — rotating identities must not grow the receiver without
+    /// bound, and must not evict an established contact to do it.
+    #[test]
+    fn identity_rotation_cannot_grow_the_receiver_without_bound() {
+        let mut gate = InviteGate::new();
+        let t0: super::Ts = 1_000_000;
+
+        // An established contact, seen once and accepted. This bit is the one
+        // thing the gate cannot reconstruct, so it must survive everything.
+        assert!(matches!(gate.admit("friend", t0), InviteVerdict::Allow));
+        gate.mark_accepted("friend");
+
+        // A flood of never-repeated senders, all at the same instant so none can
+        // be released as refilled.
+        for i in 0..(InviteGate::SENDER_CAP + 500) {
+            let _ = gate.admit(&format!("rotating-{i}"), t0);
+        }
+
+        assert!(
+            gate.tracked_senders() <= InviteGate::SENDER_CAP,
+            "the map must stay bounded under identity rotation: {} entries",
+            gate.tracked_senders()
+        );
+        assert!(
+            matches!(
+                gate.admit("another-stranger", t0),
+                InviteVerdict::Refuse {
+                    reason: RefuseReason::ReceiverAtCapacity
+                }
+            ),
+            "at capacity with nothing releasable, a NEW stranger is refused \
+             outright — the global bound is the control, since a per-sender \
+             budget is exactly what rotation defeats"
+        );
+
+        // The established contact still gets through, and is not throttled as a
+        // stranger.
+        assert!(
+            matches!(gate.admit("friend", t0), InviteVerdict::Allow),
+            "an accepted contact must never be evicted or throttled by a flood \
+             of strangers — that is the anti-spam control breaking the \
+             conversations it exists to protect"
+        );
+    }
+
+    /// Once a stranger's budget has refilled, its retained state is
+    /// indistinguishable from never having been seen — so releasing it is free
+    /// and reopens capacity.
+    #[test]
+    fn refilled_strangers_are_released_to_make_room() {
+        let mut gate = InviteGate::new();
+        let t0: super::Ts = 1_000_000;
+        for i in 0..InviteGate::SENDER_CAP {
+            let _ = gate.admit(&format!("old-{i}"), t0);
+        }
+        let later = t0 + InviteGate::REFILL_SECS + 1;
+        assert!(
+            matches!(gate.admit("newcomer", later), InviteVerdict::Allow),
+            "after the refill window the old strangers are releasable, so a new \
+             sender is admitted rather than refused at capacity"
         );
     }
 }

--- a/src/invite_gate.rs
+++ b/src/invite_gate.rs
@@ -1,0 +1,263 @@
+//! CIRISEdge#554 — the receiver-side budget on unsolicited contact requests.
+//!
+//! # The threat this covers, and why nothing else does
+//!
+//! An invite is low-volume, well-formed, correctly signed, and semantically
+//! hostile. The existing defences are all about VOLUME — AV-10 (transport
+//! flooding), AV-13 (body size), AV-48 (high-N low-T envelope flood, whose trust
+//! threshold defaults to `0.0` bootstrap-permissive) — and none of them fire on
+//! one polite message from a stranger. That class is not in the threat model.
+//!
+//! It gets worse with the federation-tier directory: once every identity is
+//! promoted so the kill switch can reach it, mass invite spam stops needing a
+//! target list, because the directory IS the target list.
+//!
+//! # Enforced at the RECEIVER
+//!
+//! A sender-side limit is advice. The budget lives where the cost lands.
+//!
+//! # Small budget, slow refill, and decay for strangers
+//!
+//! A stranger gets ONE attempt, not a retry loop: a second unanswered request is
+//! not new information, it is pressure. Senders a receiver has never accepted
+//! decay toward zero, so persistence costs the sender rather than the receiver.
+//!
+//! And the check happens BEFORE a human sees anything, so the cost of spam is
+//! borne by the node and not by the person — which is the actual point. A filter
+//! that shows you the spam and then reports it was suspicious has already failed.
+
+use std::collections::HashMap;
+
+/// Unix seconds.
+type Ts = u64;
+
+/// What the gate decided, and why.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InviteVerdict {
+    /// Deliver it to the person.
+    Allow,
+    /// Drop it. The sender has spent its budget.
+    ///
+    /// Deliberately does NOT say when they may retry: telling a spammer the
+    /// refill interval is telling them the optimal send rate.
+    Refuse { reason: RefuseReason },
+}
+
+/// Why an invite was refused. For the RECEIVER's operator, never for the sender
+/// — a refusal that explains itself over the wire is a tuning oracle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefuseReason {
+    /// This sender has an unanswered request outstanding.
+    AlreadyPending,
+    /// This sender has spent its budget and has not been accepted before.
+    BudgetSpent,
+}
+
+/// Per-(sender, receiver) invite budget. One instance per receiving node.
+#[derive(Debug, Default)]
+pub struct InviteGate {
+    senders: HashMap<String, SenderState>,
+}
+
+#[derive(Debug, Clone)]
+struct SenderState {
+    /// When the sender last spent an attempt.
+    last_attempt: Ts,
+    /// Attempts spent and not yet refilled.
+    spent: u32,
+    /// Has this receiver ever accepted anything from this sender?
+    ///
+    /// The single most important bit here. An established contact is not a
+    /// stranger and must not be throttled like one — throttling replies is how
+    /// an anti-spam control breaks the conversations it was meant to protect.
+    ever_accepted: bool,
+}
+
+impl InviteGate {
+    /// A stranger's budget. ONE: a second unanswered request is not new
+    /// information.
+    pub const STRANGER_BUDGET: u32 = 1;
+    /// An accepted contact's budget. Higher because they are not a stranger, and
+    /// still bounded because a compromised contact is the better attack.
+    pub const CONTACT_BUDGET: u32 = 8;
+    /// How long an unanswered attempt occupies the budget. Long on purpose: the
+    /// thing being rate-limited is a human's attention, which does not refill in
+    /// seconds.
+    pub const REFILL_SECS: u64 = 86_400;
+
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Decide whether an invite from `sender` reaches the person.
+    #[must_use]
+    pub fn admit(&mut self, sender: &str, now: Ts) -> InviteVerdict {
+        let state = self
+            .senders
+            .entry(sender.to_owned())
+            .or_insert(SenderState {
+                last_attempt: 0,
+                spent: 0,
+                ever_accepted: false,
+            });
+
+        // Refill first, so a long-quiet sender is not judged on ancient history.
+        if now.saturating_sub(state.last_attempt) >= Self::REFILL_SECS {
+            state.spent = 0;
+        }
+
+        let budget = if state.ever_accepted {
+            Self::CONTACT_BUDGET
+        } else {
+            Self::STRANGER_BUDGET
+        };
+
+        if state.spent >= budget {
+            let reason = if state.ever_accepted {
+                RefuseReason::BudgetSpent
+            } else {
+                // A stranger with one spent attempt has a request outstanding —
+                // the more precise reason, and the one an operator reading a log
+                // wants: this is not a flood, it is someone waiting.
+                RefuseReason::AlreadyPending
+            };
+            tracing::debug!(
+                sender,
+                spent = state.spent,
+                budget,
+                ever_accepted = state.ever_accepted,
+                "invite refused at the receiver's budget (CIRISEdge#554)"
+            );
+            return InviteVerdict::Refuse { reason };
+        }
+
+        state.spent += 1;
+        state.last_attempt = now;
+        InviteVerdict::Allow
+    }
+
+    /// Record that this receiver ACCEPTED something from `sender`.
+    ///
+    /// Promotes them out of stranger budget permanently. Called when consent is
+    /// granted — an accepted contact should never be throttled as a stranger
+    /// again, because the control exists to stop unwanted first contact, not to
+    /// ration a conversation.
+    pub fn mark_accepted(&mut self, sender: &str) {
+        let entry = self
+            .senders
+            .entry(sender.to_owned())
+            .or_insert(SenderState {
+                last_attempt: 0,
+                spent: 0,
+                ever_accepted: false,
+            });
+        entry.ever_accepted = true;
+        // Their outstanding attempt was answered; it should not still count.
+        entry.spent = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InviteGate, InviteVerdict, RefuseReason};
+
+    const T0: u64 = 1_000_000;
+
+    /// A stranger gets ONE attempt. The second is pressure, not information.
+    #[test]
+    fn a_stranger_gets_exactly_one_attempt() {
+        let mut g = InviteGate::new();
+        assert_eq!(g.admit("stranger", T0), InviteVerdict::Allow);
+        assert_eq!(
+            g.admit("stranger", T0 + 1),
+            InviteVerdict::Refuse {
+                reason: RefuseReason::AlreadyPending
+            }
+        );
+    }
+
+    /// The refusal for a waiting stranger says PENDING, not "flood". An operator
+    /// reading the log is looking at someone waiting for an answer, and calling
+    /// that a flood would misdescribe the one case that is usually legitimate.
+    #[test]
+    fn a_waiting_stranger_is_pending_not_a_flood() {
+        let mut g = InviteGate::new();
+        let _spend = g.admit("stranger", T0);
+        let InviteVerdict::Refuse { reason } = g.admit("stranger", T0 + 1) else {
+            panic!("second attempt must refuse");
+        };
+        assert_eq!(reason, RefuseReason::AlreadyPending);
+    }
+
+    /// Accepting someone must stop throttling them. An anti-spam control that
+    /// rations an established conversation has broken the thing it protects.
+    #[test]
+    fn accepting_a_contact_lifts_the_stranger_budget() {
+        let mut g = InviteGate::new();
+        let _spend = g.admit("frank", T0);
+        assert!(matches!(
+            g.admit("frank", T0 + 1),
+            InviteVerdict::Refuse { .. }
+        ));
+
+        g.mark_accepted("frank");
+        for i in 0..InviteGate::CONTACT_BUDGET {
+            assert_eq!(
+                g.admit("frank", T0 + 10 + u64::from(i)),
+                InviteVerdict::Allow,
+                "an accepted contact must not be throttled as a stranger"
+            );
+        }
+    }
+
+    /// Even an accepted contact is bounded — a compromised contact is the better
+    /// attack precisely because it is trusted.
+    #[test]
+    fn an_accepted_contact_is_still_bounded() {
+        let mut g = InviteGate::new();
+        g.mark_accepted("frank");
+        for i in 0..InviteGate::CONTACT_BUDGET {
+            assert_eq!(g.admit("frank", T0 + u64::from(i)), InviteVerdict::Allow);
+        }
+        assert_eq!(
+            g.admit("frank", T0 + 100),
+            InviteVerdict::Refuse {
+                reason: RefuseReason::BudgetSpent
+            }
+        );
+    }
+
+    /// A long-quiet sender is not judged on ancient history: the budget refills.
+    /// Without this, one refused invite would bar someone forever, and a person
+    /// who genuinely mistyped an ID once could never try again.
+    #[test]
+    fn the_budget_refills_after_a_long_silence() {
+        let mut g = InviteGate::new();
+        let _spend = g.admit("stranger", T0);
+        assert!(matches!(
+            g.admit("stranger", T0 + 1),
+            InviteVerdict::Refuse { .. }
+        ));
+        assert_eq!(
+            g.admit("stranger", T0 + InviteGate::REFILL_SECS),
+            InviteVerdict::Allow
+        );
+    }
+
+    /// Budgets are PER SENDER. One spammer must not consume the budget that
+    /// makes a real contact request reach the person.
+    #[test]
+    fn one_sender_cannot_spend_anothers_budget() {
+        let mut g = InviteGate::new();
+        // Spend the spammer's budget many times over.
+        for i in 0..50 {
+            let _spend = g.admit("spammer", T0 + i);
+        }
+        assert_eq!(
+            g.admit("real-person", T0 + 100),
+            InviteVerdict::Allow,
+            "a flood from one sender must not silence everyone else"
+        );
+    }
+}

--- a/src/invite_gate.rs
+++ b/src/invite_gate.rs
@@ -1,5 +1,26 @@
 //! CIRISEdge#554 — the receiver-side budget on unsolicited contact requests.
 //!
+//! # WHERE THIS RUNS — it is not called inside edge, deliberately
+//!
+//! A repo-wide search finds no caller, and that is the correct state rather
+//! than an oversight: **edge has no inbound contact-request path to wire it
+//! into.** The wire carries `Summary`/`Diff`/`Fetch`/`Deliver`/`Pull`/
+//! `CursorPull` — anti-entropy verbs — and no invite verb at all. Contact
+//! requests and chat are the SERVER's tier (`POST /v1/contacts`), which is also
+//! where a human is shown the invite.
+//!
+//! Enforcing the budget at replication ADMISSION would be actively wrong. An
+//! invite that arrives as a signed `Community` record is legitimate federation
+//! state; refusing to admit it would withhold carriage of a correctly-signed
+//! row on a rate heuristic — the silent-state-withholding class CIRISEdge#425
+//! exists to make impossible. The thing being rate-limited is not the record's
+//! ARRIVAL, it is its PRESENTATION to a person, and that decision lives where
+//! the presenting happens.
+//!
+//! So this is a library the presenting tier calls, in the same position as
+//! [`crate::contact::resolve`]. Wiring it here would mean inventing a call site
+//! to make a search result look better.
+//!
 //! # The threat this covers, and why nothing else does
 //!
 //! An invite is low-volume, well-formed, correctly signed, and semantically

--- a/src/invite_gate.rs
+++ b/src/invite_gate.rs
@@ -80,9 +80,13 @@ pub enum RefuseReason {
 }
 
 /// Per-(sender, receiver) invite budget. One instance per receiving node.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct InviteGate {
     senders: HashMap<String, SenderState>,
+    /// Earliest time any tracked stranger can become releasable — the minimum
+    /// `last_attempt + REFILL_SECS` over the map. Before it, an at-cap refusal
+    /// is O(1) because a scan provably cannot find anything.
+    next_release: Ts,
 }
 
 #[derive(Debug, Clone)]
@@ -113,7 +117,11 @@ impl InviteGate {
 
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            senders: HashMap::new(),
+            // Nothing tracked yet, so nothing can be released.
+            next_release: Ts::MAX,
+        }
     }
 
     /// How many senders one receiver tracks. Past it, strangers whose budget
@@ -136,6 +144,15 @@ impl InviteGate {
         self.senders.retain(|_, st| {
             st.ever_accepted || now.saturating_sub(st.last_attempt) < Self::REFILL_SECS
         });
+        // Recompute the horizon from what remains; `u64::MAX` when only
+        // established contacts are left, since those are never released.
+        self.next_release = self
+            .senders
+            .values()
+            .filter(|st| !st.ever_accepted)
+            .map(|st| st.last_attempt.saturating_add(Self::REFILL_SECS))
+            .min()
+            .unwrap_or(Ts::MAX);
         let released = before - self.senders.len();
         if released > 0 {
             tracing::debug!(
@@ -164,6 +181,19 @@ impl InviteGate {
         // therefore both bypassed and the memory-growth vector, which is the
         // opposite of what it was for.
         if !self.senders.contains_key(sender) && self.senders.len() >= Self::SENDER_CAP {
+            // O(1) refusal while nothing can be released.
+            //
+            // `release_refilled_strangers` is a full scan of the cap. Calling it
+            // per rejected invite let an attacker rotating identities inside the
+            // refill window force that scan on every message — the memory bound
+            // converted into sustained CPU. `next_release` is the earliest time
+            // any entry can become releasable, so before it there is provably
+            // nothing to find and the scan is skipped.
+            if now < self.next_release {
+                return InviteVerdict::Refuse {
+                    reason: RefuseReason::ReceiverAtCapacity,
+                };
+            }
             self.release_refilled_strangers(now);
             if self.senders.len() >= Self::SENDER_CAP {
                 return InviteVerdict::Refuse {
@@ -212,6 +242,12 @@ impl InviteGate {
 
         state.spent += 1;
         state.last_attempt = now;
+        let ever_accepted = state.ever_accepted;
+        // Keep the horizon honest as entries are added or refreshed: a new
+        // stranger can be releasable no later than one refill window out.
+        if !ever_accepted {
+            self.next_release = self.next_release.min(now.saturating_add(Self::REFILL_SECS));
+        }
         InviteVerdict::Allow
     }
 
@@ -233,6 +269,12 @@ impl InviteGate {
         entry.ever_accepted = true;
         // Their outstanding attempt was answered; it should not still count.
         entry.spent = 0;
+    }
+}
+
+impl Default for InviteGate {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,9 @@
 pub mod blob_swarm;
 pub mod bundle_gate;
 pub mod cohort_scope;
+/// CIRISEdge#552/#554 — the contact ladder: announce → discover → request →
+/// consent → chat, with one greppable log shape per rung.
+pub mod contact;
 #[cfg(feature = "debug-tools")]
 pub mod debug;
 pub mod delivery_mode;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod contact;
 pub mod debug;
 pub mod delivery_mode;
 pub mod detector;
+/// CIRISEdge#554 — the receiver-side budget on unsolicited contact requests.
+pub mod invite_gate;
 // v6.1.0 (CIRISEdge#175, FSD §3.3) — announce-suppression policy
 // + edge-side registry mirroring the recommended Leviculum
 // `AnnounceControl` extension shape.

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1583,6 +1583,12 @@ impl FederationDirectoryReplicationBridge {
         self
     }
 
+    /// How many signer recoveries are queued (diagnostics + tests).
+    #[must_use]
+    pub fn tracked_missing_signers(&self) -> usize {
+        self.missing_signers.lock().map_or(0, |m| m.len())
+    }
+
     /// CIRISEdge#552 — override the agent mode (builder, TEST ONLY).
     ///
     /// Production reads the mode from the Edge via `start_replication`; this
@@ -2307,90 +2313,54 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         signer_key_id: &str,
         source_peer: Option<&str>,
     ) {
-        // Gated on the KEY plane's retention, not on this record's plane. The
-        // row that stalled can be any kind; the row it waits on is always a Key.
-        // Under `Bodies` that Key body replicates on its own and the #544 backoff
-        // admits the row on a later round — the self-resolving case the module
-        // doc describes — so recording here would add a pull for something
-        // already in flight.
+        // Gated on the KEY plane's retention: the row that stalled can be any
+        // kind, but the row it waits on is always a Key. Under `Bodies` that
+        // body replicates on its own and #544 admits the row later.
         if !crate::replication::retention::should_note_missing_signer(
             self.retention(EnvelopeKind::Key),
         ) {
             return;
         }
+        // Queue ONLY what a Pull can actually satisfy: the delivering peer's own
+        // key. A responder answers an identifier Pull on a public plane for its
+        // OWN record and refuses a third-party probe, so queueing a third-party
+        // signer would schedule a request guaranteed to come back empty — work
+        // that also consumes a recovery slot and a round.
+        //
+        // This is what bounds the queue at the root rather than by policing it
+        // afterwards: a peer can only ever enqueue ONE name, its own, so the
+        // manufacture-unique-signers flood has nothing to manufacture.
+        if source_peer != Some(signer_key_id) {
+            tracing::debug!(
+                signer = %signer_key_id,
+                source = ?source_peer,
+                "missing signer is a THIRD PARTY — no identifier Pull can fetch it, \
+                 so the row stays visibly transient-refused (CIRISEdge#552)"
+            );
+            return;
+        }
         if let Ok(mut pending) = self.missing_signers.lock() {
             if pending.len() >= MISSING_SIGNER_CAP && !pending.contains_key(signer_key_id) {
-                // CIRISEdge#552 — charge the cap to the LARGEST source, never to
-                // whoever arrived last.
-                //
-                // An attributed peer can manufacture entries at will: deliver
-                // envelopes naming unique nonexistent signers, each refused
-                // transient, each recorded. A flat cap then lets that one peer
-                // fill the map and starve every other peer's recovery —
-                // including the signer needed to admit a legitimate REVOCATION.
-                // It replenishes far faster than the one-per-round drain. Same
-                // monopolization shape as the known-hash cap, and the same fix.
-                let dominant = {
-                    let mut counts: std::collections::HashMap<Option<&str>, usize> =
-                        std::collections::HashMap::new();
-                    for src in pending.values() {
-                        *counts.entry(src.as_deref()).or_insert(0) += 1;
-                    }
-                    counts
-                        .into_iter()
-                        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))
-                        .map(|(src, _)| src.map(str::to_owned))
-                };
-                let victim = dominant.as_ref().and_then(|d| {
-                    // Never evict on behalf of the peer that IS the hog.
-                    if d.as_deref() == source_peer {
-                        return None;
-                    }
-                    pending
-                        .iter()
-                        .find(|(_, src)| src.as_deref() == d.as_deref())
-                        .map(|(name, _)| name.clone())
-                });
-                if let Some(name) = victim {
-                    pending.remove(&name);
-                    tracing::debug!(
-                        evicted = %name,
-                        for_signer = %signer_key_id,
-                        "missing-signer set at cap — released an entry from the \
-                         largest source so one peer cannot starve recovery \
-                         (CIRISEdge#552)"
-                    );
-                } else {
-                    tracing::warn!(
-                        signer = %signer_key_id,
-                        cap = MISSING_SIGNER_CAP,
-                        "missing-signer set at cap and this source is already the \
-                         largest — DROPPING this name (CIRISEdge#552)"
-                    );
-                    return;
-                }
+                tracing::warn!(
+                    signer = %signer_key_id,
+                    cap = MISSING_SIGNER_CAP,
+                    "missing-signer set at cap — DROPPING this name (CIRISEdge#552)"
+                );
+                return;
             }
-            let slot = pending.entry(signer_key_id.to_string()).or_insert(None);
-            // Never downgrade a routed name to unrouted: a known holder
-            // candidate is strictly better than "ask anyone", and a later
-            // contact lookup for the same signer must not erase it.
-            if slot.is_none() {
-                *slot = source_peer.map(str::to_owned);
-            }
+            pending.insert(signer_key_id.to_string(), source_peer.map(str::to_owned));
         }
     }
 
     fn take_missing_signer_for(&self, peer_key_id: &str) -> Option<String> {
         let mut pending = self.missing_signers.lock().ok()?;
-        // Prefer a name this peer actually delivered; fall back to an unrouted
-        // one so a contact lookup gets tried against successive peers.
-        let pick = pending
-            .iter()
-            .find(|(_, src)| src.as_deref() == Some(peer_key_id))
-            .or_else(|| pending.iter().find(|(_, src)| src.is_none()))
-            .map(|(name, _)| name.clone())?;
-        pending.remove(&pick);
-        Some(pick)
+        // Exactly the name this peer can answer for — its own. Anything else
+        // was never enqueued, because nothing else is fetchable by identifier.
+        if pending.remove(peer_key_id).is_some() {
+            Some(peer_key_id.to_owned())
+        } else {
+            None
+        }
     }
 
     fn note_known_hashes(
@@ -2617,29 +2587,41 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
     }
 
     /// CIRISEdge#462 — serve a subject-scoped RECEIVE-axis Pull. Entitlement is
-    /// FAIL-CLOSED, with one deliberate widening (CIRISEdge#552).
+    /// FAIL-CLOSED, with one narrow widening bounded by the ADVERTISE
+    /// projection (CIRISEdge#552).
     ///
-    /// A Pull for subject `S` is answered to a requester authenticated AS `S`,
-    /// **or** to any ATTRIBUTED requester when the kind's serve cell is
-    /// unconditionally `public` ([`EnvelopeKind::is_public_subject_pull`]). An
+    /// A Pull for subject `S` is answered to a requester authenticated AS `S`
+    /// (the data-subject access path), **or** — on a plane whose serve cell is
+    /// unconditionally `public` — when `S` is THIS NODE'S OWN key_id. An
     /// unattributed requester still gets nothing, and it still says so.
     ///
-    /// The widening discloses NOTHING new. Those planes are already
-    /// `("self_own", "public")` / `("global", "public")` in the serve manifest —
-    /// public signed envelopes, no capability gate, already reachable through
-    /// ordinary anti-entropy. `subject-only` made them un-ADDRESSABLE rather
-    /// than undisclosed, because `Pull` is the only verb that names a record by
-    /// IDENTIFIER and it was written for data-subject access ("what do you hold
-    /// about me"). Under hash-first that left a node unable to ask for a public
-    /// body it had deliberately not fetched: every other read is
-    /// content-hash-addressed, and it cannot compute the hash of a record it
-    /// does not hold. A signer's Key was then permanently unfetchable, which is
-    /// a revocation that never lands.
+    /// # Why the second arm stops exactly there
     ///
-    /// `Attestation` keeps the subject-only rule: its serve cell is conditional
-    /// (`trace:*` → `capability:infra:serve`, plus the per-row G2 scores carve),
-    /// so its entitlement is decided per RECORD and a per-plane widening would
-    /// be exactly the substrate/policy conflation to avoid.
+    /// `serve: public` and `advertise: self_own` answer DIFFERENT questions, and
+    /// conflating them is how the first attempt at this went wrong. `public`
+    /// says a record needs no capability gate *once it reaches you*.
+    /// `self_own` is what decides **which** records reach you at all: on these
+    /// planes a node advertises only its own. But `subject_holdings_inner`
+    /// performs an ARBITRARY subject lookup against the node's whole local
+    /// directory. Serving that to any attributed requester would let a peer
+    /// probe identifiers for third-party keys and routes that never appeared in
+    /// any Summary it received — turning a body-holding server into an
+    /// address-book oracle and destroying the opaque-directory property
+    /// hash-first exists to create. "Already public" is not "already disclosed
+    /// to you".
+    ///
+    /// Restricting `S` to this node's own record keeps the answer inside what
+    /// `self_own` already hands every peer, so it is disclosure-neutral in fact
+    /// and not merely in claim. It recovers the case that matters most: *"you
+    /// signed a row I cannot verify — send me your key."*
+    ///
+    /// A THIRD-PARTY signer remains unfetchable by identifier. That is a real
+    /// gap, and closing it needs a separately authorized, rate-limited resolver
+    /// rather than a widening here.
+    ///
+    /// `Attestation` keeps the subject-only rule outright: its serve cell is
+    /// conditional (`trace:*` → `capability:infra:serve`, plus the per-row G2
+    /// scores carve), so its entitlement is decided per RECORD.
     ///
     /// (Owner-delegation, a node key pulling for its owner fedID, needs
     /// `owner_of` and is still a deliberate follow-up, not silently permitted.) The refs themselves come from
@@ -2652,7 +2634,14 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         peer_key_id: Option<&str>,
     ) -> Vec<EnvelopeRef> {
         match peer_key_id {
-            Some(p) if p == subject_key_id || kind.is_public_subject_pull() => {
+            // The subject itself (the data-subject access path), or a request
+            // for THIS NODE'S OWN record on a public plane — which is precisely
+            // what the `self_own` advertise projection already hands every peer.
+            Some(p)
+                if p == subject_key_id
+                    || (kind.is_public_subject_pull()
+                        && self.local_key_id.as_deref() == Some(subject_key_id)) =>
+            {
                 // CIRISEdge#531 — WIDTH bound on the subject-Pull sweep too:
                 // it is per-subject rather than whole-table, but the
                 // Attestation arm sweeps BOTH testimonial axes and a
@@ -9743,123 +9732,82 @@ mod tests {
         );
     }
 
-    /// CIRISEdge#552 (B) — a recorded signer is routed back to the peer that
-    /// DELIVERED the unverifiable row, and taken one at a time.
+    /// CIRISEdge#552 — only a peer's OWN key is queued for recovery, which
+    /// bounds the queue at its ROOT.
     ///
-    /// A Pull is answered out of the responding peer's own `lookup_public_key`.
-    /// A node-wide queue drained by whichever coordinator ticked first would ask
-    /// an arbitrary peer for a third party's key, get an empty Summary, and
-    /// consume the recovery without ever reaching a holder.
-    #[tokio::test]
-    async fn a_missing_signer_is_routed_to_the_peer_that_delivered_the_row() {
-        let (_backend, bridge) = make_bridge(&[]);
-        // Server mode, or the note is a no-op by design (under Bodies the key
-        // body replicates on its own).
-        let bridge = bridge.with_agent_mode_for_test(crate::AgentMode::Server);
-
-        bridge.note_missing_signer(EnvelopeKind::Attestation, "signer-A", Some("peer-1"));
-        bridge.note_missing_signer(EnvelopeKind::Attestation, "signer-B", Some("peer-2"));
-
-        assert_eq!(
-            bridge.take_missing_signer_for("peer-2").as_deref(),
-            Some("signer-B"),
-            "peer-2 must get the name IT delivered, not whichever was queued first"
-        );
-        assert_eq!(
-            bridge.take_missing_signer_for("peer-1").as_deref(),
-            Some("signer-A"),
-            "and peer-1 gets its own"
-        );
-        assert_eq!(
-            bridge.take_missing_signer_for("peer-1"),
-            None,
-            "taken names are removed — a name left queued would re-Pull every round"
-        );
-    }
-
-    /// CIRISEdge#552 — one peer cannot fill the missing-signer cap and starve
-    /// another peer's recovery.
+    /// A responder answers an identifier Pull on a public plane for its own
+    /// record and refuses a third-party probe, so a third-party signer is not
+    /// fetchable by identifier at all. Queueing one would schedule a request
+    /// guaranteed to come back empty while consuming a recovery slot and a
+    /// round.
     ///
-    /// An attributed peer manufactures entries for free: deliver envelopes
-    /// naming unique nonexistent signers, each refused transient, each recorded.
-    /// A flat cap then lets that peer own the map and suppress the signer needed
-    /// to admit a legitimate REVOCATION from someone else — a safety-critical
-    /// admission blocked by a stranger's noise.
+    /// The security consequence is why this is the right place to stop it: a
+    /// peer can enqueue exactly ONE name, its own, so the
+    /// manufacture-unique-signers flood has nothing to manufacture and cannot
+    /// crowd out another peer's recovery. Policing the queue after the fact
+    /// left that vector open.
     #[tokio::test]
-    async fn a_flooding_peer_cannot_starve_another_peers_signer_recovery() {
+    async fn only_the_delivering_peers_own_key_is_queued() {
         let (_backend, bridge) = make_bridge(&[]);
         let bridge = bridge.with_agent_mode_for_test(crate::AgentMode::Server);
 
-        // The hostile peer fills the map well past the cap.
-        for i in 0..(MISSING_SIGNER_CAP + 200) {
+        for i in 0..(MISSING_SIGNER_CAP + 500) {
             bridge.note_missing_signer(
                 EnvelopeKind::Attestation,
                 &format!("nonexistent-{i}"),
                 Some("peer-flood"),
             );
         }
-        // An honest peer needs ONE signer to admit a revocation.
-        bridge.note_missing_signer(EnvelopeKind::Revocation, "revoker-key", Some("peer-honest"));
+        assert_eq!(
+            bridge.tracked_missing_signers(),
+            0,
+            "a third-party signer is not fetchable by identifier, so none of a \
+             flood of them is queued"
+        );
 
+        bridge.note_missing_signer(EnvelopeKind::Revocation, "peer-honest", Some("peer-honest"));
         assert_eq!(
             bridge.take_missing_signer_for("peer-honest").as_deref(),
-            Some("revoker-key"),
-            "the honest peer's signer must be recorded and routed to it — a flat \
-             cap let one peer's noise suppress a revocation federation-wide"
+            Some("peer-honest"),
+            "the fulfillable case survives: you signed a row I cannot verify, \
+             send me your key"
         );
-    }
-
-    /// An UNROUTED name (a contact lookup has no delivering peer) is offered to
-    /// any coordinator, so successive rounds try successive peers until one
-    /// holds it — and a later routed note must not be downgraded by it.
-    #[tokio::test]
-    async fn an_unrouted_signer_is_offered_to_any_peer() {
-        let (_backend, bridge) = make_bridge(&[]);
-        let bridge = bridge.with_agent_mode_for_test(crate::AgentMode::Server);
-
-        bridge.note_missing_signer(EnvelopeKind::Key, "wanted-C", None);
         assert_eq!(
-            bridge.take_missing_signer_for("any-peer").as_deref(),
-            Some("wanted-C"),
-            "an unrouted name is available to whichever coordinator asks"
+            bridge.take_missing_signer_for("peer-honest"),
+            None,
+            "taken names are removed — one left queued would re-Pull every round"
         );
-
-        // A holder candidate must never be erased by a later unrouted note.
-        bridge.note_missing_signer(EnvelopeKind::Key, "wanted-D", Some("peer-9"));
-        bridge.note_missing_signer(EnvelopeKind::Key, "wanted-D", None);
         assert_eq!(
             bridge.take_missing_signer_for("someone-else"),
             None,
-            "the routed name stays routed — a known holder beats ask-anyone"
-        );
-        assert_eq!(
-            bridge.take_missing_signer_for("peer-9").as_deref(),
-            Some("wanted-D")
+            "and no other coordinator can consume it"
         );
     }
 
-    /// CIRISEdge#552 — a public plane answers a Pull from ANY attributed
-    /// requester; a conditional one still does not.
+    /// CIRISEdge#552 — a public plane answers a Pull for THIS NODE'S OWN
+    /// record, and refuses one that probes a third party.
     ///
-    /// This is the widening that makes hash-first survivable. `Key` serves
-    /// `public` unconditionally, so `subject-only` was making a disclosed record
-    /// un-ADDRESSABLE: a node that declined to fetch a signer's Key body had no
-    /// verb left to ask for it by name, and the rows it signed — revocations
-    /// included — could never admit.
-    ///
-    /// Three assertions, because the widening has to be exactly as wide as
-    /// claimed: public plane opens to a stranger, unattributed stays closed,
-    /// and `Attestation` — whose entitlement is per-row (`trace:*` capability,
-    /// the G2 carve) — stays subject-only.
+    /// The refusal is the load-bearing half. `serve: public` says a record needs
+    /// no capability gate once it reaches you; `advertise: self_own` decides
+    /// which records reach you at all. `subject_holdings_inner` does an
+    /// arbitrary directory lookup, so serving any attributed requester about any
+    /// subject would let a peer probe identifiers for third-party keys and
+    /// routes that never appeared in its Summaries — a body-holding server as
+    /// an address-book oracle, which is the end of the opaque directory
+    /// hash-first exists to build. An earlier revision of this branch did
+    /// exactly that.
     #[tokio::test]
-    async fn a_public_plane_answers_a_pull_from_any_attributed_requester() {
+    async fn a_public_plane_serves_its_own_record_but_is_not_an_oracle() {
         let local = "local-A";
-        let subject = "subject-S";
+        let third_party = "subject-S";
         let stranger = "stranger-X";
-        let (backend, bridge) =
-            make_bridge(&[local.to_string(), subject.to_string(), stranger.to_string()]);
+        let (backend, bridge) = make_bridge(&[
+            local.to_string(),
+            third_party.to_string(),
+            stranger.to_string(),
+        ]);
         let bridge = bridge.with_local_key_id(Some(local.to_string()));
-        for kid in [local, subject, stranger] {
+        for kid in [local, third_party, stranger] {
             backend
                 .put_public_key(SignedKeyRecord {
                     record: fixture_key_record(kid, identity_type::AGENT),
@@ -9870,28 +9818,36 @@ mod tests {
 
         assert!(
             !bridge
-                .subject_holdings(EnvelopeKind::Key, subject, Some(stranger))
+                .subject_holdings(EnvelopeKind::Key, local, Some(stranger))
                 .await
                 .is_empty(),
-            "a Key record is a PUBLIC signed envelope — a stranger that names it \
-             must be served, or a hash-first node can never fetch a signer key \
-             and the revocations it signed never land"
+            "this node's OWN Key is what `self_own` already advertises to every \
+             peer — serving it by name discloses nothing new and is what makes \
+             \"you signed a row I cannot verify, send me your key\" work"
         );
         assert!(
             bridge
-                .subject_holdings(EnvelopeKind::Key, subject, None)
+                .subject_holdings(EnvelopeKind::Key, third_party, Some(stranger))
                 .await
                 .is_empty(),
-            "an UNATTRIBUTED Pull still serves nothing — #552 widened who may \
-             name a public record, not whether an unauthenticated peer is served"
+            "a THIRD PARTY's Key must NOT be served: the holder never advertised \
+             it to this requester, and answering would make a body-holding node \
+             an address-book oracle for guessed identifiers"
         );
         assert!(
             bridge
-                .subject_holdings(EnvelopeKind::Attestation, subject, Some(stranger))
+                .subject_holdings(EnvelopeKind::Key, local, None)
                 .await
                 .is_empty(),
-            "Attestation's serve cell is CONDITIONAL per row (trace:* capability, \
-             G2 scores carve) — it keeps the subject-only rule"
+            "an UNATTRIBUTED Pull still serves nothing"
+        );
+        assert!(
+            bridge
+                .subject_holdings(EnvelopeKind::Attestation, local, Some(stranger))
+                .await
+                .is_empty(),
+            "Attestation's serve cell is CONDITIONAL per row — it keeps the \
+             subject-only rule even for this node's own subject"
         );
     }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -2317,6 +2317,13 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         }
     }
 
+    fn take_missing_signer_for(&self, peer_key_id: &str) -> bool {
+        let Ok(mut pending) = self.missing_signers.lock() else {
+            return false;
+        };
+        pending.remove(peer_key_id)
+    }
+
     fn take_missing_signers(&self) -> Vec<String> {
         let Ok(mut pending) = self.missing_signers.lock() else {
             return Vec::new();

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1196,6 +1196,16 @@ enum QuarantineConsult {
 
 // ─── The bridge ──────────────────────────────────────────────────────
 
+/// Cap on the missing-signer set (CIRISEdge#552 B). Sized for a federation's
+/// SIGNER count, not its record count: a name repeats across every row that
+/// signer signed, so the set dedupes hard. Past the cap names are dropped and
+/// the rows they gate stay transient-refused — bounded and visible, and it
+/// drains as pulls land.
+const MISSING_SIGNER_CAP: usize = 1024;
+
+/// How many missing signers become Pulls in a single round.
+const MISSING_SIGNER_DRAIN: usize = 32;
+
 /// Production-grade [`ReplicationDirectory`] implementation over
 /// persist's `FederationDirectory`.
 pub struct FederationDirectoryReplicationBridge {
@@ -1318,6 +1328,12 @@ pub struct FederationDirectoryReplicationBridge {
     /// them. In-memory: CIRISPersist#785 is where this becomes durable, and the
     /// advertise re-sweep re-learns anything lost to a restart.
     known_hashes: Mutex<crate::replication::known_hashes::KnownHashes>,
+    /// CIRISEdge#552 (B) — signers a transient refusal named that this node may
+    /// not hold. Bounded: a peer that offers unadmittable rows must not be able
+    /// to grow this without limit, so past the cap new names are DROPPED rather
+    /// than evicting older ones — the older names are the ones with rows already
+    /// waiting on them.
+    missing_signers: Mutex<std::collections::BTreeSet<String>>,
     /// CIRISEdge#531 DEPTH — the largest row count ANY single page read has
     /// returned on this bridge. The flat bound's own witness, in the same
     /// discipline as [`Self::sweep_gate`]'s `max_in_flight` and
@@ -1482,6 +1498,7 @@ impl FederationDirectoryReplicationBridge {
             owner_routed_recipients: std::sync::atomic::AtomicUsize::new(0),
             sweep_gate: SweepGate::new(config.advertise_sweep_permits),
             known_hashes: Mutex::new(crate::replication::known_hashes::KnownHashes::new()),
+            missing_signers: Mutex::new(std::collections::BTreeSet::new()),
             sweep_cursors: Mutex::new(SweepCursors::default()),
             sweep_max_page_rows: std::sync::atomic::AtomicUsize::new(0),
             // CIRISEdge#544 — always on. It is a rate limiter on asking for what
@@ -1532,6 +1549,7 @@ impl FederationDirectoryReplicationBridge {
             owner_routed_recipients: std::sync::atomic::AtomicUsize::new(0),
             sweep_gate: SweepGate::new(config.advertise_sweep_permits),
             known_hashes: Mutex::new(crate::replication::known_hashes::KnownHashes::new()),
+            missing_signers: Mutex::new(std::collections::BTreeSet::new()),
             sweep_cursors: Mutex::new(SweepCursors::default()),
             sweep_max_page_rows: std::sync::atomic::AtomicUsize::new(0),
             // CIRISEdge#544 — always on. It is a rate limiter on asking for what
@@ -2274,6 +2292,47 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
     /// that advertised them (the holder map). In-memory and local only: this is
     /// an OBSERVATION, not a claim, and CIRISPersist#785 is where it becomes
     /// durable.
+    fn note_missing_signer(&self, _kind: EnvelopeKind, signer_key_id: &str) {
+        // Gated on the KEY plane's retention, not on this record's plane. The
+        // row that stalled can be any kind; the row it waits on is always a Key.
+        // Under `Bodies` that Key body replicates on its own and the #544 backoff
+        // admits the row on a later round — the self-resolving case the module
+        // doc describes — so recording here would add a pull for something
+        // already in flight.
+        if !matches!(
+            self.retention(EnvelopeKind::Key),
+            crate::replication::retention::Retention::HashFirst
+        ) {
+            return;
+        }
+        if let Ok(mut pending) = self.missing_signers.lock() {
+            if pending.len() >= MISSING_SIGNER_CAP && !pending.contains(signer_key_id) {
+                tracing::warn!(
+                    signer = %signer_key_id,
+                    cap = MISSING_SIGNER_CAP,
+                    "missing-signer set at cap — DROPPING this name (CIRISEdge#552)"
+                );
+                return;
+            }
+            pending.insert(signer_key_id.to_string());
+        }
+    }
+
+    fn take_missing_signers(&self) -> Vec<String> {
+        let Ok(mut pending) = self.missing_signers.lock() else {
+            return Vec::new();
+        };
+        // A bounded batch per call: the set can hold a federation's worth of
+        // names after a cold start, and turning all of them into Pulls in one
+        // round is a burst this node chose to send. The rest keep until the
+        // next round.
+        let take: Vec<String> = pending.iter().take(MISSING_SIGNER_DRAIN).cloned().collect();
+        for name in &take {
+            pending.remove(name);
+        }
+        take
+    }
+
     fn note_known_hashes(
         &self,
         kind: EnvelopeKind,

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -2299,9 +2299,8 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         // admits the row on a later round — the self-resolving case the module
         // doc describes — so recording here would add a pull for something
         // already in flight.
-        if !matches!(
+        if !crate::replication::retention::should_note_missing_signer(
             self.retention(EnvelopeKind::Key),
-            crate::replication::retention::Retention::HashFirst
         ) {
             return;
         }

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -2320,12 +2320,55 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         }
         if let Ok(mut pending) = self.missing_signers.lock() {
             if pending.len() >= MISSING_SIGNER_CAP && !pending.contains_key(signer_key_id) {
-                tracing::warn!(
-                    signer = %signer_key_id,
-                    cap = MISSING_SIGNER_CAP,
-                    "missing-signer set at cap — DROPPING this name (CIRISEdge#552)"
-                );
-                return;
+                // CIRISEdge#552 — charge the cap to the LARGEST source, never to
+                // whoever arrived last.
+                //
+                // An attributed peer can manufacture entries at will: deliver
+                // envelopes naming unique nonexistent signers, each refused
+                // transient, each recorded. A flat cap then lets that one peer
+                // fill the map and starve every other peer's recovery —
+                // including the signer needed to admit a legitimate REVOCATION.
+                // It replenishes far faster than the one-per-round drain. Same
+                // monopolization shape as the known-hash cap, and the same fix.
+                let dominant = {
+                    let mut counts: std::collections::HashMap<Option<&str>, usize> =
+                        std::collections::HashMap::new();
+                    for src in pending.values() {
+                        *counts.entry(src.as_deref()).or_insert(0) += 1;
+                    }
+                    counts
+                        .into_iter()
+                        .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(&a.0)))
+                        .map(|(src, _)| src.map(str::to_owned))
+                };
+                let victim = dominant.as_ref().and_then(|d| {
+                    // Never evict on behalf of the peer that IS the hog.
+                    if d.as_deref() == source_peer {
+                        return None;
+                    }
+                    pending
+                        .iter()
+                        .find(|(_, src)| src.as_deref() == d.as_deref())
+                        .map(|(name, _)| name.clone())
+                });
+                if let Some(name) = victim {
+                    pending.remove(&name);
+                    tracing::debug!(
+                        evicted = %name,
+                        for_signer = %signer_key_id,
+                        "missing-signer set at cap — released an entry from the \
+                         largest source so one peer cannot starve recovery \
+                         (CIRISEdge#552)"
+                    );
+                } else {
+                    tracing::warn!(
+                        signer = %signer_key_id,
+                        cap = MISSING_SIGNER_CAP,
+                        "missing-signer set at cap and this source is already the \
+                         largest — DROPPING this name (CIRISEdge#552)"
+                    );
+                    return;
+                }
             }
             let slot = pending.entry(signer_key_id.to_string()).or_insert(None);
             // Never downgrade a routed name to unrouted: a known holder
@@ -9731,6 +9774,38 @@ mod tests {
             bridge.take_missing_signer_for("peer-1"),
             None,
             "taken names are removed — a name left queued would re-Pull every round"
+        );
+    }
+
+    /// CIRISEdge#552 — one peer cannot fill the missing-signer cap and starve
+    /// another peer's recovery.
+    ///
+    /// An attributed peer manufactures entries for free: deliver envelopes
+    /// naming unique nonexistent signers, each refused transient, each recorded.
+    /// A flat cap then lets that peer own the map and suppress the signer needed
+    /// to admit a legitimate REVOCATION from someone else — a safety-critical
+    /// admission blocked by a stranger's noise.
+    #[tokio::test]
+    async fn a_flooding_peer_cannot_starve_another_peers_signer_recovery() {
+        let (_backend, bridge) = make_bridge(&[]);
+        let bridge = bridge.with_agent_mode_for_test(crate::AgentMode::Server);
+
+        // The hostile peer fills the map well past the cap.
+        for i in 0..(MISSING_SIGNER_CAP + 200) {
+            bridge.note_missing_signer(
+                EnvelopeKind::Attestation,
+                &format!("nonexistent-{i}"),
+                Some("peer-flood"),
+            );
+        }
+        // An honest peer needs ONE signer to admit a revocation.
+        bridge.note_missing_signer(EnvelopeKind::Revocation, "revoker-key", Some("peer-honest"));
+
+        assert_eq!(
+            bridge.take_missing_signer_for("peer-honest").as_deref(),
+            Some("revoker-key"),
+            "the honest peer's signer must be recorded and routed to it — a flat \
+             cap let one peer's noise suppress a revocation federation-wide"
         );
     }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -2317,13 +2317,6 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         }
     }
 
-    fn take_missing_signer_for(&self, peer_key_id: &str) -> bool {
-        let Ok(mut pending) = self.missing_signers.lock() else {
-            return false;
-        };
-        pending.remove(peer_key_id)
-    }
-
     fn take_missing_signers(&self) -> Vec<String> {
         let Ok(mut pending) = self.missing_signers.lock() else {
             return Vec::new();
@@ -2563,11 +2556,32 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
     }
 
     /// CIRISEdge#462 — serve a subject-scoped RECEIVE-axis Pull. Entitlement is
-    /// FAIL-CLOSED: a Pull for subject `S` is answered only to a requester
-    /// authenticated AS `S` (`peer_key_id == Some(S)`). A requester `P ≠ S` — or
-    /// an unattributed one — gets nothing, and it says so. (Owner-delegation, a
-    /// node key pulling for its owner fedID, needs `owner_of` and is a deliberate
-    /// follow-up, not silently permitted here.) The refs themselves come from
+    /// FAIL-CLOSED, with one deliberate widening (CIRISEdge#552).
+    ///
+    /// A Pull for subject `S` is answered to a requester authenticated AS `S`,
+    /// **or** to any ATTRIBUTED requester when the kind's serve cell is
+    /// unconditionally `public` ([`EnvelopeKind::is_public_subject_pull`]). An
+    /// unattributed requester still gets nothing, and it still says so.
+    ///
+    /// The widening discloses NOTHING new. Those planes are already
+    /// `("self_own", "public")` / `("global", "public")` in the serve manifest —
+    /// public signed envelopes, no capability gate, already reachable through
+    /// ordinary anti-entropy. `subject-only` made them un-ADDRESSABLE rather
+    /// than undisclosed, because `Pull` is the only verb that names a record by
+    /// IDENTIFIER and it was written for data-subject access ("what do you hold
+    /// about me"). Under hash-first that left a node unable to ask for a public
+    /// body it had deliberately not fetched: every other read is
+    /// content-hash-addressed, and it cannot compute the hash of a record it
+    /// does not hold. A signer's Key was then permanently unfetchable, which is
+    /// a revocation that never lands.
+    ///
+    /// `Attestation` keeps the subject-only rule: its serve cell is conditional
+    /// (`trace:*` → `capability:infra:serve`, plus the per-row G2 scores carve),
+    /// so its entitlement is decided per RECORD and a per-plane widening would
+    /// be exactly the substrate/policy conflation to avoid.
+    ///
+    /// (Owner-delegation, a node key pulling for its owner fedID, needs
+    /// `owner_of` and is still a deliberate follow-up, not silently permitted.) The refs themselves come from
     /// [`Self::subject_holdings_inner`], which hashes the SAME struct the wire
     /// index keys on and applies the G2 capacity carve.
     async fn subject_holdings(
@@ -2577,7 +2591,7 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
         peer_key_id: Option<&str>,
     ) -> Vec<EnvelopeRef> {
         match peer_key_id {
-            Some(p) if p == subject_key_id => {
+            Some(p) if p == subject_key_id || kind.is_public_subject_pull() => {
                 // CIRISEdge#531 — WIDTH bound on the subject-Pull sweep too:
                 // it is per-subject rather than whole-table, but the
                 // Attestation arm sweeps BOTH testimonial axes and a
@@ -2592,8 +2606,9 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                     subject = %subject_key_id,
                     requester = ?other,
                     kind = ?kind,
-                    "subject Pull refused: requester is not the subject — serving nothing \
-                     (#462 fail-closed; owner-delegation via owner_of is a follow-up)"
+                    "subject Pull refused: requester is not the subject and this kind \
+                     is not publicly pullable — serving nothing (#462 fail-closed; \
+                     #552 widened only the unconditionally-public planes)"
                 );
                 Vec::new()
             }
@@ -9664,6 +9679,63 @@ mod tests {
                 .await
                 .is_empty(),
             "an unattributed Pull serves nothing"
+        );
+    }
+
+    /// CIRISEdge#552 — a public plane answers a Pull from ANY attributed
+    /// requester; a conditional one still does not.
+    ///
+    /// This is the widening that makes hash-first survivable. `Key` serves
+    /// `public` unconditionally, so `subject-only` was making a disclosed record
+    /// un-ADDRESSABLE: a node that declined to fetch a signer's Key body had no
+    /// verb left to ask for it by name, and the rows it signed — revocations
+    /// included — could never admit.
+    ///
+    /// Three assertions, because the widening has to be exactly as wide as
+    /// claimed: public plane opens to a stranger, unattributed stays closed,
+    /// and `Attestation` — whose entitlement is per-row (`trace:*` capability,
+    /// the G2 carve) — stays subject-only.
+    #[tokio::test]
+    async fn a_public_plane_answers_a_pull_from_any_attributed_requester() {
+        let local = "local-A";
+        let subject = "subject-S";
+        let stranger = "stranger-X";
+        let (backend, bridge) =
+            make_bridge(&[local.to_string(), subject.to_string(), stranger.to_string()]);
+        let bridge = bridge.with_local_key_id(Some(local.to_string()));
+        for kid in [local, subject, stranger] {
+            backend
+                .put_public_key(SignedKeyRecord {
+                    record: fixture_key_record(kid, identity_type::AGENT),
+                })
+                .await
+                .expect("seed key");
+        }
+
+        assert!(
+            !bridge
+                .subject_holdings(EnvelopeKind::Key, subject, Some(stranger))
+                .await
+                .is_empty(),
+            "a Key record is a PUBLIC signed envelope — a stranger that names it \
+             must be served, or a hash-first node can never fetch a signer key \
+             and the revocations it signed never land"
+        );
+        assert!(
+            bridge
+                .subject_holdings(EnvelopeKind::Key, subject, None)
+                .await
+                .is_empty(),
+            "an UNATTRIBUTED Pull still serves nothing — #552 widened who may \
+             name a public record, not whether an unauthenticated peer is served"
+        );
+        assert!(
+            bridge
+                .subject_holdings(EnvelopeKind::Attestation, subject, Some(stranger))
+                .await
+                .is_empty(),
+            "Attestation's serve cell is CONDITIONAL per row (trace:* capability, \
+             G2 scores carve) — it keeps the subject-only rule"
         );
     }
 

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -546,6 +546,26 @@ pub struct BridgeConfig {
     /// bound that costs nothing but rounds. The effective page is the `min` of
     /// the two.
     pub sweep_page_rows: u32,
+
+    /// CIRISEdge#552 — this node's posture, which decides how much directory it
+    /// keeps.
+    ///
+    /// Driven by [`AgentMode`](crate::AgentMode) rather than a switch of its
+    /// own: the mode vocabulary already exists (`client` / `proxy` / `server`,
+    /// proxy by default) and a second knob meaning almost the same thing is how
+    /// two sources of truth start disagreeing.
+    ///
+    /// * **Server** — the full directory. A node with the storage to hold it and
+    ///   the role to serve it.
+    /// * **Proxy** (default) and **Client** — a RELEVANT SUBSET only: contacts,
+    ///   and the keys needed to verify what this node holds.
+    ///
+    /// That distinction is a privacy control, not a storage one. If every node
+    /// converged the whole hash set, the directory would be enumerable from ANY
+    /// node — cheaper than holding bodies, but the same exposure. A proxy that
+    /// learns only what concerns it reveals only its own contacts if it is
+    /// compromised.
+    pub mode: crate::AgentMode,
 }
 
 impl BridgeConfig {
@@ -676,6 +696,7 @@ impl Default for BridgeConfig {
             operational_page_limit: Self::DEFAULT_OPERATIONAL_PAGE_LIMIT,
             advertise_sweep_permits: Self::DEFAULT_ADVERTISE_SWEEP_PERMITS,
             sweep_page_rows: Self::DEFAULT_SWEEP_PAGE_ROWS,
+            mode: crate::AgentMode::Proxy,
         }
     }
 }
@@ -1293,6 +1314,10 @@ pub struct FederationDirectoryReplicationBridge {
     /// `std::sync::Mutex`, never held across an `.await`: the lock is taken to
     /// read a cursor, dropped, the page is read, then taken again to record it.
     sweep_cursors: Mutex<SweepCursors>,
+    /// CIRISEdge#552 — hashes learned without their bodies, and who advertised
+    /// them. In-memory: CIRISPersist#785 is where this becomes durable, and the
+    /// advertise re-sweep re-learns anything lost to a restart.
+    known_hashes: Mutex<crate::replication::known_hashes::KnownHashes>,
     /// CIRISEdge#531 DEPTH — the largest row count ANY single page read has
     /// returned on this bridge. The flat bound's own witness, in the same
     /// discipline as [`Self::sweep_gate`]'s `max_in_flight` and
@@ -1456,6 +1481,7 @@ impl FederationDirectoryReplicationBridge {
             owner_route_walks: std::sync::atomic::AtomicUsize::new(0),
             owner_routed_recipients: std::sync::atomic::AtomicUsize::new(0),
             sweep_gate: SweepGate::new(config.advertise_sweep_permits),
+            known_hashes: Mutex::new(crate::replication::known_hashes::KnownHashes::new()),
             sweep_cursors: Mutex::new(SweepCursors::default()),
             sweep_max_page_rows: std::sync::atomic::AtomicUsize::new(0),
             // CIRISEdge#544 — always on. It is a rate limiter on asking for what
@@ -1505,6 +1531,7 @@ impl FederationDirectoryReplicationBridge {
             owner_route_walks: std::sync::atomic::AtomicUsize::new(0),
             owner_routed_recipients: std::sync::atomic::AtomicUsize::new(0),
             sweep_gate: SweepGate::new(config.advertise_sweep_permits),
+            known_hashes: Mutex::new(crate::replication::known_hashes::KnownHashes::new()),
             sweep_cursors: Mutex::new(SweepCursors::default()),
             sweep_max_page_rows: std::sync::atomic::AtomicUsize::new(0),
             // CIRISEdge#544 — always on. It is a rate limiter on asking for what
@@ -2225,6 +2252,57 @@ impl FederationDirectoryReplicationBridge {
 
 #[async_trait]
 impl ReplicationDirectory for FederationDirectoryReplicationBridge {
+    /// CIRISEdge#552 — the operator's switch, filtered through the correctness
+    /// rule. `retention_for` pins every plane that must hold bodies, so a node
+    /// configured hash-first still holds revocations, rosters, and anything else
+    /// whose body it needs — the switch cannot turn those off.
+    fn retention(&self, kind: EnvelopeKind) -> crate::replication::retention::Retention {
+        // Only a SERVER keeps a hash directory. A proxy or client holds bodies
+        // for the little it tracks — hash-first buys nothing on a small working
+        // set, and would hand a small node an enumerable directory it has no use
+        // for.
+        let configured = match self.config.mode {
+            crate::AgentMode::Server => crate::replication::retention::Retention::HashFirst,
+            crate::AgentMode::Proxy | crate::AgentMode::Client => {
+                crate::replication::retention::Retention::Bodies
+            }
+        };
+        crate::replication::retention::retention_for(kind, configured)
+    }
+
+    /// CIRISEdge#552 — record hashes learned without their bodies, with the peer
+    /// that advertised them (the holder map). In-memory and local only: this is
+    /// an OBSERVATION, not a claim, and CIRISPersist#785 is where it becomes
+    /// durable.
+    fn note_known_hashes(
+        &self,
+        kind: EnvelopeKind,
+        hashes: &[[u8; 32]],
+        advertised_by: Option<&str>,
+    ) {
+        let Some(peer) = advertised_by else {
+            // A hash with no holder is not actionable: knowing a record exists
+            // without knowing who has it cannot be resolved into anything.
+            return;
+        };
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_or(0, |d| d.as_secs());
+        // Only a SERVER accumulates the directory. A proxy that recorded every
+        // hash a peer advertised would end up holding the whole federation as
+        // hashes — which is the enumeration surface again, just cheaper to
+        // carry. What a proxy needs is the subset that concerns it, and that is
+        // reached through the on-demand path rather than by hoarding.
+        if !matches!(self.config.mode, crate::AgentMode::Server) {
+            return;
+        }
+        if let Ok(mut known) = self.known_hashes.lock() {
+            for h in hashes {
+                known.note(kind, *h, peer, now);
+            }
+        }
+    }
+
     async fn list_envelope_refs(&self, kind: EnvelopeKind) -> Vec<EnvelopeRef> {
         // CIRISEdge#531 DEPTH — the PEER-BLIND projection view (diagnostics and
         // tests; every production provider is peer-bound via

--- a/src/replication/bridge.rs
+++ b/src/replication/bridge.rs
@@ -1203,9 +1203,6 @@ enum QuarantineConsult {
 /// drains as pulls land.
 const MISSING_SIGNER_CAP: usize = 1024;
 
-/// How many missing signers become Pulls in a single round.
-const MISSING_SIGNER_DRAIN: usize = 32;
-
 /// Production-grade [`ReplicationDirectory`] implementation over
 /// persist's `FederationDirectory`.
 pub struct FederationDirectoryReplicationBridge {
@@ -1333,7 +1330,7 @@ pub struct FederationDirectoryReplicationBridge {
     /// to grow this without limit, so past the cap new names are DROPPED rather
     /// than evicting older ones — the older names are the ones with rows already
     /// waiting on them.
-    missing_signers: Mutex<std::collections::BTreeSet<String>>,
+    missing_signers: Mutex<std::collections::BTreeMap<String, Option<String>>>,
     /// CIRISEdge#531 DEPTH — the largest row count ANY single page read has
     /// returned on this bridge. The flat bound's own witness, in the same
     /// discipline as [`Self::sweep_gate`]'s `max_in_flight` and
@@ -1498,7 +1495,7 @@ impl FederationDirectoryReplicationBridge {
             owner_routed_recipients: std::sync::atomic::AtomicUsize::new(0),
             sweep_gate: SweepGate::new(config.advertise_sweep_permits),
             known_hashes: Mutex::new(crate::replication::known_hashes::KnownHashes::new()),
-            missing_signers: Mutex::new(std::collections::BTreeSet::new()),
+            missing_signers: Mutex::new(std::collections::BTreeMap::new()),
             sweep_cursors: Mutex::new(SweepCursors::default()),
             sweep_max_page_rows: std::sync::atomic::AtomicUsize::new(0),
             // CIRISEdge#544 — always on. It is a rate limiter on asking for what
@@ -1549,7 +1546,7 @@ impl FederationDirectoryReplicationBridge {
             owner_routed_recipients: std::sync::atomic::AtomicUsize::new(0),
             sweep_gate: SweepGate::new(config.advertise_sweep_permits),
             known_hashes: Mutex::new(crate::replication::known_hashes::KnownHashes::new()),
-            missing_signers: Mutex::new(std::collections::BTreeSet::new()),
+            missing_signers: Mutex::new(std::collections::BTreeMap::new()),
             sweep_cursors: Mutex::new(SweepCursors::default()),
             sweep_max_page_rows: std::sync::atomic::AtomicUsize::new(0),
             // CIRISEdge#544 — always on. It is a rate limiter on asking for what
@@ -1583,6 +1580,18 @@ impl FederationDirectoryReplicationBridge {
     #[must_use]
     pub fn with_local_key_id(mut self, local_key_id: Option<String>) -> Self {
         self.local_key_id = local_key_id;
+        self
+    }
+
+    /// CIRISEdge#552 — override the agent mode (builder, TEST ONLY).
+    ///
+    /// Production reads the mode from the Edge via `start_replication`; this
+    /// exists so a unit test can exercise the Server-mode branches without
+    /// standing up the Python host path.
+    #[cfg(test)]
+    #[must_use]
+    pub fn with_agent_mode_for_test(mut self, mode: crate::AgentMode) -> Self {
+        self.config.mode = mode;
         self
     }
 
@@ -2292,7 +2301,12 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
     /// that advertised them (the holder map). In-memory and local only: this is
     /// an OBSERVATION, not a claim, and CIRISPersist#785 is where it becomes
     /// durable.
-    fn note_missing_signer(&self, _kind: EnvelopeKind, signer_key_id: &str) {
+    fn note_missing_signer(
+        &self,
+        _kind: EnvelopeKind,
+        signer_key_id: &str,
+        source_peer: Option<&str>,
+    ) {
         // Gated on the KEY plane's retention, not on this record's plane. The
         // row that stalled can be any kind; the row it waits on is always a Key.
         // Under `Bodies` that Key body replicates on its own and the #544 backoff
@@ -2305,7 +2319,7 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
             return;
         }
         if let Ok(mut pending) = self.missing_signers.lock() {
-            if pending.len() >= MISSING_SIGNER_CAP && !pending.contains(signer_key_id) {
+            if pending.len() >= MISSING_SIGNER_CAP && !pending.contains_key(signer_key_id) {
                 tracing::warn!(
                     signer = %signer_key_id,
                     cap = MISSING_SIGNER_CAP,
@@ -2313,23 +2327,27 @@ impl ReplicationDirectory for FederationDirectoryReplicationBridge {
                 );
                 return;
             }
-            pending.insert(signer_key_id.to_string());
+            let slot = pending.entry(signer_key_id.to_string()).or_insert(None);
+            // Never downgrade a routed name to unrouted: a known holder
+            // candidate is strictly better than "ask anyone", and a later
+            // contact lookup for the same signer must not erase it.
+            if slot.is_none() {
+                *slot = source_peer.map(str::to_owned);
+            }
         }
     }
 
-    fn take_missing_signers(&self) -> Vec<String> {
-        let Ok(mut pending) = self.missing_signers.lock() else {
-            return Vec::new();
-        };
-        // A bounded batch per call: the set can hold a federation's worth of
-        // names after a cold start, and turning all of them into Pulls in one
-        // round is a burst this node chose to send. The rest keep until the
-        // next round.
-        let take: Vec<String> = pending.iter().take(MISSING_SIGNER_DRAIN).cloned().collect();
-        for name in &take {
-            pending.remove(name);
-        }
-        take
+    fn take_missing_signer_for(&self, peer_key_id: &str) -> Option<String> {
+        let mut pending = self.missing_signers.lock().ok()?;
+        // Prefer a name this peer actually delivered; fall back to an unrouted
+        // one so a contact lookup gets tried against successive peers.
+        let pick = pending
+            .iter()
+            .find(|(_, src)| src.as_deref() == Some(peer_key_id))
+            .or_else(|| pending.iter().find(|(_, src)| src.is_none()))
+            .map(|(name, _)| name.clone())?;
+        pending.remove(&pick);
+        Some(pick)
     }
 
     fn note_known_hashes(
@@ -9679,6 +9697,69 @@ mod tests {
                 .await
                 .is_empty(),
             "an unattributed Pull serves nothing"
+        );
+    }
+
+    /// CIRISEdge#552 (B) — a recorded signer is routed back to the peer that
+    /// DELIVERED the unverifiable row, and taken one at a time.
+    ///
+    /// A Pull is answered out of the responding peer's own `lookup_public_key`.
+    /// A node-wide queue drained by whichever coordinator ticked first would ask
+    /// an arbitrary peer for a third party's key, get an empty Summary, and
+    /// consume the recovery without ever reaching a holder.
+    #[tokio::test]
+    async fn a_missing_signer_is_routed_to_the_peer_that_delivered_the_row() {
+        let (_backend, bridge) = make_bridge(&[]);
+        // Server mode, or the note is a no-op by design (under Bodies the key
+        // body replicates on its own).
+        let bridge = bridge.with_agent_mode_for_test(crate::AgentMode::Server);
+
+        bridge.note_missing_signer(EnvelopeKind::Attestation, "signer-A", Some("peer-1"));
+        bridge.note_missing_signer(EnvelopeKind::Attestation, "signer-B", Some("peer-2"));
+
+        assert_eq!(
+            bridge.take_missing_signer_for("peer-2").as_deref(),
+            Some("signer-B"),
+            "peer-2 must get the name IT delivered, not whichever was queued first"
+        );
+        assert_eq!(
+            bridge.take_missing_signer_for("peer-1").as_deref(),
+            Some("signer-A"),
+            "and peer-1 gets its own"
+        );
+        assert_eq!(
+            bridge.take_missing_signer_for("peer-1"),
+            None,
+            "taken names are removed — a name left queued would re-Pull every round"
+        );
+    }
+
+    /// An UNROUTED name (a contact lookup has no delivering peer) is offered to
+    /// any coordinator, so successive rounds try successive peers until one
+    /// holds it — and a later routed note must not be downgraded by it.
+    #[tokio::test]
+    async fn an_unrouted_signer_is_offered_to_any_peer() {
+        let (_backend, bridge) = make_bridge(&[]);
+        let bridge = bridge.with_agent_mode_for_test(crate::AgentMode::Server);
+
+        bridge.note_missing_signer(EnvelopeKind::Key, "wanted-C", None);
+        assert_eq!(
+            bridge.take_missing_signer_for("any-peer").as_deref(),
+            Some("wanted-C"),
+            "an unrouted name is available to whichever coordinator asks"
+        );
+
+        // A holder candidate must never be erased by a later unrouted note.
+        bridge.note_missing_signer(EnvelopeKind::Key, "wanted-D", Some("peer-9"));
+        bridge.note_missing_signer(EnvelopeKind::Key, "wanted-D", None);
+        assert_eq!(
+            bridge.take_missing_signer_for("someone-else"),
+            None,
+            "the routed name stays routed — a known holder beats ask-anyone"
+        );
+        assert_eq!(
+            bridge.take_missing_signer_for("peer-9").as_deref(),
+            Some("wanted-D")
         );
     }
 

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -44,7 +44,7 @@ use tokio::sync::Mutex;
 
 use crate::transport::{Transport, TransportError};
 
-use super::protocol::{EnvelopeKind, ProtocolError, PullMessage, ReplicationMessage};
+use super::protocol::{EnvelopeKind, FetchMessage, ProtocolError, PullMessage, ReplicationMessage};
 use super::session::{ReplicationOutcome, Session, SessionRole};
 use super::summary::{StalenessSignal, StateApplier, StateProvider};
 
@@ -390,8 +390,34 @@ impl ReplicationCoordinator {
         // "I need these bodies" path; hash-first suppresses bulk convergence, not
         // an explicit ask. Set BEFORE the send, so a fast reply cannot land
         // before the flag does.
-        self.session.lock().await.expect_pull_response();
+        self.session.lock().await.expect_on_demand_reply();
         self.send_message(&pull).await
+    }
+
+    /// CIRISEdge#552 — resolve known hashes to their bodies from this peer.
+    ///
+    /// The other half of a hash-first directory: converging hashes is only
+    /// useful if a node can turn one back into a record when something needs it.
+    /// The holder comes from
+    /// [`KnownHashes::holder`](super::known_hashes::KnownHashes::holder) — the
+    /// peer that last advertised it — so this is a point ask, not a broadcast.
+    ///
+    /// Marks the session first, so the `Deliver` that answers is applied rather
+    /// than learned. Without that the reply looks exactly like an unsolicited
+    /// push and hash-first would decline the very body it just asked for.
+    ///
+    /// Fire-and-forget, like [`Self::start_pull`]: the reply arrives through the
+    /// ordinary dispatch path.
+    pub async fn start_fetch(&self, want: Vec<[u8; 32]>) -> Result<(), CoordinatorError> {
+        if want.is_empty() {
+            return Ok(());
+        }
+        let fetch = ReplicationMessage::Fetch(FetchMessage {
+            kind: self.kind,
+            want,
+        });
+        self.session.lock().await.expect_on_demand_reply();
+        self.send_message(&fetch).await
     }
 
     /// Try to parse on-wire bytes as a [`ReplicationMessage`].

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -380,51 +380,56 @@ impl ReplicationCoordinator {
     /// forget: the testimony converges over the peer's next round, matching the
     /// anti-entropy model — sending the Pull carries no session state (only the
     /// reply does), so there is nothing to await here.
-    /// CIRISEdge#552 (B) — turn recorded missing signers into Key Pulls.
+    /// CIRISEdge#552 (B) — recover ONE signer key this peer can actually serve.
     ///
     /// Only the `Key` coordinator does this: [`Self::start_pull`] sends a
     /// `PullMessage { kind: self.kind, .. }`, and the row every stalled record
     /// waits on is a Key row.
     ///
-    /// This asks a peer for a THIRD PARTY's key, which `subject_holdings`
-    /// refused until CIRISEdge#552 widened the four unconditionally-`public`
-    /// planes to any attributed requester. That widening is what makes this
-    /// work, and it disclosed nothing new — a Key record is a public signed
-    /// envelope; only its ADDRESSABILITY changed.
+    /// **One per round, routed to the delivering peer.** Both constraints come
+    /// from the mechanism, not from caution. A Pull is answered out of the
+    /// responding peer's own `lookup_public_key`, so a node-wide queue drained
+    /// by whichever coordinator ticked first would ask an arbitrary peer for a
+    /// third party's key, get an empty Summary, and consume the queued recovery
+    /// without reaching a holder. And the on-demand exemption is a ROUND
+    /// counter, not a per-request ledger, so a batch would outrun its own
+    /// exemption and the later replies would be suppressed as ordinary
+    /// hash-first traffic.
     ///
-    /// Called from the scheduler before a round, so the reply is fetched by that
-    /// round's Summary handling.
+    /// A name with no recorded source (a contact lookup has no delivering peer)
+    /// is offered to any coordinator, so successive rounds try successive peers.
     ///
-    /// Returns how many Pulls were SENT. A send failure is logged and the name
-    /// is not re-queued here: the record that named it refuses transient again
-    /// on its next offer and re-notes it, so the retry rides #544's backoff and
-    /// cannot become a hot loop against an unreachable peer.
+    /// Returns how many Pulls were SENT (0 or 1). A send failure is logged and
+    /// the name is not re-queued here: the record that named it refuses
+    /// transient again on its next offer and re-notes it, so the retry rides
+    /// #544's backoff rather than a hot loop against an unreachable peer.
     pub async fn pull_missing_signers(&self) -> usize {
         if self.kind != EnvelopeKind::Key {
             return 0;
         }
-        let names = self.provider.take_missing_signers();
-        let mut sent = 0usize;
-        for name in names {
-            match self.start_pull(&name).await {
-                Ok(()) => sent += 1,
-                Err(e) => tracing::warn!(
+        let Some(name) = self.provider.take_missing_signer_for(&self.peer_key_id) else {
+            return 0;
+        };
+        match self.start_pull(&name).await {
+            Ok(()) => {
+                tracing::debug!(
+                    peer = %self.peer_key_id,
+                    signer = %name,
+                    "pulled a Key row for a signer that stalled admission (CIRISEdge#552)"
+                );
+                1
+            }
+            Err(e) => {
+                tracing::warn!(
                     peer = %self.peer_key_id,
                     signer = %name,
                     error = %e,
                     "missing-signer Pull send failed — the row that named it will \
                      re-note it on its next transient refusal (CIRISEdge#552)"
-                ),
+                );
+                0
             }
         }
-        if sent > 0 {
-            tracing::debug!(
-                peer = %self.peer_key_id,
-                sent,
-                "pulled Key rows for signers that stalled admission (CIRISEdge#552)"
-            );
-        }
-        sent
     }
 
     pub async fn start_pull(&self, subject_key_id: &str) -> Result<(), CoordinatorError> {

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -391,7 +391,14 @@ impl ReplicationCoordinator {
         // an explicit ask. Set BEFORE the send, so a fast reply cannot land
         // before the flag does.
         self.session.lock().await.expect_on_demand_reply();
-        self.send_message(&pull).await
+        // Roll back if the send never left. An exemption installed for a Pull
+        // that was not sent would exempt whatever arrives next instead — a
+        // window opened for a request that does not exist.
+        let sent = self.send_message(&pull).await;
+        if sent.is_err() {
+            self.session.lock().await.cancel_on_demand_reply();
+        }
+        sent
     }
 
     /// CIRISEdge#552 — resolve known hashes to their bodies from this peer.

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -380,56 +380,42 @@ impl ReplicationCoordinator {
     /// forget: the testimony converges over the peer's next round, matching the
     /// anti-entropy model — sending the Pull carries no session state (only the
     /// reply does), so there is nothing to await here.
-    /// CIRISEdge#552 (B) — recover ONE signer key this peer can actually serve.
+    /// Take this peer's queued signer name and send the `Pull` that recovers it
+    /// (FSD-SIGNER-RECOVERY D4).
     ///
-    /// Only the `Key` coordinator does this: [`Self::start_pull`] sends a
-    /// `PullMessage { kind: self.kind, .. }`, and the row every stalled record
-    /// waits on is a Key row.
+    /// Returns the name Pulled, or `None` when nothing is queued for this peer —
+    /// the common case, and the caller then runs an ordinary round.
     ///
-    /// **One per round, routed to the delivering peer.** Both constraints come
-    /// from the mechanism, not from caution. A Pull is answered out of the
-    /// responding peer's own `lookup_public_key`, so a node-wide queue drained
-    /// by whichever coordinator ticked first would ask an arbitrary peer for a
-    /// third party's key, get an empty Summary, and consume the queued recovery
-    /// without reaching a holder. And the on-demand exemption is a ROUND
-    /// counter, not a per-request ledger, so a batch would outrun its own
-    /// exemption and the later replies would be suppressed as ordinary
-    /// hash-first traffic.
+    /// # What can be recovered, and why only that
     ///
-    /// A name with no recorded source (a contact lookup has no delivering peer)
-    /// is offered to any coordinator, so successive rounds try successive peers.
+    /// Exactly one thing: **this peer's own `Key`**, asked of this peer. The
+    /// responder answers an identifier `Pull` for the subject itself or for its
+    /// OWN record, and refuses a third-party probe — that refusal is what stops
+    /// a body-holding node becoming an address-book oracle for records it never
+    /// advertised. So "you signed a row I cannot verify, send me your key" is
+    /// the recoverable case, and a third-party signer is not fetchable by
+    /// identifier at all. Nothing else is ever queued, which is also what bounds
+    /// the queue: a peer can enqueue one name, its own.
     ///
-    /// Returns how many Pulls were SENT (0 or 1). A send failure is logged and
-    /// the name is not re-queued here: the record that named it refuses
-    /// transient again on its next offer and re-notes it, so the retry rides
-    /// #544's backoff rather than a hot loop against an unreachable peer.
-    pub async fn pull_missing_signers(&self) -> usize {
+    /// Only the `Key` coordinator recovers, because `start_pull` sends
+    /// `PullMessage { kind: self.kind, .. }` and the row every stalled record
+    /// waits on is a `Key` row.
+    ///
+    /// # Failure
+    ///
+    /// A send error is returned to the caller and the name is NOT re-queued
+    /// here. The record that named it re-notes it on its next transient
+    /// refusal, so the retry rides #544's existing backoff rather than a second
+    /// unbounded timer (FSD-SIGNER-RECOVERY D6).
+    pub async fn send_recovery_pull(&self) -> Result<Option<String>, CoordinatorError> {
         if self.kind != EnvelopeKind::Key {
-            return 0;
+            return Ok(None);
         }
-        let Some(name) = self.provider.take_missing_signer_for(&self.peer_key_id) else {
-            return 0;
+        let Some(signer) = self.provider.take_missing_signer_for(&self.peer_key_id) else {
+            return Ok(None);
         };
-        match self.start_pull(&name).await {
-            Ok(()) => {
-                tracing::debug!(
-                    peer = %self.peer_key_id,
-                    signer = %name,
-                    "pulled a Key row for a signer that stalled admission (CIRISEdge#552)"
-                );
-                1
-            }
-            Err(e) => {
-                tracing::warn!(
-                    peer = %self.peer_key_id,
-                    signer = %name,
-                    error = %e,
-                    "missing-signer Pull send failed — the row that named it will \
-                     re-note it on its next transient refusal (CIRISEdge#552)"
-                );
-                0
-            }
-        }
+        self.start_pull(&signer).await?;
+        Ok(Some(signer))
     }
 
     pub async fn start_pull(&self, subject_key_id: &str) -> Result<(), CoordinatorError> {

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -380,53 +380,51 @@ impl ReplicationCoordinator {
     /// forget: the testimony converges over the peer's next round, matching the
     /// anti-entropy model — sending the Pull carries no session state (only the
     /// reply does), so there is nothing to await here.
-    /// CIRISEdge#552 (B) — recover THIS peer's own signing key, when a row it
-    /// signed could not be verified.
+    /// CIRISEdge#552 (B) — turn recorded missing signers into Key Pulls.
     ///
-    /// Only the `Key` coordinator does this, and only for the peer it is bound
-    /// to. That narrowness is forced, not chosen: `subject_holdings` serves a
-    /// subject Pull *only* when the requester IS the subject and otherwise
-    /// "serves nothing", so asking peer P for third-party S's key returns an
-    /// empty Summary forever. The one authorized case is S == P — "you signed a
-    /// row I cannot verify, send me your key" — which leaks nothing, since this
-    /// node already holds a row naming P as its signer.
+    /// Only the `Key` coordinator does this: [`Self::start_pull`] sends a
+    /// `PullMessage { kind: self.kind, .. }`, and the row every stalled record
+    /// waits on is a Key row.
     ///
-    /// **A third-party signer is NOT recoverable this way**, and there is no
-    /// wire verb that would make it so: `EnvelopeRef` carries `envelope_hash`
-    /// and `seq` only, so a node cannot name the record it wants by identifier,
-    /// and it cannot derive the hash without the body it is missing. Those rows
-    /// stay transient-refused, visibly, rather than being papered over by a Pull
-    /// that is refused by design.
+    /// This asks a peer for a THIRD PARTY's key, which `subject_holdings`
+    /// refused until CIRISEdge#552 widened the four unconditionally-`public`
+    /// planes to any attributed requester. That widening is what makes this
+    /// work, and it disclosed nothing new — a Key record is a public signed
+    /// envelope; only its ADDRESSABILITY changed.
     ///
-    /// Called from the scheduler before a round, so any reply is fetched by that
+    /// Called from the scheduler before a round, so the reply is fetched by that
     /// round's Summary handling.
+    ///
+    /// Returns how many Pulls were SENT. A send failure is logged and the name
+    /// is not re-queued here: the record that named it refuses transient again
+    /// on its next offer and re-notes it, so the retry rides #544's backoff and
+    /// cannot become a hot loop against an unreachable peer.
     pub async fn pull_missing_signers(&self) -> usize {
         if self.kind != EnvelopeKind::Key {
             return 0;
         }
-        let peer = self.peer_key_id.clone();
-        if !self.provider.take_missing_signer_for(&peer) {
-            return 0;
-        }
-        match self.start_pull(&peer).await {
-            Ok(()) => {
-                tracing::debug!(
-                    peer = %peer,
-                    "pulled this peer's own Key row — it signed a row this node \
-                     could not verify (CIRISEdge#552)"
-                );
-                1
-            }
-            Err(e) => {
-                tracing::warn!(
-                    peer = %peer,
+        let names = self.provider.take_missing_signers();
+        let mut sent = 0usize;
+        for name in names {
+            match self.start_pull(&name).await {
+                Ok(()) => sent += 1,
+                Err(e) => tracing::warn!(
+                    peer = %self.peer_key_id,
+                    signer = %name,
                     error = %e,
                     "missing-signer Pull send failed — the row that named it will \
                      re-note it on its next transient refusal (CIRISEdge#552)"
-                );
-                0
+                ),
             }
         }
+        if sent > 0 {
+            tracing::debug!(
+                peer = %self.peer_key_id,
+                sent,
+                "pulled Key rows for signers that stalled admission (CIRISEdge#552)"
+            );
+        }
+        sent
     }
 
     pub async fn start_pull(&self, subject_key_id: &str) -> Result<(), CoordinatorError> {

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -385,6 +385,12 @@ impl ReplicationCoordinator {
             kind: self.kind,
             subject_key_id: subject_key_id.to_string(),
         });
+        // CIRISEdge#552 — mark the session so the Summary that answers this Pull
+        // is fetched even under hash-first retention. A Pull is the deliberate
+        // "I need these bodies" path; hash-first suppresses bulk convergence, not
+        // an explicit ask. Set BEFORE the send, so a fast reply cannot land
+        // before the flag does.
+        self.session.lock().await.expect_pull_response();
         self.send_message(&pull).await
     }
 

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -380,43 +380,53 @@ impl ReplicationCoordinator {
     /// forget: the testimony converges over the peer's next round, matching the
     /// anti-entropy model — sending the Pull carries no session state (only the
     /// reply does), so there is nothing to await here.
-    /// CIRISEdge#552 (B) — turn recorded missing signers into Key Pulls.
+    /// CIRISEdge#552 (B) — recover THIS peer's own signing key, when a row it
+    /// signed could not be verified.
     ///
-    /// Only the `Key` coordinator does this: [`Self::start_pull`] sends a
-    /// `PullMessage { kind: self.kind, .. }`, and the row every stalled record
-    /// waits on is a Key row. Called from the scheduler after a round, so it
-    /// rides the cadence the operator already tuned rather than adding a timer.
+    /// Only the `Key` coordinator does this, and only for the peer it is bound
+    /// to. That narrowness is forced, not chosen: `subject_holdings` serves a
+    /// subject Pull *only* when the requester IS the subject and otherwise
+    /// "serves nothing", so asking peer P for third-party S's key returns an
+    /// empty Summary forever. The one authorized case is S == P — "you signed a
+    /// row I cannot verify, send me your key" — which leaks nothing, since this
+    /// node already holds a row naming P as its signer.
     ///
-    /// Returns how many Pulls were SENT. A send failure is logged and the name
-    /// is not re-queued here: the record that named it refuses transient again
-    /// on its next offer and re-notes it, so the retry rides #544's backoff and
-    /// cannot become a hot loop against an unreachable peer.
+    /// **A third-party signer is NOT recoverable this way**, and there is no
+    /// wire verb that would make it so: `EnvelopeRef` carries `envelope_hash`
+    /// and `seq` only, so a node cannot name the record it wants by identifier,
+    /// and it cannot derive the hash without the body it is missing. Those rows
+    /// stay transient-refused, visibly, rather than being papered over by a Pull
+    /// that is refused by design.
+    ///
+    /// Called from the scheduler before a round, so any reply is fetched by that
+    /// round's Summary handling.
     pub async fn pull_missing_signers(&self) -> usize {
         if self.kind != EnvelopeKind::Key {
             return 0;
         }
-        let names = self.provider.take_missing_signers();
-        let mut sent = 0usize;
-        for name in names {
-            match self.start_pull(&name).await {
-                Ok(()) => sent += 1,
-                Err(e) => tracing::warn!(
-                    peer = %self.peer_key_id,
-                    signer = %name,
+        let peer = self.peer_key_id.clone();
+        if !self.provider.take_missing_signer_for(&peer) {
+            return 0;
+        }
+        match self.start_pull(&peer).await {
+            Ok(()) => {
+                tracing::debug!(
+                    peer = %peer,
+                    "pulled this peer's own Key row — it signed a row this node \
+                     could not verify (CIRISEdge#552)"
+                );
+                1
+            }
+            Err(e) => {
+                tracing::warn!(
+                    peer = %peer,
                     error = %e,
                     "missing-signer Pull send failed — the row that named it will \
                      re-note it on its next transient refusal (CIRISEdge#552)"
-                ),
+                );
+                0
             }
         }
-        if sent > 0 {
-            tracing::debug!(
-                peer = %self.peer_key_id,
-                sent,
-                "pulled Key rows for signers that stalled admission (CIRISEdge#552)"
-            );
-        }
-        sent
     }
 
     pub async fn start_pull(&self, subject_key_id: &str) -> Result<(), CoordinatorError> {

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -380,6 +380,45 @@ impl ReplicationCoordinator {
     /// forget: the testimony converges over the peer's next round, matching the
     /// anti-entropy model — sending the Pull carries no session state (only the
     /// reply does), so there is nothing to await here.
+    /// CIRISEdge#552 (B) — turn recorded missing signers into Key Pulls.
+    ///
+    /// Only the `Key` coordinator does this: [`Self::start_pull`] sends a
+    /// `PullMessage { kind: self.kind, .. }`, and the row every stalled record
+    /// waits on is a Key row. Called from the scheduler after a round, so it
+    /// rides the cadence the operator already tuned rather than adding a timer.
+    ///
+    /// Returns how many Pulls were SENT. A send failure is logged and the name
+    /// is not re-queued here: the record that named it refuses transient again
+    /// on its next offer and re-notes it, so the retry rides #544's backoff and
+    /// cannot become a hot loop against an unreachable peer.
+    pub async fn pull_missing_signers(&self) -> usize {
+        if self.kind != EnvelopeKind::Key {
+            return 0;
+        }
+        let names = self.provider.take_missing_signers();
+        let mut sent = 0usize;
+        for name in names {
+            match self.start_pull(&name).await {
+                Ok(()) => sent += 1,
+                Err(e) => tracing::warn!(
+                    peer = %self.peer_key_id,
+                    signer = %name,
+                    error = %e,
+                    "missing-signer Pull send failed — the row that named it will \
+                     re-note it on its next transient refusal (CIRISEdge#552)"
+                ),
+            }
+        }
+        if sent > 0 {
+            tracing::debug!(
+                peer = %self.peer_key_id,
+                sent,
+                "pulled Key rows for signers that stalled admission (CIRISEdge#552)"
+            );
+        }
+        sent
+    }
+
     pub async fn start_pull(&self, subject_key_id: &str) -> Result<(), CoordinatorError> {
         let pull = ReplicationMessage::Pull(PullMessage {
             kind: self.kind,

--- a/src/replication/coordinator.rs
+++ b/src/replication/coordinator.rs
@@ -414,9 +414,15 @@ impl ReplicationCoordinator {
         }
         let fetch = ReplicationMessage::Fetch(FetchMessage {
             kind: self.kind,
-            want,
+            want: want.clone(),
         });
-        self.session.lock().await.expect_on_demand_reply();
+        // CIRISEdge#552 — record the EXACT hashes, so only these are applied.
+        // A responder can append whatever it likes to the reply; appending does
+        // not make it requested.
+        self.session
+            .lock()
+            .await
+            .expect_bodies(want.iter().copied());
         self.send_message(&fetch).await
     }
 

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -201,6 +201,25 @@ pub trait ReplicationDirectory: Send + Sync {
     ) {
     }
 
+    /// CIRISEdge#552 (B) — a transient refusal named a signer this node may not
+    /// hold. Recording it is all that happens here: admission stays LOCAL and
+    /// still fails transient, because the revocation admission path is the one
+    /// path that must never depend on a peer answering. Something out of band
+    /// pulls the key; the #544 backoff then re-offers the row and it admits.
+    ///
+    /// Sync by design, like [`Self::note_known_hashes`] — it sits on the apply
+    /// loop. Whether the key is genuinely absent is decided at the DRAIN, which
+    /// can afford the store lookup this cannot.
+    fn note_missing_signer(&self, _kind: EnvelopeKind, _signer_key_id: &str) {}
+
+    /// CIRISEdge#552 (B) — see [`StateProvider::take_missing_signers`].
+    ///
+    /// [`StateProvider::take_missing_signers`]:
+    ///     super::summary::StateProvider::take_missing_signers
+    fn take_missing_signers(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
         false
     }
@@ -321,6 +340,14 @@ impl StateProvider for DirectoryStateAdapter {
         advertised_by: Option<&str>,
     ) {
         self.inner.note_known_hashes(kind, hashes, advertised_by);
+    }
+
+    fn note_missing_signer(&self, kind: EnvelopeKind, signer_key_id: &str) {
+        self.inner.note_missing_signer(kind, signer_key_id);
+    }
+
+    fn take_missing_signers(&self) -> Vec<String> {
+        self.inner.take_missing_signers()
     }
 
     fn retry_suppressed(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> bool {
@@ -586,6 +613,66 @@ mod tests {
     }
 
     /// apply_envelope_bytes admits new envelopes, refuses duplicates.
+    /// CIRISEdge#552 (B) — the adapter must FORWARD the missing-signer seam.
+    ///
+    /// This test exists because of how #552 (A) failed: `retention()` was
+    /// implemented on the bridge, defaulted on the trait, and never forwarded
+    /// here — so production took the default and six review rounds ran against
+    /// a feature that could not execute. A default-bodied trait method that
+    /// nothing forwards is indistinguishable from a working one until you look
+    /// for the call. So: assert the forward, in both directions.
+    #[test]
+    fn the_adapter_forwards_the_missing_signer_seam() {
+        #[derive(Default)]
+        struct RecordingDir {
+            noted: std::sync::Mutex<Vec<String>>,
+        }
+        #[async_trait::async_trait]
+        impl ReplicationDirectory for RecordingDir {
+            async fn list_envelope_refs(&self, _k: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            async fn fetch_envelope_bytes(
+                &self,
+                _k: EnvelopeKind,
+                _h: &[u8; 32],
+            ) -> Option<Vec<u8>> {
+                None
+            }
+            async fn apply_envelope_bytes(
+                &self,
+                _k: EnvelopeKind,
+                _b: &[u8],
+                _p: Option<&str>,
+            ) -> ApplyOutcome {
+                ApplyOutcome::Admitted
+            }
+            fn note_missing_signer(&self, _k: EnvelopeKind, signer: &str) {
+                self.noted.lock().unwrap().push(signer.to_string());
+            }
+            fn take_missing_signers(&self) -> Vec<String> {
+                vec!["drained-from-inner".to_string()]
+            }
+        }
+
+        let inner = Arc::new(RecordingDir::default());
+        let adapter =
+            DirectoryStateAdapter::new(Arc::clone(&inner) as Arc<dyn ReplicationDirectory>);
+
+        StateProvider::note_missing_signer(&adapter, EnvelopeKind::Attestation, "steward-xyz");
+        assert_eq!(
+            inner.noted.lock().unwrap().as_slice(),
+            ["steward-xyz"],
+            "note_missing_signer must reach the inner directory — an unforwarded \
+             seam silently takes the no-op default (the #552 A inertness bug)"
+        );
+        assert_eq!(
+            StateProvider::take_missing_signers(&adapter),
+            ["drained-from-inner"],
+            "take_missing_signers must reach the inner directory too"
+        );
+    }
+
     #[tokio::test]
     async fn apply_admits_new_refuses_duplicates() {
         let dir = MockReplicationDirectory::new();

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -186,6 +186,21 @@ pub trait ReplicationDirectory: Send + Sync {
     /// mock and any host impl need no change; the bridge overrides it with the
     /// [`RefusalBackoff`](super::refusal_backoff::RefusalBackoff) its apply path
     /// populates.
+    /// CIRISEdge#552 — how much of `kind` this node keeps. Defaults to
+    /// `Bodies`, the pre-#552 behaviour; the bridge overrides it from config.
+    fn retention(&self, _kind: EnvelopeKind) -> super::retention::Retention {
+        super::retention::Retention::Bodies
+    }
+
+    /// CIRISEdge#552 — learn hashes whose bodies this node did not fetch.
+    fn note_known_hashes(
+        &self,
+        _kind: EnvelopeKind,
+        _hashes: &[[u8; 32]],
+        _advertised_by: Option<&str>,
+    ) {
+    }
+
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
         false
     }
@@ -288,6 +303,26 @@ impl StateProvider for DirectoryStateAdapter {
     /// Node-wide by construction — peer A's refusal removes the row from peer
     /// B's `want` too, which is the point (the verdict is about this node's
     /// state, not about who carried the bytes).
+    /// CIRISEdge#552 — FORWARD, do not answer.
+    ///
+    /// This adapter is the production `StateProvider`, and until it forwarded
+    /// these the whole feature was inert: every node took the trait default
+    /// (`Bodies`) no matter what the bridge was configured to do. Nothing broke,
+    /// which is exactly why it went unnoticed — a retention policy that is never
+    /// consulted looks identical to one that decides "keep everything".
+    fn retention(&self, kind: EnvelopeKind) -> super::retention::Retention {
+        self.inner.retention(kind)
+    }
+
+    fn note_known_hashes(
+        &self,
+        kind: EnvelopeKind,
+        hashes: &[[u8; 32]],
+        advertised_by: Option<&str>,
+    ) {
+        self.inner.note_known_hashes(kind, hashes, advertised_by);
+    }
+
     fn retry_suppressed(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> bool {
         self.inner.retry_suppressed(kind, envelope_hash)
     }

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -220,6 +220,14 @@ pub trait ReplicationDirectory: Send + Sync {
         Vec::new()
     }
 
+    /// CIRISEdge#552 (B) — see [`StateProvider::take_missing_signer_for`].
+    ///
+    /// [`StateProvider::take_missing_signer_for`]:
+    ///     super::summary::StateProvider::take_missing_signer_for
+    fn take_missing_signer_for(&self, _peer_key_id: &str) -> bool {
+        false
+    }
+
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
         false
     }
@@ -348,6 +356,10 @@ impl StateProvider for DirectoryStateAdapter {
 
     fn take_missing_signers(&self) -> Vec<String> {
         self.inner.take_missing_signers()
+    }
+
+    fn take_missing_signer_for(&self, peer_key_id: &str) -> bool {
+        self.inner.take_missing_signer_for(peer_key_id)
     }
 
     fn retry_suppressed(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> bool {

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -210,14 +210,24 @@ pub trait ReplicationDirectory: Send + Sync {
     /// Sync by design, like [`Self::note_known_hashes`] — it sits on the apply
     /// loop. Whether the key is genuinely absent is decided at the DRAIN, which
     /// can afford the store lookup this cannot.
-    fn note_missing_signer(&self, _kind: EnvelopeKind, _signer_key_id: &str) {}
+    fn note_missing_signer(
+        &self,
+        _kind: EnvelopeKind,
+        _signer_key_id: &str,
+        _source_peer: Option<&str>,
+    ) {
+    }
 
     /// CIRISEdge#552 (B) — see [`StateProvider::take_missing_signers`].
     ///
     /// [`StateProvider::take_missing_signers`]:
     ///     super::summary::StateProvider::take_missing_signers
-    fn take_missing_signers(&self) -> Vec<String> {
-        Vec::new()
+    /// CIRISEdge#552 (B) — see [`StateProvider::take_missing_signer_for`].
+    ///
+    /// [`StateProvider::take_missing_signer_for`]:
+    ///     super::summary::StateProvider::take_missing_signer_for
+    fn take_missing_signer_for(&self, _peer_key_id: &str) -> Option<String> {
+        None
     }
 
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
@@ -342,12 +352,18 @@ impl StateProvider for DirectoryStateAdapter {
         self.inner.note_known_hashes(kind, hashes, advertised_by);
     }
 
-    fn note_missing_signer(&self, kind: EnvelopeKind, signer_key_id: &str) {
-        self.inner.note_missing_signer(kind, signer_key_id);
+    fn note_missing_signer(
+        &self,
+        kind: EnvelopeKind,
+        signer_key_id: &str,
+        source_peer: Option<&str>,
+    ) {
+        self.inner
+            .note_missing_signer(kind, signer_key_id, source_peer);
     }
 
-    fn take_missing_signers(&self) -> Vec<String> {
-        self.inner.take_missing_signers()
+    fn take_missing_signer_for(&self, peer_key_id: &str) -> Option<String> {
+        self.inner.take_missing_signer_for(peer_key_id)
     }
 
     fn retry_suppressed(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> bool {
@@ -647,11 +663,19 @@ mod tests {
             ) -> ApplyOutcome {
                 ApplyOutcome::Admitted
             }
-            fn note_missing_signer(&self, _k: EnvelopeKind, signer: &str) {
-                self.noted.lock().unwrap().push(signer.to_string());
+            fn note_missing_signer(
+                &self,
+                _k: EnvelopeKind,
+                signer: &str,
+                source_peer: Option<&str>,
+            ) {
+                self.noted
+                    .lock()
+                    .unwrap()
+                    .push(format!("{signer}@{}", source_peer.unwrap_or("-")));
             }
-            fn take_missing_signers(&self) -> Vec<String> {
-                vec!["drained-from-inner".to_string()]
+            fn take_missing_signer_for(&self, peer: &str) -> Option<String> {
+                Some(format!("drained-for-{peer}"))
             }
         }
 
@@ -659,17 +683,23 @@ mod tests {
         let adapter =
             DirectoryStateAdapter::new(Arc::clone(&inner) as Arc<dyn ReplicationDirectory>);
 
-        StateProvider::note_missing_signer(&adapter, EnvelopeKind::Attestation, "steward-xyz");
+        StateProvider::note_missing_signer(
+            &adapter,
+            EnvelopeKind::Attestation,
+            "steward-xyz",
+            Some("peer-src"),
+        );
         assert_eq!(
             inner.noted.lock().unwrap().as_slice(),
-            ["steward-xyz"],
+            ["steward-xyz@peer-src"],
             "note_missing_signer must reach the inner directory — an unforwarded \
              seam silently takes the no-op default (the #552 A inertness bug)"
         );
         assert_eq!(
-            StateProvider::take_missing_signers(&adapter),
-            ["drained-from-inner"],
-            "take_missing_signers must reach the inner directory too"
+            StateProvider::take_missing_signer_for(&adapter, "peer-src").as_deref(),
+            Some("drained-for-peer-src"),
+            "take_missing_signer_for must reach the inner directory too, carrying \
+             the peer it is routing for"
         );
     }
 

--- a/src/replication/directory.rs
+++ b/src/replication/directory.rs
@@ -220,14 +220,6 @@ pub trait ReplicationDirectory: Send + Sync {
         Vec::new()
     }
 
-    /// CIRISEdge#552 (B) — see [`StateProvider::take_missing_signer_for`].
-    ///
-    /// [`StateProvider::take_missing_signer_for`]:
-    ///     super::summary::StateProvider::take_missing_signer_for
-    fn take_missing_signer_for(&self, _peer_key_id: &str) -> bool {
-        false
-    }
-
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
         false
     }
@@ -356,10 +348,6 @@ impl StateProvider for DirectoryStateAdapter {
 
     fn take_missing_signers(&self) -> Vec<String> {
         self.inner.take_missing_signers()
-    }
-
-    fn take_missing_signer_for(&self, peer_key_id: &str) -> bool {
-        self.inner.take_missing_signer_for(peer_key_id)
     }
 
     fn retry_suppressed(&self, kind: EnvelopeKind, envelope_hash: &[u8; 32]) -> bool {

--- a/src/replication/known_hashes.rs
+++ b/src/replication/known_hashes.rs
@@ -1,0 +1,266 @@
+//! CIRISEdge#552 — hashes this node KNOWS EXIST but whose bodies it does not
+//! hold.
+//!
+//! # The one invariant
+//!
+//! `want = remote ∖ holdings`. This set is **not holdings**. A hash in here has
+//! never been fetched, verified or admitted — it is hearsay from a peer's
+//! Summary. If it ever reaches the holdings side of that difference, the node
+//! concludes it already has everything it has merely heard of and silently
+//! stops fetching: CIRISEdge#416's non-convergence with the sign flipped, and
+//! invisible, because nothing errors and anti-entropy just goes quiet.
+//!
+//! That is why this type yields no [`EnvelopeRef`](super::protocol::EnvelopeRef)
+//! and never will. `diff_refs` takes `&[EnvelopeRef]`; a set that cannot produce
+//! one cannot be passed to it by accident. Adding such an accessor "for
+//! symmetry" is the single change that would undo this module.
+//!
+//! # Ageing
+//!
+//! Entries age on **last advertised**, never first seen. CIRISPersist#776 is the
+//! cautionary case: a prune aged on `asserted_at`, a value its writer freezes,
+//! so the cutoff never advanced — and both consumers independently refused to
+//! call it rather than reporting a fault. `last_advertised` moves because the
+//! advertise axis re-sweeps and wraps, which is also what makes eviction
+//! recoverable. Ageing column and recovery mechanism are the same fact; built
+//! from different columns, that is the bug.
+//!
+//! # Eviction
+//!
+//! The caller supplies a cutoff — never a period. Recovery latency is one wrap
+//! of the peer's rolling re-sweep (`corpus ÷ page_budget × cadence`), and all
+//! three inputs live on this side. Passing a cutoff rather than a period keeps
+//! one owner for that number instead of a frozen copy on the other side of a
+//! boundary.
+//!
+//! # Disclosure
+//!
+//! The advertising peer is recorded because it is the holder map — the
+//! difference between knowing Frank exists and knowing who to ask. It is an
+//! OBSERVATION ("this peer advertised H to me"), not a claim, it is derived from
+//! Summaries this node already received, and it is **local only**: no
+//! replication policy kind, no wire-index coverage, nothing that reaches an
+//! envelope. Serialising it "for debugging" is how it becomes a who-holds-what
+//! index for the whole corpus.
+
+use std::collections::HashMap;
+
+use super::protocol::EnvelopeKind;
+
+/// A hash known to exist, and where it was last heard.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KnownHash {
+    /// Unix seconds when a peer last advertised it. The ageing column.
+    pub last_advertised_unix: u64,
+    /// The peer that last advertised it — the holder map. Local only.
+    pub last_advertised_by: String,
+}
+
+/// Bounded set of known-but-not-held hashes.
+#[derive(Debug)]
+pub struct KnownHashes {
+    entries: HashMap<(EnvelopeKind, [u8; 32]), KnownHash>,
+    cap: usize,
+}
+
+impl KnownHashes {
+    /// Default cap. Sized like the other bounded memories in this crate: large
+    /// enough that a real federation directory fits, small enough that a
+    /// hostile peer advertising nonsense cannot grow it without bound.
+    pub const DEFAULT_CAP: usize = 262_144;
+
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_cap(Self::DEFAULT_CAP)
+    }
+
+    #[must_use]
+    pub fn with_cap(cap: usize) -> Self {
+        Self {
+            entries: HashMap::new(),
+            cap: cap.max(1),
+        }
+    }
+
+    /// Record that `peer` advertised `hash` for `kind` at `now`.
+    ///
+    /// Re-noting an existing entry advances `last_advertised_unix` — that is the
+    /// re-sweep keeping it alive, and the reason ageing on first-seen would be
+    /// wrong.
+    pub fn note(&mut self, kind: EnvelopeKind, hash: [u8; 32], peer: &str, now: u64) {
+        if self.entries.len() >= self.cap && !self.entries.contains_key(&(kind, hash)) {
+            // At cap: drop the least-recently-advertised entry. Evicting is
+            // recoverable — the peer's rolling re-sweep wraps and re-offers it.
+            if let Some(victim) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, v)| v.last_advertised_unix)
+                .map(|(k, _)| *k)
+            {
+                self.entries.remove(&victim);
+            }
+        }
+        let slot = self.entries.entry((kind, hash)).or_insert(KnownHash {
+            last_advertised_unix: now,
+            last_advertised_by: peer.to_owned(),
+        });
+        // Monotonic: a peer with a lagging clock must not age an entry the
+        // re-sweep just refreshed.
+        if now >= slot.last_advertised_unix {
+            slot.last_advertised_unix = now;
+            peer.clone_into(&mut slot.last_advertised_by);
+        }
+    }
+
+    /// Is this hash known (without being held)?
+    #[must_use]
+    pub fn contains(&self, kind: EnvelopeKind, hash: &[u8; 32]) -> bool {
+        self.entries.contains_key(&(kind, *hash))
+    }
+
+    /// Who last advertised it — the holder to ask. Local only.
+    #[must_use]
+    pub fn holder(&self, kind: EnvelopeKind, hash: &[u8; 32]) -> Option<&str> {
+        self.entries
+            .get(&(kind, *hash))
+            .map(|e| e.last_advertised_by.as_str())
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Drop entries not advertised since `cutoff_unix`.
+    ///
+    /// The CALLER computes the cutoff, because recovery latency is one wrap of
+    /// the advertise re-sweep and its inputs live on this side. A cutoff younger
+    /// than one wrap evicts entries the re-sweep has not come back around to,
+    /// and the set thrashes against the mechanism that refills it.
+    pub fn evict_advertised_before(&mut self, cutoff_unix: u64) -> usize {
+        let before = self.entries.len();
+        self.entries
+            .retain(|_, v| v.last_advertised_unix >= cutoff_unix);
+        before - self.entries.len()
+    }
+}
+
+impl Default for KnownHashes {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KnownHashes;
+    use crate::replication::protocol::EnvelopeKind;
+
+    fn h(n: u8) -> [u8; 32] {
+        [n; 32]
+    }
+
+    /// A known hash is recorded with its holder, so a later fetch knows who to
+    /// ask rather than broadcasting.
+    #[test]
+    fn a_noted_hash_is_known_and_carries_its_holder() {
+        let mut k = KnownHashes::new();
+        k.note(EnvelopeKind::Attestation, h(1), "peer-a", 100);
+        assert!(k.contains(EnvelopeKind::Attestation, &h(1)));
+        assert_eq!(k.holder(EnvelopeKind::Attestation, &h(1)), Some("peer-a"));
+    }
+
+    /// Kind is part of the key. The same content hash on two planes is two
+    /// records, and collapsing them would let a fetch on one plane satisfy a
+    /// want on another.
+    #[test]
+    fn the_same_hash_on_two_planes_is_two_entries() {
+        let mut k = KnownHashes::new();
+        k.note(EnvelopeKind::Attestation, h(1), "peer-a", 100);
+        assert!(!k.contains(EnvelopeKind::Key, &h(1)));
+        assert_eq!(k.len(), 1);
+    }
+
+    /// CIRISPersist#776's lesson, applied. Re-advertisement REFRESHES the entry;
+    /// if this aged on first-seen the cutoff would never advance for a record the
+    /// re-sweep keeps offering, and eviction would delete live knowledge.
+    #[test]
+    fn re_advertising_refreshes_the_ageing_column() {
+        let mut k = KnownHashes::new();
+        k.note(EnvelopeKind::Attestation, h(1), "peer-a", 100);
+        k.note(EnvelopeKind::Attestation, h(1), "peer-b", 500);
+
+        assert_eq!(
+            k.evict_advertised_before(400),
+            0,
+            "it was re-advertised at 500"
+        );
+        assert!(k.contains(EnvelopeKind::Attestation, &h(1)));
+        assert_eq!(
+            k.holder(EnvelopeKind::Attestation, &h(1)),
+            Some("peer-b"),
+            "the holder is the peer that most recently offered it"
+        );
+    }
+
+    /// A lagging peer clock must not age an entry backwards — the same
+    /// monotonic discipline the liveness stamp uses, for the same reason.
+    #[test]
+    fn a_backwards_clock_cannot_age_an_entry() {
+        let mut k = KnownHashes::new();
+        k.note(EnvelopeKind::Attestation, h(1), "peer-a", 500);
+        k.note(EnvelopeKind::Attestation, h(1), "peer-late", 100);
+        assert_eq!(k.evict_advertised_before(400), 0, "500 must stand");
+        assert_eq!(
+            k.holder(EnvelopeKind::Attestation, &h(1)),
+            Some("peer-a"),
+            "a stale advertisement must not take over the holder slot either"
+        );
+    }
+
+    /// Eviction drops only what the cutoff names.
+    #[test]
+    fn eviction_drops_only_entries_older_than_the_cutoff() {
+        let mut k = KnownHashes::new();
+        k.note(EnvelopeKind::Attestation, h(1), "peer-a", 100);
+        k.note(EnvelopeKind::Attestation, h(2), "peer-a", 900);
+        assert_eq!(k.evict_advertised_before(500), 1);
+        assert!(!k.contains(EnvelopeKind::Attestation, &h(1)));
+        assert!(k.contains(EnvelopeKind::Attestation, &h(2)));
+    }
+
+    /// At the cap the LEAST RECENTLY ADVERTISED entry goes, not an arbitrary
+    /// one: eviction is recoverable via the re-sweep, so the entry furthest from
+    /// its last refresh is the cheapest to re-learn.
+    #[test]
+    fn at_the_cap_the_stalest_entry_is_evicted() {
+        let mut k = KnownHashes::with_cap(2);
+        k.note(EnvelopeKind::Attestation, h(1), "p", 100);
+        k.note(EnvelopeKind::Attestation, h(2), "p", 900);
+        k.note(EnvelopeKind::Attestation, h(3), "p", 950);
+
+        assert_eq!(k.len(), 2);
+        assert!(
+            !k.contains(EnvelopeKind::Attestation, &h(1)),
+            "stalest goes"
+        );
+        assert!(k.contains(EnvelopeKind::Attestation, &h(3)));
+    }
+
+    /// Re-noting an entry at the cap must not evict anything — it is a refresh,
+    /// not an insert. Getting this wrong would make a busy set evict itself.
+    #[test]
+    fn refreshing_at_the_cap_evicts_nothing() {
+        let mut k = KnownHashes::with_cap(2);
+        k.note(EnvelopeKind::Attestation, h(1), "p", 100);
+        k.note(EnvelopeKind::Attestation, h(2), "p", 200);
+        k.note(EnvelopeKind::Attestation, h(1), "p", 300);
+        assert_eq!(k.len(), 2);
+        assert!(k.contains(EnvelopeKind::Attestation, &h(2)));
+    }
+}

--- a/src/replication/known_hashes.rs
+++ b/src/replication/known_hashes.rs
@@ -129,22 +129,65 @@ impl KnownHashes {
             self.entries.clear();
             return;
         }
-        // Evict by RANK, not by timestamp threshold.
+        // Evict from the LARGEST HOLDER first, then by RANK within it.
         //
-        // A threshold over-evicts on ties, and ties are the normal case here:
-        // every hash learned in one round shares a timestamp, so `retain(stamp >
-        // cutoff)` could drop a whole round's worth — far more than the batch,
-        // and precisely the entries most recently learned if the cap is hit
+        // Staleness alone is monopolizable. A peer that advertises a torrent of
+        // hashes always holds the YOUNGEST entries, so a global stalest-first
+        // pass evicts everyone ELSE — one peer can push every honest peer's
+        // directory knowledge out of a cap it is simultaneously filling. The
+        // holder map is what makes a hash actionable (it names who to fetch
+        // from), so losing it for honest peers is the whole feature degrading
+        // under exactly the hostile case the cap exists to tolerate.
+        //
+        // Charging eviction to the peer with the most entries is max-min
+        // fairness: under contention no peer can hold much more than its share,
+        // while a node talking to ONE peer still gets the whole cap — a fixed
+        // per-peer quota would waste it in the common case.
+        let mut per_peer: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        for v in self.entries.values() {
+            *per_peer.entry(v.last_advertised_by.as_str()).or_insert(0) += 1;
+        }
+        // Ties broken by peer id so the choice is deterministic — an arbitrary
+        // pick would make eviction depend on map iteration order.
+        let dominant: Option<String> = per_peer
+            .into_iter()
+            .max_by(|a, b| a.1.cmp(&b.1).then_with(|| b.0.cmp(a.0)))
+            .map(|(p, _)| p.to_owned());
+
+        // Rank, not a timestamp threshold: a threshold over-evicts on ties, and
+        // ties are the normal case here — every hash learned in one round shares
+        // a timestamp, so `retain(stamp > cutoff)` could drop a whole round's
+        // worth, precisely the entries most recently learned if the cap is hit
         // mid-round. Selecting exactly `target` keys keeps the batch a batch.
         let mut keys: Vec<(u64, (EnvelopeKind, [u8; 32]))> = self
             .entries
             .iter()
+            .filter(|(_, v)| {
+                // `map_or(true, ..)`, not `is_none_or`: that is stable since
+                // 1.82 and this crate's MSRV is 1.75.
+                dominant
+                    .as_deref()
+                    .map_or(true, |d| v.last_advertised_by == d)
+            })
             .map(|(k, v)| (v.last_advertised_unix, *k))
             .collect();
-        // `select_nth_unstable` is O(n) and needs no full sort — we want the
-        // `target` stalest, not an ordering of all of them.
-        keys.select_nth_unstable_by_key(target, |(stamp, _)| *stamp);
-        for (_, key) in keys.into_iter().take(target) {
+        // The dominant holder may hold fewer than a batch (many small peers).
+        // Then it is not monopolizing anything and the global stalest pass is
+        // the right one — take everything it has and fall back for the rest.
+        if keys.len() < target {
+            keys = self
+                .entries
+                .iter()
+                .map(|(k, v)| (v.last_advertised_unix, *k))
+                .collect();
+        }
+        let take = target.min(keys.len());
+        if take < keys.len() {
+            // `select_nth_unstable` is O(n) and needs no full sort — we want the
+            // `take` stalest, not an ordering of all of them.
+            keys.select_nth_unstable_by_key(take, |(stamp, _)| *stamp);
+        }
+        for (_, key) in keys.into_iter().take(take) {
             self.entries.remove(&key);
         }
     }
@@ -357,5 +400,84 @@ mod tests {
         k.note(EnvelopeKind::Attestation, h(1), "p", 300);
         assert_eq!(k.len(), 2);
         assert!(k.contains(EnvelopeKind::Attestation, &h(2)));
+    }
+
+    /// CIRISEdge#552 — one peer must not be able to evict every OTHER peer's
+    /// entries out of the cap.
+    ///
+    /// Staleness alone is monopolizable: a peer advertising a torrent always
+    /// holds the youngest entries, so a global stalest-first pass charges every
+    /// eviction to the quiet, honest peers. Losing their entries loses the
+    /// HOLDER — the thing that makes a hash actionable — under exactly the
+    /// hostile case the cap exists to tolerate.
+    #[test]
+    fn a_flooding_peer_cannot_evict_a_quiet_peers_entries() {
+        let mut k = KnownHashes::with_cap(64);
+
+        // A quiet, honest peer's entries, learned first and never refreshed —
+        // the stalest in the set, and under stalest-first the first to go.
+        let quiet: Vec<[u8; 32]> = (0..8).map(h).collect();
+        for hash in &quiet {
+            k.note(EnvelopeKind::Attestation, *hash, "peer-quiet", 100);
+        }
+
+        // A flooding peer advertises many times the cap, always fresher.
+        for i in 0..500u32 {
+            let mut hash = [0u8; 32];
+            hash[0..4].copy_from_slice(&i.to_be_bytes());
+            hash[31] = 0xFF;
+            k.note(
+                EnvelopeKind::Attestation,
+                hash,
+                "peer-flood",
+                200 + u64::from(i),
+            );
+        }
+
+        let survived = quiet
+            .iter()
+            .filter(|hash| k.contains(EnvelopeKind::Attestation, hash))
+            .count();
+        assert_eq!(
+            survived,
+            quiet.len(),
+            "the quiet peer's entries must survive a flood — eviction is charged \
+             to the LARGEST holder, not to whoever happens to be stalest"
+        );
+        assert!(
+            k.len() <= 64,
+            "the cap still bounds memory: {} entries",
+            k.len()
+        );
+        assert_eq!(
+            k.holder(EnvelopeKind::Attestation, &quiet[0]),
+            Some("peer-quiet"),
+            "and the holder map survives with them — a hash without a holder \
+             cannot be fetched"
+        );
+    }
+
+    /// The fair-share pass must not stall eviction when NO peer dominates: with
+    /// many small holders the largest may hold less than a batch, and the cap
+    /// still has to be enforced.
+    #[test]
+    fn eviction_still_bounds_the_cap_when_no_peer_dominates() {
+        let mut k = KnownHashes::with_cap(32);
+        for i in 0..400u32 {
+            let mut hash = [0u8; 32];
+            hash[0..4].copy_from_slice(&i.to_be_bytes());
+            // A different holder for nearly every entry.
+            k.note(
+                EnvelopeKind::Attestation,
+                hash,
+                &format!("peer-{i}"),
+                100 + u64::from(i),
+            );
+        }
+        assert!(
+            k.len() <= 32,
+            "the cap is enforced regardless of holder distribution: {} entries",
+            k.len()
+        );
     }
 }

--- a/src/replication/known_hashes.rs
+++ b/src/replication/known_hashes.rs
@@ -125,22 +125,28 @@ impl KnownHashes {
     /// Drop the stalest slice of the set in ONE pass.
     fn evict_stalest_batch(&mut self) {
         let target = (self.cap / Self::EVICT_BATCH_FRACTION).max(1);
-        let mut stamps: Vec<u64> = self
-            .entries
-            .values()
-            .map(|v| v.last_advertised_unix)
-            .collect();
-        if stamps.len() <= target {
+        if self.entries.len() <= target {
             self.entries.clear();
             return;
         }
-        // `select_nth_unstable` is O(n) and needs no full sort — the cutoff is a
-        // rank, not an order.
-        let (_, cutoff, _) = stamps.select_nth_unstable(target);
-        let cutoff = *cutoff;
-        // `>` not `>=`: entries sharing the cutoff instant stay, so a tie cannot
-        // over-evict past the batch.
-        self.entries.retain(|_, v| v.last_advertised_unix > cutoff);
+        // Evict by RANK, not by timestamp threshold.
+        //
+        // A threshold over-evicts on ties, and ties are the normal case here:
+        // every hash learned in one round shares a timestamp, so `retain(stamp >
+        // cutoff)` could drop a whole round's worth — far more than the batch,
+        // and precisely the entries most recently learned if the cap is hit
+        // mid-round. Selecting exactly `target` keys keeps the batch a batch.
+        let mut keys: Vec<(u64, (EnvelopeKind, [u8; 32]))> = self
+            .entries
+            .iter()
+            .map(|(k, v)| (v.last_advertised_unix, *k))
+            .collect();
+        // `select_nth_unstable` is O(n) and needs no full sort — we want the
+        // `target` stalest, not an ordering of all of them.
+        keys.select_nth_unstable_by_key(target, |(stamp, _)| *stamp);
+        for (_, key) in keys.into_iter().take(target) {
+            self.entries.remove(&key);
+        }
     }
 
     /// Is this hash known (without being held)?
@@ -289,6 +295,35 @@ mod tests {
         assert!(
             k.contains(EnvelopeKind::Key, &h(19)),
             "the freshest prior entry must survive a batch eviction"
+        );
+    }
+
+    /// Ties must not over-evict, and ties are the NORMAL case: every hash
+    /// learned in one round shares a Unix second. A timestamp threshold would
+    /// drop the whole second — far more than the batch, and precisely the
+    /// entries most recently learned when the cap is hit mid-round.
+    #[test]
+    fn a_whole_round_sharing_one_second_is_not_evicted_together() {
+        let mut k = KnownHashes::with_cap(20);
+        // 18 entries all learned in the same second, plus two older ones.
+        k.note(EnvelopeKind::Key, h(200), "p", 10);
+        k.note(EnvelopeKind::Key, h(201), "p", 11);
+        for i in 0..18u8 {
+            k.note(EnvelopeKind::Key, h(i), "p", 500);
+        }
+        assert_eq!(k.len(), 20);
+
+        k.note(EnvelopeKind::Key, h(210), "p", 900);
+
+        // The batch is cap/10 = 2. Only the two genuinely older entries should
+        // go; the 18 sharing 500 must survive.
+        let survivors = (0..18u8)
+            .filter(|i| k.contains(EnvelopeKind::Key, &h(*i)))
+            .count();
+        assert!(
+            survivors >= 17,
+            "a shared timestamp must not take the whole second with it — only \
+             {survivors} of 18 survived"
         );
     }
 

--- a/src/replication/known_hashes.rs
+++ b/src/replication/known_hashes.rs
@@ -89,16 +89,21 @@ impl KnownHashes {
     /// wrong.
     pub fn note(&mut self, kind: EnvelopeKind, hash: [u8; 32], peer: &str, now: u64) {
         if self.entries.len() >= self.cap && !self.entries.contains_key(&(kind, hash)) {
-            // At cap: drop the least-recently-advertised entry. Evicting is
-            // recoverable — the peer's rolling re-sweep wraps and re-offers it.
-            if let Some(victim) = self
-                .entries
-                .iter()
-                .min_by_key(|(_, v)| v.last_advertised_unix)
-                .map(|(k, _)| *k)
-            {
-                self.entries.remove(&victim);
-            }
+            // At cap: drop a BATCH of the least-recently-advertised entries, not
+            // one.
+            //
+            // Evicting one per insert meant a full map scan per advertised hash.
+            // A peer that keeps advertising fresh hashes then turns every Summary
+            // into O(page × cap) work — sustained CPU exhaustion in exactly the
+            // hostile-peer case this cap exists to tolerate, where the cap bounds
+            // memory and nothing bounds the scan. Batching amortises one scan
+            // across `EVICT_BATCH_FRACTION` of the cap, so the per-insert cost is
+            // bounded regardless of what a peer advertises.
+            //
+            // Evicting more than strictly necessary is cheap here: eviction is
+            // RECOVERABLE, because the advertise axis re-sweeps and wraps, so a
+            // dropped entry comes back around.
+            self.evict_stalest_batch();
         }
         let slot = self.entries.entry((kind, hash)).or_insert(KnownHash {
             last_advertised_unix: now,
@@ -110,6 +115,32 @@ impl KnownHashes {
             slot.last_advertised_unix = now;
             peer.clone_into(&mut slot.last_advertised_by);
         }
+    }
+
+    /// How much of the cap one eviction pass reclaims. A tenth: large enough
+    /// that the amortised scan cost per insert is ~10 comparisons, small enough
+    /// that a burst does not discard most of what the node knows.
+    const EVICT_BATCH_FRACTION: usize = 10;
+
+    /// Drop the stalest slice of the set in ONE pass.
+    fn evict_stalest_batch(&mut self) {
+        let target = (self.cap / Self::EVICT_BATCH_FRACTION).max(1);
+        let mut stamps: Vec<u64> = self
+            .entries
+            .values()
+            .map(|v| v.last_advertised_unix)
+            .collect();
+        if stamps.len() <= target {
+            self.entries.clear();
+            return;
+        }
+        // `select_nth_unstable` is O(n) and needs no full sort — the cutoff is a
+        // rank, not an order.
+        let (_, cutoff, _) = stamps.select_nth_unstable(target);
+        let cutoff = *cutoff;
+        // `>` not `>=`: entries sharing the cutoff instant stay, so a tie cannot
+        // over-evict past the batch.
+        self.entries.retain(|_, v| v.last_advertised_unix > cutoff);
     }
 
     /// Is this hash known (without being held)?
@@ -238,18 +269,47 @@ mod tests {
     /// one: eviction is recoverable via the re-sweep, so the entry furthest from
     /// its last refresh is the cheapest to re-learn.
     #[test]
-    fn at_the_cap_the_stalest_entry_is_evicted() {
-        let mut k = KnownHashes::with_cap(2);
-        k.note(EnvelopeKind::Attestation, h(1), "p", 100);
-        k.note(EnvelopeKind::Attestation, h(2), "p", 900);
-        k.note(EnvelopeKind::Attestation, h(3), "p", 950);
+    fn at_the_cap_the_stalest_entries_are_evicted() {
+        let mut k = KnownHashes::with_cap(20);
+        for i in 0..20u8 {
+            // Ascending recency: h(0) is the stalest.
+            k.note(EnvelopeKind::Key, h(i), "p", 100 + u64::from(i));
+        }
+        k.note(EnvelopeKind::Key, h(200), "p", 9_999);
 
-        assert_eq!(k.len(), 2);
+        assert!(k.len() <= 20, "the cap holds");
         assert!(
-            !k.contains(EnvelopeKind::Attestation, &h(1)),
-            "stalest goes"
+            !k.contains(EnvelopeKind::Key, &h(0)),
+            "the stalest entry must be among those dropped"
         );
-        assert!(k.contains(EnvelopeKind::Attestation, &h(3)));
+        assert!(
+            k.contains(EnvelopeKind::Key, &h(200)),
+            "the newly advertised hash must survive its own insert"
+        );
+        assert!(
+            k.contains(EnvelopeKind::Key, &h(19)),
+            "the freshest prior entry must survive a batch eviction"
+        );
+    }
+
+    /// The eviction pass is BATCHED, so a peer advertising a stream of fresh
+    /// hashes cannot turn every insert into a full scan. Without this the cap
+    /// bounds memory while nothing bounds CPU — sustained exhaustion in exactly
+    /// the hostile-peer case the cap exists for.
+    #[test]
+    fn a_flood_of_fresh_hashes_does_not_rescan_per_insert() {
+        let mut k = KnownHashes::with_cap(100);
+        for i in 0..100u8 {
+            k.note(EnvelopeKind::Key, h(i), "p", 100 + u64::from(i));
+        }
+        assert_eq!(k.len(), 100);
+
+        k.note(EnvelopeKind::Key, h(200), "p", 5_000);
+        assert!(
+            k.len() <= 100 - (100 / KnownHashes::EVICT_BATCH_FRACTION) + 1,
+            "one pass must reclaim a batch, not a single slot — got {}",
+            k.len()
+        );
     }
 
     /// Re-noting an entry at the cap must not evict anything — it is a refresh,

--- a/src/replication/missing_signer.rs
+++ b/src/replication/missing_signer.rs
@@ -1,0 +1,144 @@
+//! CIRISEdge#552 (B) — resolving the one dependency hash-first cannot hold.
+//!
+//! # Why this exists
+//!
+//! The dependency-closure analysis for #552 found that `Key` is the root of
+//! every admission's closure: persist's shared ingest gate resolves the signer's
+//! registered pubkeys via `lookup_public_key` before verifying anything —
+//! `attesting_key_id` for a row, `revoking_key_id` for a revocation. So NO plane
+//! admits while its signer's Key body is absent.
+//!
+//! Today that resolves itself: the bridge classifies `UnverifiableSignature` as
+//! TRANSIENT precisely because *"the scrub key is itself a Key-plane row that
+//! replicates, so this is ordinary bootstrap ordering"* — the key arrives on its
+//! own and the backoff retry admits the row.
+//!
+//! Under hash-first for `Key` it never arrives, and the retry spins forever. A
+//! revocation whose revoker is unknown is then permanently unadmittable — which
+//! is a kill order that does not land, defeating #553 through the plane it
+//! depends on rather than through itself.
+//!
+//! # The resolution, and what it deliberately does NOT do
+//!
+//! It does **not** put a network fetch on the admission path. Admission stays
+//! local and still fails transient; this only records WHICH key was missing, so
+//! something out of band can pull it. The existing #544 backoff then re-offers
+//! the row and it admits normally.
+//!
+//! That ordering matters: the revocation admission path is the one path that
+//! must never depend on a peer answering.
+//!
+//! No new wire verb and nothing from persist — `PullMessage { kind: Key,
+//! subject_key_id }` is already "give me the Key record for this subject"
+//! (CIRISEdge#462), and Pull replies are already exempt from hash-first
+//! suppression.
+
+use super::protocol::EnvelopeKind;
+
+/// The signer field a plane's admission resolves, if this kind has one.
+///
+/// Not a guess: these are the fields persist's gate reads. A row is verified
+/// against `attesting_key_id`, a revocation against `revoking_key_id`, and a key
+/// registration against `scrub_key_id` (which for a self-attested registration
+/// is the subject itself, and therefore never missing).
+#[must_use]
+pub const fn signer_field(kind: EnvelopeKind) -> &'static str {
+    match kind {
+        EnvelopeKind::Revocation
+        | EnvelopeKind::IdentityOccurrenceRevocation
+        | EnvelopeKind::FamilyMembershipRevocation
+        | EnvelopeKind::CommunityMembershipRevocation => "revoking_key_id",
+        EnvelopeKind::Key => "scrub_key_id",
+        _ => "attesting_key_id",
+    }
+}
+
+/// The key whose absence would explain an unverifiable signature on these bytes.
+///
+/// `None` when the envelope does not name one — a malformed record, which
+/// `UnverifiableSignature` also covers and which no fetch can repair. Returning
+/// `None` there is the point: the token fuses a recoverable arm with an
+/// unrecoverable one, and only the recoverable arm names a key to go and get.
+#[must_use]
+pub fn missing_signer_of(kind: EnvelopeKind, envelope_bytes: &[u8]) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_slice(envelope_bytes).ok()?;
+    let field = signer_field(kind);
+    // Top level first, then one level into the record wrapper: the Signed*
+    // wrappers carry the row under a single key, and the signer lives on the row.
+    value
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| {
+            value
+                .as_object()?
+                .values()
+                .find_map(|v| v.get(field).and_then(serde_json::Value::as_str))
+        })
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{missing_signer_of, signer_field};
+    use crate::replication::protocol::EnvelopeKind;
+
+    /// A revocation is verified against its REVOKER, not its subject. Reading
+    /// the wrong field would send the node to fetch the key being revoked —
+    /// which it may well already hold, so the pull would "succeed" and the
+    /// revocation would still never admit.
+    #[test]
+    fn a_revocation_names_its_revoker_not_its_subject() {
+        assert_eq!(signer_field(EnvelopeKind::Revocation), "revoking_key_id");
+        let bytes = br#"{"revoked_key_id":"victim-aaa","revoking_key_id":"revoker-bbb"}"#;
+        assert_eq!(
+            missing_signer_of(EnvelopeKind::Revocation, bytes).as_deref(),
+            Some("revoker-bbb")
+        );
+    }
+
+    /// Every non-revocation plane is verified against `attesting_key_id` — the
+    /// field persist's shared row gate reads.
+    #[test]
+    fn a_row_names_its_attester() {
+        let bytes = br#"{"attestation_id":"a-1","attesting_key_id":"producer-ccc"}"#;
+        assert_eq!(
+            missing_signer_of(EnvelopeKind::Attestation, bytes).as_deref(),
+            Some("producer-ccc")
+        );
+    }
+
+    /// The signer commonly sits one level in, under the `Signed*` wrapper.
+    #[test]
+    fn the_signer_is_found_inside_a_signed_wrapper() {
+        let bytes = br#"{"revocation":{"revoked_key_id":"v","revoking_key_id":"revoker-ddd"}}"#;
+        assert_eq!(
+            missing_signer_of(EnvelopeKind::Revocation, bytes).as_deref(),
+            Some("revoker-ddd")
+        );
+    }
+
+    /// `UnverifiableSignature` also covers a MALFORMED record, which no fetch
+    /// repairs. Naming no key is the correct answer there — inventing one would
+    /// send the node chasing a dependency that was never the problem, and the
+    /// row would keep failing for the reason it actually failed.
+    #[test]
+    fn a_malformed_record_names_no_one_to_fetch() {
+        assert_eq!(
+            missing_signer_of(EnvelopeKind::Attestation, b"not json"),
+            None
+        );
+        assert_eq!(
+            missing_signer_of(EnvelopeKind::Attestation, br#"{"no_signer_here":1}"#),
+            None
+        );
+    }
+
+    /// An empty signer is absence, not a key id. Fetching "" would be a
+    /// guaranteed-miss pull on every retry.
+    #[test]
+    fn an_empty_signer_is_not_a_key_to_fetch() {
+        let bytes = br#"{"attesting_key_id":""}"#;
+        assert_eq!(missing_signer_of(EnvelopeKind::Attestation, bytes), None);
+    }
+}

--- a/src/replication/missing_signer.rs
+++ b/src/replication/missing_signer.rs
@@ -35,52 +35,64 @@
 
 use super::protocol::EnvelopeKind;
 
-/// The signer field a plane's admission resolves, if this kind has one.
+/// The fields a record can name its signer in, in the order persist's gate
+/// prefers them.
 ///
-/// Not a guess: these are the fields persist's gate reads. A row is verified
-/// against `attesting_key_id`, a revocation against `revoking_key_id`, and a key
-/// registration against `scrub_key_id` (which for a self-attested registration
-/// is the subject itself, and therefore never missing).
-#[must_use]
-pub const fn signer_field(kind: EnvelopeKind) -> &'static str {
-    match kind {
-        EnvelopeKind::Revocation
-        | EnvelopeKind::IdentityOccurrenceRevocation
-        | EnvelopeKind::FamilyMembershipRevocation
-        | EnvelopeKind::CommunityMembershipRevocation => "revoking_key_id",
-        EnvelopeKind::Key => "scrub_key_id",
-        _ => "attesting_key_id",
-    }
-}
+/// NOT a per-kind mapping. I wrote one twice and got it wrong twice: the
+/// membership-revocation planes have no `revoking_key_id` at all — they are
+/// authority-signed, carrying `authority_key_id` on the wrapper and
+/// `family_key_id` / `community_key_id` inside — so a kind-keyed guess looked
+/// for a field that does not exist, found nothing, and silently fetched no key.
+///
+/// A record names its signer in exactly one of these, so trying them in the
+/// gate's own order of specificity removes the guess. Order matters where a
+/// record carries several: a `Revocation` has BOTH `revoking_key_id` and
+/// `scrub_key_id`, and `verify_revocation_admission` reads the revoker.
+const SIGNER_FIELDS: [&str; 4] = [
+    // The revoker — read by `verify_revocation_admission`.
+    "revoking_key_id",
+    // The authority — read by the E4 keyless-declaration and roster planes
+    // (Family, Community, both membership revocations, LocationProof,
+    // Organization, OrgMembership, PartnerRecord).
+    "authority_key_id",
+    // The attester — the shared row gate's field, and the common case.
+    "attesting_key_id",
+    // A key registration's scrubber. Last because a self-attested registration
+    // names ITSELF here, and a key that is its own signer is never the missing
+    // dependency.
+    "scrub_key_id",
+];
 
 /// The key whose absence would explain an unverifiable signature on these bytes.
 ///
-/// `None` when the envelope does not name one — a malformed record, which
+/// `None` when the envelope names no signer — a malformed record, which
 /// `UnverifiableSignature` also covers and which no fetch can repair. Returning
 /// `None` there is the point: the token fuses a recoverable arm with an
 /// unrecoverable one, and only the recoverable arm names a key to go and get.
 #[must_use]
-pub fn missing_signer_of(kind: EnvelopeKind, envelope_bytes: &[u8]) -> Option<String> {
+pub fn missing_signer_of(_kind: EnvelopeKind, envelope_bytes: &[u8]) -> Option<String> {
     let value: serde_json::Value = serde_json::from_slice(envelope_bytes).ok()?;
-    let field = signer_field(kind);
-    // Top level first, then one level into the record wrapper: the Signed*
-    // wrappers carry the row under a single key, and the signer lives on the row.
-    value
-        .get(field)
-        .and_then(serde_json::Value::as_str)
-        .or_else(|| {
-            value
-                .as_object()?
-                .values()
-                .find_map(|v| v.get(field).and_then(serde_json::Value::as_str))
-        })
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned)
+    SIGNER_FIELDS.iter().find_map(|field| {
+        // Top level first, then one level into the `Signed*` wrapper: the wrapper
+        // carries the row under a single key, and some signers sit on the wrapper
+        // while others sit on the row.
+        value
+            .get(*field)
+            .and_then(serde_json::Value::as_str)
+            .or_else(|| {
+                value
+                    .as_object()?
+                    .values()
+                    .find_map(|v| v.get(*field).and_then(serde_json::Value::as_str))
+            })
+            .filter(|candidate| !candidate.is_empty())
+            .map(str::to_owned)
+    })
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{missing_signer_of, signer_field};
+    use super::missing_signer_of;
     use crate::replication::protocol::EnvelopeKind;
 
     /// A revocation is verified against its REVOKER, not its subject. Reading
@@ -89,8 +101,31 @@ mod tests {
     /// revocation would still never admit.
     #[test]
     fn a_revocation_names_its_revoker_not_its_subject() {
-        assert_eq!(signer_field(EnvelopeKind::Revocation), "revoking_key_id");
         let bytes = br#"{"revoked_key_id":"victim-aaa","revoking_key_id":"revoker-bbb"}"#;
+        assert_eq!(
+            missing_signer_of(EnvelopeKind::Revocation, bytes).as_deref(),
+            Some("revoker-bbb")
+        );
+    }
+
+    /// An authority-signed plane names `authority_key_id`, and the membership
+    /// revocations have NO `revoking_key_id` — a kind-keyed mapping looked for
+    /// one, found nothing, and fetched no key at all.
+    #[test]
+    fn an_authority_signed_revocation_names_its_authority() {
+        let bytes = br#"{"community_key_id":"c-1","removed_identity_key_id":"v","authority_key_id":"authority-eee"}"#;
+        assert_eq!(
+            missing_signer_of(EnvelopeKind::CommunityMembershipRevocation, bytes).as_deref(),
+            Some("authority-eee")
+        );
+    }
+
+    /// A revocation carries BOTH `revoking_key_id` and `scrub_key_id`, and the
+    /// gate reads the revoker. Order of preference is the whole correctness of
+    /// a candidate list.
+    #[test]
+    fn the_revoker_wins_over_the_scrubber() {
+        let bytes = br#"{"revoking_key_id":"revoker-bbb","scrub_key_id":"scrubber-fff"}"#;
         assert_eq!(
             missing_signer_of(EnvelopeKind::Revocation, bytes).as_deref(),
             Some("revoker-bbb")

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -120,11 +120,18 @@ pub mod accord_relay_gate;
 pub mod bridge;
 pub mod coordinator;
 pub mod directory;
+/// CIRISEdge#552 — hashes known to exist whose bodies this node does not
+/// hold. NEVER holdings; see the module docs for why that distinction is the
+/// whole safety of the design.
+pub mod known_hashes;
 pub mod mesh_config;
 pub mod protocol;
 pub mod refusal_backoff;
 pub mod registry;
 pub mod resolved_state;
+/// CIRISEdge#552/#553 — how much of a plane this node keeps, and the
+/// revocation carve-out a configured retention cannot reach.
+pub mod retention;
 pub mod runtime;
 pub mod scheduler;
 pub mod serve_policy;

--- a/src/replication/mod.rs
+++ b/src/replication/mod.rs
@@ -125,6 +125,9 @@ pub mod directory;
 /// whole safety of the design.
 pub mod known_hashes;
 pub mod mesh_config;
+/// CIRISEdge#552 — which Key an unverifiable signature was missing, so it can
+/// be pulled. `Key` is the root of every admission's dependency closure.
+pub mod missing_signer;
 pub mod protocol;
 pub mod refusal_backoff;
 pub mod registry;

--- a/src/replication/protocol.rs
+++ b/src/replication/protocol.rs
@@ -251,6 +251,36 @@ impl EnvelopeKind {
         )
     }
 
+    /// CIRISEdge#552 — does this kind answer a subject-scoped Pull from ANY
+    /// attributed requester, rather than only from the subject itself?
+    ///
+    /// EXACTLY the subject-pullable planes whose serve cell is unconditionally
+    /// `public` — a public signed envelope, no capability gate. For those, the
+    /// federation already discloses the record to anyone through ordinary
+    /// anti-entropy; `subject-only` on the RECEIVE axis made it un-ADDRESSABLE,
+    /// not undisclosed. That gap is load-bearing under hash-first retention: a
+    /// node that declined to fetch a public body has no other way to name it
+    /// (every other read is content-hash-addressed, and it cannot compute the
+    /// hash of a record it does not hold).
+    ///
+    /// `Attestation` is deliberately NOT here. Its serve cell is conditional —
+    /// `trace:*` rides `capability:infra:serve` and the G2 scores carve is
+    /// per-row — so its entitlement is genuinely decided per record and cannot
+    /// be answered by a per-plane predicate.
+    ///
+    /// A requester must still be ATTRIBUTED: this widens *who* may name a
+    /// public record, never whether an unauthenticated peer is served.
+    #[must_use]
+    pub fn is_public_subject_pull(self) -> bool {
+        matches!(
+            self,
+            Self::Key
+                | Self::IdentityOccurrence
+                | Self::TransportDestination
+                | Self::IdentityOccurrenceRevocation
+        )
+    }
+
     /// CIRISEdge#474 — is this kind served over the dedicated CURSOR path
     /// (`CursorPull` → `Deliver`, resume on `evidence_at`) rather than the
     /// content-hash Summary/Diff/Fetch flow? EXACTLY the kinds with no
@@ -777,6 +807,38 @@ mod tests {
     /// (the persist `ReplicatedKind` set), checked over ALL 14 so a new pullable
     /// kind must be a deliberate edit here. MUST agree with the serve-policy
     /// `receive` witness.
+    /// CIRISEdge#552 — the public-Pull set is a strict SUBSET of the
+    /// subject-pullable set, and excludes `Attestation`.
+    ///
+    /// Both halves matter. A kind that answers a public Pull without being
+    /// subject-pullable would be served through a path the manifest says it has
+    /// no receive axis for; and `Attestation` inside this set would blanket a
+    /// plane whose entitlement is decided per ROW (`trace:*` capability, the G2
+    /// scores carve) — the exact conflation that turns a per-record gate into a
+    /// per-plane one.
+    #[test]
+    fn the_public_subject_pull_set_is_a_subset_that_excludes_attestation() {
+        for kind in EnvelopeKind::ALL {
+            if kind.is_public_subject_pull() {
+                assert!(
+                    kind.is_subject_pullable(),
+                    "{kind:?} answers a public Pull but has no subject-pull \
+                     receive axis at all"
+                );
+            }
+        }
+        assert!(
+            !EnvelopeKind::Attestation.is_public_subject_pull(),
+            "Attestation's serve cell is CONDITIONAL (trace:* → capability, \
+             plus the per-row G2 carve) — it cannot be widened per-plane"
+        );
+        assert!(
+            EnvelopeKind::Key.is_public_subject_pull(),
+            "Key is a public signed envelope; refusing to let a peer NAME it is \
+             what stranded hash-first admission"
+        );
+    }
+
     #[test]
     fn is_subject_pullable_is_exactly_the_five_replicated_kinds() {
         for kind in EnvelopeKind::ALL {

--- a/src/replication/retention.rs
+++ b/src/replication/retention.rs
@@ -34,6 +34,26 @@ pub enum Retention {
     Bodies,
 }
 
+/// CIRISEdge#552 (B) — should a stalled row's signer be recorded for an
+/// out-of-band pull, given the retention this node applies to the **`Key`**
+/// plane?
+///
+/// The row that stalled can be any kind; the row it waits on is always a Key.
+/// So this asks about `Key`'s retention, never the stalled row's.
+///
+/// Under [`Retention::Bodies`] the answer is no: the signer's Key body
+/// replicates on its own and the #544 backoff admits the row on a later round.
+/// That is the self-resolving case, and recording it would add a pull for
+/// something already in flight. Only `HashFirst` breaks that, because then the
+/// key is a hash this node never fetches and the retry spins forever.
+#[must_use]
+pub fn should_note_missing_signer(key_retention: Retention) -> bool {
+    match key_retention {
+        Retention::HashFirst => true,
+        Retention::Bodies => false,
+    }
+}
+
 /// CIRISEdge#553 — the retention this node actually applies to `kind`.
 ///
 /// **A configured `HashFirst` cannot reach the revocation class.** Persist
@@ -139,7 +159,7 @@ pub const fn retention_for(kind: EnvelopeKind, configured: Retention) -> Retenti
 
 #[cfg(test)]
 mod tests {
-    use super::{retention_for, Retention};
+    use super::{retention_for, should_note_missing_signer, Retention};
     use crate::replication::protocol::EnvelopeKind;
 
     /// Every kind whose BODY a node must hold, and why — spelled out here
@@ -255,6 +275,23 @@ mod tests {
                 got, expected,
                 "{kind:?} is not deliberately classified — a new plane must be \
                  assigned a retention by whoever adds it (CIRISEdge#553)"
+            );
+        }
+    }
+
+    /// CIRISEdge#552 (B) — the record-a-missing-signer decision, over EVERY
+    /// retention. Exhaustive rather than two asserts: a third `Retention`
+    /// variant must not silently take a default here, and the input is the
+    /// exact value the field computes — `retention(EnvelopeKind::Key)`.
+    #[test]
+    fn only_hash_first_records_a_missing_signer() {
+        for r in [Retention::HashFirst, Retention::Bodies] {
+            let expected = r == Retention::HashFirst;
+            assert_eq!(
+                should_note_missing_signer(r),
+                expected,
+                "under {r:?} the signer's Key body {} replicate on its own",
+                if expected { "does NOT" } else { "DOES" }
             );
         }
     }

--- a/src/replication/retention.rs
+++ b/src/replication/retention.rs
@@ -1,0 +1,152 @@
+//! CIRISEdge#552 / #553 — how much of a plane this node keeps.
+//!
+//! # Why there is a choice at all
+//!
+//! Anti-entropy's model is *every node in the projection holds every record*.
+//! That is affordable while identities are `SelfOwn` and never travel. Once
+//! agent/node/fed IDs are promoted to federation tier — opt-out, and required
+//! to run an agent, because the kill switch needs the ID announced — every node
+//! is asked to hold every identity in the federation.
+//!
+//! Two things break at once: the corpus stops fitting (CIRISEdge#547, a
+//! canonical unreachable after ~22 h on 1.3 GB), and the directory becomes an
+//! address book. Holding HASHES instead answers both: a hash is not a mailing
+//! address, and resolving one to a contactable identity takes a fetch, which is
+//! observable, rate-limitable and refusable.
+//!
+//! # What must not happen
+//!
+//! `want = remote ∖ holdings`. A hash this node merely KNOWS ABOUT must never
+//! reach the holdings side of that difference, or the node concludes it already
+//! has everything it has heard of and silently stops fetching — CIRISEdge#416's
+//! non-convergence with the sign flipped, and invisible from outside, because
+//! nothing errors and anti-entropy simply goes quiet.
+
+use super::protocol::EnvelopeKind;
+
+/// How much of a plane this node keeps.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Retention {
+    /// Converge the hash set; fetch a body only on demand.
+    HashFirst,
+    /// Hold every body this node is offered. The pre-#552 behaviour, and the
+    /// only lawful mode for the revocation class.
+    Bodies,
+}
+
+/// CIRISEdge#553 — the retention this node actually applies to `kind`.
+///
+/// **A configured `HashFirst` cannot reach the revocation class.** Persist
+/// states the rule this enforces: a tombstone travels at its plane's ceiling
+/// regardless of scope, because *"a tombstone that relayed narrower than any
+/// copy could have traveled would starve holders, silently un-revoking"*.
+///
+/// A node holding the HASH of a kill order has not been killed. Worse, a node
+/// that cannot fetch the body — offline, rate-limited, no holder answering —
+/// un-revokes silently: nothing errors, the agent simply keeps running. That is
+/// the one failure on this path that fails in the safe-LOOKING direction, which
+/// is why the carve-out is a function of the kind and not a flag a caller can
+/// get wrong.
+#[must_use]
+pub const fn retention_for(kind: EnvelopeKind, configured: Retention) -> Retention {
+    match kind {
+        // The revocation class. Bodies, always, whatever is configured.
+        EnvelopeKind::Revocation
+        | EnvelopeKind::IdentityOccurrenceRevocation
+        | EnvelopeKind::FamilyMembershipRevocation
+        | EnvelopeKind::CommunityMembershipRevocation => Retention::Bodies,
+
+        // Everything else honours the configuration. Listed EXHAUSTIVELY rather
+        // than with a `_` arm: a kind added later must be classified by whoever
+        // adds it, and a new revocation plane defaulting into `HashFirst`
+        // through a wildcard is exactly how this carve-out would be lost.
+        EnvelopeKind::Key
+        | EnvelopeKind::Attestation
+        | EnvelopeKind::IdentityOccurrence
+        | EnvelopeKind::Family
+        | EnvelopeKind::Community
+        | EnvelopeKind::LocationProof
+        | EnvelopeKind::Organization
+        | EnvelopeKind::OrgMembership
+        | EnvelopeKind::PartnerRecord
+        | EnvelopeKind::TransportDestination
+        | EnvelopeKind::AccordQuorumEvidence => configured,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{retention_for, Retention};
+    use crate::replication::protocol::EnvelopeKind;
+
+    /// The kinds that retract something. Spelled out here, independently of the
+    /// implementation, so the test is a statement of intent rather than a mirror
+    /// of the code it checks.
+    const RETRACTING: [EnvelopeKind; 4] = [
+        EnvelopeKind::Revocation,
+        EnvelopeKind::IdentityOccurrenceRevocation,
+        EnvelopeKind::FamilyMembershipRevocation,
+        EnvelopeKind::CommunityMembershipRevocation,
+    ];
+
+    /// CIRISEdge#553 — the carve-out. A configured `HashFirst` must not reach a
+    /// plane whose job is to retract something.
+    #[test]
+    fn the_revocation_class_is_never_hash_first() {
+        for kind in RETRACTING {
+            assert_eq!(
+                retention_for(kind, Retention::HashFirst),
+                Retention::Bodies,
+                "{kind:?} retracts something — a node holding the HASH of a \
+                 retraction has not applied it"
+            );
+        }
+    }
+
+    /// The carve-out must not swallow the feature. If it did, #552 would be
+    /// silently inert and the corpus problem would remain with a passing suite.
+    #[test]
+    fn a_non_retracting_kind_honours_the_configured_retention() {
+        assert_eq!(
+            retention_for(EnvelopeKind::Attestation, Retention::HashFirst),
+            Retention::HashFirst
+        );
+        assert_eq!(
+            retention_for(EnvelopeKind::Key, Retention::HashFirst),
+            Retention::HashFirst
+        );
+    }
+
+    /// `Bodies` is a floor, never a thing the carve-out has to override.
+    #[test]
+    fn configured_bodies_stays_bodies_everywhere() {
+        for kind in EnvelopeKind::ALL {
+            assert_eq!(retention_for(kind, Retention::Bodies), Retention::Bodies);
+        }
+    }
+
+    /// The guard that catches a FUTURE kind rather than today's.
+    ///
+    /// Every kind is either in `RETRACTING` and pinned to `Bodies`, or it is not
+    /// and honours configuration. A new plane added upstream lands in exactly one
+    /// of those, and if someone adds a fifth revocation kind without listing it
+    /// here, this fails — which is the whole point, since the alternative is a
+    /// retraction plane quietly becoming hash-only and nobody finding out until a
+    /// kill order does not land.
+    #[test]
+    fn every_kind_is_deliberately_classified() {
+        for kind in EnvelopeKind::ALL {
+            let got = retention_for(kind, Retention::HashFirst);
+            let expected = if RETRACTING.contains(&kind) {
+                Retention::Bodies
+            } else {
+                Retention::HashFirst
+            };
+            assert_eq!(
+                got, expected,
+                "{kind:?} is not deliberately classified — a new plane must be \
+                 assigned a retention by whoever adds it (CIRISEdge#553)"
+            );
+        }
+    }
+}

--- a/src/replication/retention.rs
+++ b/src/replication/retention.rs
@@ -104,7 +104,16 @@ pub const fn retention_for(kind: EnvelopeKind, configured: Retention) -> Retenti
         // what a holder evaluates. It is also the one kind persist keeps OUT of
         // the content-hash index by construction — its hash moves as votes land
         // — so a hash of it is not even a stable name for the thing.
-        | EnvelopeKind::AccordQuorumEvidence => Retention::Bodies,
+        | EnvelopeKind::AccordQuorumEvidence
+
+        // ── LocationProof. Bodies until there is something that resolves it.
+        //
+        // Its Summary exposes only opaque hashes, and nothing in edge yet
+        // consumes a location proof by hash — so hash-first here buys no memory
+        // that matters and loses the only readable form. A plane joins hash-first
+        // when a consumer can ASK for it, not merely when it is technically able
+        // to hold hashes.
+        | EnvelopeKind::LocationProof => Retention::Bodies,
 
         // ── Planes that cannot retract anything. These are the identity and
         // routing planes the federation directory is made of, which is exactly
@@ -124,8 +133,7 @@ pub const fn retention_for(kind: EnvelopeKind, configured: Retention) -> Retenti
         // observable and refusable.
         EnvelopeKind::Key
         | EnvelopeKind::IdentityOccurrence
-        | EnvelopeKind::TransportDestination
-        | EnvelopeKind::LocationProof => configured,
+        | EnvelopeKind::TransportDestination => configured,
     }
 }
 
@@ -146,7 +154,7 @@ mod tests {
     /// * it is a ROSTER its members read locally and unprompted. A chat room is
     ///   a 2-member `Community`, and reading it goes through the roster in the
     ///   body. Holding the hash of your own chat room is not being in it.
-    const MUST_HOLD_BODIES: [EnvelopeKind; 11] = [
+    const MUST_HOLD_BODIES: [EnvelopeKind; 12] = [
         EnvelopeKind::Revocation,
         EnvelopeKind::IdentityOccurrenceRevocation,
         EnvelopeKind::FamilyMembershipRevocation,
@@ -160,9 +168,33 @@ mod tests {
         EnvelopeKind::Family,
         // Carries withdrawal evidence, and its hash moves as votes land.
         EnvelopeKind::AccordQuorumEvidence,
+        // Nothing resolves a location proof by hash yet.
+        EnvelopeKind::LocationProof,
     ];
 
     /// CIRISEdge#553 — the carve-out. A configured `HashFirst` must not reach a
+    /// CIRISEdge#552 — only a SERVER keeps a hash directory.
+    ///
+    /// Not a storage preference: if every node converged the whole hash set the
+    /// directory would be enumerable from ANY node — cheaper to carry than
+    /// bodies, and the same exposure. A proxy that learns only what concerns it
+    /// reveals only its own contacts when compromised.
+    #[test]
+    fn only_server_mode_takes_the_hash_first_posture() {
+        use crate::AgentMode;
+        let posture = |m: AgentMode| match m {
+            AgentMode::Server => Retention::HashFirst,
+            AgentMode::Proxy | AgentMode::Client => Retention::Bodies,
+        };
+        assert_eq!(posture(AgentMode::Server), Retention::HashFirst);
+        assert_eq!(
+            posture(AgentMode::Proxy),
+            Retention::Bodies,
+            "proxy is the DEFAULT — the default must not be the enumerable one"
+        );
+        assert_eq!(posture(AgentMode::Client), Retention::Bodies);
+    }
+
     /// plane whose job is to retract something.
     #[test]
     fn a_plane_that_needs_its_body_is_never_hash_first() {

--- a/src/replication/retention.rs
+++ b/src/replication/retention.rs
@@ -81,7 +81,30 @@ pub const fn retention_for(kind: EnvelopeKind, configured: Retention) -> Retenti
         | EnvelopeKind::Attestation
         | EnvelopeKind::Organization
         | EnvelopeKind::OrgMembership
-        | EnvelopeKind::PartnerRecord => Retention::Bodies,
+        | EnvelopeKind::PartnerRecord
+
+        // ── ROSTER planes. Bodies, because a member READS them locally.
+        //
+        // A chat room IS a 2-member `Community`, and reading its messages goes
+        // through `active_community_members(community_id)` — the roster, which
+        // lives in the BODY. A node holding only the hash knows a community
+        // exists and cannot tell whether it is in it, who else is, or read a
+        // word of it. `Family` is the same shape.
+        //
+        // This is the line the classification turns on, and it is not about
+        // retraction: hash-first is for records a node needs to KNOW ABOUT and
+        // can fetch when something asks. A roster is a record its members need
+        // to READ, unprompted, to function at all. Holding a hash of your own
+        // chat room is not a smaller copy of it — it is not being in it.
+        | EnvelopeKind::Community
+        | EnvelopeKind::Family
+
+        // ── Accord quorum evidence. Bodies, because it carries WITHDRAWAL
+        // evidence: a participation can retract a vote, and the aggregate is
+        // what a holder evaluates. It is also the one kind persist keeps OUT of
+        // the content-hash index by construction — its hash moves as votes land
+        // — so a hash of it is not even a stable name for the thing.
+        | EnvelopeKind::AccordQuorumEvidence => Retention::Bodies,
 
         // ── Planes that cannot retract anything. These are the identity and
         // routing planes the federation directory is made of, which is exactly
@@ -91,13 +114,18 @@ pub const fn retention_for(kind: EnvelopeKind, configured: Retention) -> Retenti
         // must be classified by whoever adds it, and a new retracting plane
         // defaulting into `HashFirst` through a wildcard is how this carve-out
         // would be lost silently.
+        // ── The DIRECTORY. Who exists, and how to reach them.
+        //
+        // These are exactly what a node needs to find a person and open a
+        // channel to them, and exactly what should not be an address book
+        // sitting on every node in the federation. Nothing here is read
+        // unprompted: a node resolves one of these when it is trying to reach
+        // someone, which is precisely the fetch that makes enumeration
+        // observable and refusable.
         EnvelopeKind::Key
         | EnvelopeKind::IdentityOccurrence
-        | EnvelopeKind::Family
-        | EnvelopeKind::Community
-        | EnvelopeKind::LocationProof
         | EnvelopeKind::TransportDestination
-        | EnvelopeKind::AccordQuorumEvidence => configured,
+        | EnvelopeKind::LocationProof => configured,
     }
 }
 
@@ -106,15 +134,19 @@ mod tests {
     use super::{retention_for, Retention};
     use crate::replication::protocol::EnvelopeKind;
 
-    /// Every kind that can carry a retraction — by name OR from inside the
-    /// envelope. Spelled out here independently of the implementation, so the
-    /// test states intent rather than mirroring the code it checks.
+    /// Every kind whose BODY a node must hold, and why — spelled out here
+    /// independently of the implementation, so the test states intent rather
+    /// than mirroring the code it checks.
     ///
-    /// The last four are the ones a kind-keyed carve-out misses: they retract
-    /// per RECORD (`withdraws` / `recants`, withdrawn/revoked states), and a
-    /// receiver cannot tell without the body — which under hash-first it does
-    /// not have.
-    const RETRACTING: [EnvelopeKind; 8] = [
+    /// Two distinct reasons, and both are easy to miss:
+    ///
+    /// * it can RETRACT something, by name or from inside the envelope
+    ///   (`withdraws` / `recants`, withdrawn/revoked states) — and a receiver
+    ///   cannot tell which without the body, which under hash-first it lacks;
+    /// * it is a ROSTER its members read locally and unprompted. A chat room is
+    ///   a 2-member `Community`, and reading it goes through the roster in the
+    ///   body. Holding the hash of your own chat room is not being in it.
+    const MUST_HOLD_BODIES: [EnvelopeKind; 11] = [
         EnvelopeKind::Revocation,
         EnvelopeKind::IdentityOccurrenceRevocation,
         EnvelopeKind::FamilyMembershipRevocation,
@@ -123,18 +155,23 @@ mod tests {
         EnvelopeKind::Organization,
         EnvelopeKind::OrgMembership,
         EnvelopeKind::PartnerRecord,
+        // Roster planes: a member reads these locally, unprompted.
+        EnvelopeKind::Community,
+        EnvelopeKind::Family,
+        // Carries withdrawal evidence, and its hash moves as votes land.
+        EnvelopeKind::AccordQuorumEvidence,
     ];
 
     /// CIRISEdge#553 — the carve-out. A configured `HashFirst` must not reach a
     /// plane whose job is to retract something.
     #[test]
-    fn the_revocation_class_is_never_hash_first() {
-        for kind in RETRACTING {
+    fn a_plane_that_needs_its_body_is_never_hash_first() {
+        for kind in MUST_HOLD_BODIES {
             assert_eq!(
                 retention_for(kind, Retention::HashFirst),
                 Retention::Bodies,
-                "{kind:?} can carry a retraction — a node holding only its HASH \
-                 has not applied it, and cannot tell that it was one"
+                "{kind:?} needs its BODY — it either retracts something a hash \
+                 cannot apply, or is a roster its members must read locally"
             );
         }
     }
@@ -177,7 +214,7 @@ mod tests {
     fn every_kind_is_deliberately_classified() {
         for kind in EnvelopeKind::ALL {
             let got = retention_for(kind, Retention::HashFirst);
-            let expected = if RETRACTING.contains(&kind) {
+            let expected = if MUST_HOLD_BODIES.contains(&kind) {
                 Retention::Bodies
             } else {
                 Retention::HashFirst

--- a/src/replication/retention.rs
+++ b/src/replication/retention.rs
@@ -50,25 +50,52 @@ pub enum Retention {
 #[must_use]
 pub const fn retention_for(kind: EnvelopeKind, configured: Retention) -> Retention {
     match kind {
-        // The revocation class. Bodies, always, whatever is configured.
+        // ── Planes that RETRACT, by name. Bodies, always.
         EnvelopeKind::Revocation
         | EnvelopeKind::IdentityOccurrenceRevocation
         | EnvelopeKind::FamilyMembershipRevocation
-        | EnvelopeKind::CommunityMembershipRevocation => Retention::Bodies,
+        | EnvelopeKind::CommunityMembershipRevocation
 
-        // Everything else honours the configuration. Listed EXHAUSTIVELY rather
-        // than with a `_` arm: a kind added later must be classified by whoever
-        // adds it, and a new revocation plane defaulting into `HashFirst`
-        // through a wildcard is exactly how this carve-out would be lost.
-        EnvelopeKind::Key
+        // ── Planes that retract from INSIDE. Bodies, always, and this is the
+        // half a kind-keyed carve-out gets wrong.
+        //
+        // Retraction is a per-RECORD property, not a per-kind one. The
+        // Attestation plane carries `withdraws` / `recants` tombstones — the
+        // bridge passes `is_withdraw_or_revocation(attestation_type)` into the
+        // projection, and notes that "a `withdraws` tombstone gossips GLOBAL
+        // (anti-rollback) even at `self`". Organization, OrgMembership and
+        // PartnerRecord likewise carry withdrawn/revoked states inside the
+        // envelope.
+        //
+        // A node cannot tell a tombstone from an ordinary row WITHOUT THE BODY,
+        // and hash-first is precisely the state of not having it. So the
+        // classification cannot be made per record on the receive side, and
+        // these planes are pinned whole. That costs the Attestation corpus —
+        // the largest one — which is the honest price of the carve-out being
+        // correct rather than convenient.
+        //
+        // Deciding per record needs the ADVERTISER to mark retractions on the
+        // wire, which is a vocabulary change and its own cut. Until then this
+        // is the safe side of the trade, and the trade is stated rather than
+        // discovered.
         | EnvelopeKind::Attestation
+        | EnvelopeKind::Organization
+        | EnvelopeKind::OrgMembership
+        | EnvelopeKind::PartnerRecord => Retention::Bodies,
+
+        // ── Planes that cannot retract anything. These are the identity and
+        // routing planes the federation directory is made of, which is exactly
+        // what #552 needs to hold as hashes.
+        //
+        // Listed EXHAUSTIVELY rather than with a `_` arm: a kind added later
+        // must be classified by whoever adds it, and a new retracting plane
+        // defaulting into `HashFirst` through a wildcard is how this carve-out
+        // would be lost silently.
+        EnvelopeKind::Key
         | EnvelopeKind::IdentityOccurrence
         | EnvelopeKind::Family
         | EnvelopeKind::Community
         | EnvelopeKind::LocationProof
-        | EnvelopeKind::Organization
-        | EnvelopeKind::OrgMembership
-        | EnvelopeKind::PartnerRecord
         | EnvelopeKind::TransportDestination
         | EnvelopeKind::AccordQuorumEvidence => configured,
     }
@@ -79,14 +106,23 @@ mod tests {
     use super::{retention_for, Retention};
     use crate::replication::protocol::EnvelopeKind;
 
-    /// The kinds that retract something. Spelled out here, independently of the
-    /// implementation, so the test is a statement of intent rather than a mirror
-    /// of the code it checks.
-    const RETRACTING: [EnvelopeKind; 4] = [
+    /// Every kind that can carry a retraction — by name OR from inside the
+    /// envelope. Spelled out here independently of the implementation, so the
+    /// test states intent rather than mirroring the code it checks.
+    ///
+    /// The last four are the ones a kind-keyed carve-out misses: they retract
+    /// per RECORD (`withdraws` / `recants`, withdrawn/revoked states), and a
+    /// receiver cannot tell without the body — which under hash-first it does
+    /// not have.
+    const RETRACTING: [EnvelopeKind; 8] = [
         EnvelopeKind::Revocation,
         EnvelopeKind::IdentityOccurrenceRevocation,
         EnvelopeKind::FamilyMembershipRevocation,
         EnvelopeKind::CommunityMembershipRevocation,
+        EnvelopeKind::Attestation,
+        EnvelopeKind::Organization,
+        EnvelopeKind::OrgMembership,
+        EnvelopeKind::PartnerRecord,
     ];
 
     /// CIRISEdge#553 — the carve-out. A configured `HashFirst` must not reach a
@@ -97,8 +133,8 @@ mod tests {
             assert_eq!(
                 retention_for(kind, Retention::HashFirst),
                 Retention::Bodies,
-                "{kind:?} retracts something — a node holding the HASH of a \
-                 retraction has not applied it"
+                "{kind:?} can carry a retraction — a node holding only its HASH \
+                 has not applied it, and cannot tell that it was one"
             );
         }
     }
@@ -108,11 +144,15 @@ mod tests {
     #[test]
     fn a_non_retracting_kind_honours_the_configured_retention() {
         assert_eq!(
-            retention_for(EnvelopeKind::Attestation, Retention::HashFirst),
+            retention_for(EnvelopeKind::Key, Retention::HashFirst),
             Retention::HashFirst
         );
         assert_eq!(
-            retention_for(EnvelopeKind::Key, Retention::HashFirst),
+            retention_for(EnvelopeKind::IdentityOccurrence, Retention::HashFirst),
+            Retention::HashFirst
+        );
+        assert_eq!(
+            retention_for(EnvelopeKind::TransportDestination, Retention::HashFirst),
             Retention::HashFirst
         );
     }

--- a/src/replication/scheduler.rs
+++ b/src/replication/scheduler.rs
@@ -474,12 +474,26 @@ async fn run_one_coordinator_forever(
             _ = interval.tick() => {
                 let span = tracing::info_span!("anti_entropy_round", peer = %peer_id, kind = %kind_str);
                 let _enter = span.enter();
-                // CIRISEdge#552 (B) — drain missing signers into Key Pulls
-                // BEFORE the round, not after: a Pull sent now has its reply
-                // fetched by THIS round's Summary handling, so the stalled row
-                // can admit a round earlier. No-op on every kind but `Key`, and
-                // no-op entirely unless hash-first is active.
-                coord.pull_missing_signers().await;
+                // CIRISEdge#552 (B) — a recovery Pull REPLACES this tick's
+                // ordinary round; it never overlaps it.
+                //
+                // The two exchanges are indistinguishable on the wire — both
+                // answer with a Summary, and `expect_on_demand_reply` carries no
+                // request correlation. Overlapping them let the SCHEDULED
+                // Summary be read as the Pull's reply, which put the peer's
+                // whole Key page into `pending_bodies` and fetched every body on
+                // a node that had just chosen not to — hash-first defeated by
+                // its own recovery path. Their Diff/Deliver states can also
+                // clobber each other under unordered delivery.
+                //
+                // One in-flight exchange per coordinator IS the correlation, and
+                // it is how the rest of this protocol already works: the session
+                // is a sequential per-peer state machine. Recovery costs one
+                // cadence tick, and only on a tick where a signer was actually
+                // queued.
+                if coord.pull_missing_signers().await > 0 {
+                    continue;
+                }
                 let event = match run_one_round(&coord, round_timeout).await {
                     // CIRISEdge#380 — run_one_round converts SendThenComplete to
                     // Complete after sending; the merged arm is defensive if it

--- a/src/replication/scheduler.rs
+++ b/src/replication/scheduler.rs
@@ -474,24 +474,37 @@ async fn run_one_coordinator_forever(
             _ = interval.tick() => {
                 let span = tracing::info_span!("anti_entropy_round", peer = %peer_id, kind = %kind_str);
                 let _enter = span.enter();
-                // CIRISEdge#552 (B) — a recovery Pull REPLACES this tick's
-                // ordinary round; it never overlaps it.
-                //
-                // The two exchanges are indistinguishable on the wire — both
-                // answer with a Summary, and `expect_on_demand_reply` carries no
-                // request correlation. Overlapping them let the SCHEDULED
-                // Summary be read as the Pull's reply, which put the peer's
-                // whole Key page into `pending_bodies` and fetched every body on
-                // a node that had just chosen not to — hash-first defeated by
-                // its own recovery path. Their Diff/Deliver states can also
-                // clobber each other under unordered delivery.
-                //
-                // One in-flight exchange per coordinator IS the correlation, and
-                // it is how the rest of this protocol already works: the session
-                // is a sequential per-peer state machine. Recovery costs one
-                // cadence tick, and only on a tick where a signer was actually
-                // queued.
-                if coord.pull_missing_signers().await > 0 {
+                // FSD-SIGNER-RECOVERY D3 — a recovery round REPLACES this
+                // tick's ordinary round; the two never overlap. It costs one
+                // cadence tick per recovered key, and only on a tick where a
+                // name is actually queued. At most one name per peer can exist
+                // (D4), so recovery displaces at most one ordinary round per
+                // peer before it is done.
+                let recovery = match run_one_recovery_round(&coord, round_timeout).await {
+                    Ok(step) => step,
+                    Err(e) => {
+                        // A failed recovery must not also cost this peer its
+                        // ordinary round. The row stays transient-refused and
+                        // re-notes its signer on the next offer (D6).
+                        tracing::warn!(
+                            error = ?e,
+                            "signer-recovery round failed; running ordinary \
+                             anti-entropy this tick instead (FSD-SIGNER-RECOVERY D6)"
+                        );
+                        None
+                    }
+                };
+                if let Some(step) = recovery {
+                    let event = match step {
+                        DriveStep::Complete(report) | DriveStep::SendThenComplete(_, report) => {
+                            RoundEvent::Completed(report)
+                        }
+                        DriveStep::Refused => RoundEvent::Refused,
+                        DriveStep::SendThenWait(_) => RoundEvent::TimedOut,
+                    };
+                    if let Some(sink) = &event_sink {
+                        let _ = sink.send((peer_id.clone(), event)).await;
+                    }
                     continue;
                 }
                 let event = match run_one_round(&coord, round_timeout).await {
@@ -580,11 +593,73 @@ impl From<CoordinatorError> for RoundError {
 /// Drive a single round end-to-end on one coordinator: start_round →
 /// loop { send_outbound; await inbound; drive_round_step } until
 /// Complete or Refused.
+/// Anti-entropy: INITIATE the exchange, then drive it to completion.
+///
+/// The initiating step is what sends this node's Summary. Recovery
+/// ([`run_one_recovery_round`]) deliberately omits it — see
+/// `docs/FSD_SIGNER_RECOVERY.md` §3, where sending a second Summary alongside a
+/// Pull is the single fact that broke three earlier attempts.
 async fn run_one_round(
     coord: &ReplicationCoordinator,
     round_timeout: Duration,
 ) -> Result<DriveStep, RoundError> {
-    let mut step = coord.drive_round_step(None).await?;
+    let first = coord.drive_round_step(None).await?;
+    drive_exchange_to_completion(coord, round_timeout, first).await
+}
+
+/// Signer-key recovery: send ONE `Pull` and drive **only its reply** to
+/// completion (FSD-SIGNER-RECOVERY D1/D2).
+///
+/// Returns `Ok(None)` when nothing was queued for this peer, which is the
+/// common case — the caller then runs an ordinary round instead.
+///
+/// # Why this exists as a separate round type
+///
+/// An Initiator reads inbound messages only inside the drive loop, and the
+/// loop's first step opens by sending a Summary. A Pull issued *around* an
+/// ordinary round therefore leaves two exchanges outstanding whose replies are
+/// both Summaries, with no request correlation — the scheduled reply could be
+/// consumed as the Pull's, putting the peer's whole page into `pending_bodies`
+/// on a node that had just chosen not to fetch bodies.
+///
+/// Entering the same loop with `SendThenWait(∅)` sends nothing and waits, so the
+/// only reply it can consume is the Pull's. Combined with the per-peer scheduler
+/// task being sequential — a recovery round REPLACES the tick's ordinary round —
+/// at most one exchange is ever outstanding on a coordinator. That is the
+/// correlation, achieved by construction rather than by a request id, and it
+/// needs no wire change.
+async fn run_one_recovery_round(
+    coord: &ReplicationCoordinator,
+    round_timeout: Duration,
+) -> Result<Option<DriveStep>, RoundError> {
+    let Some(signer) = coord
+        .send_recovery_pull()
+        .await
+        .map_err(RoundError::Coordinator)?
+    else {
+        return Ok(None);
+    };
+    tracing::debug!(
+        signer = %signer,
+        "recovery round: asked this peer for its own Key (FSD-SIGNER-RECOVERY)"
+    );
+    // `SendThenWait(∅)`: send nothing, wait. The Pull is already on the wire and
+    // this node must NOT put a Summary beside it.
+    drive_exchange_to_completion(coord, round_timeout, DriveStep::SendThenWait(Vec::new()))
+        .await
+        .map(Some)
+}
+
+/// The send-and-wait loop shared by both round types, given its first step.
+///
+/// Owns no policy about what OPENS an exchange — that is the caller's choice and
+/// the only difference between anti-entropy and recovery.
+async fn drive_exchange_to_completion(
+    coord: &ReplicationCoordinator,
+    round_timeout: Duration,
+    first_step: DriveStep,
+) -> Result<DriveStep, RoundError> {
+    let mut step = first_step;
     loop {
         // CIRISEdge#380 — initiator-final: send the messages, then the round
         // is complete WITHOUT waiting (the peer's last Summary confirmed full
@@ -1166,5 +1241,151 @@ mod tests {
             "a reader answering NO relief must leave the configured cadence \
              untouched (absence = today); got {unrelieved} rounds"
         );
+    }
+
+    /// A provider that hands out exactly one queued signer, once — the shape
+    /// `note_missing_signer` produces for the delivering peer's own key.
+    struct RecoveryProvider {
+        queued: std::sync::Mutex<Option<String>>,
+    }
+    impl StateProvider for RecoveryProvider {
+        fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+            // Deliberately non-empty is unnecessary: invariant 1 is about what
+            // a RECOVERY round puts on the wire, and it must send no Summary
+            // even when this node has refs it would otherwise advertise.
+            vec![EnvelopeRef {
+                envelope_hash: [9u8; 32],
+                seq: 1,
+            }]
+        }
+        fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+            None
+        }
+        fn take_missing_signer_for(&self, peer_key_id: &str) -> Option<String> {
+            let mut q = self.queued.lock().unwrap();
+            if q.as_deref() == Some(peer_key_id) {
+                q.take()
+            } else {
+                None
+            }
+        }
+    }
+
+    fn recovery_coord(
+        peer: &str,
+        queued: Option<String>,
+    ) -> (
+        Arc<ReplicationCoordinator>,
+        tokio::sync::mpsc::UnboundedReceiver<Vec<u8>>,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut inbox = HashMap::new();
+        inbox.insert(peer.to_string(), tx);
+        let transport = Arc::new(InMemTransport { peer_inbox: inbox });
+        let provider = Arc::new(RecoveryProvider {
+            queued: std::sync::Mutex::new(queued),
+        });
+        let applier = RecordingApplier::with(HashMap::new(), std::collections::HashSet::new());
+        let coord = Arc::new(ReplicationCoordinator::new(
+            transport,
+            peer,
+            EnvelopeKind::Key,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        ));
+        (coord, rx)
+    }
+
+    /// FSD-SIGNER-RECOVERY invariant 1 — **a recovery round sends no Summary.**
+    ///
+    /// This is the invariant three previous attempts violated, each in a
+    /// different way, and it is the whole reason recovery is a separate round
+    /// type. A Summary beside the Pull leaves two outstanding exchanges whose
+    /// replies are indistinguishable, so the scheduled reply can be consumed as
+    /// the Pull's — putting the peer's entire Key page into `pending_bodies` on
+    /// a node that had just chosen not to fetch bodies.
+    #[tokio::test]
+    async fn a_recovery_round_puts_only_the_pull_on_the_wire() {
+        let (coord, mut rx) = recovery_coord("peer-1", Some("peer-1".to_string()));
+
+        // Times out waiting for a reply nobody sends; the wire is what matters.
+        let _ = run_one_recovery_round(&coord, Duration::from_millis(50)).await;
+
+        let mut sent = Vec::new();
+        while let Ok(bytes) = rx.try_recv() {
+            sent.push(bytes);
+        }
+        assert_eq!(
+            sent.len(),
+            1,
+            "a recovery round must put EXACTLY ONE message on the wire; \
+             {} were sent",
+            sent.len()
+        );
+        let text = String::from_utf8_lossy(&sent[0]).to_string();
+        assert!(
+            text.contains("pull"),
+            "the one message must be the Pull, got: {text}"
+        );
+        assert!(
+            !text.contains("summary"),
+            "a recovery round must NOT send a Summary — that is the ambiguity \
+             that broke three earlier attempts (FSD §3), got: {text}"
+        );
+    }
+
+    /// FSD-SIGNER-RECOVERY invariant 2 — nothing queued means no recovery
+    /// exchange at all, so the tick runs an ordinary round instead.
+    ///
+    /// Without this the scheduler would burn a cadence tick per peer per round
+    /// waiting for a reply to a Pull it never sent.
+    #[tokio::test]
+    async fn no_queued_signer_means_no_recovery_exchange() {
+        let (coord, mut rx) = recovery_coord("peer-1", None);
+
+        let outcome = run_one_recovery_round(&coord, Duration::from_millis(50))
+            .await
+            .expect("no queued name is not an error");
+        assert!(
+            outcome.is_none(),
+            "with nothing queued the caller must fall through to an ordinary round"
+        );
+        assert!(rx.try_recv().is_err(), "and nothing may be put on the wire");
+    }
+
+    /// FSD-SIGNER-RECOVERY invariant 3 — only the `Key` coordinator recovers.
+    ///
+    /// `start_pull` sends `PullMessage { kind: self.kind, .. }`, and the row
+    /// every stalled record waits on is a Key row. A recovery Pull on another
+    /// plane would ask a peer for the wrong thing entirely.
+    #[tokio::test]
+    async fn only_the_key_coordinator_recovers_a_signer() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut inbox = HashMap::new();
+        inbox.insert("peer-1".to_string(), tx);
+        let transport = Arc::new(InMemTransport { peer_inbox: inbox });
+        let provider = Arc::new(RecoveryProvider {
+            queued: std::sync::Mutex::new(Some("peer-1".to_string())),
+        });
+        let applier = RecordingApplier::with(HashMap::new(), std::collections::HashSet::new());
+        let coord = Arc::new(ReplicationCoordinator::new(
+            transport,
+            "peer-1",
+            EnvelopeKind::Attestation,
+            SessionRole::Initiator,
+            provider,
+            applier,
+        ));
+
+        assert!(
+            coord
+                .send_recovery_pull()
+                .await
+                .expect("not an error")
+                .is_none(),
+            "a non-Key coordinator must not recover"
+        );
+        assert!(rx.try_recv().is_err(), "and must send nothing");
     }
 }

--- a/src/replication/scheduler.rs
+++ b/src/replication/scheduler.rs
@@ -474,6 +474,12 @@ async fn run_one_coordinator_forever(
             _ = interval.tick() => {
                 let span = tracing::info_span!("anti_entropy_round", peer = %peer_id, kind = %kind_str);
                 let _enter = span.enter();
+                // CIRISEdge#552 (B) — drain missing signers into Key Pulls
+                // BEFORE the round, not after: a Pull sent now has its reply
+                // fetched by THIS round's Summary handling, so the stalled row
+                // can admit a round earlier. No-op on every kind but `Key`, and
+                // no-op entirely unless hash-first is active.
+                coord.pull_missing_signers().await;
                 let event = match run_one_round(&coord, round_timeout).await {
                     // CIRISEdge#380 — run_one_round converts SendThenComplete to
                     // Complete after sending; the merged arm is defensive if it

--- a/src/replication/serve_policy.rs
+++ b/src/replication/serve_policy.rs
@@ -69,15 +69,25 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
     };
     // CIRISEdge#462 — `receive`: whether this kind answers a subject-scoped Pull
     // (the RECEIVE axis), and under what rule. The FIVE replicated kinds are
-    // subject-pullable, entitlement FAIL-CLOSED to the subject itself; the
+    // subject-pullable; entitlement is FAIL-CLOSED to the subject itself except
+    // on the four unconditionally-`public` planes, which CIRISEdge#552 widened
+    // to any attributed requester (they were already disclosed — see
+    // `EnvelopeKind::is_public_subject_pull`); the
     // Attestation plane sweeps BOTH testimonial axes with the G2 score carve;
     // every other kind is NOT subject-pullable (`none`). This column is the
     // coordinated-cut witness CIRISServer pins alongside `serve`.
     let receive = match kind {
+        // CIRISEdge#552 — these four planes serve `public` unconditionally, so
+        // the subject-only entitlement made them un-ADDRESSABLE rather than
+        // undisclosed. Widened to any ATTRIBUTED requester; unattributed still
+        // gets nothing. Derived from `is_public_subject_pull` (test-locked
+        // below), so the predicate and this cell cannot drift.
         EnvelopeKind::Key
         | EnvelopeKind::IdentityOccurrence
         | EnvelopeKind::TransportDestination
-        | EnvelopeKind::IdentityOccurrenceRevocation => "subject_pull:data_subject; subject-only",
+        | EnvelopeKind::IdentityOccurrenceRevocation => {
+            "subject_pull:data_subject+any_attributed; public envelope"
+        }
         EnvelopeKind::Attestation => {
             "subject_pull:data_subject+sender; subject-only; \
              non-retainable scores-plane rows carved on data_subject axis \
@@ -155,9 +165,21 @@ pub fn serve_advertise_policy_sha256() -> String {
 // rule). `per_record_projection` now names only the Attestation plane, the one
 // whose projection is genuinely decided per row. NO serve-path behavior
 // changed — this is the manifest catching up to the code it witnesses.
-// **CIRISServer must mirror**: re-pin from 328d73b0… to this value.
+// **CIRISServer must mirror**: re-pin from 328d73b0… to 20499cab….
+//
+// CIRISEdge#552 — RE-PINNED AGAIN, 20499cab… → e8216fec…. The RECEIVE cell on
+// the four unconditionally-`public` planes (Key, IdentityOccurrence,
+// TransportDestination, IdentityOccurrenceRevocation) widened from
+// `subject-only` to `+any_attributed`. This is a DISCLOSURE-NEUTRAL cut: those
+// planes already serve `public` on the advertise axis and are already reachable
+// through ordinary anti-entropy. What changed is ADDRESSABILITY — `Pull` is the
+// only verb that names a record by identifier, and reserving it for
+// data-subject access left a hash-first node unable to ask for a public body it
+// had chosen not to fetch, stranding signer keys and therefore revocations.
+// `Attestation` is untouched: its serve cell is conditional per row.
+// **CIRISServer must mirror this pin.**
 pub const SERVE_ADVERTISE_POLICY_HASH: &str =
-    "20499cabaf1c0566b5a8d66f8d03c8a980b760c733e83444b7345a7733f22d74";
+    "e8216fec51cdb2a417e2b24ce55a5854e40c661cbea2888989d4c173a29925fd";
 
 #[cfg(test)]
 mod tests {
@@ -252,6 +274,34 @@ mod tests {
         }
         // The predicate currently names exactly one cursor plane.
         assert!(EnvelopeKind::AccordQuorumEvidence.is_cursor_served());
+    }
+
+    /// CIRISEdge#552 — the RECEIVE cell's entitlement is DERIVED from
+    /// `is_public_subject_pull`, not written twice.
+    ///
+    /// The manifest is the artifact CIRISServer pins, and the gate in
+    /// `subject_holdings` reads the predicate. If those two could drift, the
+    /// pinned witness would attest to an entitlement the code does not enforce
+    /// — the manifest describing a mechanism the planes never had, which is the
+    /// error the `per_record_projection` cell had to be corrected for.
+    #[test]
+    fn the_public_pull_cell_is_derived_from_the_predicate() {
+        let manifest = serve_advertise_manifest();
+        for policy in manifest["policies"].as_array().unwrap() {
+            let wire = policy["kind"].as_str().unwrap();
+            let kind = EnvelopeKind::ALL
+                .into_iter()
+                .find(|k| k.as_wire_str() == wire)
+                .expect("every manifest row names a real kind");
+            let recv = policy["receive"].as_str().unwrap();
+            assert_eq!(
+                recv.contains("any_attributed"),
+                kind.is_public_subject_pull(),
+                "{kind:?}: the manifest's receive cell and \
+                 is_public_subject_pull disagree — the pinned witness would \
+                 attest to an entitlement the gate does not enforce"
+            );
+        }
     }
 
     /// CIRISEdge#393 item 3 — the manifest's columns are TEST-LOCKED to the

--- a/src/replication/serve_policy.rs
+++ b/src/replication/serve_policy.rs
@@ -69,24 +69,26 @@ fn policy_for(kind: EnvelopeKind) -> serde_json::Value {
     };
     // CIRISEdge#462 — `receive`: whether this kind answers a subject-scoped Pull
     // (the RECEIVE axis), and under what rule. The FIVE replicated kinds are
-    // subject-pullable; entitlement is FAIL-CLOSED to the subject itself except
-    // on the four unconditionally-`public` planes, which CIRISEdge#552 widened
-    // to any attributed requester (they were already disclosed — see
+    // subject-pullable; entitlement is FAIL-CLOSED to the subject itself, plus
+    // CIRISEdge#552's own-record arm on the four unconditionally-`public`
+    // planes (bounded by the `self_own` advertise projection — see
     // `EnvelopeKind::is_public_subject_pull`); the
     // Attestation plane sweeps BOTH testimonial axes with the G2 score carve;
     // every other kind is NOT subject-pullable (`none`). This column is the
     // coordinated-cut witness CIRISServer pins alongside `serve`.
     let receive = match kind {
-        // CIRISEdge#552 — these four planes serve `public` unconditionally, so
-        // the subject-only entitlement made them un-ADDRESSABLE rather than
-        // undisclosed. Widened to any ATTRIBUTED requester; unattributed still
-        // gets nothing. Derived from `is_public_subject_pull` (test-locked
-        // below), so the predicate and this cell cannot drift.
+        // CIRISEdge#552 — on these four planes a Pull is also answered when the
+        // SUBJECT IS THE RESPONDING NODE ITSELF, which is exactly what the
+        // `self_own` advertise projection already hands every peer. Not "any
+        // attributed requester for any subject": `subject_holdings_inner` does
+        // an arbitrary directory lookup, so that would make a body-holding
+        // server an address-book oracle for subjects it never advertised.
+        // Derived from `is_public_subject_pull` (test-locked below).
         EnvelopeKind::Key
         | EnvelopeKind::IdentityOccurrence
         | EnvelopeKind::TransportDestination
         | EnvelopeKind::IdentityOccurrenceRevocation => {
-            "subject_pull:data_subject+any_attributed; public envelope"
+            "subject_pull:data_subject+own_record; within self_own projection"
         }
         EnvelopeKind::Attestation => {
             "subject_pull:data_subject+sender; subject-only; \
@@ -167,19 +169,27 @@ pub fn serve_advertise_policy_sha256() -> String {
 // changed — this is the manifest catching up to the code it witnesses.
 // **CIRISServer must mirror**: re-pin from 328d73b0… to 20499cab….
 //
-// CIRISEdge#552 — RE-PINNED AGAIN, 20499cab… → e8216fec…. The RECEIVE cell on
-// the four unconditionally-`public` planes (Key, IdentityOccurrence,
-// TransportDestination, IdentityOccurrenceRevocation) widened from
-// `subject-only` to `+any_attributed`. This is a DISCLOSURE-NEUTRAL cut: those
-// planes already serve `public` on the advertise axis and are already reachable
-// through ordinary anti-entropy. What changed is ADDRESSABILITY — `Pull` is the
-// only verb that names a record by identifier, and reserving it for
-// data-subject access left a hash-first node unable to ask for a public body it
-// had chosen not to fetch, stranding signer keys and therefore revocations.
-// `Attestation` is untouched: its serve cell is conditional per row.
+// CIRISEdge#552 — RE-PINNED, 20499cab… → e54c5677…. On the four
+// unconditionally-`public` planes (Key, IdentityOccurrence,
+// TransportDestination, IdentityOccurrenceRevocation) a subject Pull is now
+// ALSO answered when the subject is the RESPONDING NODE ITSELF.
+//
+// Bounded deliberately at the node's own record, because `serve: public` and
+// `advertise: self_own` answer different questions. `public` means no
+// capability gate once a record reaches you; `self_own` decides which records
+// reach you at all. `subject_holdings_inner` does an arbitrary directory
+// lookup, so answering any attributed requester about any subject would let a
+// peer probe identifiers for third-party keys and routes that never appeared in
+// its Summaries — a body-holding server as address-book oracle, and the end of
+// the opaque-directory property. The own-record arm stays inside what
+// `self_own` already advertises, so it is disclosure-neutral in fact.
+//
+// It recovers "you signed a row I cannot verify — send me your key". A
+// THIRD-PARTY signer stays unfetchable by identifier; that needs a separately
+// authorized, rate-limited resolver. `Attestation` is untouched.
 // **CIRISServer must mirror this pin.**
 pub const SERVE_ADVERTISE_POLICY_HASH: &str =
-    "e8216fec51cdb2a417e2b24ce55a5854e40c661cbea2888989d4c173a29925fd";
+    "e54c56775e8d56442f9fdbaa0346397cdc169e7cc6237f5a6fe71681710dbf25";
 
 #[cfg(test)]
 mod tests {
@@ -295,7 +305,7 @@ mod tests {
                 .expect("every manifest row names a real kind");
             let recv = policy["receive"].as_str().unwrap();
             assert_eq!(
-                recv.contains("any_attributed"),
+                recv.contains("own_record"),
                 kind.is_public_subject_pull(),
                 "{kind:?}: the manifest's receive cell and \
                  is_public_subject_pull disagree — the pinned witness would \

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -939,6 +939,25 @@ impl Session {
                 // token maps to which. It is a stable token, never prose.
                 ApplyOutcome::Refused { reason, retry } => {
                     refused += 1;
+                    // CIRISEdge#552 (B) — a TRANSIENT refusal is the one that
+                    // waits on more state, and the state it most often waits on
+                    // is the signer's own Key row. Under hash-first that row can
+                    // be a hash this node never fetches, so the #544 backoff
+                    // would re-offer forever and a revocation whose revoker is
+                    // unknown would never land.
+                    //
+                    // Extract the candidate signer HERE (pure, no store) and
+                    // record it; whether it is genuinely absent is the drain's
+                    // question. Deliberately keyed on the DISPOSITION, not on
+                    // the reason prose — consumers key on stable tokens, and a
+                    // spurious note costs one deduped lookup at the drain.
+                    if !retry.is_terminal() {
+                        if let Some(signer) = crate::replication::missing_signer::missing_signer_of(
+                            self.kind, env_bytes,
+                        ) {
+                            provider.note_missing_signer(self.kind, &signer);
+                        }
+                    }
                     tracing::warn!(
                         kind = ?self.kind,
                         reason = %reason,
@@ -1921,6 +1940,75 @@ mod tests {
             }
             o => panic!("expected Applied, got {o:?}"),
         }
+    }
+
+    /// CIRISEdge#552 (B) — the choke point RECORDS the signer a transient
+    /// refusal named. Not "the resolver exists" — that was true while nothing
+    /// called it. This delivers a record whose signer is unknown and asserts the
+    /// name reached the PROVIDER, which is the seam that was missing.
+    #[test]
+    fn a_transient_refusal_records_the_signer_it_named() {
+        use std::sync::Mutex;
+        struct RecordingProvider(Mutex<Vec<String>>);
+        impl StateProvider for RecordingProvider {
+            fn local_refs(&self, _k: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            fn fetch_envelope(&self, _k: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+            fn note_missing_signer(&self, _k: EnvelopeKind, signer: &str) {
+                self.0.lock().unwrap().push(signer.to_string());
+            }
+        }
+        struct TransientRefuser;
+        impl StateApplier for TransientRefuser {
+            fn apply_envelope(
+                &self,
+                _k: EnvelopeKind,
+                _b: &[u8],
+                _p: Option<&str>,
+            ) -> ApplyOutcome {
+                ApplyOutcome::refused("signer not registered")
+            }
+        }
+        struct TerminalRefuser;
+        impl StateApplier for TerminalRefuser {
+            fn apply_envelope(
+                &self,
+                _k: EnvelopeKind,
+                _b: &[u8],
+                _p: Option<&str>,
+            ) -> ApplyOutcome {
+                ApplyOutcome::refused_terminal("this row will never admit")
+            }
+        }
+
+        let row = br#"{"revoking_key_id":"steward-abc123"}"#.to_vec();
+        let deliver = DeliverMessage {
+            kind: EnvelopeKind::Attestation,
+            envelopes: vec![row],
+        };
+
+        let provider = RecordingProvider(Mutex::new(Vec::new()));
+        let mut responder = Session::new(SessionRole::Responder, EnvelopeKind::Attestation);
+        responder.on_deliver(&deliver, &provider, &TransientRefuser, Some("peer-x"));
+        assert_eq!(
+            provider.0.lock().unwrap().as_slice(),
+            ["steward-abc123"],
+            "a TRANSIENT refusal must record the signer it waits on — without \
+             this the resolver is dead code and the kill order never lands"
+        );
+
+        // A terminal refusal is not waiting on anything. Pulling a key for it
+        // would be a request this node can never use.
+        let provider = RecordingProvider(Mutex::new(Vec::new()));
+        let mut responder = Session::new(SessionRole::Responder, EnvelopeKind::Attestation);
+        responder.on_deliver(&deliver, &provider, &TerminalRefuser, Some("peer-x"));
+        assert!(
+            provider.0.lock().unwrap().is_empty(),
+            "a TERMINAL refusal waits on nothing — it must not queue a pull"
+        );
     }
 
     /// CIRISEdge#544 — the re-offer loop is RECEIVER-PULLED, and this is the

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -409,7 +409,9 @@ impl Session {
                 self.on_summary(&remote_summary, provider, source_peer)
             }
             ReplicationMessage::Diff(diff) => self.on_diff(&diff, provider, source_peer),
-            ReplicationMessage::Deliver(deliver) => self.on_deliver(&deliver, applier, source_peer),
+            ReplicationMessage::Deliver(deliver) => {
+                self.on_deliver(&deliver, provider, applier, source_peer)
+            }
             ReplicationMessage::Fetch(fetch) => self.on_fetch(&fetch, provider, source_peer),
             ReplicationMessage::Pull(pull) => self.on_pull(&pull, provider),
             ReplicationMessage::CursorPull(cp) => self.on_cursor_pull(&cp, provider),
@@ -681,14 +683,75 @@ impl Session {
         )
     }
 
+    // CIRISEdge#552 pushed this past the 100-line bound. One scenario — decide
+    // retention, then admit — and splitting it would put the hash-first decision
+    // in a different function from the apply it guards, which is the coupling
+    // worth keeping visible.
+    #[allow(clippy::too_many_lines)]
     fn on_deliver(
         &mut self,
         deliver: &DeliverMessage,
+        // CIRISEdge#552 — the retention decision lives on the provider, and the
+        // apply path needs it: clearing `want` stops us ASKING, and stops
+        // nothing from arriving.
+        provider: &dyn StateProvider,
         applier: &dyn StateApplier,
         source_peer: Option<&str>,
     ) -> ReplicationOutcome {
         if deliver.kind != self.kind {
             return ReplicationOutcome::UnexpectedMessage;
+        }
+        // ── CIRISEdge#552: an UNSOLICITED body does not backfill the corpus ──
+        //
+        // Hash-first empties `want`, so under it this session asks for nothing —
+        // which means any Deliver reaching here was not invited by an
+        // anti-entropy round. A `#927` proactive publish would otherwise hand the
+        // node exactly the bodies it declined to fetch, and the corpus-size and
+        // address-book properties would be lost to a peer's generosity rather
+        // than to any decision of ours.
+        //
+        // Keyed on `diff_want_count` — the SOLICITED marker the session already
+        // keeps — so an explicit on-demand fetch still applies normally. That is
+        // the whole point of hash-first: fetch when something needs the body.
+        //
+        // `retention_for` keeps the carve-out: a retracting plane is never
+        // HashFirst, so a pushed revocation still applies. This deliberately
+        // gates the ADMIT, where #544's suppression deliberately does not — the
+        // reasons differ. Suppression is about a row we tried and could not
+        // admit; hash-first is about a body we chose not to store, and applying
+        // it anyway would defeat the choice.
+        if self.diff_want_count.is_none()
+            && retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst
+        {
+            let learned: Vec<[u8; 32]> = deliver
+                .envelopes
+                .iter()
+                .map(|bytes| {
+                    use sha2::{Digest as _, Sha256};
+                    let h: [u8; 32] = Sha256::digest(bytes).into();
+                    h
+                })
+                .collect();
+            provider.note_known_hashes(self.kind, &learned, source_peer);
+            tracing::debug!(
+                kind = ?self.kind,
+                count = learned.len(),
+                peer = ?source_peer,
+                "hash-first: an unsolicited Deliver was LEARNED, not applied — \
+                 a proactive push must not backfill a corpus this node declined \
+                 to fetch (CIRISEdge#552)"
+            );
+            // `admitted: 0, refused: 0` is the honest pair: nothing was admitted,
+            // and nothing was REFUSED either — the bodies were declined, not
+            // rejected. The learn is not lost: it is in the known set and in this
+            // log line, which is where a "why did my push not land" question gets
+            // answered.
+            return ReplicationOutcome::Applied {
+                kind: self.kind,
+                admitted: 0,
+                refused: 0,
+                staleness: StalenessSignal::InSync,
+            };
         }
         // CIRISEdge#426 — distinguish a SOLICITED Deliver (it answers a `Diff` we
         // sent this round — `diff_want_count` is set) from an UNSOLICITED one (a
@@ -1735,7 +1798,7 @@ mod tests {
             kind: EnvelopeKind::Attestation,
             envelopes: vec![b"a".to_vec(), b"b".to_vec(), b"c".to_vec()],
         };
-        match responder.on_deliver(&deliver, &RefusingApplier, Some("peer-x")) {
+        match responder.on_deliver(&deliver, &BodiesProvider, &RefusingApplier, Some("peer-x")) {
             ReplicationOutcome::Applied {
                 admitted, refused, ..
             } => {
@@ -1787,9 +1850,12 @@ mod tests {
             noted: Mutex::new(Vec::new()),
             peer: Mutex::new(None),
         };
-        let mut session = Session::new(SessionRole::Responder, EnvelopeKind::Attestation);
+        // Key, not Attestation: the Attestation plane carries `withdraws`
+        // tombstones and is pinned to Bodies (CIRISEdge#553). Key is an identity
+        // plane that cannot retract anything, which is what hash-first is for.
+        let mut session = Session::new(SessionRole::Responder, EnvelopeKind::Key);
         let remote = SummaryMessage {
-            kind: EnvelopeKind::Attestation,
+            kind: EnvelopeKind::Key,
             refs: vec![
                 EnvelopeRef {
                     envelope_hash: h(1),
@@ -1950,6 +2016,18 @@ mod tests {
         );
     }
 
+    /// A provider with default retention (`Bodies`), for deliver-side tests
+    /// that are not about retention at all.
+    struct BodiesProvider;
+    impl StateProvider for BodiesProvider {
+        fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+            Vec::new()
+        }
+        fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+            None
+        }
+    }
+
     /// An applier for want-side tests, which never see a Deliver.
     struct NoApply;
     impl StateApplier for NoApply {
@@ -1996,7 +2074,7 @@ mod tests {
             kind: EnvelopeKind::Attestation,
             envelopes: vec![b"x".to_vec(), b"y".to_vec()],
         };
-        responder.on_deliver(&deliver, &applier, Some("canonical-1"));
+        responder.on_deliver(&deliver, &BodiesProvider, &applier, Some("canonical-1"));
         assert_eq!(
             *applier.seen.lock().unwrap(),
             vec![

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -138,9 +138,9 @@ pub enum ReplicationOutcome {
 // sake would make the type lie about that.
 #[allow(clippy::struct_excessive_bools)]
 pub struct Session {
-    /// CIRISEdge#552 — a Pull we sent is awaiting its Summary. See
-    /// [`Self::expect_pull_response`].
-    pull_response_pending: bool,
+    /// CIRISEdge#552 — this node asked for something ON PURPOSE and the reply is
+    /// outstanding. See [`Self::expect_on_demand_reply`].
+    on_demand_reply_pending: bool,
     role: SessionRole,
     kind: EnvelopeKind,
     /// What we sent the peer in our most recent Summary — used to
@@ -216,7 +216,7 @@ impl Session {
             role,
             kind,
             last_summary_sent: None,
-            pull_response_pending: false,
+            on_demand_reply_pending: false,
             last_remote_summary: None,
             diff_want_count: None,
             completed: false,
@@ -251,6 +251,12 @@ impl Session {
         self.diff_want_count = None;
         self.completed = false;
         self.awaiting_cursor_deliver = false;
+        // CIRISEdge#552 — the on-demand exemption is ROUND-scoped, not
+        // message-scoped. It cannot be consumed by whichever reply happens to
+        // arrive first (it carries no correlation to the request), so it is
+        // released when the round it belongs to ends. That bounds the
+        // over-fetch to one round instead of exempting the session forever.
+        self.on_demand_reply_pending = false;
     }
 
     pub fn role(&self) -> SessionRole {
@@ -470,20 +476,27 @@ impl Session {
     /// needs (`remote ∖ holdings`) is *exactly* what `on_summary` already is; the
     /// Pull's only job is to seed that machinery with a SUBJECT-scoped ref set
     /// instead of the advertise set the `SelfOwn` plane never produces.
-    /// CIRISEdge#552 — the NEXT Summary answers a Pull this node sent, so its
-    /// wants are on-demand and must be fetched even under hash-first.
+    /// CIRISEdge#552 — the next reply answers something this node asked for ON
+    /// PURPOSE, so it is fetched and applied even under hash-first.
     ///
-    /// A Pull is the explicit "I need these bodies now" path (#462: a fedID
-    /// pulling its own testimony, or a moderation duty conferred on it, that no
-    /// peer would ever advertise). Hash-first exists to stop bulk convergence,
-    /// not to stop a node asking for something on purpose — and the Pull reply
-    /// arrives as an ordinary `Summary`, indistinguishable from anti-entropy
-    /// without this.
+    /// Covers both deliberate asks, because both are invisible without it:
     ///
-    /// One-shot: consumed by the Summary it was set for, so a later
-    /// anti-entropy round is not silently promoted to a body pull.
-    pub fn expect_pull_response(&mut self) {
-        self.pull_response_pending = true;
+    /// * a **Pull** (#462 — a fedID pulling its own testimony, or a moderation
+    ///   duty conferred on it, that no peer would ever advertise) replies with an
+    ///   ordinary `Summary`, indistinguishable from anti-entropy;
+    /// * a **Fetch** (resolving a known hash to its body — the whole point of
+    ///   holding a directory of hashes) replies with a bare `Deliver`, which
+    ///   without this reads as an unsolicited push and gets learned instead of
+    ///   applied.
+    ///
+    /// Hash-first suppresses BULK CONVERGENCE. It was never meant to suppress a
+    /// deliberate ask, and these are the two shapes a deliberate ask takes.
+    ///
+    /// One-shot: consumed by the reply it was set for, so a single on-demand ask
+    /// cannot quietly promote every later round on this session into a full body
+    /// fetch — a permanent opt-out from hash-first bought with one Pull.
+    pub fn expect_on_demand_reply(&mut self) {
+        self.on_demand_reply_pending = true;
     }
 
     fn on_pull(&mut self, pull: &PullMessage, provider: &dyn StateProvider) -> ReplicationOutcome {
@@ -558,11 +571,26 @@ impl Session {
         // `retention_for` is not bypassable by a provider: a `HashFirst` answer
         // for a plane that RETRACTS something still comes back `Bodies`. A node
         // holding the hash of a revocation has not applied it (CIRISEdge#553).
-        // A Pull reply is an ON-DEMAND fetch and is never suppressed: #462 exists
-        // so a fedID can pull its own testimony, which no peer advertises. Taken
-        // (not peeked) so it cannot leak into the next anti-entropy round.
-        let answering_pull = std::mem::take(&mut self.pull_response_pending);
-        if !answering_pull
+        // An on-demand reply is never suppressed.
+        //
+        // PEEKED, not taken. The marker identifies "a deliberate ask is
+        // outstanding", and it carries no correlation to the request — a Summary
+        // reply to a Pull is byte-identical in shape to an ordinary
+        // anti-entropy Summary. Consuming it on the next Summary meant a racing
+        // scheduled round could eat the exemption, and the actual Pull reply was
+        // then suppressed: testimony recovery broken NONDETERMINISTICALLY, which
+        // is the worst way to be broken.
+        //
+        // So the exemption stands until the round completes (see `reset`). The
+        // cost is over-fetching a round's worth of bodies on a session that
+        // pulled; the alternative is silently returning nothing for the one flow
+        // whose entire purpose is asking on purpose. Fetching too much is
+        // wasteful and visible. Fetching nothing is neither.
+        //
+        // Correlating properly needs the reply to identify its request, which is
+        // a wire change and its own cut.
+        let answering_on_demand = self.on_demand_reply_pending;
+        if !answering_on_demand
             && retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst
         {
             provider.note_known_hashes(self.kind, &want, source_peer);
@@ -752,7 +780,18 @@ impl Session {
         // reasons differ. Suppression is about a row we tried and could not
         // admit; hash-first is about a body we chose not to store, and applying
         // it anyway would defeat the choice.
-        if self.diff_want_count.is_none()
+        // A Fetch reply is a bare Deliver with no round behind it, so it would
+        // otherwise read as an unsolicited push. Peeked for the same reason as
+        // the Summary path: the reply carries no correlation to the request.
+        let answering_on_demand = self.on_demand_reply_pending;
+        // `unwrap_or(0) == 0`, not `is_none()`: a hash-first Summary sets
+        // `diff_want_count = Some(0)`, so `is_none()` was false and a proactive
+        // publisher's Deliver — which arrives right after its Summary — sailed
+        // through and applied. The node then accumulated exactly the corpus it
+        // had just declined. The question is "did we ask for anything", and an
+        // empty ask is not an ask.
+        if !answering_on_demand
+            && self.diff_want_count.unwrap_or(0) == 0
             && retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst
         {
             let learned: Vec<[u8; 32]> = deliver
@@ -1934,6 +1973,64 @@ mod tests {
         );
     }
 
+    /// CIRISEdge#552 — a proactive publisher's Deliver, arriving right after its
+    /// Summary, must NOT be applied under hash-first.
+    ///
+    /// The hash-first Summary sets `diff_want_count = Some(0)`, so an
+    /// `is_none()` gate read it as solicited and let the bodies through — the
+    /// node accumulated exactly the corpus it had just declined. An empty ask is
+    /// not an ask.
+    #[test]
+    fn a_proactive_deliver_after_an_empty_hash_first_diff_is_not_applied() {
+        struct HashFirstEverywhere;
+        impl StateProvider for HashFirstEverywhere {
+            fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+            fn retention(&self, _kind: EnvelopeKind) -> crate::replication::retention::Retention {
+                crate::replication::retention::Retention::HashFirst
+            }
+        }
+
+        let mut session = Session::new(SessionRole::Responder, EnvelopeKind::Key);
+        // The publisher's Summary — hash-first empties the want and sets Some(0).
+        let _ = session.on_message(
+            ReplicationMessage::Summary(SummaryMessage {
+                kind: EnvelopeKind::Key,
+                refs: vec![EnvelopeRef {
+                    envelope_hash: h(1),
+                    seq: 1,
+                }],
+            }),
+            &HashFirstEverywhere,
+            &NoApply,
+            Some("publisher"),
+        );
+        // ...immediately followed by the bodies we did not ask for.
+        let applier = TrackingApplier::default();
+        let outcome = session.on_message(
+            ReplicationMessage::Deliver(DeliverMessage {
+                kind: EnvelopeKind::Key,
+                envelopes: vec![b"a-body".to_vec()],
+            }),
+            &HashFirstEverywhere,
+            &applier,
+            Some("publisher"),
+        );
+        assert!(
+            matches!(outcome, ReplicationOutcome::Applied { admitted: 0, .. }),
+            "a proactive body must be learned, not applied — got {outcome:?}"
+        );
+        assert_eq!(
+            applier.count(),
+            0,
+            "the applier must not have seen the body at all"
+        );
+    }
+
     /// CIRISEdge#552/#462 — a Pull reply is fetched even under hash-first.
     ///
     /// This is the path that exists so a fedID can pull its OWN testimony, or a
@@ -1957,7 +2054,7 @@ mod tests {
         }
 
         let mut session = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
-        session.expect_pull_response();
+        session.expect_on_demand_reply();
 
         let reply = SummaryMessage {
             kind: EnvelopeKind::Key,
@@ -1988,11 +2085,19 @@ mod tests {
         );
     }
 
-    /// The flag is ONE-SHOT. A pull must not quietly promote every later
-    /// anti-entropy round on that session into a full body fetch — which would
-    /// turn one on-demand ask into a permanent opt-out from hash-first.
+    /// The exemption is ROUND-scoped, and released by `reset`.
+    ///
+    /// It cannot be message-scoped: the reply to a Pull is byte-identical in
+    /// shape to an ordinary Summary, so consuming it on the next message let a
+    /// racing scheduled round eat it — and the actual Pull reply was then
+    /// suppressed, breaking testimony recovery nondeterministically.
+    ///
+    /// So it stands for the round and is released with it. That over-fetches a
+    /// round's worth on a session that pulled, and does NOT become a permanent
+    /// opt-out from hash-first. Fetching too much is wasteful and visible;
+    /// fetching nothing is neither.
     #[test]
-    fn the_pull_exemption_does_not_leak_into_the_next_round() {
+    fn the_on_demand_exemption_is_released_when_the_round_resets() {
         struct HashFirstEverywhere;
         impl StateProvider for HashFirstEverywhere {
             fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
@@ -2007,7 +2112,7 @@ mod tests {
         }
 
         let mut session = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
-        session.expect_pull_response();
+        session.expect_on_demand_reply();
         let summary = |n: u8| SummaryMessage {
             kind: EnvelopeKind::Key,
             refs: vec![EnvelopeRef {
@@ -2016,14 +2121,25 @@ mod tests {
             }],
         };
 
-        // First Summary consumes the exemption.
-        let _ = session.on_message(
+        // Within the round the exemption stands — a racing Summary must not be
+        // able to consume it out from under the reply it was set for.
+        let ReplicationOutcome::Send(first) = session.on_message(
             ReplicationMessage::Summary(summary(1)),
             &HashFirstEverywhere,
             &NoApply,
             Some("peer-a"),
+        ) else {
+            panic!("a summary must produce a round");
+        };
+        assert!(
+            first
+                .iter()
+                .any(|m| matches!(m, ReplicationMessage::Diff(d) if !d.want.is_empty())),
+            "the exemption must survive a Summary that is not the Pull reply"
         );
-        // Second is ordinary anti-entropy and must be hash-first again.
+
+        // The round ends; the exemption goes with it.
+        session.reset();
         let ReplicationOutcome::Send(msgs) = session.on_message(
             ReplicationMessage::Summary(summary(2)),
             &HashFirstEverywhere,
@@ -2041,7 +2157,7 @@ mod tests {
             .expect("the round sends a Diff");
         assert!(
             diff.want.is_empty(),
-            "the exemption is one-shot — got {} wanted on the following round",
+            "the exemption must not outlive its round — got {} wanted after reset",
             diff.want.len()
         );
     }
@@ -2169,6 +2285,28 @@ mod tests {
         }
         fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
             None
+        }
+    }
+
+    /// Counts what actually reached the applier.
+    #[derive(Default)]
+    struct TrackingApplier {
+        seen: std::sync::atomic::AtomicUsize,
+    }
+    impl TrackingApplier {
+        fn count(&self) -> usize {
+            self.seen.load(std::sync::atomic::Ordering::Relaxed)
+        }
+    }
+    impl StateApplier for TrackingApplier {
+        fn apply_envelope(
+            &self,
+            _kind: EnvelopeKind,
+            _bytes: &[u8],
+            _peer: Option<&str>,
+        ) -> ApplyOutcome {
+            self.seen.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            ApplyOutcome::Admitted
         }
     }
 

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -955,7 +955,7 @@ impl Session {
                         if let Some(signer) = crate::replication::missing_signer::missing_signer_of(
                             self.kind, env_bytes,
                         ) {
-                            provider.note_missing_signer(self.kind, &signer);
+                            provider.note_missing_signer(self.kind, &signer, source_peer);
                         }
                     }
                     tracing::warn!(
@@ -1957,8 +1957,16 @@ mod tests {
             fn fetch_envelope(&self, _k: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
                 None
             }
-            fn note_missing_signer(&self, _k: EnvelopeKind, signer: &str) {
-                self.0.lock().unwrap().push(signer.to_string());
+            fn note_missing_signer(
+                &self,
+                _k: EnvelopeKind,
+                signer: &str,
+                source_peer: Option<&str>,
+            ) {
+                self.0
+                    .lock()
+                    .unwrap()
+                    .push(format!("{signer}@{}", source_peer.unwrap_or("-")));
             }
         }
         struct TransientRefuser;
@@ -1995,8 +2003,10 @@ mod tests {
         responder.on_deliver(&deliver, &provider, &TransientRefuser, Some("peer-x"));
         assert_eq!(
             provider.0.lock().unwrap().as_slice(),
-            ["steward-abc123"],
-            "a TRANSIENT refusal must record the signer it waits on — without \
+            ["steward-abc123@peer-x"],
+            "a TRANSIENT refusal must record the signer it waits on, AND the peer \
+             that delivered the row — a Pull to any other peer reads that peer's \
+             own lookup_public_key and comes back empty — without \
              this the resolver is dead code and the kill order never lands"
         );
 

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -141,7 +141,15 @@ pub struct Session {
     /// CIRISEdge#552 — the exact hashes this node asked for ON PURPOSE. Only
     /// these are applied under hash-first; a peer answering a Fetch cannot
     /// append arbitrary bodies and have them accepted.
-    pending_bodies: std::collections::HashSet<[u8; 32]>,
+    /// Hashes this node explicitly ASKED for, each with its own remaining
+    /// lifetime in rounds (FSD-SIGNER-RECOVERY D5).
+    ///
+    /// An expectation is REQUEST state, not ROUND state. It is the only thing
+    /// that lets requested bytes past the hash-first gate, so a round completing
+    /// must not discard a request the node still wants — a `Fetch` sets no
+    /// on-demand exemption at all, and used to lose its expectation on the very
+    /// next reset.
+    pending_bodies: std::collections::HashMap<[u8; 32], u8>,
     /// CIRISEdge#552 — rounds for which a Pull's reply is still expected.
     ///
     /// A COUNTER, not a flag, and decremented rather than cleared on reset: a
@@ -226,7 +234,7 @@ impl Session {
             role,
             kind,
             last_summary_sent: None,
-            pending_bodies: std::collections::HashSet::new(),
+            pending_bodies: std::collections::HashMap::new(),
             pull_exempt_rounds: 0,
             last_remote_summary: None,
             diff_want_count: None,
@@ -267,10 +275,15 @@ impl Session {
         // round completing: the subject-scoped reply had not arrived yet, and
         // clearing here made testimony recovery timing-dependent.
         self.pull_exempt_rounds = self.pull_exempt_rounds.saturating_sub(1);
-        if self.pull_exempt_rounds == 0 {
-            // The window closed; anything still outstanding was never answered.
-            self.pending_bodies.clear();
-        }
+        // FSD-SIGNER-RECOVERY D5 — age each expectation on its OWN clock and
+        // drop only what expired. Clearing the whole set when the Pull window
+        // closed discarded `Fetch` expectations, which never open one: the
+        // request survived exactly zero rounds and its body was then treated as
+        // unsolicited and dropped.
+        self.pending_bodies.retain(|_, rounds_left| {
+            *rounds_left = rounds_left.saturating_sub(1);
+            *rounds_left > 0
+        });
     }
 
     pub fn role(&self) -> SessionRole {
@@ -520,7 +533,47 @@ impl Session {
     /// append arbitrary directory bodies and have every one accepted — the
     /// corpus-size and address-book properties lost to a generous responder.
     pub fn expect_bodies(&mut self, hashes: impl IntoIterator<Item = [u8; 32]>) {
-        self.pending_bodies.extend(hashes);
+        self.expect_bodies_for_rounds(hashes, Self::DEFAULT_EXPECTATION_ROUNDS);
+    }
+
+    /// Record expectations with an explicit lifetime in rounds.
+    ///
+    /// The lifetime is the answer to "how long is this node still willing to
+    /// accept the body it asked for?" — not "how long is this round?". A
+    /// request outlives the round that issued it (FSD-SIGNER-RECOVERY D5).
+    pub fn expect_bodies_for_rounds(
+        &mut self,
+        hashes: impl IntoIterator<Item = [u8; 32]>,
+        rounds: u8,
+    ) {
+        let rounds = rounds.max(1);
+        for h in hashes {
+            // Never shorten an existing expectation: a re-ask means the node
+            // wants it MORE, not less.
+            let slot = self.pending_bodies.entry(h).or_insert(rounds);
+            *slot = (*slot).max(rounds);
+        }
+    }
+
+    /// Default lifetime of an expectation, in rounds.
+    ///
+    /// Long enough to survive the round that issued it plus a peer that answers
+    /// on its next cadence tick; short enough that an unanswered request is
+    /// forgotten rather than accumulating.
+    pub const DEFAULT_EXPECTATION_ROUNDS: u8 = 3;
+
+    /// Is this hash still expected? (tests)
+    #[cfg(test)]
+    #[must_use]
+    pub fn is_expecting_body_for_test(&self, hash: &[u8; 32]) -> bool {
+        self.pending_bodies.contains_key(hash)
+    }
+
+    /// Remaining on-demand exemption rounds (tests).
+    #[cfg(test)]
+    #[must_use]
+    pub fn pull_exempt_rounds_for_test(&self) -> u8 {
+        self.pull_exempt_rounds
     }
 
     /// Undo [`Self::expect_on_demand_reply`] — the request never left.
@@ -610,7 +663,7 @@ impl Session {
         // actually asked for rather than merely arriving during the window.
         let answering_on_demand = self.pull_exempt_rounds > 0;
         if answering_on_demand {
-            self.pending_bodies.extend(want.iter().copied());
+            self.expect_bodies_for_rounds(want.iter().copied(), Self::DEFAULT_EXPECTATION_ROUNDS);
         }
         // An on-demand reply is never suppressed.
         //
@@ -665,7 +718,7 @@ impl Session {
         // CIRISEdge#552 — whatever this round asks for is, by definition, wanted.
         // Recording it here means the deliver gate has ONE source of truth for
         // "did we ask for this", covering the on-demand and ordinary paths alike.
-        self.pending_bodies.extend(want.iter().copied());
+        self.expect_bodies_for_rounds(want.iter().copied(), Self::DEFAULT_EXPECTATION_ROUNDS);
         self.diff_want_count = Some(want.len());
         outbound.push(ReplicationMessage::Diff(DiffMessage {
             kind: self.kind,
@@ -911,7 +964,7 @@ impl Session {
             if hash_first_active {
                 use sha2::{Digest as _, Sha256};
                 let h: [u8; 32] = Sha256::digest(env_bytes).into();
-                if self.pending_bodies.remove(&h) {
+                if self.pending_bodies.remove(&h).is_some() {
                     // Remember it: a TRANSIENT refusal below must put it back.
                     requested_hash = Some(h);
                 } else {
@@ -953,7 +1006,10 @@ impl Session {
                     // arrival.
                     if !retry.is_terminal() {
                         if let Some(h) = requested_hash {
-                            self.pending_bodies.insert(h);
+                            // Refresh, not merely restore: the node still wants
+                            // this body and has just learned its dependency is
+                            // not yet satisfied.
+                            self.expect_bodies_for_rounds([h], Self::DEFAULT_EXPECTATION_ROUNDS);
                         }
                     }
                     // CIRISEdge#552 (B) — a TRANSIENT refusal is the one that
@@ -1957,6 +2013,62 @@ mod tests {
             }
             o => panic!("expected Applied, got {o:?}"),
         }
+    }
+
+    /// FSD-SIGNER-RECOVERY invariant 4 — an expectation SURVIVES a round reset
+    /// until its own TTL expires.
+    ///
+    /// The production path this pins: `start_fetch` records an expectation and
+    /// sets no on-demand exemption, so the old "clear the whole set once the
+    /// Pull window closes" rule discarded it on the very next reset — the
+    /// request survived zero rounds and its body was then treated as
+    /// unsolicited and dropped. An expectation is REQUEST state, not ROUND
+    /// state.
+    #[test]
+    fn an_expectation_survives_a_round_reset_until_its_own_ttl_expires() {
+        let h = [7u8; 32];
+        let mut sess = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
+        sess.expect_bodies([h]);
+
+        // A Fetch sets NO exemption; this is exactly the case that used to be
+        // discarded immediately.
+        assert_eq!(sess.pull_exempt_rounds_for_test(), 0);
+
+        for round in 1..Session::DEFAULT_EXPECTATION_ROUNDS {
+            sess.reset();
+            assert!(
+                sess.is_expecting_body_for_test(&h),
+                "the expectation must outlive round {round} — a round completing \
+                 does not mean the node stopped wanting the body it asked for"
+            );
+        }
+        sess.reset();
+        assert!(
+            !sess.is_expecting_body_for_test(&h),
+            "and it is forgotten once its OWN lifetime expires, so an unanswered \
+             request cannot accumulate"
+        );
+    }
+
+    /// FSD-SIGNER-RECOVERY invariant 7 — recovery never runs under
+    /// `Retention::Bodies`.
+    ///
+    /// There the signer's Key body replicates on its own and #544 admits the row
+    /// on a later round, so recording a name would schedule a Pull for something
+    /// already in flight.
+    #[test]
+    fn nothing_is_recorded_for_recovery_under_bodies_retention() {
+        use crate::replication::retention::{should_note_missing_signer, Retention};
+        assert!(
+            !should_note_missing_signer(Retention::Bodies),
+            "under Bodies the Key body arrives on its own — recovery would be \
+             duplicate work"
+        );
+        assert!(
+            should_note_missing_signer(Retention::HashFirst),
+            "under HashFirst it never arrives, which is the whole reason \
+             recovery exists"
+        );
     }
 
     /// CIRISEdge#552 — a requested body that refuses TRANSIENTLY stays

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -907,10 +907,14 @@ impl Session {
             // requested. Gating the whole message on "any envelope matched"
             // would let one requested body carry an arbitrary payload of
             // unrequested ones past the gate.
+            let mut requested_hash: Option<[u8; 32]> = None;
             if hash_first_active {
                 use sha2::{Digest as _, Sha256};
                 let h: [u8; 32] = Sha256::digest(env_bytes).into();
-                if !self.pending_bodies.remove(&h) {
+                if self.pending_bodies.remove(&h) {
+                    // Remember it: a TRANSIENT refusal below must put it back.
+                    requested_hash = Some(h);
+                } else {
                     provider.note_known_hashes(self.kind, &[h], source_peer);
                     tracing::debug!(
                         kind = ?self.kind,
@@ -939,6 +943,19 @@ impl Session {
                 // token maps to which. It is a stable token, never prose.
                 ApplyOutcome::Refused { reason, retry } => {
                     refused += 1;
+                    // CIRISEdge#552 — an explicitly requested body that refuses
+                    // TRANSIENTLY must stay expected. The expectation is the only
+                    // thing that lets its bytes through this gate: hash-first
+                    // suppresses the ordinary want, so a redelivery after the
+                    // dependency lands would be treated as unsolicited and
+                    // dropped, and the row this node ASKED for could never admit.
+                    // Consume the expectation on outcomes that settle it, not on
+                    // arrival.
+                    if !retry.is_terminal() {
+                        if let Some(h) = requested_hash {
+                            self.pending_bodies.insert(h);
+                        }
+                    }
                     // CIRISEdge#552 (B) — a TRANSIENT refusal is the one that
                     // waits on more state, and the state it most often waits on
                     // is the signer's own Key row. Under hash-first that row can
@@ -1938,6 +1955,75 @@ mod tests {
                 assert_eq!(admitted, 0, "nothing admitted");
                 assert_eq!(refused, 3, "every refused envelope is counted, not dropped");
             }
+            o => panic!("expected Applied, got {o:?}"),
+        }
+    }
+
+    /// CIRISEdge#552 — a requested body that refuses TRANSIENTLY stays
+    /// expected.
+    ///
+    /// The expectation is the only thing that lets those bytes through the
+    /// hash-first gate. Consuming it on ARRIVAL means that once the dependency
+    /// lands, the redelivery is treated as unsolicited and dropped — and
+    /// ordinary Summaries cannot repair it either, because hash-first records
+    /// the hash and clears the want. The row this node explicitly ASKED for
+    /// could then never admit.
+    #[test]
+    fn a_requested_body_refused_transiently_is_still_expected() {
+        use std::sync::Mutex;
+        struct P;
+        impl StateProvider for P {
+            fn local_refs(&self, _k: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            fn fetch_envelope(&self, _k: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+            fn retention(&self, _k: EnvelopeKind) -> crate::replication::retention::Retention {
+                crate::replication::retention::Retention::HashFirst
+            }
+        }
+        struct Refuser(Mutex<bool>);
+        impl StateApplier for Refuser {
+            fn apply_envelope(
+                &self,
+                _k: EnvelopeKind,
+                _b: &[u8],
+                _p: Option<&str>,
+            ) -> ApplyOutcome {
+                let mut done = self.0.lock().unwrap();
+                if *done {
+                    ApplyOutcome::Admitted
+                } else {
+                    *done = true;
+                    ApplyOutcome::refused("signer not registered yet")
+                }
+            }
+        }
+
+        use sha2::{Digest as _, Sha256};
+        let body = b"the-requested-key-row".to_vec();
+        let h: [u8; 32] = Sha256::digest(&body).into();
+
+        let mut sess = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
+        sess.expect_bodies([h]);
+        let deliver = DeliverMessage {
+            kind: EnvelopeKind::Key,
+            envelopes: vec![body.clone()],
+        };
+        let applier = Refuser(Mutex::new(false));
+
+        // First delivery: transiently refused. The expectation must survive.
+        sess.on_deliver(&deliver, &P, &applier, Some("peer-1"));
+
+        // The dependency has landed; the SAME bytes are redelivered.
+        match sess.on_deliver(&deliver, &P, &applier, Some("peer-1")) {
+            ReplicationOutcome::Applied { admitted, .. } => assert_eq!(
+                admitted, 1,
+                "the redelivered body must still be expected and therefore \
+                 applied — consuming the expectation on arrival strands the row \
+                 this node explicitly asked for"
+            ),
             o => panic!("expected Applied, got {o:?}"),
         }
     }

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -523,6 +523,11 @@ impl Session {
         self.pending_bodies.extend(hashes);
     }
 
+    /// Undo [`Self::expect_on_demand_reply`] — the request never left.
+    pub fn cancel_on_demand_reply(&mut self) {
+        self.pull_exempt_rounds = 0;
+    }
+
     /// How many round-resets a Pull's exemption survives. Small: it bounds the
     /// over-fetch, and a reply that has not arrived in three rounds is not
     /// coming.
@@ -657,6 +662,10 @@ impl Session {
             self.last_summary_sent = Some(my_summary.clone());
             outbound.push(ReplicationMessage::Summary(my_summary));
         }
+        // CIRISEdge#552 — whatever this round asks for is, by definition, wanted.
+        // Recording it here means the deliver gate has ONE source of truth for
+        // "did we ask for this", covering the on-demand and ordinary paths alike.
+        self.pending_bodies.extend(want.iter().copied());
         self.diff_want_count = Some(want.len());
         outbound.push(ReplicationMessage::Diff(DiffMessage {
             kind: self.kind,
@@ -830,8 +839,15 @@ impl Session {
         // publisher's Deliver — arriving right after its Summary — sailed
         // through and applied. An empty ask is not an ask. A NON-empty want
         // means this exchange is ordinary solicited anti-entropy and is ungated.
-        let hash_first_active = self.diff_want_count.unwrap_or(0) == 0
-            && retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst;
+        // Gated whenever the plane is hash-first — NOT only when the want was
+        // empty. A Pull's reply produces a NON-empty Diff, so keying on
+        // `diff_want_count == 0` turned the gate off for exactly the exchange
+        // where a responder is most able to append extras. Under hash-first every
+        // legitimately wanted hash is in `pending_bodies` (the Diff path puts it
+        // there), so the per-envelope check below is sufficient on its own and
+        // the want count adds nothing but a hole.
+        let hash_first_active =
+            retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst;
         // CIRISEdge#426 — distinguish a SOLICITED Deliver (it answers a `Diff` we
         // sent this round — `diff_want_count` is set) from an UNSOLICITED one (a
         // bare push with no in-flight round we invited — the #927 proactive-publish

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -39,6 +39,7 @@ use super::protocol::{
     CursorPullMessage, DeliverMessage, DiffMessage, EnvelopeKind, EnvelopeRef, FetchMessage,
     PullMessage, ReplicationMessage, SummaryMessage,
 };
+use super::retention::{retention_for, Retention};
 use super::summary::{diff_refs, ApplyOutcome, StalenessSignal, StateApplier, StateProvider};
 
 /// What role a session is playing in this round. Initiator emits
@@ -405,7 +406,7 @@ impl Session {
     ) -> ReplicationOutcome {
         match msg {
             ReplicationMessage::Summary(remote_summary) => {
-                self.on_summary(&remote_summary, provider)
+                self.on_summary(&remote_summary, provider, source_peer)
             }
             ReplicationMessage::Diff(diff) => self.on_diff(&diff, provider, source_peer),
             ReplicationMessage::Deliver(deliver) => self.on_deliver(&deliver, applier, source_peer),
@@ -477,6 +478,10 @@ impl Session {
         &mut self,
         remote: &SummaryMessage,
         provider: &dyn StateProvider,
+        // CIRISEdge#552 — the advertising peer. A Summary is where the holder map
+        // is learned: knowing a record exists is only actionable alongside who
+        // offered it, and this is the one arm that sees both.
+        source_peer: Option<&str>,
     ) -> ReplicationOutcome {
         if remote.kind != self.kind {
             return ReplicationOutcome::UnexpectedMessage;
@@ -515,6 +520,31 @@ impl Session {
                  instead of re-asking every round (CIRISEdge#544)"
             );
         }
+        // ── CIRISEdge#552: HASH-FIRST ────────────────────────────────────────
+        // Learn the peer's hashes; ask for no bodies. The node still knows every
+        // record exists and who offered it — it simply has not pulled the corpus.
+        // That is what keeps a federation-tier identity directory from being an
+        // address book: a hash is not a mailing address, and resolving one takes
+        // a fetch, which is observable and refusable.
+        //
+        // `retention_for` is not bypassable by a provider: a `HashFirst` answer
+        // for a plane that RETRACTS something still comes back `Bodies`. A node
+        // holding the hash of a revocation has not applied it (CIRISEdge#553).
+        if retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst {
+            provider.note_known_hashes(self.kind, &want, source_peer);
+            let learned = want.len();
+            want.clear();
+            if learned > 0 {
+                tracing::debug!(
+                    kind = ?self.kind,
+                    learned,
+                    peer = ?source_peer,
+                    "hash-first: learned the peer's hashes without pulling bodies \
+                     (CIRISEdge#552)"
+                );
+            }
+        }
+
         let mut outbound = Vec::new();
         // Responder ALSO needs to send its Summary so the
         // initiator's side of the round can progress. We include it
@@ -1720,6 +1750,141 @@ mod tests {
     /// pull. A peer advertises two rows the node lacks; the node has already
     /// refused one of them, so its Diff asks for the OTHER one only. Nothing is
     /// sent to the peer to make this happen — the sender was never the one
+    /// CIRISEdge#552 — under hash-first retention the round LEARNS the peer's
+    /// hashes and asks for no bodies.
+    ///
+    /// This is the whole mechanism: the node still computes what it lacks (so it
+    /// knows the record exists and who has it) but does not pull the corpus.
+    #[test]
+    fn hash_first_learns_the_hashes_and_asks_for_no_bodies() {
+        use std::sync::Mutex;
+        struct HashFirstProvider {
+            noted: Mutex<Vec<[u8; 32]>>,
+            peer: Mutex<Option<String>>,
+        }
+        impl StateProvider for HashFirstProvider {
+            fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+            fn retention(&self, _kind: EnvelopeKind) -> crate::replication::retention::Retention {
+                crate::replication::retention::Retention::HashFirst
+            }
+            fn note_known_hashes(
+                &self,
+                _kind: EnvelopeKind,
+                hashes: &[[u8; 32]],
+                peer: Option<&str>,
+            ) {
+                self.noted.lock().unwrap().extend_from_slice(hashes);
+                *self.peer.lock().unwrap() = peer.map(str::to_owned);
+            }
+        }
+
+        let provider = HashFirstProvider {
+            noted: Mutex::new(Vec::new()),
+            peer: Mutex::new(None),
+        };
+        let mut session = Session::new(SessionRole::Responder, EnvelopeKind::Attestation);
+        let remote = SummaryMessage {
+            kind: EnvelopeKind::Attestation,
+            refs: vec![
+                EnvelopeRef {
+                    envelope_hash: h(1),
+                    seq: 1,
+                },
+                EnvelopeRef {
+                    envelope_hash: h(2),
+                    seq: 2,
+                },
+            ],
+        };
+        let ReplicationOutcome::Send(msgs) = session.on_message(
+            ReplicationMessage::Summary(remote),
+            &provider,
+            &NoApply,
+            Some("peer-a"),
+        ) else {
+            panic!("a summary must produce a round");
+        };
+
+        let diff = msgs
+            .iter()
+            .find_map(|m| match m {
+                ReplicationMessage::Diff(d) => Some(d),
+                _ => None,
+            })
+            .expect("the round still sends a Diff");
+        assert!(
+            diff.want.is_empty(),
+            "hash-first asks for NO bodies — got {} wanted",
+            diff.want.len()
+        );
+        assert_eq!(
+            provider.noted.lock().unwrap().len(),
+            2,
+            "both advertised hashes must be LEARNED, or the node cannot later \
+             discover the record exists"
+        );
+        assert_eq!(
+            provider.peer.lock().unwrap().as_deref(),
+            Some("peer-a"),
+            "the advertising peer is the holder to ask — without it the node \
+             knows a record exists but not who has it"
+        );
+    }
+
+    /// CIRISEdge#553 — the carve-out reaches the round, not just the pure
+    /// function. A node configured hash-first STILL pulls revocation bodies.
+    #[test]
+    fn a_hash_first_node_still_pulls_revocation_bodies() {
+        struct HashFirstEverywhere;
+        impl StateProvider for HashFirstEverywhere {
+            fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+            fn retention(&self, _kind: EnvelopeKind) -> crate::replication::retention::Retention {
+                crate::replication::retention::Retention::HashFirst
+            }
+        }
+
+        let mut session = Session::new(SessionRole::Responder, EnvelopeKind::Revocation);
+        let remote = SummaryMessage {
+            kind: EnvelopeKind::Revocation,
+            refs: vec![EnvelopeRef {
+                envelope_hash: h(1),
+                seq: 1,
+            }],
+        };
+        let ReplicationOutcome::Send(msgs) = session.on_message(
+            ReplicationMessage::Summary(remote),
+            &HashFirstEverywhere,
+            &NoApply,
+            Some("peer-a"),
+        ) else {
+            panic!("a summary must produce a round");
+        };
+
+        let diff = msgs
+            .iter()
+            .find_map(|m| match m {
+                ReplicationMessage::Diff(d) => Some(d),
+                _ => None,
+            })
+            .expect("the round still sends a Diff");
+        assert_eq!(
+            diff.want,
+            vec![h(1)],
+            "a node holding the HASH of a revocation has not applied it — the \
+             body must still be asked for (CIRISEdge#553)"
+        );
+    }
+
     /// choosing, which is why the fix needs no wire change.
     #[test]
     fn the_rounds_want_omits_hashes_this_node_has_already_refused() {

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -138,9 +138,19 @@ pub enum ReplicationOutcome {
 // sake would make the type lie about that.
 #[allow(clippy::struct_excessive_bools)]
 pub struct Session {
-    /// CIRISEdge#552 — this node asked for something ON PURPOSE and the reply is
-    /// outstanding. See [`Self::expect_on_demand_reply`].
-    on_demand_reply_pending: bool,
+    /// CIRISEdge#552 — the exact hashes this node asked for ON PURPOSE. Only
+    /// these are applied under hash-first; a peer answering a Fetch cannot
+    /// append arbitrary bodies and have them accepted.
+    pending_bodies: std::collections::HashSet<[u8; 32]>,
+    /// CIRISEdge#552 — rounds for which a Pull's reply is still expected.
+    ///
+    /// A COUNTER, not a flag, and decremented rather than cleared on reset: a
+    /// Pull issued during an ordinary scheduled round would otherwise have its
+    /// exemption cleared by THAT round completing, before the subject-scoped
+    /// reply arrived. A Pull cannot name its hashes in advance — that is what it
+    /// is for — so this is the one window that must stay a window. It converts
+    /// to exact hashes the moment the reply names them.
+    pull_exempt_rounds: u8,
     role: SessionRole,
     kind: EnvelopeKind,
     /// What we sent the peer in our most recent Summary — used to
@@ -216,7 +226,8 @@ impl Session {
             role,
             kind,
             last_summary_sent: None,
-            on_demand_reply_pending: false,
+            pending_bodies: std::collections::HashSet::new(),
+            pull_exempt_rounds: 0,
             last_remote_summary: None,
             diff_want_count: None,
             completed: false,
@@ -251,12 +262,15 @@ impl Session {
         self.diff_want_count = None;
         self.completed = false;
         self.awaiting_cursor_deliver = false;
-        // CIRISEdge#552 — the on-demand exemption is ROUND-scoped, not
-        // message-scoped. It cannot be consumed by whichever reply happens to
-        // arrive first (it carries no correlation to the request), so it is
-        // released when the round it belongs to ends. That bounds the
-        // over-fetch to one round instead of exempting the session forever.
-        self.on_demand_reply_pending = false;
+        // CIRISEdge#552 — DECREMENT, never clear. A Pull issued during an
+        // ordinary scheduled round must not have its exemption killed by THAT
+        // round completing: the subject-scoped reply had not arrived yet, and
+        // clearing here made testimony recovery timing-dependent.
+        self.pull_exempt_rounds = self.pull_exempt_rounds.saturating_sub(1);
+        if self.pull_exempt_rounds == 0 {
+            // The window closed; anything still outstanding was never answered.
+            self.pending_bodies.clear();
+        }
     }
 
     pub fn role(&self) -> SessionRole {
@@ -496,8 +510,23 @@ impl Session {
     /// cannot quietly promote every later round on this session into a full body
     /// fetch — a permanent opt-out from hash-first bought with one Pull.
     pub fn expect_on_demand_reply(&mut self) {
-        self.on_demand_reply_pending = true;
+        self.pull_exempt_rounds = Self::PULL_EXEMPT_ROUNDS;
     }
+
+    /// CIRISEdge#552 — record the exact hashes a Fetch asked for.
+    ///
+    /// Precise where the Pull window cannot be: a Fetch names its want, so only
+    /// those bodies are applied. Without this, a peer answering a Fetch could
+    /// append arbitrary directory bodies and have every one accepted — the
+    /// corpus-size and address-book properties lost to a generous responder.
+    pub fn expect_bodies(&mut self, hashes: impl IntoIterator<Item = [u8; 32]>) {
+        self.pending_bodies.extend(hashes);
+    }
+
+    /// How many round-resets a Pull's exemption survives. Small: it bounds the
+    /// over-fetch, and a reply that has not arrived in three rounds is not
+    /// coming.
+    const PULL_EXEMPT_ROUNDS: u8 = 3;
 
     fn on_pull(&mut self, pull: &PullMessage, provider: &dyn StateProvider) -> ReplicationOutcome {
         if pull.kind != self.kind {
@@ -571,6 +600,13 @@ impl Session {
         // `retention_for` is not bypassable by a provider: a `HashFirst` answer
         // for a plane that RETRACTS something still comes back `Bodies`. A node
         // holding the hash of a revocation has not applied it (CIRISEdge#553).
+        // A Pull's reply names the hashes at last: convert the WINDOW into an
+        // exact set, so the Deliver that follows is checked against what we
+        // actually asked for rather than merely arriving during the window.
+        let answering_on_demand = self.pull_exempt_rounds > 0;
+        if answering_on_demand {
+            self.pending_bodies.extend(want.iter().copied());
+        }
         // An on-demand reply is never suppressed.
         //
         // PEEKED, not taken. The marker identifies "a deliberate ask is
@@ -589,7 +625,6 @@ impl Session {
         //
         // Correlating properly needs the reply to identify its request, which is
         // a wire change and its own cut.
-        let answering_on_demand = self.on_demand_reply_pending;
         if !answering_on_demand
             && retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst
         {
@@ -780,50 +815,23 @@ impl Session {
         // reasons differ. Suppression is about a row we tried and could not
         // admit; hash-first is about a body we chose not to store, and applying
         // it anyway would defeat the choice.
-        // A Fetch reply is a bare Deliver with no round behind it, so it would
-        // otherwise read as an unsolicited push. Peeked for the same reason as
-        // the Summary path: the reply carries no correlation to the request.
-        let answering_on_demand = self.on_demand_reply_pending;
+        // Only the bodies this node ASKED FOR are exempt, checked per envelope
+        // rather than per message. A peer answering a Fetch can append whatever
+        // it likes; appending does not make it requested.
+        // CIRISEdge#552 — under hash-first a body is applied only if this node
+        // ASKED for it, and the check is PER ENVELOPE (in the apply loop below).
+        // A responder can append bodies to a Fetch reply, and appending does not
+        // make them requested; gating the whole message on "any envelope
+        // matched" would let one requested body carry an arbitrary payload past
+        // the gate.
+        //
         // `unwrap_or(0) == 0`, not `is_none()`: a hash-first Summary sets
         // `diff_want_count = Some(0)`, so `is_none()` was false and a proactive
-        // publisher's Deliver — which arrives right after its Summary — sailed
-        // through and applied. The node then accumulated exactly the corpus it
-        // had just declined. The question is "did we ask for anything", and an
-        // empty ask is not an ask.
-        if !answering_on_demand
-            && self.diff_want_count.unwrap_or(0) == 0
-            && retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst
-        {
-            let learned: Vec<[u8; 32]> = deliver
-                .envelopes
-                .iter()
-                .map(|bytes| {
-                    use sha2::{Digest as _, Sha256};
-                    let h: [u8; 32] = Sha256::digest(bytes).into();
-                    h
-                })
-                .collect();
-            provider.note_known_hashes(self.kind, &learned, source_peer);
-            tracing::debug!(
-                kind = ?self.kind,
-                count = learned.len(),
-                peer = ?source_peer,
-                "hash-first: an unsolicited Deliver was LEARNED, not applied — \
-                 a proactive push must not backfill a corpus this node declined \
-                 to fetch (CIRISEdge#552)"
-            );
-            // `admitted: 0, refused: 0` is the honest pair: nothing was admitted,
-            // and nothing was REFUSED either — the bodies were declined, not
-            // rejected. The learn is not lost: it is in the known set and in this
-            // log line, which is where a "why did my push not land" question gets
-            // answered.
-            return ReplicationOutcome::Applied {
-                kind: self.kind,
-                admitted: 0,
-                refused: 0,
-                staleness: StalenessSignal::InSync,
-            };
-        }
+        // publisher's Deliver — arriving right after its Summary — sailed
+        // through and applied. An empty ask is not an ask. A NON-empty want
+        // means this exchange is ordinary solicited anti-entropy and is ungated.
+        let hash_first_active = self.diff_want_count.unwrap_or(0) == 0
+            && retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst;
         // CIRISEdge#426 — distinguish a SOLICITED Deliver (it answers a `Diff` we
         // sent this round — `diff_want_count` is set) from an UNSOLICITED one (a
         // bare push with no in-flight round we invited — the #927 proactive-publish
@@ -878,6 +886,25 @@ impl Session {
         // withholds carriage can therefore never again read as absence of work; the
         // `refused` count in the `RoundReport` always has a matching WARN saying WHY.
         for env_bytes in &deliver.envelopes {
+            // CIRISEdge#552 — PER ENVELOPE, not per message. A responder can
+            // append bodies to a Fetch reply, and appending does not make them
+            // requested. Gating the whole message on "any envelope matched"
+            // would let one requested body carry an arbitrary payload of
+            // unrequested ones past the gate.
+            if hash_first_active {
+                use sha2::{Digest as _, Sha256};
+                let h: [u8; 32] = Sha256::digest(env_bytes).into();
+                if !self.pending_bodies.remove(&h) {
+                    provider.note_known_hashes(self.kind, &[h], source_peer);
+                    tracing::debug!(
+                        kind = ?self.kind,
+                        peer = ?source_peer,
+                        "hash-first: a body this node did not ask for was LEARNED, \
+                         not applied (CIRISEdge#552)"
+                    );
+                    continue;
+                }
+            }
             match applier.apply_envelope(self.kind, env_bytes, source_peer) {
                 ApplyOutcome::Admitted => admitted += 1,
                 // Routine non-progress (a re-delivered held row) — quiet by design;
@@ -2085,7 +2112,7 @@ mod tests {
         );
     }
 
-    /// The exemption is ROUND-scoped, and released by `reset`.
+    /// The exemption survives a round it does not belong to.
     ///
     /// It cannot be message-scoped: the reply to a Pull is byte-identical in
     /// shape to an ordinary Summary, so consuming it on the next message let a
@@ -2138,7 +2165,27 @@ mod tests {
             "the exemption must survive a Summary that is not the Pull reply"
         );
 
-        // The round ends; the exemption goes with it.
+        // An UNRELATED round completes. The exemption must survive it: a Pull
+        // issued during a scheduled round would otherwise have its exemption
+        // killed by that round finishing first, and testimony recovery became
+        // timing-dependent.
+        session.reset();
+        let ReplicationOutcome::Send(mid) = session.on_message(
+            ReplicationMessage::Summary(summary(3)),
+            &HashFirstEverywhere,
+            &NoApply,
+            Some("peer-a"),
+        ) else {
+            panic!("a summary must produce a round");
+        };
+        assert!(
+            mid.iter()
+                .any(|m| matches!(m, ReplicationMessage::Diff(d) if !d.want.is_empty())),
+            "one unrelated round completing must not kill the exemption"
+        );
+
+        // It is bounded, though: after its window it lapses.
+        session.reset();
         session.reset();
         let ReplicationOutcome::Send(msgs) = session.on_message(
             ReplicationMessage::Summary(summary(2)),
@@ -2157,7 +2204,7 @@ mod tests {
             .expect("the round sends a Diff");
         assert!(
             diff.want.is_empty(),
-            "the exemption must not outlive its round — got {} wanted after reset",
+            "the exemption is bounded — got {} wanted after its window lapsed",
             diff.want.len()
         );
     }

--- a/src/replication/session.rs
+++ b/src/replication/session.rs
@@ -131,7 +131,16 @@ pub enum ReplicationOutcome {
 /// After a round completes (`Applied` outcome), call [`Self::reset`]
 /// to clear the per-round state and prepare for the next round with
 /// the same peer.
+// CIRISEdge#552 — the fourth bool. These are four INDEPENDENT one-shot round
+// facts (role-phase markers and the pull exemption), not a state enum wearing
+// booleans: no two are mutually exclusive, and collapsing them into one would
+// invent transitions the protocol does not have. Grouping them for the lint's
+// sake would make the type lie about that.
+#[allow(clippy::struct_excessive_bools)]
 pub struct Session {
+    /// CIRISEdge#552 — a Pull we sent is awaiting its Summary. See
+    /// [`Self::expect_pull_response`].
+    pull_response_pending: bool,
     role: SessionRole,
     kind: EnvelopeKind,
     /// What we sent the peer in our most recent Summary — used to
@@ -207,6 +216,7 @@ impl Session {
             role,
             kind,
             last_summary_sent: None,
+            pull_response_pending: false,
             last_remote_summary: None,
             diff_want_count: None,
             completed: false,
@@ -460,6 +470,22 @@ impl Session {
     /// needs (`remote ∖ holdings`) is *exactly* what `on_summary` already is; the
     /// Pull's only job is to seed that machinery with a SUBJECT-scoped ref set
     /// instead of the advertise set the `SelfOwn` plane never produces.
+    /// CIRISEdge#552 — the NEXT Summary answers a Pull this node sent, so its
+    /// wants are on-demand and must be fetched even under hash-first.
+    ///
+    /// A Pull is the explicit "I need these bodies now" path (#462: a fedID
+    /// pulling its own testimony, or a moderation duty conferred on it, that no
+    /// peer would ever advertise). Hash-first exists to stop bulk convergence,
+    /// not to stop a node asking for something on purpose — and the Pull reply
+    /// arrives as an ordinary `Summary`, indistinguishable from anti-entropy
+    /// without this.
+    ///
+    /// One-shot: consumed by the Summary it was set for, so a later
+    /// anti-entropy round is not silently promoted to a body pull.
+    pub fn expect_pull_response(&mut self) {
+        self.pull_response_pending = true;
+    }
+
     fn on_pull(&mut self, pull: &PullMessage, provider: &dyn StateProvider) -> ReplicationOutcome {
         if pull.kind != self.kind {
             return ReplicationOutcome::UnexpectedMessage;
@@ -532,7 +558,13 @@ impl Session {
         // `retention_for` is not bypassable by a provider: a `HashFirst` answer
         // for a plane that RETRACTS something still comes back `Bodies`. A node
         // holding the hash of a revocation has not applied it (CIRISEdge#553).
-        if retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst {
+        // A Pull reply is an ON-DEMAND fetch and is never suppressed: #462 exists
+        // so a fedID can pull its own testimony, which no peer advertises. Taken
+        // (not peeked) so it cannot leak into the next anti-entropy round.
+        let answering_pull = std::mem::take(&mut self.pull_response_pending);
+        if !answering_pull
+            && retention_for(self.kind, provider.retention(self.kind)) == Retention::HashFirst
+        {
             provider.note_known_hashes(self.kind, &want, source_peer);
             let learned = want.len();
             want.clear();
@@ -1899,6 +1931,118 @@ mod tests {
             Some("peer-a"),
             "the advertising peer is the holder to ask — without it the node \
              knows a record exists but not who has it"
+        );
+    }
+
+    /// CIRISEdge#552/#462 — a Pull reply is fetched even under hash-first.
+    ///
+    /// This is the path that exists so a fedID can pull its OWN testimony, or a
+    /// moderation duty conferred on it, which no peer would ever advertise.
+    /// Suppressing it would make hash-first silently break the one flow whose
+    /// entire purpose is asking for bodies on purpose — and the reply arrives as
+    /// an ordinary Summary, so nothing would have looked wrong.
+    #[test]
+    fn a_pull_reply_is_fetched_even_under_hash_first() {
+        struct HashFirstEverywhere;
+        impl StateProvider for HashFirstEverywhere {
+            fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+            fn retention(&self, _kind: EnvelopeKind) -> crate::replication::retention::Retention {
+                crate::replication::retention::Retention::HashFirst
+            }
+        }
+
+        let mut session = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
+        session.expect_pull_response();
+
+        let reply = SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![EnvelopeRef {
+                envelope_hash: h(1),
+                seq: 1,
+            }],
+        };
+        let ReplicationOutcome::Send(msgs) = session.on_message(
+            ReplicationMessage::Summary(reply),
+            &HashFirstEverywhere,
+            &NoApply,
+            Some("peer-a"),
+        ) else {
+            panic!("a summary must produce a round");
+        };
+        let diff = msgs
+            .iter()
+            .find_map(|m| match m {
+                ReplicationMessage::Diff(d) => Some(d),
+                _ => None,
+            })
+            .expect("the round sends a Diff");
+        assert_eq!(
+            diff.want,
+            vec![h(1)],
+            "an explicitly pulled body must still be asked for (CIRISEdge#462)"
+        );
+    }
+
+    /// The flag is ONE-SHOT. A pull must not quietly promote every later
+    /// anti-entropy round on that session into a full body fetch — which would
+    /// turn one on-demand ask into a permanent opt-out from hash-first.
+    #[test]
+    fn the_pull_exemption_does_not_leak_into_the_next_round() {
+        struct HashFirstEverywhere;
+        impl StateProvider for HashFirstEverywhere {
+            fn local_refs(&self, _kind: EnvelopeKind) -> Vec<EnvelopeRef> {
+                Vec::new()
+            }
+            fn fetch_envelope(&self, _kind: EnvelopeKind, _h: &[u8; 32]) -> Option<Vec<u8>> {
+                None
+            }
+            fn retention(&self, _kind: EnvelopeKind) -> crate::replication::retention::Retention {
+                crate::replication::retention::Retention::HashFirst
+            }
+        }
+
+        let mut session = Session::new(SessionRole::Initiator, EnvelopeKind::Key);
+        session.expect_pull_response();
+        let summary = |n: u8| SummaryMessage {
+            kind: EnvelopeKind::Key,
+            refs: vec![EnvelopeRef {
+                envelope_hash: h(n),
+                seq: 1,
+            }],
+        };
+
+        // First Summary consumes the exemption.
+        let _ = session.on_message(
+            ReplicationMessage::Summary(summary(1)),
+            &HashFirstEverywhere,
+            &NoApply,
+            Some("peer-a"),
+        );
+        // Second is ordinary anti-entropy and must be hash-first again.
+        let ReplicationOutcome::Send(msgs) = session.on_message(
+            ReplicationMessage::Summary(summary(2)),
+            &HashFirstEverywhere,
+            &NoApply,
+            Some("peer-a"),
+        ) else {
+            panic!("a summary must produce a round");
+        };
+        let diff = msgs
+            .iter()
+            .find_map(|m| match m {
+                ReplicationMessage::Diff(d) => Some(d),
+                _ => None,
+            })
+            .expect("the round sends a Diff");
+        assert!(
+            diff.want.is_empty(),
+            "the exemption is one-shot — got {} wanted on the following round",
+            diff.want.len()
         );
     }
 

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -175,6 +175,19 @@ pub trait StateProvider: Send + Sync {
         Vec::new()
     }
 
+    /// CIRISEdge#552 (B) — take ONE recorded signer, but only if it is this
+    /// peer, removing it. Returns whether it was queued.
+    ///
+    /// A subject Pull is served only when the requester IS the subject
+    /// (`subject_holdings` refuses anything else and serves nothing), so asking
+    /// peer P for third-party S's key returns an empty Summary forever. The one
+    /// authorized case is S == P: "you signed a row I cannot verify, send me
+    /// your key." Filtering by peer keeps every other name queued for the peer
+    /// that can actually answer it.
+    fn take_missing_signer_for(&self, _peer_key_id: &str) -> bool {
+        false
+    }
+
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
         false
     }

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -164,15 +164,37 @@ pub trait StateProvider: Send + Sync {
     ///
     /// [`ReplicationDirectory::note_missing_signer`]:
     ///     super::directory::ReplicationDirectory::note_missing_signer
-    fn note_missing_signer(&self, _kind: EnvelopeKind, _signer_key_id: &str) {}
+    fn note_missing_signer(
+        &self,
+        _kind: EnvelopeKind,
+        _signer_key_id: &str,
+        _source_peer: Option<&str>,
+    ) {
+    }
 
     /// CIRISEdge#552 (B) — take signers to pull, at most a bounded batch. The
     /// names are REMOVED: a name that stays queued after its pull was sent would
     /// re-pull every round. If the key still does not arrive, the row refuses
     /// transient again and re-notes it — the retry rides the existing #544
     /// backoff rather than a second timer.
-    fn take_missing_signers(&self) -> Vec<String> {
-        Vec::new()
+    /// CIRISEdge#552 (B) — take ONE signer to pull from `peer_key_id`, removing
+    /// it.
+    ///
+    /// Per-peer and one-at-a-time, both forced by the mechanism. **Possession:**
+    /// a Pull reads the answering peer's own `lookup_public_key`, so asking an
+    /// arbitrary peer for a third party's key returns an empty Summary and
+    /// silently consumes the queued recovery. The peer that DELIVERED the
+    /// unverifiable row is the one candidate known to have handled it, so the
+    /// name is routed back to it. **Serialization:** the on-demand exemption is
+    /// a ROUND counter, not a per-request ledger, so a batch of Pulls would
+    /// outrun its own exemption and the later replies would be suppressed as
+    /// ordinary hash-first traffic.
+    ///
+    /// A name recorded with no source peer (a contact lookup, which has no
+    /// delivering peer) is offered to any coordinator, so successive rounds try
+    /// it against successive peers until one holds it.
+    fn take_missing_signer_for(&self, _peer_key_id: &str) -> Option<String> {
+        None
     }
 
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -158,6 +158,23 @@ pub trait StateProvider: Send + Sync {
     ) {
     }
 
+    /// CIRISEdge#552 (B) — record a signer a transient refusal named, so the
+    /// key can be pulled out of band. See
+    /// [`ReplicationDirectory::note_missing_signer`] for why this only records.
+    ///
+    /// [`ReplicationDirectory::note_missing_signer`]:
+    ///     super::directory::ReplicationDirectory::note_missing_signer
+    fn note_missing_signer(&self, _kind: EnvelopeKind, _signer_key_id: &str) {}
+
+    /// CIRISEdge#552 (B) — take signers to pull, at most a bounded batch. The
+    /// names are REMOVED: a name that stays queued after its pull was sent would
+    /// re-pull every round. If the key still does not arrive, the row refuses
+    /// transient again and re-notes it — the retry rides the existing #544
+    /// backoff rather than a second timer.
+    fn take_missing_signers(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
         false
     }

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -175,19 +175,6 @@ pub trait StateProvider: Send + Sync {
         Vec::new()
     }
 
-    /// CIRISEdge#552 (B) — take ONE recorded signer, but only if it is this
-    /// peer, removing it. Returns whether it was queued.
-    ///
-    /// A subject Pull is served only when the requester IS the subject
-    /// (`subject_holdings` refuses anything else and serves nothing), so asking
-    /// peer P for third-party S's key returns an empty Summary forever. The one
-    /// authorized case is S == P: "you signed a row I cannot verify, send me
-    /// your key." Filtering by peer keeps every other name queued for the peer
-    /// that can actually answer it.
-    fn take_missing_signer_for(&self, _peer_key_id: &str) -> bool {
-        false
-    }
-
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
         false
     }

--- a/src/replication/summary.rs
+++ b/src/replication/summary.rs
@@ -125,6 +125,39 @@ pub trait StateProvider: Send + Sync {
     /// The production `DirectoryStateAdapter` forwards to the ONE shared bridge,
     /// so the verdict is node-wide: the first peer's refusal teaches every
     /// peer's next round.
+    /// CIRISEdge#552 — how much of `kind` this node keeps.
+    ///
+    /// Defaults to [`Retention::Bodies`](super::retention::Retention::Bodies),
+    /// the pre-#552 behaviour, so every existing provider, mock and DST harness
+    /// is unchanged. Sync for the same reason `retry_suppressed` is: a
+    /// configuration read consulted once per round, never I/O.
+    ///
+    /// A provider cannot bypass the revocation carve-out by answering
+    /// `HashFirst` here — the round passes this through
+    /// [`retention_for`](super::retention::retention_for), which pins the
+    /// retracting planes to `Bodies` regardless.
+    fn retention(&self, _kind: EnvelopeKind) -> super::retention::Retention {
+        super::retention::Retention::Bodies
+    }
+
+    /// CIRISEdge#552 — learn that `advertised_by` offered these hashes for
+    /// `kind`, without this node fetching their bodies.
+    ///
+    /// The node knows the records exist and who to ask; it simply has not pulled
+    /// them. Defaults to a no-op, so a `Bodies` provider needs nothing.
+    ///
+    /// These are **not holdings** and must never be returned from
+    /// [`Self::local_holdings`]. `want = remote ∖ holdings`, so a
+    /// known-but-not-held hash on the holdings side makes the node conclude it
+    /// already has what it has merely heard of — and stop fetching, silently.
+    fn note_known_hashes(
+        &self,
+        _kind: EnvelopeKind,
+        _hashes: &[[u8; 32]],
+        _advertised_by: Option<&str>,
+    ) {
+    }
+
     fn retry_suppressed(&self, _kind: EnvelopeKind, _envelope_hash: &[u8; 32]) -> bool {
         false
     }


### PR DESCRIPTION
**RC.** Persistence rides on CIRISPersist#786 (`known_wire_hashes`, merged); this builds against an in-memory set so the protocol half does not wait. Not for merge until the remaining open findings are closed.

Twenty-plus review findings across seven rounds are folded in. The three that changed the *design* rather than the code are worth reading before the diff.

## What the review rounds actually found

**The feature was inert.** The only `retention()` overrides were in tests — the production `DirectoryStateAdapter` never forwarded it, so every node took the trait default `Bodies` whatever the bridge was configured to do. Nothing broke, because nothing ran. A retention policy that is never consulted looks identical to one deciding "keep everything".

**`Key` is the root of every admission's dependency closure.** persist's shared ingest gate resolves the signer's pubkeys via `lookup_public_key` before verifying anything. So no plane admits while its signer's Key body is absent — and hash-first on `Key` would make a revocation whose revoker is unknown permanently unadmittable. A kill order that does not land, defeating #553 through the plane it depends on rather than through itself.

**Retraction is a per-record property, not a per-kind one.** The Attestation plane carries `withdraws`/`recants` tombstones. A kind-keyed carve-out could not see that, and its exhaustiveness test ranged over kinds — validating the axis while the axis was wrong.

## The classification, after closure

**Bodies, always:** everything that retracts (by name or from inside the envelope — Attestation, Organization, OrgMembership, PartnerRecord), the rosters a member reads locally (a chat room IS a 2-member `Community`; `Family` likewise), accord quorum evidence, and LocationProof until something resolves it.

**Hash-first eligible:** `Key`, `IdentityOccurrence`, `TransportDestination` — the directory itself.

**And only a SERVER takes that posture**, driven by the existing `AgentMode` (`client`/`proxy`/`server`, proxy by default) rather than a knob of its own. That is a privacy control: if every node converged the whole hash set the directory would be enumerable from ANY node — cheaper to carry than bodies, same exposure. The default is proxy, so the default is the non-enumerable one.

## The safety invariants

- **Revocations never hash-only.** A node holding the hash of a kill order has not been killed, and one that cannot fetch un-revokes *silently*. Mutation-tested.
- **The known set is not holdings.** `want = remote ∖ holdings`; a hash merely heard of, reaching the holdings side, makes the node conclude it has everything it knows about and stop fetching. `KnownHashes` yields no `EnvelopeRef` and never will.
- **On-demand exemptions are a SET OF HASHES, not a window.** A responder can append bodies to a Fetch reply; appending does not make them requested. Checked per envelope.
- **Ageing on last-advertised, eviction by cutoff.** CIRISPersist#776's lesson: a column the writer freezes never advances. Eviction is by rank, not threshold — a whole round shares a timestamp.

## The contact ladder (#554), edge's tier only

Any identifier — fedID, nodeID, agentID — resolves to the **person** and the **nodes that reach them**. `key_id` is `"<label>-<fingerprint>"` with an operator-chosen label, so the string cannot discriminate; `identity_type` is the authority. An agent resolves to its owner (it cannot consent); a steward is **terminal**, not "wait for convergence".

`discover` proves **reachability**, not ownership — a person can own nodes this node has no route to, and reporting that as discovered hands back a subject whose every send fails.

**Consent and chat are CIRISServer's** and are not reimplemented here: `POST /v1/contacts`, `/v1/chat`, `/v1/chat/{id}/messages` already exist. `Rung` names those steps because the ladder is a shared diagnostic vocabulary, but naming a rung is not a claim to execute it.

**Multi-hop is free.** Once discovery yields the peer's RNS transport key, Reticulum routes across however many hops separate the nodes. Edge implements no relaying — which is also why hash-first needs no multi-hop hash propagation to deliver contact.

**Invite budget:** receiver-enforced (a sender-side limit is advice), one attempt for a stranger, lifted permanently on acceptance, and checked before a human sees anything.

## Harness

`ladder.discover` runs in edge's own runner, **both directions**, against the transport's own `knows_peer` readback — the same question the send path asks before it dials. The leg records what it does not cover.

## Evidence

- 1404 lib tests, clippy `--all-targets` under `-D warnings` clean, census self-tests pass
- Mesh run dispatched against this branch

## Round-seven P1/P2s, closed

- **Missing signer** — the resolver had zero callers since the closure analysis, the same inertness shape as retention. Now: choke point → adapter → bridge (bounded 1024, hash-first only) → Key coordinator drains ≤32/round into Pulls, *before* the round so the reply lands in it. The adapter-forward test is mutation-verified.
- **Hash-cap monopolization** — stalest-first eviction was monopolizable: a flooding peer always holds the youngest entries, so every eviction was charged to the quiet ones. The mutation test shows it was total — **all 8** of the quiet peer's entries gone at a cap of 64. Eviction is now charged to the largest holder, stalest-first within it (max-min fairness, so a single-peer node still gets the whole cap).
- **Contact resolution miss** — user-facing. On a hash-first node `identity_type_of` answers `None` because the body was never fetched, and `resolve` reported "wait for the peer to announce". It already announced. Now the miss queues a fetch on the *same* missing-signer path and returns `BodyFetchQueued`, whose remedy says so.

## Still open, stated plainly

- **The resolution API has no caller inside edge.** `resolve`, `discover`, and `PersistLens` are a tested library surface awaiting their consumer, which is the server tier (contacts/chat live there). The `BodyFetchQueued` path is correct and unit-tested but is not yet exercised by a running edge node. The harness leg covers the *route* half only, against `transport.knows_peer`, and its own `covers` field says so.
- **Multi-hop hash propagation** — downgraded: the transport delivers contact without it.
- **Persistence** rides CIRISPersist#786; this builds against an in-memory set.

## A note on the evidence

The mesh census was reporting the checkout as results: release baselines are force-added into `bench-mesh/results/`, and the census globbed the same directory, so a one-config run announced `legs=106 ran=102 passed=102` when 34 ran. The two extra files in that run's own artifact were byte-identical to the committed ones. Fixed in 1ba3a90 — the directory is emptied first, so a config that did not run is *absent* rather than silently green — and verified by re-running the identical dispatch: 106 → 36 legs, 34 ran, 34 passed.
