### PR TITLE
v18.12.1 — chat-harness integration guide, compile-pinned

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ciris-edge"
-version = "18.12.0"
+version = "18.12.1"
 edition = "2021"
 rust-version = "1.75"
 authors = ["Eric Moore <mooreericnyc@gmail.com>"]

--- a/docs/CHAT_HARNESS_INTEGRATION.md
+++ b/docs/CHAT_HARNESS_INTEGRATION.md
@@ -1,0 +1,183 @@
+# Chat Harness Integration — edge's contact-ladder DX
+
+**Audience:** CIRISServer, building the chat harness on edge (CIRISServer#524).
+**Compile-pinned by:** `tests/chat_harness_dx.rs` — every symbol named here is
+referenced by that test, so an edge API change that would invalidate this
+document reds the build instead of silently rotting the guide.
+
+Edge `main` (`d321256`, CIRISEdge#556) ships the contact-ladder DX the chat harness needs. This is the precise integration: what to call, in what order, what each failure means, and the three places the API will let you do something that silently does not work.
+
+Everything below is `ciris_edge::contact` and `ciris_edge::invite_gate`, both `pub mod` in `lib.rs`. Server composes edge in Rust, so these are direct calls — no FFI.
+
+**Feature required:** `transport-reticulum`, for the production `RouteLens`
+(`ReticulumRoutes`). Everything else in this guide is available on a default
+build.
+
+---
+
+## 0. Wiring you MUST do, or the whole path is inert
+
+Edge's Python entry point sets two config fields that a **Rust composer has to set itself**. Both default to something that looks correct and behaves wrong:
+
+```rust
+let mut config = ciris_edge::replication::ReplicationRuntimeConfig::default();
+
+// Selects retention. Default is Proxy => Retention::Bodies for every plane.
+// A server that wants hash-first MUST say so; there is no autodetect.
+config.bridge.mode = ciris_edge::AgentMode::Server;
+
+// The Pull responder answers an identifier request for THIS NODE'S OWN record.
+// It cannot recognise "its own" without knowing which key_id that is. Left
+// None, signer-key recovery is silently inert.
+config.local_key_id = Some(my_signer_key_id.to_string());
+```
+
+Neither failure is loud. A server-mode node with `mode` unset behaves *exactly* like a correctly configured proxy; recovery with `local_key_id` unset just never recovers. We shipped both bugs during #556 and only found them in review — hence this section first.
+
+`AgentMode` is `Client | Proxy | Server`, **Proxy by default**. Only `Server` takes hash-first retention, and that is deliberate: if every node converged the whole hash set, the directory would be enumerable from any node.
+
+---
+
+## 1. The ladder, and who owns each rung
+
+`Rung` is a shared diagnostic vocabulary, not a claim about who executes what:
+
+| rung | `as_str()` | owner |
+|---|---|---|
+| `Announce` | `announce` | **edge** — publishes identity + transport key |
+| `Discover` | `discover` | **edge** — `contact::discover` |
+| `RequestContact` | `request_contact` | **server** — `POST /v1/contacts` |
+| `Consent` | `consent` | **server** — grants replication consent |
+| `OpenChat` | `open_chat` | **server** — the 2-member community |
+| `SendMessage` | `send_message` | **server** — `/v1/chat/{id}/messages` |
+
+`Rung::previous()` gives the rung before, because a failure is nearly always the previous rung not having completed. Use it to point an operator at the right place instead of the symptom.
+
+---
+
+## 2. Contact by fedID, nodeID, or agentID — one call
+
+**Do not branch on identifier shape.** `key_id` is `"<label>-<fingerprint>"` with an operator-chosen label, so the string cannot tell you what it is; `identity_type` in the directory is the only authority.
+
+```rust
+use ciris_edge::contact::{self, PersistLens, ReticulumRoutes};
+
+let lens = PersistLens::new(federation_directory)
+    .with_replication(replication_directory); // see §5
+
+// ReticulumRoutes is behind the `transport-reticulum` feature. Without it you
+// get "no `ReticulumRoutes` in `contact`", which reads like a missing symbol
+// rather than a missing feature — enable it in your Cargo.toml.
+let routes = ReticulumRoutes::new(&reticulum_transport);
+
+match contact::discover(&lens, &routes, whatever_the_user_typed).await {
+    Ok(found) => {
+        // found.subject.fed_id     — the PERSON. Who consents.
+        // found.subject.nodes      — every node they own.
+        // found.reachable          — the subset you can actually dial. Never empty.
+        // found.subject.resolved_from — Person | Node | Agent | Other(String)
+    }
+    Err(stall) => { /* §3 */ }
+}
+```
+
+Three rules the resolution encodes, so the harness does not have to:
+
+* **An agent resolves to its OWNER.** An agent cannot consent, so "add frank-laptop" means "add Frank". `resolved_from` tells you it arrived via a node/agent, which matters for the log line.
+* **A steward or accord holder is `NotContactable` and TERMINAL** — not "wait for convergence". Retrying is retrying forever.
+* **`discover` proves REACHABILITY, `resolve` proves ownership.** A person can own nodes you have no route to. Use `discover` before any send; `resolve` alone hands you a `Subject` whose every send fails.
+
+Once a destination is known, distance stops mattering: the peer's published RNS transport key gives Reticulum multi-hop routing for free. Edge does no relaying to make that work, and you do not need to ask for it.
+
+---
+
+## 3. Stalls: what to retry, what to surface, what to stop
+
+`LadderStall` is deliberately not a wrapper over underlying errors. Branch on the variant; never parse prose.
+
+```rust
+if stall.self_resolving() {
+    // Converges on its own. Log at INFO, retry later, do NOT alarm a user.
+} else {
+    // A person or an operator must act. Surface it, with:
+    show(stall.remedy());
+}
+```
+
+| variant | `self_resolving()` | what the harness should do |
+|---|---|---|
+| `NotYetDiscovered { fed_id }` | ✅ | wait for replication; retry |
+| `Unreachable { fed_id }` | ✅ | peer offline; RNS routes when it returns |
+| `BodyFetchQueued { key_id }` | ✅ | a fetch is queued; retry after the next Key round |
+| `AwaitingConsent { fed_id }` | ❌ | waiting on a **human**. Retrying does not help and re-sending is spam |
+| `ConsentNotGranted { fed_id }` | ❌ | *this* node has not granted; accept the request |
+| `NotContactable { key_id, identity_type }` | ❌ | a steward/accord holder is not a person. Contact its owner |
+| `DirectoryUnreadable { key_id }` | ❌ | **LOCAL** backend fault. Send them to the node, not the mesh |
+| `PriorRungIncomplete { rung, prior }` | ❌ | look at `prior` on this node first |
+
+`remedy()` returns operator-facing prose for every variant — a stall with no remedy is a bug report, not a diagnostic. Use it verbatim rather than writing your own; they are worded to stop specific wrong actions (e.g. `AwaitingConsent` explicitly says re-sending is spam).
+
+---
+
+## 4. The invite gate — receiver-side, before a human sees anything
+
+```rust
+use ciris_edge::invite_gate::{InviteGate, InviteVerdict, RefuseReason, Ts};
+
+// ONE instance per receiving node, long-lived. Not per request.
+let mut gate = InviteGate::new();
+
+match gate.admit(sender_fed_id, now_unix_seconds as Ts) {
+    InviteVerdict::Allow => present_to_user(invite),
+    InviteVerdict::Refuse { reason } => {
+        // Drop it. Log `reason` for the RECEIVER's operator.
+        // Never tell the sender why, and never tell them when they may retry —
+        // that is telling a spammer the optimal send rate.
+    }
+}
+
+// When the person accepts, permanently lift the stranger budget:
+gate.mark_accepted(sender_fed_id);
+```
+
+Placement is the whole design:
+
+* **Receiver-side.** A sender-side limit is advice.
+* **Before presentation, not at admission.** Do NOT gate replication admission on this. An invite arriving as a signed `Community` record is legitimate federation state; refusing to admit it would withhold carriage of correctly-signed data on a rate heuristic. What is being limited is *presentation to a person*, which is why the gate lives in your tier and not in edge's replication path.
+* `STRANGER_BUDGET = 1`, `CONTACT_BUDGET = 8`, `REFILL_SECS = 86_400`. An accepted contact is never throttled like a stranger — throttling replies is how an anti-spam control breaks the conversations it protects.
+* `mark_accepted` is what makes that promotion permanent. **If you forget to call it, every established contact stays on the 1-invite stranger budget.**
+* `RefuseReason::ReceiverAtCapacity` means the node is tracking its cap of strangers (65,536) and none could be released. Treat as backpressure, not as a verdict about that sender.
+
+The clock is yours — the gate never reads one, so it is testable and drives off whatever time source you already trust.
+
+---
+
+## 5. Logging: one shape for every rung
+
+```rust
+contact::log_rung(Rung::Discover, &fed_id, Some(&stall)); // or None on success
+```
+
+Emits one structured line per rung with a stable `step=` field, so an operator greps and a dashboard groups without parsing prose. Success is INFO (walking the ladder is rare and meaningful, not a hot path). **Use this for your rungs too** — the value of a shared vocabulary is that `step=consent` and `step=discover` appear in the same stream with the same shape.
+
+`contact::discover` already logs its own resolution stalls before returning, so do not double-log what it hands you.
+
+---
+
+## 6. Three things that will not work, by design
+
+Know these before you build against them:
+
+1. **A third-party identifier cannot be resolved on a hash-first node whose directory lacks the body.** `request_key_body` returns `false` always, and says why. The Pull responder answers for the subject itself or for the responding node's own record; a third-party probe is refused, because answering it would make a body-holding server an address-book oracle for records it never advertised. Closing this needs a separately authorized, rate-limited resolver — not built. See `docs/FSD_SIGNER_RECOVERY.md` §7.
+2. **`KnownHashes` records holders but nothing dispatches a point `Fetch` yet.** The learned directory is a sink until that path is wired.
+3. **Stranger contact is meant to start from a nodecode, not a directory lookup.** You hand out an identifier out-of-band, the peer dials that specific node (which serves its own record), and consent follows. Building "search the federation for a person" on top of `discover` will work only for people you already have a consented relationship with — that is the boundary, not a gap to route around.
+
+---
+
+## 7. Pin
+
+Adopt `SERVE_ADVERTISE_POLICY_HASH = e54c56775e8d56442f9fdbaa0346397cdc169e7cc6237f5a6fe71681710dbf25` (CIRISServer#522). `REPLICATION_POLICY_HASH` is unchanged.
+
+---
+
+Anything in here that does not compile against edge `main` is a bug in this guide — tell me and I will fix edge or the guide, whichever is actually wrong.

--- a/evidence/CIRISEdge.cc_impl.tsv
+++ b/evidence/CIRISEdge.cc_impl.tsv
@@ -7,10 +7,10 @@
 # failure. Vendored by CIRISConstitution/tools/check_evidence.py.
 # Columns: cc_section <TAB> clm <TAB> repo <TAB> path#symbol <TAB> crate@version
 decimal_id	claim_id	repo	path#symbol	crate@version
-5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.12.0
-3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.12.0
-3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.12.0
-3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.12.0
-5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.12.0
-5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.12.0
-5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.12.0
+5.3.3	CLM-nsproc-delivery-mode	CIRISEdge	src/delivery_mode.rs#decide	ciris-edge@v18.12.1
+3.3.6	CLM-nsproc-cohort-scope	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.12.1
+3.1	CLM-nsproc-dimension	CIRISEdge	src/replication/bridge.rs#attestation_is_advertised	ciris-edge@v18.12.1
+3.4	CLM-nsproc-key-boundary-scope	CIRISEdge	src/key_boundary.rs#KeyBoundaryScope	ciris-edge@v18.12.1
+5.3.3.5	CLM-nsproc-recipient-serve-capability	CIRISEdge	src/replication/bridge.rs#peer_has_serve_capability	ciris-edge@v18.12.1
+5.3.2.4	CLM-nsproc-recipient-capability	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.12.1
+5.3.2.4	CLM-nsproc-attestation-prefixes	CIRISEdge	src/replication/bridge.rs#recipient_capability_withholds	ciris-edge@v18.12.1

--- a/src/invite_gate.rs
+++ b/src/invite_gate.rs
@@ -50,7 +50,12 @@
 use std::collections::HashMap;
 
 /// Unix seconds.
-type Ts = u64;
+///
+/// Public because it appears in [`InviteGate::admit`]'s signature: a caller that
+/// cannot NAME the type is a caller reading rustdoc for an alias it has no path
+/// to. The clock is the caller's — the gate never reads one itself, so it stays
+/// testable and a host can drive it from whatever time source it already trusts.
+pub type Ts = u64;
 
 /// What the gate decided, and why.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/tests/chat_harness_dx.rs
+++ b/tests/chat_harness_dx.rs
@@ -1,0 +1,200 @@
+//! Compile-pin for `docs/CHAT_HARNESS_INTEGRATION.md`.
+//!
+//! The integration guide handed to CIRISServer (CIRISServer#524) names a
+//! specific public surface and tells them to build a chat harness on it. A
+//! document is the one artifact that cannot fail its own CI, so this test
+//! references every symbol the guide names.
+//!
+//! It asserts almost nothing at runtime, and that is the point: the value is
+//! entirely in COMPILING. If someone renames `LadderStall::BodyFetchQueued`,
+//! changes `discover`'s arity, or makes `Ts` private again, this file stops
+//! building and the guide is known-stale in the same commit — instead of a
+//! downstream team discovering it against a version we already shipped.
+//!
+//! Add a symbol here whenever the guide starts naming it.
+
+use ciris_edge::contact::{Discovered, IdentityKind, LadderStall, PersistLens, Rung, Subject};
+use ciris_edge::invite_gate::{InviteGate, InviteVerdict, RefuseReason, Ts};
+use ciris_edge::replication::ReplicationRuntimeConfig;
+use ciris_edge::AgentMode;
+
+/// §0 — the two fields a Rust composer must set itself, because the Python
+/// entry point sets them and a default-constructed config does not.
+#[test]
+fn the_wiring_the_guide_says_is_mandatory_exists() {
+    let mut config = ReplicationRuntimeConfig::default();
+
+    config.bridge.mode = AgentMode::Server;
+    config.local_key_id = Some("node-abc123".to_string());
+
+    assert!(
+        matches!(config.bridge.mode, AgentMode::Server),
+        "§0 tells the server to set bridge.mode; it must remain settable"
+    );
+    assert!(
+        config.local_key_id.is_some(),
+        "§0 tells the server to set local_key_id; without it the Pull responder \
+         cannot recognise a request for its own record"
+    );
+
+    // And the default really is the quiet one the guide warns about.
+    let default = ReplicationRuntimeConfig::default();
+    assert!(
+        matches!(default.bridge.mode, AgentMode::Proxy),
+        "the guide says the default is Proxy and looks correct while behaving \
+         as a proxy — if that changes, §0's warning is wrong"
+    );
+}
+
+/// §1 — the rung vocabulary, and `previous()` for pointing at the right place.
+#[test]
+fn the_rung_ladder_is_the_documented_shape() {
+    let documented = [
+        (Rung::Announce, "announce", None),
+        (Rung::Discover, "discover", Some(Rung::Announce)),
+        (
+            Rung::RequestContact,
+            "request_contact",
+            Some(Rung::Discover),
+        ),
+        (Rung::Consent, "consent", Some(Rung::RequestContact)),
+        (Rung::OpenChat, "open_chat", Some(Rung::Consent)),
+        (Rung::SendMessage, "send_message", Some(Rung::OpenChat)),
+    ];
+    for (rung, wire, prior) in documented {
+        assert_eq!(rung.as_str(), wire, "§1 prints these strings in a table");
+        assert_eq!(rung.previous(), prior, "§1 documents the ladder order");
+    }
+}
+
+/// §3 — the stall table. Every variant the guide lists, with the
+/// `self_resolving()` value it tells the harness to branch on, and a
+/// non-empty `remedy()` the guide says to surface verbatim.
+#[test]
+fn every_documented_stall_has_the_documented_disposition() {
+    let fed = || "frank-abc123".to_string();
+    let documented: Vec<(LadderStall, bool)> = vec![
+        (LadderStall::NotYetDiscovered { fed_id: fed() }, true),
+        (LadderStall::Unreachable { fed_id: fed() }, true),
+        (LadderStall::BodyFetchQueued { key_id: fed() }, true),
+        (LadderStall::AwaitingConsent { fed_id: fed() }, false),
+        (LadderStall::ConsentNotGranted { fed_id: fed() }, false),
+        (LadderStall::DirectoryUnreadable { key_id: fed() }, false),
+        (
+            LadderStall::NotContactable {
+                key_id: fed(),
+                identity_type: "steward".to_string(),
+            },
+            false,
+        ),
+        (
+            LadderStall::PriorRungIncomplete {
+                rung: Rung::Consent,
+                prior: Rung::RequestContact,
+            },
+            false,
+        ),
+    ];
+    for (stall, self_resolving) in documented {
+        assert_eq!(
+            stall.self_resolving(),
+            self_resolving,
+            "§3's table says self_resolving={self_resolving} for {stall:?}; the \
+             harness branches retry-vs-surface on exactly this"
+        );
+        assert!(
+            !stall.remedy().is_empty(),
+            "§3 tells the server to show remedy() verbatim, so every variant \
+             must have one: {stall:?}"
+        );
+    }
+}
+
+/// §4 — the invite gate's placement and promotion contract.
+#[test]
+fn the_invite_gate_behaves_as_the_guide_describes() {
+    let now: Ts = 1_000_000;
+    let mut gate = InviteGate::new();
+
+    assert!(
+        matches!(gate.admit("stranger", now), InviteVerdict::Allow),
+        "§4: a stranger's first invite reaches the person"
+    );
+    assert!(
+        matches!(
+            gate.admit("stranger", now),
+            InviteVerdict::Refuse {
+                reason: RefuseReason::AlreadyPending | RefuseReason::BudgetSpent
+            }
+        ),
+        "§4: STRANGER_BUDGET is 1"
+    );
+
+    // The line the guide warns about forgetting.
+    gate.mark_accepted("stranger");
+    assert!(
+        matches!(gate.admit("stranger", now), InviteVerdict::Allow),
+        "§4: mark_accepted promotes permanently — forgetting it leaves every \
+         established contact on the 1-invite stranger budget"
+    );
+
+    assert_eq!(InviteGate::STRANGER_BUDGET, 1, "§4 quotes this");
+    assert_eq!(InviteGate::CONTACT_BUDGET, 8, "§4 quotes this");
+    assert_eq!(InviteGate::REFILL_SECS, 86_400, "§4 quotes this");
+}
+
+/// Consume a value at a stated type. The call is what makes each line a real
+/// use rather than a no-effect binding, and the turbofish is the assertion.
+#[allow(dead_code)]
+fn pin<T>(_: T) {}
+
+/// §2/§5 — the resolution entry points and result types the harness
+/// destructures, plus the logging call.
+///
+/// Compile-only: exercising these needs a live directory, but their SHAPES are
+/// what the guide's code blocks depend on.
+#[allow(
+    dead_code,
+    unreachable_code,
+    unused_variables,
+    clippy::diverging_sub_expression
+)]
+async fn the_documented_call_shapes_typecheck() {
+    let lens: PersistLens<'_> = unreachable!();
+
+    // §2: `resolve` — identifier in, Subject out.
+    pin::<Result<Subject, LadderStall>>(ciris_edge::contact::resolve(&lens, "frank-abc123").await);
+
+    // §2: `discover` — identifier + routes in, Discovered out.
+    let routes: &dyn ciris_edge::contact::RouteLens = unreachable!();
+    let found: Result<Discovered, LadderStall> =
+        ciris_edge::contact::discover(&lens, routes, "frank-abc123").await;
+
+    // The fields §2 tells the harness to read. `pin` consumes each one, so the
+    // reference is a real use and the TYPE is what is being asserted.
+    let found: Discovered = found.unwrap();
+    pin::<&Subject>(&found.subject);
+    pin::<&String>(&found.subject.fed_id);
+    pin::<&Vec<String>>(&found.subject.nodes);
+    pin::<&Vec<String>>(&found.reachable);
+    pin::<&IdentityKind>(&found.subject.resolved_from);
+
+    // §5's one-shape-per-rung logger.
+    ciris_edge::contact::log_rung(Rung::Discover, "frank-abc123", None);
+}
+
+/// §2 — `ReticulumRoutes` is the production `RouteLens`, and it is behind the
+/// `transport-reticulum` feature. The guide says so; this pins that it is true,
+/// because a downstream build that omits the feature gets a confusing
+/// "no `ReticulumRoutes` in `contact`" rather than a missing-feature message.
+#[cfg(feature = "transport-reticulum")]
+#[allow(
+    dead_code,
+    unreachable_code,
+    unused_variables,
+    clippy::diverging_sub_expression
+)]
+fn the_production_route_lens_exists_under_its_feature() {
+    let routes: ciris_edge::contact::ReticulumRoutes<'_> = unreachable!();
+    pin::<&dyn ciris_edge::contact::RouteLens>(&routes);
+}


### PR DESCRIPTION
**v18.12.1** — docs and test only, no behaviour change from `d321256`.

CIRISServer is building a chat harness on the contact ladder (CIRISServer#524). This gives them a precise integration and makes it impossible for that document to rot silently.

## `docs/CHAT_HARNESS_INTEGRATION.md`

The call sequence, who owns which rung, what every stall means and whether to retry it, where the invite gate goes and why it is receiver-side and pre-presentation, and three things that deliberately do not work.

## `tests/chat_harness_dx.rs` — the guide's compile-pin

A document is the one artifact that cannot fail its own CI. Every symbol the guide names is referenced here, so a rename or an arity change reds the build in the same commit rather than surfacing downstream against a shipped version.

Writing it immediately found a real error in the guide: `ReticulumRoutes` is behind `transport-reticulum`, and omitting the feature yields `no ReticulumRoutes in contact` — a missing-symbol message for a missing-feature problem. Now stated in the guide and pinned by a cfg'd test.

Four pins are runtime assertions, picked as what a harness would actually get wrong:

| pin | why |
|---|---|
| §0's wiring exists, and the default is the quiet one | `bridge.mode` defaults to `Proxy` and a mis-wired server behaves *exactly* like a correct proxy; `local_key_id` left `None` makes the Pull responder unable to recognise its own record. **Both shipped inert during #556.** |
| §1's rung order + wire strings | the guide prints them as a table the server will grep against |
| §3's stall table | the harness branches retry-vs-surface on `self_resolving()`; every variant also needs a non-empty `remedy()` |
| §4's promotion contract | forgetting `mark_accepted` leaves every established contact throttled at the 1-invite stranger budget |

## Also

- `invite_gate::Ts` is public — it appears in `admit`'s signature, so a downstream reader saw a type it had no path to.
- Patch bump with `evidence/CIRISEdge.cc_impl.tsv` regenerated. The `crate@version` is embedded per row, and a stale TSV reddens every test lane — verified by watching `evidence_tsv_matches_emitted` fail on the bump and pass after.

1197 lib tests + 4 harness pins green, clippy clean across the four feature combos.
